### PR TITLE
Clear badge count on load on App foreground

### DIFF
--- a/src/services/native-mobile-interface/types.ts
+++ b/src/services/native-mobile-interface/types.ts
@@ -36,6 +36,7 @@ export enum MessageType {
   REQUEST_TWITTER_AUTH = 'request-twiter-auth',
 
   // Lifecycle
+  ENTER_FOREGROUND = 'action/enter-foreground',
   BACKEND_SETUP = 'backend-setup',
   REQUEST_NETWORK_CONNECTED = 'request-network-connected',
   IS_NETWORK_CONNECTED = 'is-network-connected',


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/hy9V9hZ3/1489-notification-badge-regression-no-longer-clears-on-app-opening-if-theres-nothing-see-attached-video

### Description
Adds a saga listener for the app enter foreground action to clear the notification badge count

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I manually dispatched actions in the dapp to check that the saga takeEvery was being run. 
This will be testing on audius bounce where there are real notification & messages are passed from the react-native layer.
