### PR TITLE
Move notification polling interval to remote config

### DIFF
--- a/src/containers/notification/store/sagas.ts
+++ b/src/containers/notification/store/sagas.ts
@@ -35,6 +35,8 @@ import { retrieveCollections } from 'store/cache/collections/utils'
 import { retrieveTracks } from 'store/cache/tracks/utils'
 import Track from 'models/Track'
 import { MessageType } from 'services/native-mobile-interface/types'
+import { getRemoteVar, IntKeys } from 'services/remote-config'
+import { remoteConfigIntDefaults } from 'services/remote-config/defaults'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
@@ -42,8 +44,14 @@ const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 // NOTE: the rest are loading in in the user list modal
 export const USER_INITIAL_LOAD_COUNT = 9
 
-// The interval in ms to poll for new notifications
-export const NOTIFICATION_POLLING_INTERVAL = 10000
+// Gets the polling interval from remoteconfig
+const getPollingIntervalMs = () => {
+  const pollingInterval = getRemoteVar(IntKeys.NOTIFICATION_POLLING_FREQ_MS)
+  return (
+    pollingInterval ??
+    (remoteConfigIntDefaults[IntKeys.NOTIFICATION_POLLING_FREQ_MS] as number)
+  )
+}
 
 const getTimeAgo = (now: moment.Moment, date: string) => {
   const notifDate = moment(date)
@@ -402,7 +410,7 @@ function* getNotifications(isFirstFetch: boolean) {
             )
           )
         }
-        yield delay(NOTIFICATION_POLLING_INTERVAL)
+        yield delay(getPollingIntervalMs())
         return
       }
       const {
@@ -509,7 +517,7 @@ function* notificationPollingDaemon() {
     if (!isBrowserInBackground || isElectron()) {
       yield call(getNotifications, isFirstFetch)
     }
-    yield delay(NOTIFICATION_POLLING_INTERVAL)
+    yield delay(getPollingIntervalMs())
   }
 }
 

--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -19,7 +19,12 @@ export enum IntKeys {
   /**
    * Frequency (in ms) to poll for user wallet balance on the client dashboard page
    */
-  DASHBOARD_WALLET_BALANCE_POLLING_FREQ_MS = 'DASHBOARD_WALLET_BALANCE_POLLING_FREQ_MS'
+  DASHBOARD_WALLET_BALANCE_POLLING_FREQ_MS = 'DASHBOARD_WALLET_BALANCE_POLLING_FREQ_MS',
+
+  /**
+   * Frequency (in ms) to poll for notifications from identity service.
+   */
+  NOTIFICATION_POLLING_FREQ_MS = 'NOTIFICATION_POLLING_FREQ_MS'
 }
 
 export enum BooleanKeys {

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -4,7 +4,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.IMAGE_QUICK_FETCH_TIMEOUT_MS]: 5000,
   [IntKeys.IMAGE_QUICK_FETCH_PERFORMANCE_BATCH_SIZE]: 20,
   [IntKeys.DISCOVERY_PROVIDER_SELECTION_TIMEOUT_MS]: null,
-  [IntKeys.DASHBOARD_WALLET_BALANCE_POLLING_FREQ_MS]: 5000
+  [IntKeys.DASHBOARD_WALLET_BALANCE_POLLING_FREQ_MS]: 5000,
+  [IntKeys.NOTIFICATION_POLLING_FREQ_MS]: 60 * 1000
 }
 
 export const remoteConfigStringDefaults: {


### PR DESCRIPTION
### Description

Sets notif polling interval to 60s, and uses remote config.

### Dragons

None


### How Has This Been Tested?

Tested locally, changed in optimizely

