### PR TITLE
hotfix 10 9 bugfix

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1001,6 +1001,7 @@ class AudiusBackend {
   }
 
   static async getListenHistoryTracks(limit = 100, offset = 0) {
+    await waitForLibsInit()
     try {
       const trackListens = await audiusLibs.Track.getListenHistoryTracks(
         limit,

--- a/src/services/audius-backend/eagerLoadUtils.ts
+++ b/src/services/audius-backend/eagerLoadUtils.ts
@@ -127,10 +127,15 @@ const makeRequest = async (
     headers['X-User-ID'] = user.user_id
   }
 
+  let baseUrl = `${endpoint}/${req.endpoint}`
+  if (req.urlParams) {
+    baseUrl = `${baseUrl}${req.urlParams}`
+  }
+
   let res: any
   if (req?.method?.toLowerCase() === 'post') {
     headers['Content-Type'] = 'application/json'
-    const url = `${endpoint}/${req.endpoint}?${parmsToQS(
+    const url = `${baseUrl}?${parmsToQS(
       req.queryParams,
       endpoint === eagerDiscprov
     )}`
@@ -140,7 +145,7 @@ const makeRequest = async (
       body: JSON.stringify(req.data)
     })
   } else {
-    const url = `${endpoint}/${req.endpoint}?${parmsToQS(
+    const url = `${baseUrl}?${parmsToQS(
       req.queryParams,
       endpoint === eagerDiscprov
     )}`


### PR DESCRIPTION
### Description
This fixes two bugs we've actually had for a while:
* direct linking into /history fails because we don't wait for libs init
* eager load util straight up had a bug where it was not using a full URL if url params were passed in. this led to visiting /profile and looking at their reposts, you'd actually just see YOUR feed. 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
nah

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Manually by running the dapp