### PR TITLE
Hide 0 plays on mobile just like desktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audius-dapp",
-  "version": "0.21.28",
+  "version": "0.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Audius",
   "description": "The Audius decentralized application",
   "author": "Audius",
-  "version": "0.21.28",
+  "version": "0.22.0",
   "private": true,
   "dependencies": {
     "@audius/libs": "1.0.8",

--- a/src/components/track/mobile/TrackTile.tsx
+++ b/src/components/track/mobile/TrackTile.tsx
@@ -42,6 +42,7 @@ type ExtraProps = {
 }
 
 const formatListenCount = (listenCount?: number) => {
+  if (!listenCount) return null
   const suffix = listenCount === 1 ? 'Play' : 'Plays'
   return `${formatCount(listenCount)} ${suffix}`
 }


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/F4sWZtX0/1643-0-play-counts-in-reposts-tab

### Description
Hides plays when 0 on mobile to replicate desktop behavior. The real bug is that get_repost_feed_for_user.py doesn't call populate track metadata in discprov, so it doesn't contain all the data we want.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Dapp locally against prod
