### PR TITLE
Fix check for route names that have no real characters

### DIFF
--- a/src/containers/collection-page/CollectionPageProvider.tsx
+++ b/src/containers/collection-page/CollectionPageProvider.tsx
@@ -223,7 +223,7 @@ class CollectionPage extends Component<
         const newCollectionName = formatUrlName(metadata.playlist_name)
 
         const routeLacksCollectionInfo =
-          (!title || !handle || !collectionType) && user
+          (title === null || handle === null || collectionType === null) && user
         if (routeLacksCollectionInfo) {
           // Check if we are coming from a non-canonical route and replace route if necessary.
           const newPath = metadata.is_album

--- a/src/containers/profile-page/ProfilePageProvider.tsx
+++ b/src/containers/profile-page/ProfilePageProvider.tsx
@@ -172,7 +172,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       const params = parseUserRoute(pathname)
       if (params) {
         const { handle } = params
-        if (!handle) {
+        if (handle === null) {
           const newPath = profilePage(profile.profile.handle)
           this.props.replaceRoute(newPath)
         }

--- a/src/containers/track-page/TrackPageProvider.tsx
+++ b/src/containers/track-page/TrackPageProvider.tsx
@@ -154,7 +154,7 @@ class TrackPageProvider extends Component<
         // Check if we are coming from a non-canonical route and replace route if necessary.
         const { trackTitle, trackId, handle } = params
         const newTrackTitle = formatUrlName(track.title)
-        if (!trackTitle || !handle) {
+        if (trackTitle === null || handle === null) {
           if (this.props.user) {
             const newPath = trackPage(
               this.props.user.handle,


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/YSw7Cbkg/1514-fix-fully-escaped-url-names

### Description
Playlists that have no real characters in the title, e.g. '///' get escaped down to '' in the route. We should check for null here instead of falsey.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
http://localhost:3002/archangel/playlist/-9580
