### PR TITLE
Fix duplicate image uploads after first edit

### DIFF
--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -319,6 +319,18 @@ function* confirmUpdateProfile(userId, metadata) {
       function* (confirmedUser) {
         // Store the update in local storage so it is correct upon reload
         yield setAudiusAccountUser(confirmedUser)
+        // Update the cached user so it no longer contains image upload artifacts
+        yield put(
+          cacheActions.update(Kind.USERS, [
+            {
+              id: confirmedUser.user_id,
+              metadata: {
+                updatedProfilePicture: null,
+                updatedCoverPhoto: null
+              }
+            }
+          ])
+        )
       },
       function* () {
         yield put(profileActions.updateProfileFailed())

--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -308,11 +308,12 @@ function* confirmEditPlaylist(playlistId, userId, formFields) {
         return yield call(pollPlaylist, confirmedPlaylistId, userId, check)
       },
       function* (confirmedPlaylist) {
+        // Update the cached collection so it no longer contains image upload artifacts
         yield put(
           cacheActions.update(Kind.COLLECTIONS, [
             {
               id: confirmedPlaylist.playlist_id,
-              metadata: reformat(confirmedPlaylist)
+              metadata: { ...reformat(confirmedPlaylist), artwork: {} }
             }
           ])
         )

--- a/src/store/cache/tracks/sagas.js
+++ b/src/store/cache/tracks/sagas.js
@@ -238,9 +238,13 @@ function* confirmEditTrack(
         if (wasUnlisted && isNowListed) {
           confirmedTrack._is_publishing = false
         }
+        // Update the cached track so it no longer contains image upload artifacts
         yield put(
           cacheActions.update(Kind.TRACKS, [
-            { id: confirmedTrack.track_id, metadata: confirmedTrack }
+            {
+              id: confirmedTrack.track_id,
+              metadata: { ...confirmedTrack, artwork: {} }
+            }
           ])
         )
 


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/cgHC2F4j/1658-handle-multiple-calls-to-upload-image-on-editing-profile-in-same-session-as-updating-profile-picture

### Description
Fun little bug where if you update an image on a user/track/collection, save the update, and then go update it again, we re upload the image because it's still attached to the cached metadata.  Whole thing deserves better typing.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Not really

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Made sure subsequent edits of track/user/playlist don't send calls to image_upload
