### PR TITLE
Fix legacy playlist cover art fields

### DIFF
--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -297,7 +297,8 @@ function* confirmEditPlaylist(playlistId, userId, formFields) {
           check = playlist => {
             return (
               some([playlist], toConfirm) &&
-              playlist.cover_art_sizes !== formFields.cover_art_sizes
+              playlist.playlist_image_sizes_multihash !==
+                formFields.cover_art_sizes
             )
           }
         } else {


### PR DESCRIPTION
### Trello Card Link
na

### Description
The old DP api returns the playlist fields `playlist_image_multihash` and `playlist_image_sizes_multihash` instead of `cover_art` and `cover_art_sizes` respectively returned from the v1 API. 

Since the collections saga func watchFetchCoverArt was updated to only look for the new fields, I added a mapping in the audiusBackend instead of updating the `watchFetchCoverArt` function to handle both fields for redux store consistency, but I could see the argument to also add the check in watchFetchCoverArt. lmk what you guys think.  

Also fix the confirmer comparing against the correct image field. 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran it against staging!
