### PR TITLE
Fix dropdown placement

### DIFF
--- a/src/components/general/Modal.js
+++ b/src/components/general/Modal.js
@@ -18,7 +18,8 @@ const Modal = props => {
     closeable,
     onClose,
     onVisible,
-    children
+    children,
+    zIndex
   } = props
 
   useEffect(() => {
@@ -37,7 +38,7 @@ const Modal = props => {
       centered
       onCancel={onClose}
       destroyOnClose
-      zIndex={11000}
+      zIndex={zIndex}
     >
       <div className={cn(styles.modal, className)}>
         <div className={cn(styles.header, headerClassName)}>
@@ -62,7 +63,8 @@ Modal.propTypes = {
   headerClassName: PropTypes.string,
   onClose: PropTypes.func,
   onVisible: PropTypes.func,
-  children: PropTypes.node
+  children: PropTypes.node,
+  zIndex: PropTypes.number
 }
 
 Modal.defaultProps = {
@@ -70,7 +72,8 @@ Modal.defaultProps = {
   title: '',
   width: 360,
   visible: true,
-  closeable: true
+  closeable: true,
+  zIndex: 11000
 }
 
 export default Modal

--- a/src/components/source-files-modal/SourceFilesModal.module.css
+++ b/src/components/source-files-modal/SourceFilesModal.module.css
@@ -61,6 +61,7 @@
   font-weight: var(--font-medium);
   letter-spacing: 0;
   line-height: 20px;
+  margin-right: 16px;
 }
 
 .dropzoneTitle {

--- a/src/components/track/EditTrackModal.js
+++ b/src/components/track/EditTrackModal.js
@@ -84,7 +84,14 @@ const EditTrackModal = props => {
   }
 
   return (
-    <Modal title={title} width={1080} visible={visible} onClose={onClose}>
+    <Modal
+      title={title}
+      width={1080}
+      visible={visible}
+      onClose={onClose}
+      // Antd modal default value, behind DropdownInput
+      zIndex={1000}
+    >
       <div className={styles.editTrack}>
         <FormTile
           // Key the form tile by id so each id gets a different instance


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/Bsd1cdey/1657-fix-dropdown-modal-zindex-clash

### Description
Fixes dropdown showing behind modal (on edit track modal)

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Just touches edit track, but is a modal thing

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
<img width="1124" alt="Screen Shot 2020-11-04 at 1 29 20 PM" src="https://user-images.githubusercontent.com/2731362/98170099-453b9500-1ea2-11eb-85cf-eafd02335f01.png">
<img width="1159" alt="Screen Shot 2020-11-04 at 1 28 58 PM" src="https://user-images.githubusercontent.com/2731362/98170100-466cc200-1ea2-11eb-8a5a-596a84ed5c71.png">

