### PR TITLE
Fix API 404 handling and storing outdated data

### DIFF
--- a/src/containers/profile-page/store/lineups/tracks/sagas.js
+++ b/src/containers/profile-page/store/lineups/tracks/sagas.js
@@ -54,7 +54,7 @@ function* getTracks({ offset, limit, payload }) {
     // Pinned tracks *should* be unpinned
     // when deleted, but just in case they're not,
     // defend against that edge case here.
-    if (pinnedTrack[0].is_delete) {
+    if (!pinnedTrack.length || pinnedTrack[0].is_delete) {
       pinnedTrack = []
     }
 

--- a/src/models/Collection.ts
+++ b/src/models/Collection.ts
@@ -17,6 +17,7 @@ type PlaylistContents = {
 }
 
 export type CollectionMetadata = {
+  blocknumber: number
   variant: Variant.USER_GENERATED
   description: Nullable<string>
   followee_reposts: Repost[]

--- a/src/models/Track.ts
+++ b/src/models/Track.ts
@@ -50,6 +50,7 @@ export type RemixOf = {
 }
 
 export type TrackMetadata = {
+  blocknumber: number
   activity_timestamp?: string
   is_delete: boolean
   track_id: number

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -182,6 +182,19 @@ type InitializationState =
       endpoint: string
     }
 
+const emptySearchResponse: APIResponse<APISearch> = {
+  data: {
+    users: [],
+    followed_users: [],
+    tracks: [],
+    saved_tracks: [],
+    playlists: [],
+    saved_playlists: [],
+    saved_albums: [],
+    albums: []
+  }
+}
+
 class AudiusAPIClient {
   initializationState: InitializationState = { state: 'uninitialized ' }
   overrideEndpoint?: string
@@ -671,9 +684,9 @@ class AudiusAPIClient {
 
     const endpoint = this._constructUrl(ENDPOINT_MAP.searchFull, params)
 
-    const searchResponse: APIResponse<APISearch> = await this._getResponse(
-      endpoint
-    )
+    const searchResponse: Nullable<APIResponse<APISearch>> =
+      (await this._getResponse(endpoint)) ?? emptySearchResponse
+
     const adapted = adapter.adaptSearchResponse(searchResponse)
     return processSearchResults({ searchText: query, ...adapted })
   }
@@ -697,9 +710,8 @@ class AudiusAPIClient {
 
     const endpoint = this._constructUrl(ENDPOINT_MAP.searchAutocomplete, params)
 
-    const searchResponse: APIResponse<APISearchAutocomplete> = await this._getResponse(
-      endpoint
-    )
+    const searchResponse: Nullable<APIResponse<APISearchAutocomplete>> =
+      (await this._getResponse(endpoint)) ?? emptySearchResponse
     const adapted = adapter.adaptSearchAutocompleteResponse(searchResponse)
     return processSearchResults({ searchText: query, ...adapted })
   }

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -208,9 +208,12 @@ class AudiusAPIClient {
     }
 
     const endpoint = this._constructUrl(ENDPOINT_MAP.trending, params)
-    const trendingResponse: APIResponse<APITrack[]> = await this._getResponse(
-      endpoint
-    )
+    const trendingResponse: Nullable<APIResponse<
+      APITrack[]
+    >> = await this._getResponse(endpoint)
+
+    if (!trendingResponse) return []
+
     const adapted = trendingResponse.data
       .map(adapter.makeTrack)
       .filter(removeNullable)
@@ -235,9 +238,10 @@ class AudiusAPIClient {
       ENDPOINT_MAP.following(encodedProfileUserId),
       params
     )
-    const followingResponse: APIResponse<APIUser[]> = await this._getResponse(
-      endpoint
-    )
+    const followingResponse: Nullable<APIResponse<
+      APIUser[]
+    >> = await this._getResponse(endpoint)
+    if (!followingResponse) return []
     const adapted = followingResponse.data
       .map(adapter.makeUser)
       .filter(removeNullable)
@@ -262,9 +266,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.followers(encodedProfileUserId),
       params
     )
-    const followersResponse: APIResponse<APIUser[]> = await this._getResponse(
-      endpoint
-    )
+    const followersResponse: Nullable<APIResponse<
+      APIUser[]
+    >> = await this._getResponse(endpoint)
+
+    if (!followersResponse) return []
+
     const adapted = followersResponse.data
       .map(adapter.makeUser)
       .filter(removeNullable)
@@ -289,9 +296,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.trackRepostUsers(encodedTrackId),
       params
     )
-    const repostUsers: APIResponse<APIUser[]> = await this._getResponse(
-      endpoint
-    )
+    const repostUsers: Nullable<APIResponse<
+      APIUser[]
+    >> = await this._getResponse(endpoint)
+
+    if (!repostUsers) return []
+
     const adapted = repostUsers.data
       .map(adapter.makeUser)
       .filter(removeNullable)
@@ -316,9 +326,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.trackFavoriteUsers(encodedTrackId),
       params
     )
-    const followingResponse: APIResponse<APIUser[]> = await this._getResponse(
-      endpoint
-    )
+    const followingResponse: Nullable<APIResponse<
+      APIUser[]
+    >> = await this._getResponse(endpoint)
+
+    if (!followingResponse) return []
+
     const adapted = followingResponse.data
       .map(adapter.makeUser)
       .filter(removeNullable)
@@ -343,9 +356,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.playlistRepostUsers(encodedPlaylistId),
       params
     )
