### PR TITLE
Fix wrap on long title deleted track

### DIFF
--- a/src/containers/deleted-page/components/desktop/DeletedPage.module.css
+++ b/src/containers/deleted-page/components/desktop/DeletedPage.module.css
@@ -23,7 +23,6 @@
   user-select: none;
 
   display: flex;
-  flex-wrap: wrap;
 }
 
 .image {
@@ -32,6 +31,7 @@
   margin: 24px 12px 24px 24px;
   border-radius: 8px;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .rightSide {


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/LbfTvZCx/1666-line-wrapping-issue-on-soft-404-page

### Description
Don't wrap if the title is too long on deleted track pg

### Dragons
none

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the site locally against prod to use the deleted track noted in the trello card to confirm it doesn't wrap.
