### PR TITLE
Fix web3 race

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,7 +34,7 @@
 
     <script
       defer
-      onLoad="window.dispatchEvent(new CustomEvent('WEB3_LOADED'))"
+      onLoad="window.web3Loaded = true; window.dispatchEvent(new CustomEvent('WEB3_LOADED'))"
       src="%PUBLIC_URL%/scripts/web3.min.js"
     ></script>
 

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -388,9 +388,13 @@ class AudiusBackend {
 
   static async setup() {
     // Wait for web3 to load if necessary
-    if (!window.Web3) {
+    if (!window.web3Loaded) {
       await new Promise(resolve => {
-        window.addEventListener('WEB3_LOADED', resolve)
+        const onLoad = () => {
+          window.removeEventListener('WEB3_LOADED', onLoad)
+          resolve()
+        }
+        window.addEventListener('WEB3_LOADED', onLoad)
       })
     }
 


### PR DESCRIPTION
### Description

Attempts to address `this.web3.eth.Contract is not a constructor` error by having internal web3 stick a `web3Loaded` flag on the window, and testing for that in backend setup, rather than the existence of window.Web3.

### Dragons

Nah

### How Has This Been Tested?

Tested locally

