### PR TITLE
Add caching eth provider url endpoint

### DIFF
--- a/.env/.env.prod
+++ b/.env/.env.prod
@@ -10,7 +10,7 @@ REACT_APP_WEB3_PROVIDER_URL=https://poa-gateway.audius.co,https://core.poa.netwo
 REACT_APP_WEB3_NETWORK_ID=99
 
 REACT_APP_ETH_REGISTRY_ADDRESS=0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C
-REACT_APP_ETH_PROVIDER_URL=https://eth-mainnet.alchemyapi.io/v2/iSnek4T02BFCUEkcPGKo0eEY1aWLJgxF,https://eth-mainnet.alchemyapi.io/v2/qSUBgXJpg5Vj75otrSHFXCh7YCqaiOhX,https://eth-mainnet.alchemyapi.io/v2/eaVcvbYPXbDYMl8tVhU9fJTdDQEuV-BZ,https://eth-mainnet.alchemyapi.io/v2/pRPV5QniatDLodjIgp7NSTP4YqFRkiws,https://eth-mainnet.alchemyapi.io/v2/agp6LkT-l6c5iuoA8Tqzp2r3ODRd4Vbq,https://eth-mainnet.alchemyapi.io/v2/mG2N2RK2Dl_qe4a7RlbfriIJ29EpYx0N
+REACT_APP_ETH_PROVIDER_URL=https://eth.audius.co
 REACT_APP_ETH_NETWORK_ID=1
 REACT_APP_ETH_TOKEN_ADDRESS=0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
 REACT_APP_ETH_OWNER_WALLET=0xC7310a03e930DD659E15305ed7e1F5Df0F0426C5

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -14,7 +14,7 @@ import { Name } from 'services/analytics'
 import placeholderCoverArt from 'assets/img/imageBlank2x.png'
 import placeholderProfilePicture from 'assets/img/imageProfilePicEmpty2X.png'
 import imageCoverPhotoBlank from 'assets/img/imageCoverPhotoBlank.jpg'
-import { IntKeys, getRemoteVar } from 'services/remote-config'
+import { IntKeys, getRemoteVar, StringKeys } from 'services/remote-config'
 import {
   waitForLibsInit,
   withEagerOption,
@@ -34,9 +34,9 @@ const WEB3_PROVIDER_URLS = process.env.REACT_APP_WEB3_PROVIDER_URL.split(',')
 const WEB3_NETWORK_ID = process.env.REACT_APP_WEB3_NETWORK_ID
 
 const ETH_REGISTRY_ADDRESS = process.env.REACT_APP_ETH_REGISTRY_ADDRESS
-const ETH_PROVIDER_URLS = process.env.REACT_APP_ETH_PROVIDER_URL.split(',')
 const ETH_TOKEN_ADDRESS = process.env.REACT_APP_ETH_TOKEN_ADDRESS
 const ETH_OWNER_WALLET = process.env.REACT_APP_ETH_OWNER_WALLET
+const ETH_PROVIDER_URLS = process.env.REACT_APP_ETH_PROVIDER_URL.split(',')
 const COMSTOCK_URL = process.env.REACT_APP_COMSTOCK_URL
 const CLAIM_DISTRIBUTION_CONTRACT_ADDRESS =
   process.env.REACT_APP_CLAIM_DISTRIBUTION_CONTRACT_ADDRESS
@@ -468,11 +468,13 @@ class AudiusBackend {
   }
 
   static getEthWeb3Config() {
+    const ethProviderUrls =
+      getRemoteVar(StringKeys.ETH_PROVIDER_URLS) || ETH_PROVIDER_URLS
     return {
       ethWeb3Config: AudiusLibs.configEthWeb3(
         ETH_TOKEN_ADDRESS,
         ETH_REGISTRY_ADDRESS,
-        ETH_PROVIDER_URLS,
+        ethProviderUrls,
         ETH_OWNER_WALLET,
         CLAIM_DISTRIBUTION_CONTRACT_ADDRESS
       )

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -397,6 +397,16 @@ class AudiusBackend {
         window.addEventListener('WEB3_LOADED', onLoad)
       })
     }
+    // Wait for optimizely to load if necessary
+    if (!window.optimizelyDatafile) {
+      await new Promise(resolve => {
+        const onLoad = () => {
+          window.removeEventListener('OPTIMIZELY_LOADED', onLoad)
+          resolve()
+        }
+        window.addEventListener('OPTIMIZELY_LOADED', onLoad)
+      })
+    }
 
     const { libs, libsUtils, libsSanityChecks } = await import(
       './audius-backend/AudiusLibsLazyLoader'

--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -47,7 +47,12 @@ export enum StringKeys {
   /**
    * Custom text for a top of page notice.
    */
-  APP_WIDE_NOTICE_TEXT = 'APP_WIDE_NOTICE_TEXT'
+  APP_WIDE_NOTICE_TEXT = 'APP_WIDE_NOTICE_TEXT',
+
+  /**
+   * Custom eth provider urls to use for talking to main-net contracts
+   */
+  ETH_PROVIDER_URLS = 'ETH_PROVIDER_URLS'
 }
 
 export type AllRemoteConfigKeys =

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -1,5 +1,7 @@
 import { IntKeys, StringKeys, DoubleKeys, BooleanKeys } from './RemoteConfig'
 
+const ETH_PROVIDER_URLS = process.env.REACT_APP_ETH_PROVIDER_URL || ''
+
 export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.IMAGE_QUICK_FETCH_TIMEOUT_MS]: 5000,
   [IntKeys.IMAGE_QUICK_FETCH_PERFORMANCE_BATCH_SIZE]: 20,
@@ -13,7 +15,8 @@ export const remoteConfigStringDefaults: {
 } = {
   [StringKeys.AUDIUS_LOGO_VARIANT]: null,
   [StringKeys.AUDIUS_LOGO_VARIANT_CLICK_TARGET]: null,
-  [StringKeys.APP_WIDE_NOTICE_TEXT]: null
+  [StringKeys.APP_WIDE_NOTICE_TEXT]: null,
+  [StringKeys.ETH_PROVIDER_URLS]: ETH_PROVIDER_URLS
 }
 export const remoteConfigDoubleDefaults: {
   [key in DoubleKeys]: number | null


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/bTn3yiff/1678-add-libs-mechanism-to-select-cdn-eth-proxy-for-reads

### Description
Switches provider urls from alchemy to a generic eth.audius.co

Ping me so I can walk you through what eth.audius.co does :)

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Impacts initial load (libs init)

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Manually running client against production. No change to staging as of now.
