### PR TITLE
Reject non audio mime upfront

### DIFF
--- a/src/containers/upload-page/store/utils/processFiles.ts
+++ b/src/containers/upload-page/store/utils/processFiles.ts
@@ -49,6 +49,8 @@ const ALLOWED_AUDIO_FILE_EXTENSIONS = [
   'tsa'
 ]
 
+const ALLOWED_AUDIO_FILE_MIME = /^audio/
+
 const readMediaTags = (file: File): Promise<any> => {
   return new Promise(function (resolve, reject) {
     jsmediatags.read(file, {
@@ -85,12 +87,19 @@ export const processFiles = (
       handleInvalid(file.name, 'size')
       return null
     }
+    // Check file extension (heuristic for failure)
     if (
       !ALLOWED_AUDIO_FILE_EXTENSIONS.some(ext =>
         file.name.trim().toLowerCase().endsWith(ext)
       )
     ) {
       handleInvalid(file.name, 'type')
+      return null
+    }
+    // If the mime type is somehow undefined or it doesn't begin with audio/ reject.
+    // Backend will try to match on mime again and if it's not an audio/ match, it'll error
+    if (file.type && !file.type.match(ALLOWED_AUDIO_FILE_MIME)) {
+      handleInvalid(file.type, 'type')
       return null
     }
     const title = file.name.replace(/\.[^/.]+$/, '') // strip file extension


### PR DESCRIPTION
### Trello Card Link


### Description
Handle invalid mime type upfront.
We do this check on the creator node, but not on the client
https://github.com/AudiusProject/audius-protocol/blob/master/creator-node/src/fileManager.js#L22

If mime can't be determined, just allow it and let BE reject it.


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Impacts all uploads

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
- Upload mp4 is rejected (mime: video/mp4)
- Uploaded mp3
- Uploaded flac
- Uploaded wav
- Uploaded aif