### PR TITLE
Exit dist.js with exit(1) if build notarization fails

### DIFF
--- a/scripts/dist.js
+++ b/scripts/dist.js
@@ -183,6 +183,6 @@ console.log(buildParams)
 copyBuildDir(program.env === 'production').then(() => {
   builder.build(buildParams).catch(e => {
     console.error(e)
-    throw new Error(e)
+    process.exit(1)
   })
 })


### PR DESCRIPTION
### Trello Card Link
n/a

### Description
If our notarization job fails, explicitly return exit code 1 so CircleCI knows the job failed.

### Dragons
Very dragon-less


### How Has This Been Tested?
This is untested.

