### PR TITLE
Fix handle case sensitivity

### DIFF
--- a/src/store/cache/users/selectors.ts
+++ b/src/store/cache/users/selectors.ts
@@ -13,8 +13,8 @@ export const getUser = (
   state: AppState,
   props: { handle?: string | null; id?: ID | null; uid?: UID | null }
 ) => {
-  if (props.handle && state.users.handles[props.handle]) {
-    props.id = state.users.handles[props.handle].id
+  if (props.handle && state.users.handles[props.handle.toLowerCase()]) {
+    props.id = state.users.handles[props.handle.toLowerCase()].id
   }
   return getEntry(state, {
     ...props,


### PR DESCRIPTION
### Trello Card Link


### Description
https://audius.co/DJRROS3
Links with non-case-sensitivity in handles are broken. We always cache handles as lowercase
```
handleStatuses[status.handle.toLowerCase()] = {
            id: status.id,
            status: status.status
          }
```

So we've probably had some bugs from this for a while

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

verified fetching both http://localhost:3002/DJRROS3 and http://localhost:3002/djrros3 work
