### PR TITLE
Fixes saved albums to have album label instead of playlist

### DIFF
--- a/src/containers/saved-page/components/desktop/SavedPage.tsx
+++ b/src/containers/saved-page/components/desktop/SavedPage.tsx
@@ -160,6 +160,7 @@ const SavedPage = ({
             size='medium'
             playlistName={album.playlist_name}
             playlistId={album.playlist_id}
+            isPlaylist={false}
             isPublic={!album.is_private}
             handle={album.ownerHandle}
             primaryText={album.playlist_name}


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/9a8Ck7rc/1667-playlist-instead-of-the-album-in-overflow-menu-and-on-the-album-page-in-favorites-album

### Description
Fix text to say album instead of playlist by passing in correct prop

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Ran it locally
