### PR TITLE
Call clear notification badges on native app init

### DIFF
--- a/src/containers/notification/store/sagas.ts
+++ b/src/containers/notification/store/sagas.ts
@@ -537,7 +537,7 @@ function* watchTogglePanel() {
 }
 
 // On Native App open, clear the notification badges
-function* notificationsInit() {
+function* resetNotificationBadgeCount() {
   try {
     yield call(waitForBackendSetup)
 
@@ -553,8 +553,7 @@ function* notificationsInit() {
 }
 
 export default function sagas() {
-  return [
-    notificationsInit,
+  const sagas: (() => Generator)[] = [
     watchFetchNotifications,
     watchFetchNotificationUsers,
     watchMarkNotificationsRead,
@@ -567,4 +566,8 @@ export default function sagas() {
     watchTogglePanel,
     watchNotificationError
   ]
+  if (NATIVE_MOBILE) {
+    sagas.push(resetNotificationBadgeCount)
+  }
+  return sagas
 }

--- a/src/containers/notification/store/sagas.ts
+++ b/src/containers/notification/store/sagas.ts
@@ -536,8 +536,25 @@ function* watchTogglePanel() {
   })
 }
 
+// On Native App open, clear the notification badges
+function* notificationsInit() {
+  try {
+    yield call(waitForBackendSetup)
+
+    const hasAccount = yield select(getHasAccount)
+    if (hasAccount && NATIVE_MOBILE) {
+      const message = new ResetNotificationsBadgeCount()
+      message.send()
+      yield call(AudiusBackend.clearNotificationBadges)
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
 export default function sagas() {
   return [
+    notificationsInit,
     watchFetchNotifications,
     watchFetchNotificationUsers,
     watchMarkNotificationsRead,

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1950,6 +1950,25 @@ class AudiusBackend {
     }
   }
 
+  static async clearNotificationBadges() {
+    await waitForLibsInit()
+    const account = audiusLibs.Account.getCurrentUser()
+    if (!account) return
+    try {
+      const { data, signature } = await AudiusBackend.signData()
+      return fetch(`${IDENTITY_SERVICE}/notifications/clear_badges`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [AuthHeaders.Message]: data,
+          [AuthHeaders.Signature]: signature
+        }
+      }).then(res => res.json())
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
   static async getEmailNotificationSettings() {
     await waitForLibsInit()
     const account = audiusLibs.Account.getCurrentUser()


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/hy9V9hZ3/1489-notification-badge-regression-no-longer-clears-on-app-opening-if-theres-nothing-see-attached-video

### Description
On app load, call clear badge count via the react native action and to the identity service. 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

I need to test this on the bounce app post merge, but what I did test that w/out the NATIVE_MOBILE (so on desktop), that the app did call the identity endpoint to clear badges on load. 
Post merge: Test that on app load the badges clear out. 