-    const repostUsers: APIResponse<APIUser[]> = await this._getResponse(
-      endpoint
-    )
+    const repostUsers: Nullable<APIResponse<
+      APIUser[]
+    >> = await this._getResponse(endpoint)
+
+    if (!repostUsers) return []
+
     const adapted = repostUsers.data
       .map(adapter.makeUser)
       .filter(removeNullable)
@@ -370,9 +386,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.playlistFavoriteUsers(encodedPlaylistId),
       params
     )
-    const followingResponse: APIResponse<APIUser[]> = await this._getResponse(
-      endpoint
-    )
+    const followingResponse: Nullable<APIResponse<
+      APIUser[]
+    >> = await this._getResponse(endpoint)
+
+    if (!followingResponse) return []
+
     const adapted = followingResponse.data
       .map(adapter.makeUser)
       .filter(removeNullable)
@@ -396,9 +415,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.getTrack(encodedTrackId),
       args
     )
-    const trackResponse: APIResponse<APITrack> = await this._getResponse(
-      endpoint
-    )
+    const trackResponse: Nullable<APIResponse<
+      APITrack
+    >> = await this._getResponse(endpoint)
+
+    if (!trackResponse) return null
+
     const adapted = adapter.makeTrack(trackResponse.data)
     return adapted
   }
@@ -407,7 +429,12 @@ class AudiusAPIClient {
     this._assertInitialized()
     const encodedTrackId = this._encodeOrThrow(trackId)
     const endpoint = this._constructUrl(ENDPOINT_MAP.getStems(encodedTrackId))
-    const response: APIResponse<APIStem[]> = await this._getResponse(endpoint)
+    const response: Nullable<APIResponse<APIStem[]>> = await this._getResponse(
+      endpoint
+    )
+
+    if (!response) return []
+
     const adapted = response.data
       .map(adapter.makeStemTrack)
       .filter(removeNullable)
@@ -427,9 +454,11 @@ class AudiusAPIClient {
       ENDPOINT_MAP.getRemixes(encodedTrackId),
       params
     )
-    const remixesResponse: APIResponse<RemixesResponse> = await this._getResponse(
-      endpoint
-    )
+    const remixesResponse: Nullable<APIResponse<
+      RemixesResponse
+    >> = await this._getResponse(endpoint)
+
+    if (!remixesResponse) return []
 
     const tracks = remixesResponse.data.tracks.map(adapter.makeTrack)
     return { count: remixesResponse.data.count, tracks }
@@ -453,9 +482,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.getRemixing(encodedTrackId),
       params
     )
-    const remixingResponse: APIResponse<APITrack[]> = await this._getResponse(
-      endpoint
-    )
+    const remixingResponse: Nullable<APIResponse<
+      APITrack[]
+    >> = await this._getResponse(endpoint)
+
+    if (!remixingResponse) return []
+
     const tracks = remixingResponse.data.map(adapter.makeTrack)
     return tracks
   }
@@ -471,7 +503,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.userByHandle(handle),
       params
     )
-    const response: APIResponse<APIUser[]> = await this._getResponse(endpoint)
+    const response: Nullable<APIResponse<APIUser[]>> = await this._getResponse(
+      endpoint
+    )
+
+    if (!response) return []
+
     const adapted = response.data.map(adapter.makeUser).filter(removeNullable)
     return adapted
   }
@@ -496,7 +533,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.userTracksByHandle(handle),
       params
     )
-    const response: APIResponse<APITrack[]> = await this._getResponse(endpoint)
+    const response: Nullable<APIResponse<APITrack[]>> = await this._getResponse(
+      endpoint
+    )
+
+    if (!response) return []
+
     const adapted = response.data.map(adapter.makeTrack).filter(removeNullable)
     return adapted
   }
@@ -521,9 +563,12 @@ class AudiusAPIClient {
       params
     )
 
