### PR TITLE
Fix user search img to be circle always

### DIFF
--- a/src/components/search/SearchBarResult.js
+++ b/src/components/search/SearchBarResult.js
@@ -40,7 +40,7 @@ const Image = memo(props => {
       wrapperClassName={cn(styles.imageContainer)}
       className={cn({
         [styles.image]: image,
-        [styles.userImage]: isUser && image,
+        [styles.userImage]: isUser,
         [styles.emptyUserImage]: isUser && image === defaultImage
       })}
       image={image}


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/RYLp0NUv/1668-autocomplete-search-tiles-briefly-show-as-square-for-users-and-then-transition-to-circles

### Description
Just made the user autocomplete img always be a circle and not wait for load. 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
nope

### How Has This Been Tested?
Ran the client against staging and recorded the search autocomplete to ensure it was working properly 
