### PR TITLE
Filter out bad gateways

### DIFF
--- a/src/utils/gatewayUtil.js
+++ b/src/utils/gatewayUtil.js
@@ -2,7 +2,10 @@ import { USER_NODE, LEGACY_USER_NODE } from 'services/AudiusBackend'
 
 export const getCreatorNodeIPFSGateways = endpoint => {
   if (endpoint) {
-    return endpoint.split(',').map(endpoint => `${endpoint}/ipfs/`)
+    return endpoint
+      .split(',')
+      .filter(Boolean)
+      .map(endpoint => `${endpoint}/ipfs/`)
   }
   const gateways = [`${USER_NODE}/ipfs/`]
   if (LEGACY_USER_NODE) {


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/zzrS6SgS/1680-fix-broken-stream-bug-caused-by-invalid-cn-endpoint-race

### Description
Fixes bug in streaming where we end up fetching CIDs directly from audius.co/ (or rather "/") because an endpoint is configured incorrectly.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Should be fine.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Manually ran dapp & streamed a song (while manually setting a bad cn endpoint to be "creatornode.audius.co,"