-    const response: APIResponse<APIActivity[]> = await this._getResponse(
-      endpoint
-    )
+    const response: Nullable<APIResponse<
+      APIActivity[]
+    >> = await this._getResponse(endpoint)
+
+    if (!response) return []
+
     const adapted = response.data.map(({ item, ...props }) => ({
       timestamp: props.timestamp,
       track: adapter.makeTrack(item as APITrack)
@@ -549,9 +594,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.userRepostsByHandle(handle),
       params
     )
-    const response: APIResponse<APIActivity[]> = await this._getResponse(
-      endpoint
-    )
+    const response: Nullable<APIResponse<
+      APIActivity[]
+    >> = await this._getResponse(endpoint)
+
+    if (!response) return []
+
     const adapted = response.data
       .map(adapter.makeActivity)
       .filter(removeNullable)
@@ -568,9 +616,12 @@ class AudiusAPIClient {
     }
 
     const endpoint = this._constructUrl(ENDPOINT_MAP.topGenreUsers, params)
-    const favoritedTrackResponse: APIResponse<
+    const favoritedTrackResponse: Nullable<APIResponse<
       APIUser[]
-    > = await this._getResponse(endpoint)
+    >> = await this._getResponse(endpoint)
+
+    if (!favoritedTrackResponse) return []
+
     const adapted = favoritedTrackResponse.data
       .map(adapter.makeUser)
       .filter(removeNullable)
@@ -589,9 +640,12 @@ class AudiusAPIClient {
       ENDPOINT_MAP.getPlaylist(encodedPlaylistId),
       params
     )
-    const response: APIResponse<APIPlaylist[]> = await this._getResponse(
-      endpoint
-    )
+    const response: Nullable<APIResponse<
+      APIPlaylist[]
+    >> = await this._getResponse(endpoint)
+
+    if (!response) return []
+
     const adapted = response.data
       .map(adapter.makePlaylist)
       .filter(removeNullable)
@@ -689,9 +743,12 @@ class AudiusAPIClient {
       throw new Error('AudiusAPIClient must be initialized before use')
   }
 
-  async _getResponse<T>(resource: string): Promise<T> {
+  async _getResponse<T>(resource: string): Promise<Nullable<T>> {
     const response = await fetch(resource)
-    if (!response.ok) throw new Error(response.statusText)
+    if (!response.ok) {
+      if (response.status === 404) return null
+      throw new Error(response.statusText)
+    }
     return response.json()
   }
 

--- a/src/services/audius-api-client/ResponseAdapter.ts
+++ b/src/services/audius-api-client/ResponseAdapter.ts
@@ -284,6 +284,7 @@ export const makeStemTrack = (stem: APIStem): StemTrackMetadata | undefined => {
   if (!(id && parentId && ownerId)) return undefined
 
   return {
+    blocknumber: stem.blocknumber,
     is_delete: false,
     track_id: id,
     created_at: '',

--- a/src/services/audius-api-client/types.ts
+++ b/src/services/audius-api-client/types.ts
@@ -17,6 +17,7 @@ type PlaylistContents = {
 
 export type APIUser = {
   album_count: number
+  blocknumber: number
   bio: Nullable<string>
   cover_photo: CoverPhotoSizes
   followee_count: number
@@ -75,6 +76,7 @@ export type APIRemix = {
 }
 
 export type APITrack = {
+  blocknumber: number
   artwork: CoverArtSizes
   description: Nullable<string>
   genre: string
@@ -132,6 +134,7 @@ export type APIStem = {
   user_id: OpaqueID
   category: StemCategory
   cid: CID
+  blocknumber: number
 }
 
 export type APIPlaylistAddedTimestamp = {
@@ -140,6 +143,7 @@ export type APIPlaylistAddedTimestamp = {
 }
 
 export type APIPlaylist = {
+  blocknumber: number
   artwork: CoverArtSizes
   description: Nullable<string>
   id: OpaqueID

--- a/src/store/cache/reducer.js
+++ b/src/store/cache/reducer.js
@@ -96,6 +96,17 @@ const actionsMap = {
     const newIdsToPrune = new Set([...state.idsToPrune])
 
     action.entries.forEach(e => {
+      // Don't add if block number is < existing
+      const existing = unwrapEntry(newEntries[e.id])
+      if (
+        existing &&
+        existing.blocknumber &&
+        e.metadata.blocknumber &&
+        existing.blocknumber > e.metadata.blocknumber
+      ) {
+        return
+      }
+
       if (action.replace) newEntries[e.id] = wrapEntry(e.metadata)
       else {
         newEntries[e.id] = wrapEntry(


### PR DESCRIPTION

### Description

Fixes two bugs:

- DP returns 404 for deleted content, breaking profile pages
- User profile updates will flicker back and forth between old and new on profile page refresh because we load outdated cached users from tracks. This change won't cache any object with an outdated blocknumber

### Dragons

**Yes** This touches cache code.


### How Has This Been Tested?

Tested locally, ensured that user flickering disappeared, ensured that 404s don't break track pages anymore. 

