### PR TITLE
Add DP v1 api user follows/following

### DIFF
--- a/src/containers/discover-page/store/lineups/trending/reducer.js
+++ b/src/containers/discover-page/store/lineups/trending/reducer.js
@@ -11,6 +11,7 @@ const initialState = {
   ...initialLineupState,
   antiBot: true,
   dedupe: true,
+  containsDeleted: false,
   prefix: PREFIX
 }
 

--- a/src/containers/favorites-page/store/sagas.ts
+++ b/src/containers/favorites-page/store/sagas.ts
@@ -12,24 +12,18 @@ import { createUserListProvider } from 'containers/user-list/utils'
 import { FavoriteType } from 'models/Favorite'
 import { trackFavoriteError, playlistFavoriteError } from './actions'
 import { watchFavoriteError } from './errorSagas'
-import { encodeHashId } from 'utils/route/hashIds'
 
 const getPlaylistFavorites = createUserListProvider<Collection>({
   getExistingEntity: getCollection,
   extractUserIDSubsetFromEntity: (collection: Collection) =>
     collection.followee_saves.map(r => r.user_id),
-  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) => {
-    const playlistId = encodeHashId(entityId)!
-    const encodedUserId = currentUserId
-      ? encodeHashId(currentUserId) ?? undefined
-      : undefined
-    return apiClient.getPlaylistFavoriteUsers({
+  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) =>
+    apiClient.getPlaylistFavoriteUsers({
       limit,
       offset,
-      playlistId,
-      currentUserId: encodedUserId
-    })
-  },
+      playlistId: entityId,
+      currentUserId
+    }),
   selectCurrentUserIDsInList: getUserIds,
   canFetchMoreUsers: (collection: Collection, combinedUserIDs: ID[]) =>
     combinedUserIDs.length < collection.save_count,
@@ -40,18 +34,13 @@ const getTrackFavorites = createUserListProvider<Track>({
   getExistingEntity: getTrack,
   extractUserIDSubsetFromEntity: (track: Track) =>
     track.followee_saves.map(r => r.user_id),
-  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) => {
-    const trackId = encodeHashId(entityId)!
-    const encodedUserId = currentUserId
-      ? encodeHashId(currentUserId) ?? undefined
-      : undefined
-    return apiClient.getTrackFavoriteUsers({
+  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) =>
+    apiClient.getTrackFavoriteUsers({
       limit,
       offset,
-      trackId,
-      currentUserId: encodedUserId
-    })
-  },
+      trackId: entityId,
+      currentUserId
+    }),
   selectCurrentUserIDsInList: getUserIds,
   canFetchMoreUsers: (track: Track, combinedUserIDs: ID[]) =>
     combinedUserIDs.length < track.save_count,

--- a/src/containers/favorites-page/store/sagas.ts
+++ b/src/containers/favorites-page/store/sagas.ts
@@ -7,22 +7,29 @@ import Track from 'models/Track'
 import { ID } from 'models/common/Identifiers'
 import Collection from 'models/Collection'
 import { getCollection } from 'store/cache/collections/selectors'
-import AudiusBackend from 'services/AudiusBackend'
+import apiClient from 'services/audius-api-client/AudiusAPIClient'
 import { createUserListProvider } from 'containers/user-list/utils'
 import { FavoriteType } from 'models/Favorite'
 import { trackFavoriteError, playlistFavoriteError } from './actions'
 import { watchFavoriteError } from './errorSagas'
