### PR TITLE
Fix input bg

### DIFF
--- a/src/components/data-entry/Input.module.css
+++ b/src/components/data-entry/Input.module.css
@@ -40,8 +40,7 @@
   font-size: var(--font-xl);
 }
 
-.input.disabled,
-.input.disabled .placeholder {
+.input.disabled {
   cursor: default !important;
   background-color: var(--neutral-light-9);
 }
@@ -87,6 +86,7 @@
 }
 
 :global(.placeholder.focus).placeholder {
+  /* Z-index of 2 here to be on top of password managers */
   z-index: 2;
   pointer-events: none;
   color: var(--neutral-light-4);


### PR DESCRIPTION
### Trello Card Link


### Description
I believe this bug has been around for forever (or browsers changed how they do things, which I doubt).
https://github.com/AudiusProject/audius-client-old/commit/8f57bd28309630b6410f87fd95269d60db69834d#diff-081e9cd26dc46773db656642905fae33c5851bdb37c4b4ec38ea416c0b7c41ecR38
This PR added (I think erroneously) a background color to disabled placeholders, which actually show on top of handles (placeholder being the elevated "handle" here)
<img width="363" alt="Screen Shot 2020-10-29 at 2 27 23 PM" src="https://user-images.githubusercontent.com/2731362/97637076-4169c780-19f7-11eb-9b1f-0d6bdca90ea3.png">

This manifests as a "bug" where artists coming in who are verified on twitter, prepopulate their sign on form, and aren't allowed to change their handle (input disabled). So it displays weirdly and they back out and try again (sometimes even giving up) which does write to identity & generates a lot of noise


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
low-level input change

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

* Made it so that sign up thought I was verified from twitter and made sure the input looked correct
* Manually disabled all the inputs and walked through the app (didn't see anything weird)
* Searched through codebase of all <Input with disabled and didn't catch anything obvious