+import { encodeHashId } from 'utils/route/hashIds'
 
 const getPlaylistFavorites = createUserListProvider<Collection>({
   getExistingEntity: getCollection,
   extractUserIDSubsetFromEntity: (collection: Collection) =>
     collection.followee_saves.map(r => r.user_id),
-  fetchAllUsersForEntity: ({ limit, offset, entityId }) =>
-    AudiusBackend.getFavoritersForPlaylist({
+  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) => {
+    const playlistId = encodeHashId(entityId)!
+    const encodedUserId = currentUserId
+      ? encodeHashId(currentUserId) ?? undefined
+      : undefined
+    return apiClient.getPlaylistFavoriteUsers({
       limit,
       offset,
-      playlistId: entityId
-    }),
+      playlistId,
+      currentUserId: encodedUserId
+    })
+  },
   selectCurrentUserIDsInList: getUserIds,
   canFetchMoreUsers: (collection: Collection, combinedUserIDs: ID[]) =>
     combinedUserIDs.length < collection.save_count,
@@ -33,8 +40,18 @@ const getTrackFavorites = createUserListProvider<Track>({
   getExistingEntity: getTrack,
   extractUserIDSubsetFromEntity: (track: Track) =>
     track.followee_saves.map(r => r.user_id),
-  fetchAllUsersForEntity: ({ limit, offset, entityId }) =>
-    AudiusBackend.getFavoritersForTrack({ limit, offset, trackId: entityId }),
+  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) => {
+    const trackId = encodeHashId(entityId)!
+    const encodedUserId = currentUserId
+      ? encodeHashId(currentUserId) ?? undefined
+      : undefined
+    return apiClient.getTrackFavoriteUsers({
+      limit,
+      offset,
+      trackId,
+      currentUserId: encodedUserId
+    })
+  },
   selectCurrentUserIDsInList: getUserIds,
   canFetchMoreUsers: (track: Track, combinedUserIDs: ID[]) =>
     combinedUserIDs.length < track.save_count,

--- a/src/containers/followers-page/store/sagas.ts
+++ b/src/containers/followers-page/store/sagas.ts
@@ -9,7 +9,6 @@ import { watchFollowersError } from './errorSagas'
 import User from 'models/User'
 import { getUser } from 'store/cache/users/selectors'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
-import { encodeHashId } from 'utils/route/hashIds'
 
 const provider = createUserListProvider<User>({
   getExistingEntity: getUser,
@@ -25,13 +24,9 @@ const provider = createUserListProvider<User>({
     entityId: ID
     currentUserId: ID | null
   }) => {
-    const encodedUserId = currentUserId
-      ? encodeHashId(currentUserId) ?? undefined
-      : undefined
-    const profileUserId = encodeHashId(entityId)!
     return apiClient.getFollowers({
-      currentUserId: encodedUserId,
-      profileUserId,
+      currentUserId,
+      profileUserId: entityId,
       limit: limit,
       offset: offset
     })

--- a/src/containers/following-page/store/sagas.ts
+++ b/src/containers/following-page/store/sagas.ts
@@ -9,7 +9,6 @@ import { watchFollowingError } from './errorSagas'
 import User from 'models/User'
 import { getUser } from 'store/cache/users/selectors'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
-import { encodeHashId } from 'utils/route/hashIds'
 
 const provider = createUserListProvider<User>({
   getExistingEntity: getUser,
@@ -25,13 +24,9 @@ const provider = createUserListProvider<User>({
     entityId: ID
     currentUserId: ID | null
   }) => {
-    const encodedUserId = currentUserId
-      ? encodeHashId(currentUserId) ?? undefined
-      : undefined
-    const profileUserId = encodeHashId(entityId)!
     return apiClient.getFollowing({
-      currentUserId: encodedUserId,
-      profileUserId,
+      currentUserId,
+      profileUserId: entityId,
       limit: limit,
       offset: offset
     })

--- a/src/containers/following-page/store/sagas.ts
+++ b/src/containers/following-page/store/sagas.ts
@@ -3,12 +3,13 @@ import { USER_LIST_TAG } from '../FollowingPage'
 import { put, select } from 'redux-saga/effects'
 import { getId, getUserList, getUserIds } from './selectors'
 import { ID } from 'models/common/Identifiers'
-import AudiusBackend from 'services/AudiusBackend'
 import { createUserListProvider } from 'containers/user-list/utils'
 import { getFollowingError } from './actions'
 import { watchFollowingError } from './errorSagas'
 import User from 'models/User'
 import { getUser } from 'store/cache/users/selectors'
+import apiClient from 'services/audius-api-client/AudiusAPIClient'
+import { encodeHashId } from 'utils/route/hashIds'
 
 const provider = createUserListProvider<User>({
   getExistingEntity: getUser,
@@ -16,12 +17,25 @@ const provider = createUserListProvider<User>({
   fetchAllUsersForEntity: ({
     limit,
     offset,
-    entityId
+    entityId,
+    currentUserId
   }: {
     limit: number
     offset: number
     entityId: ID
-  }) => AudiusBackend.getFollowees(entityId, limit, offset),
+    currentUserId: ID | null
+  }) => {
+    const encodedUserId = currentUserId
+      ? encodeHashId(currentUserId) ?? undefined
+      : undefined
+    const profileUserId = encodeHashId(entityId)!
+    return apiClient.getFollowing({
+      currentUserId: encodedUserId,
+      profileUserId,
+      limit: limit,
+      offset: offset
+    })
+  },
   selectCurrentUserIDsInList: getUserIds,
   canFetchMoreUsers: (user: User, combinedUserIDs: ID[]) =>
     combinedUserIDs.length < user.followee_count,

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -167,7 +167,7 @@ function* fetchFollowerUsers(action) {
   const encodedUserId = userId ? encodeHashId(userId) ?? undefined : undefined
   const encodedProfileId = encodeHashId(profileUserId)
 
-  const followers = yield apiClient.getFollowing({
+  const followers = yield apiClient.getFollowers({
     currentUserId: encodedUserId,
     profileUserId: encodedProfileId,
     limit: action.limit,
@@ -192,7 +192,7 @@ function* fetchFollowees(action) {
   const encodedUserId = userId ? encodeHashId(userId) ?? undefined : undefined
   const encodedProfileId = encodeHashId(profileUserId)
 
-  const followees = yield apiClient.getFollowers({
+  const followees = yield apiClient.getFollowing({
     currentUserId: encodedUserId,
     profileUserId: encodedProfileId,
     limit: action.limit,

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -39,7 +39,6 @@ import { squashNewLines } from 'utils/formatUtil'
 import { getIsReachable } from 'store/reachability/selectors'
 import { isMobile } from 'utils/clientUtil'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
-import { encodeHashId } from 'utils/route/hashIds'
 import { processAndCacheUsers } from 'store/cache/users/utils'
 
 function* watchFetchProfile() {
@@ -163,13 +162,10 @@ function* fetchMostUsedTags(userId, trackCount) {
 function* fetchFollowerUsers(action) {
   const profileUserId = yield select(getProfileUserId)
   if (!profileUserId) return
-  const userId = yield select(getUserId)
-  const encodedUserId = userId ? encodeHashId(userId) ?? undefined : undefined
-  const encodedProfileId = encodeHashId(profileUserId)
-
+  const currentUserId = yield select(getUserId)
   const followers = yield apiClient.getFollowers({
-    currentUserId: encodedUserId,
-    profileUserId: encodedProfileId,
+    currentUserId,
+    profileUserId,
     limit: action.limit,
     offset: action.offset
   })
@@ -188,13 +184,10 @@ function* fetchFollowerUsers(action) {
 function* fetchFollowees(action) {
   const profileUserId = yield select(getProfileUserId)
   if (!profileUserId) return
-  const userId = yield select(getUserId)
-  const encodedUserId = userId ? encodeHashId(userId) ?? undefined : undefined
-  const encodedProfileId = encodeHashId(profileUserId)
-
+  const currentUserId = yield select(getUserId)
   const followees = yield apiClient.getFollowing({
-    currentUserId: encodedUserId,
-    profileUserId: encodedProfileId,
+    currentUserId,
+    profileUserId,
     limit: action.limit,
     offset: action.offset
   })

--- a/src/containers/reposts-page/store/sagas.ts
+++ b/src/containers/reposts-page/store/sagas.ts
@@ -12,24 +12,18 @@ import apiClient from 'services/audius-api-client/AudiusAPIClient'
 import { createUserListProvider } from 'containers/user-list/utils'
 import { trackRepostError, playlistRepostError } from './actions'
 import { watchRepostsError } from './errorSagas'
-import { encodeHashId } from 'utils/route/hashIds'
 
 const getPlaylistReposts = createUserListProvider<Collection>({
   getExistingEntity: getCollection,
   extractUserIDSubsetFromEntity: (collection: Collection) =>
     collection.followee_reposts.map(r => r.user_id),
-  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) => {
-    const playlistId = encodeHashId(entityId)!
-    const encodedUserId = currentUserId
-      ? encodeHashId(currentUserId) ?? undefined
-      : undefined
-    return apiClient.getPlaylistRepostUsers({
+  fetchAllUsersForEntity: ({ limit, offset, entityId, currentUserId }) =>
+    apiClient.getPlaylistRepostUsers({
       limit,
       offset,
-      playlistId,
-      currentUserId: encodedUserId
-    })
-  },
+      playlistId: entityId,
+      currentUserId
+    }),
   selectCurrentUserIDsInList: getUserIds,
   canFetchMoreUsers: (collection: Collection, combinedUserIDs: ID[]) =>
     combinedUserIDs.length < collection.repost_count,
@@ -50,18 +44,13 @@ const getTrackReposts = createUserListProvider<Track>({
     offset: number
     entityId: ID
     currentUserId: ID | null
-  }) => {
-    const trackId = encodeHashId(entityId)!
-    const encodedUserId = currentUserId
-      ? encodeHashId(currentUserId) ?? undefined
-      : undefined
-    return apiClient.getTrackRepostUsers({
+  }) =>
+    apiClient.getTrackRepostUsers({
       limit,
       offset,
-      trackId,
-      currentUserId: encodedUserId
-    })
-  },
+      trackId: entityId,
+      currentUserId
+    }),
   selectCurrentUserIDsInList: getUserIds,
   canFetchMoreUsers: (track: Track, combinedUserIDs: ID[]) =>
     combinedUserIDs.length < track.repost_count,

--- a/src/containers/user-list/utils.ts
+++ b/src/containers/user-list/utils.ts
@@ -1,10 +1,10 @@
 import { AppState } from 'store/types'
 
-import { fetchUsers } from 'store/cache/users/sagas'
-import User from 'models/User'
+import User, { UserMetadata } from 'models/User'
 import { call, select } from 'redux-saga/effects'
 import { ID } from 'models/common/Identifiers'
-import { getAccountUser } from 'store/account/selectors'
+import { getAccountUser, getUserId } from 'store/account/selectors'
+import { processAndCacheUsers } from 'store/cache/users/utils'
 
 export type UserListProviderArgs<T> = {
   // Gets the track or playlist we're referencing.
@@ -21,7 +21,8 @@ export type UserListProviderArgs<T> = {
     limit: number
     offset: number
     entityId: ID
-  }) => Promise<User[]>
+    currentUserId: ID | null
+  }) => Promise<UserMetadata[]>
 
   includeCurrentUser: (entity: T) => boolean
 
@@ -64,12 +65,14 @@ export function createUserListProvider<T>({
     const subsetIds = extractUserIDSubsetFromEntity(existingEntity)
     const subsetIdSet = new Set(subsetIds)
 
+    const userId = yield select(getUserId)
     // Get the next page of users
     const offset = currentPage * pageSize
     const allUsers: User[] = yield call(fetchAllUsersForEntity, {
       limit: pageSize,
       offset,
-      entityId: id
+      entityId: id,
+      currentUserId: userId
     })
     if (includeCurrentUser(existingEntity)) {
       const currentUser = yield select(getAccountUser)
@@ -96,7 +99,7 @@ export function createUserListProvider<T>({
     combinedUserIds = [...new Set(combinedUserIds)]
 
     // Insert new users into the cache
-    yield call(fetchUsers, combinedUserIds)
+    yield processAndCacheUsers(allUsers)
 
     const hasMoreUsers = canFetchMoreUsers(existingEntity, combinedUserIds)
 

--- a/src/containers/user-list/utils.ts
+++ b/src/containers/user-list/utils.ts
@@ -100,7 +100,6 @@ export function createUserListProvider<T>({
 
     // Insert new users into the cache
     yield processAndCacheUsers(allUsers)
-
     const hasMoreUsers = canFetchMoreUsers(existingEntity, combinedUserIds)
 
     return { userIds: combinedUserIds, hasMore: hasMoreUsers }

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -8,7 +8,13 @@ import { getEagerDiscprov } from 'services/audius-backend/eagerLoadUtils'
 const ENDPOINT_MAP = {
   trending: '/tracks/trending',
   following: (userId: string) => `/users/${userId}/following`,
-  followers: (userId: string) => `/users/${userId}/followers`
+  followers: (userId: string) => `/users/${userId}/followers`,
+  trackRepostUsers: (trackId: string) => `/tracks/${trackId}/reposts`,
+  trackFavoriteUsers: (trackId: string) => `/tracks/${trackId}/favorites`,
+  playlistRepostUsers: (playlistId: string) =>
+    `/playlists/${playlistId}/reposts`,
+  playlistFavoriteUsers: (playlistId: string) =>
+    `/playlists/${playlistId}/favorites`
 }
 
 const TRENDING_LIMIT = 100
@@ -33,6 +39,34 @@ type GetFollowersArgs = {
   currentUserId?: string
   offset?: number
   limit?: number
+}
+
+type GetTrackRepostUsersArgs = {
+  trackId: string
+  currentUserId?: string
+  limit?: number
+  offset?: number
+}
+
+type GetTrackFavoriteUsersArgs = {
+  trackId: string
+  currentUserId?: string
+  limit?: number
+  offset?: number
+}
+
+type GetPlaylistRepostUsersArgs = {
+  playlistId: string
+  currentUserId?: string
+  limit?: number
+  offset?: number
+}
+
+type GetPlaylistFavoriteUsersArgs = {
+  playlistId: string
+  currentUserId?: string
+  limit?: number
+  offset?: number
 }
 
 type InitializationState =
@@ -121,6 +155,106 @@ class AudiusAPIClient {
       endpoint
     )
     const adapted = followersResponse.data
+      .map(adapter.makeUser)
+      .filter(removeNullable)
+    return adapted
+  }
+
+  async getTrackRepostUsers({
+    currentUserId,
+    trackId,
+    limit,
+    offset
+  }: GetTrackRepostUsersArgs) {
+    this._assertInitialized()
+    const params = {
+      user_id: currentUserId,
+      limit,
+      offset
+    }
+    const endpoint = this._constructUrl(
+      ENDPOINT_MAP.trackRepostUsers(trackId),
+      params
+    )
+    const repostUsers: APIResponse<APIUser[]> = await this._getResponse(
+      endpoint
+    )
+    const adapted = repostUsers.data
+      .map(adapter.makeUser)
+      .filter(removeNullable)
+    return adapted
+  }
+
+  async getTrackFavoriteUsers({
+    currentUserId,
+    trackId,
+    limit,
+    offset
+  }: GetTrackFavoriteUsersArgs) {
+    this._assertInitialized()
+    const params = {
+      user_id: currentUserId,
+      limit,
+      offset
+    }
+    const endpoint = this._constructUrl(
+      ENDPOINT_MAP.trackFavoriteUsers(trackId),
+      params
+    )
+    const followingResponse: APIResponse<APIUser[]> = await this._getResponse(
+      endpoint
+    )
+    const adapted = followingResponse.data
+      .map(adapter.makeUser)
+      .filter(removeNullable)
+    return adapted
+  }
+
+  async getPlaylistRepostUsers({
+    currentUserId,
+    playlistId,
+    limit,
+    offset
+  }: GetPlaylistRepostUsersArgs) {
+    this._assertInitialized()
+    const params = {
+      user_id: currentUserId,
+      limit,
+      offset
+    }
+    const endpoint = this._constructUrl(
+      ENDPOINT_MAP.playlistRepostUsers(playlistId),
+      params
+    )
+    const repostUsers: APIResponse<APIUser[]> = await this._getResponse(
+      endpoint
+    )
+    const adapted = repostUsers.data
+      .map(adapter.makeUser)
+      .filter(removeNullable)
+    return adapted
+  }
+
+  async getPlaylistFavoriteUsers({
+    currentUserId,
+    playlistId,
+    limit,
+    offset
+  }: GetPlaylistFavoriteUsersArgs) {
+    this._assertInitialized()
+    const params = {
+      user_id: currentUserId,
+      limit,
+      offset
+    }
+    const endpoint = this._constructUrl(
+      ENDPOINT_MAP.playlistFavoriteUsers(playlistId),
+      params
+    )
+    const followingResponse: APIResponse<APIUser[]> = await this._getResponse(
+      endpoint
+    )
+    const adapted = followingResponse.data
       .map(adapter.makeUser)
       .filter(removeNullable)
     return adapted

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1,9 +1,11 @@
 import TimeRange from 'models/TimeRange'
 import { removeNullable } from 'utils/typeUtils'
 import { APIResponse, APITrack, APIUser } from './types'
+import { ID } from 'models/common/Identifiers'
 import * as adapter from './ResponseAdapter'
 import AudiusBackend from 'services/AudiusBackend'
 import { getEagerDiscprov } from 'services/audius-backend/eagerLoadUtils'
+import { encodeHashId } from 'utils/route/hashIds'
 
 const ENDPOINT_MAP = {
   trending: '/tracks/trending',
@@ -28,43 +30,43 @@ type GetTrendingArgs = {
 }
 
 type GetFollowingArgs = {
-  profileUserId: string
-  currentUserId?: string
+  profileUserId: ID
+  currentUserId: ID | null
   offset?: number
   limit?: number
 }
 
 type GetFollowersArgs = {
-  profileUserId: string
-  currentUserId?: string
+  profileUserId: ID
+  currentUserId: ID | null
   offset?: number
   limit?: number
 }
 
 type GetTrackRepostUsersArgs = {
-  trackId: string
-  currentUserId?: string
+  trackId: ID
+  currentUserId: ID | null
   limit?: number
   offset?: number
 }
 
 type GetTrackFavoriteUsersArgs = {
-  trackId: string
-  currentUserId?: string
+  trackId: ID
+  currentUserId: ID | null
   limit?: number
   offset?: number
 }
 
 type GetPlaylistRepostUsersArgs = {
-  playlistId: string
-  currentUserId?: string
+  playlistId: ID
+  currentUserId: ID | null
   limit?: number
   offset?: number
 }
 
 type GetPlaylistFavoriteUsersArgs = {
-  playlistId: string
-  currentUserId?: string
+  playlistId: ID
+  currentUserId: ID | null
   limit?: number
   offset?: number
 }
@@ -117,13 +119,18 @@ class AudiusAPIClient {
     offset
   }: GetFollowingArgs) {
     this._assertInitialized()
+    const encodedUserId = encodeHashId(currentUserId)
+    const encodedProfileUserId = encodeHashId(profileUserId)
+    if (!encodedProfileUserId) {
+      throw new Error(`Unable to encode profile user id: ${profileUserId}`)
+    }
     const params = {
-      user_id: currentUserId,
+      user_id: encodedUserId || undefined,
       limit,
       offset
     }
     const endpoint = this._constructUrl(
-      ENDPOINT_MAP.following(profileUserId),
+      ENDPOINT_MAP.following(encodedProfileUserId),
       params
     )
     const followingResponse: APIResponse<APIUser[]> = await this._getResponse(
@@ -142,13 +149,18 @@ class AudiusAPIClient {
     offset
   }: GetFollowersArgs) {
     this._assertInitialized()
+    const encodedUserId = encodeHashId(currentUserId)
+    const encodedProfileUserId = encodeHashId(profileUserId)
+    if (!encodedProfileUserId) {
+      throw new Error(`Unable to encode profile user id: ${profileUserId}`)
+    }
     const params = {
-      user_id: currentUserId,
+      user_id: encodedUserId || undefined,
       limit,
       offset
     }
     const endpoint = this._constructUrl(
-      ENDPOINT_MAP.followers(profileUserId),
+      ENDPOINT_MAP.followers(encodedProfileUserId),
       params
     )
     const followersResponse: APIResponse<APIUser[]> = await this._getResponse(
@@ -167,13 +179,18 @@ class AudiusAPIClient {
     offset
   }: GetTrackRepostUsersArgs) {
     this._assertInitialized()
+    const encodedUserId = encodeHashId(currentUserId)
+    const encodedTrackId = encodeHashId(trackId)
+    if (!encodedTrackId) {
+      throw new Error(`Unable to encode profile user id: ${trackId}`)
+    }
     const params = {
-      user_id: currentUserId,
+      user_id: encodedUserId || undefined,
       limit,
       offset
     }
     const endpoint = this._constructUrl(
-      ENDPOINT_MAP.trackRepostUsers(trackId),
+      ENDPOINT_MAP.trackRepostUsers(encodedTrackId),
       params
     )
     const repostUsers: APIResponse<APIUser[]> = await this._getResponse(
@@ -192,13 +209,18 @@ class AudiusAPIClient {
     offset
   }: GetTrackFavoriteUsersArgs) {
     this._assertInitialized()
+    const encodedUserId = encodeHashId(currentUserId)
+    const encodedTrackId = encodeHashId(trackId)
+    if (!encodedTrackId) {
+      throw new Error(`Unable to encode profile user id: ${trackId}`)
+    }
     const params = {
-      user_id: currentUserId,
+      user_id: encodedUserId || undefined,
       limit,
       offset
     }
     const endpoint = this._constructUrl(
-      ENDPOINT_MAP.trackFavoriteUsers(trackId),
+      ENDPOINT_MAP.trackFavoriteUsers(encodedTrackId),
       params
     )
     const followingResponse: APIResponse<APIUser[]> = await this._getResponse(
@@ -217,13 +239,18 @@ class AudiusAPIClient {
     offset
   }: GetPlaylistRepostUsersArgs) {
     this._assertInitialized()
+    const encodedUserId = encodeHashId(currentUserId)
+    const encodedPlaylistId = encodeHashId(playlistId)
+    if (!encodedPlaylistId) {
+      throw new Error(`Unable to encode profile user id: ${playlistId}`)
+    }
     const params = {
-      user_id: currentUserId,
+      user_id: encodedUserId || undefined,
       limit,
       offset
     }
     const endpoint = this._constructUrl(
-      ENDPOINT_MAP.playlistRepostUsers(playlistId),
+      ENDPOINT_MAP.playlistRepostUsers(encodedPlaylistId),
       params
     )
     const repostUsers: APIResponse<APIUser[]> = await this._getResponse(
@@ -242,13 +269,18 @@ class AudiusAPIClient {
     offset
   }: GetPlaylistFavoriteUsersArgs) {
     this._assertInitialized()
+    const encodedUserId = encodeHashId(currentUserId)
+    const encodedPlaylistId = encodeHashId(playlistId)
+    if (!encodedPlaylistId) {
+      throw new Error(`Unable to encode profile user id: ${playlistId}`)
+    }
     const params = {
-      user_id: currentUserId,
+      user_id: encodedUserId || undefined,
       limit,
       offset
     }
     const endpoint = this._constructUrl(
-      ENDPOINT_MAP.playlistFavoriteUsers(playlistId),
+      ENDPOINT_MAP.playlistFavoriteUsers(encodedPlaylistId),
       params
     )
     const followingResponse: APIResponse<APIUser[]> = await this._getResponse(

--- a/src/services/audius-api-client/ResponseAdapter.ts
+++ b/src/services/audius-api-client/ResponseAdapter.ts
@@ -6,7 +6,7 @@ import { decodeHashId } from 'utils/route/hashIds'
 import { removeNullable } from 'utils/typeUtils'
 import { APIFavorite, APIRemix, APIRepost, APITrack, APIUser } from './types'
 
-const makeUser = (user: APIUser): UserMetadata | undefined => {
+export const makeUser = (user: APIUser): UserMetadata | undefined => {
   const decodedUserId = decodeHashId(user.id)
   if (!decodedUserId) {
     return undefined

--- a/src/utils/route/hashIds.ts
+++ b/src/utils/route/hashIds.ts
@@ -19,8 +19,9 @@ export const decodeHashId = (id: string): Nullable<number> => {
   }
 }
 
-export const encodeHashId = (id: number): Nullable<string> => {
+export const encodeHashId = (id: number | null = null): Nullable<string> => {
   try {
+    if (id === null) return null
     const encodedId = hashids.encode(id)
     return encodedId
   } catch (e) {


### PR DESCRIPTION
### Trello Card Link
https://www.notion.so/audiusproject/Porting-Client-to-API-9beefcc007ff4242be96124874606227
`/users/<id>/following` & `/users/<id>/followers`

### Description
Updates the get user following and get user follows endpoint to use the new api DP v1 api

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
This shouldn't be merged until DP is merged

### How Has This Been Tested?
I ran this locally against a local DP pointed at a prod DB snapshot. and loaded the user followers and following modals from the user page on the desktop. 
