### PR TITLE
Mobile upload CTA button

### DIFF
--- a/src/assets/img/iconGradientUpload.svg
+++ b/src/assets/img/iconGradientUpload.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="15px" viewBox="0 0 18 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <linearGradient id="gradientCrown" gradientTransform="rotate(45)" height="100%" width="100%">
+        <stop offset="0%" stop-color="#A22FEB"/>
+        <stop offset="100%" stop-color="#5B23E1"/>
+    </linearGradient>
+    <g id="🌈-Style-Guides" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Icon-Guide" transform="translate(-69.000000, -300.000000)" fill="#858199">
+            <g id="Stacked-Group-2" transform="translate(66.000000, 199.000000)">
+                <g id="icon/Upload" transform="translate(0.000000, 96.000000)">
+                    <path d="M17.625,10.7375 C17.625,10.7375 17.625,10.625 17.625,10.625 C17.625,7.475 15.15,5 12,5 C9.1875,5 6.825,7.025 6.4875,9.8375 C4.4625,10.5125 3,12.3125 3,14.5625 C3,17.375 5.25,19.625 8.0625,19.625 C9.975,19.625 14.7,19.625 16.5,19.625 C18.975,19.625 21,17.6 21,15.125 C21,12.9875 19.5375,11.3 17.625,10.7375 Z M13.125,14 L13.125,17.375 L10.875,17.375 L10.875,14 L7.5,14 L12,9.5 L16.5,14 L13.125,14 Z" id="Fill" fill-rule="evenodd" style="fill: url(#gradientCrown);"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/drawer/Drawer.module.css
+++ b/src/components/drawer/Drawer.module.css
@@ -1,0 +1,18 @@
+.drawer {
+  z-index: 22;
+  position: fixed;
+  right: 0;
+  left: 0;
+  top: 100vh;
+  background: var(--white);
+  margin-bottom: 0px;
+  margin-bottom: env(safe-area-inset-bottom, 0px);
+  padding-top: 0px;
+  padding-top: calc(env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px));
+
+  user-select: none;
+  touch-action: none;
+  border-radius: 40px 40px 0px 0px;
+  box-shadow: 0 16px 20px 15px var(--notification-panel-box-shadow);
+}
+

--- a/src/components/drawer/Drawer.module.css
+++ b/src/components/drawer/Drawer.module.css
@@ -6,9 +6,7 @@
   top: 100vh;
   background: var(--white);
   margin-bottom: 0px;
-  margin-bottom: env(safe-area-inset-bottom, 0px);
   padding-top: 0px;
-  padding-top: calc(env(safe-area-inset-top, 0px) + env(safe-area-inset-bottom, 0px));
 
   user-select: none;
   touch-action: none;
@@ -18,7 +16,7 @@
 
 /* Fixes positioning on ios Safari */
 @supports (-webkit-overflow-scrolling: touch) {
-  .drawer {
+  .drawer:not(.native) {
     top: calc(100vh - 100px);
   }
 }

--- a/src/components/drawer/Drawer.module.css
+++ b/src/components/drawer/Drawer.module.css
@@ -16,3 +16,25 @@
   box-shadow: 0 16px 20px 15px var(--notification-panel-box-shadow);
 }
 
+/* Fixes positioning on ios Safari */
+@supports (-webkit-overflow-scrolling: touch) {
+  .drawer {
+    top: calc(100vh - 100px);
+  }
+}
+
+.skirt {
+  position: absolute;
+  /* Need to provide a small overlap
+    between skirt and now playing,
+    otherwise we see a ~1px gap
+    between them when the drawer translates.
+    (Probably something to due with fractional
+    pixel translations/aliasing etc)
+  */
+  bottom: -799px;
+  left: 0;
+  right: 0;
+  background: var(--white);
+  height: 800px;
+}

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -13,7 +13,7 @@ import { usePortal } from 'hooks/usePortal'
 import { useClickOutside } from '@audius/stems'
 
 // Translation values for the play bar stub
-const STUB_HIDDEN_TRANSLATION = -96 // 20 //-96
+const STUB_HIDDEN_TRANSLATION = -96
 // Hide the drawer when the keyboard is down
 const DRAWER_KEYBOARD_UP = 50
 

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -1,0 +1,302 @@
+import React, { useEffect, useCallback, useRef } from 'react'
+
+import styles from './Drawer.module.css'
+
+import { useSpring, animated } from 'react-spring'
+import { useDrag } from 'react-use-gesture'
+import cn from 'classnames'
+import useInstanceVar from 'hooks/useInstanceVar'
+import {
+  EnablePullToRefreshMessage,
+  DisablePullToRefreshMessage
+} from 'services/native-mobile-interface/android/pulltorefresh'
+
+const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
+
+// Translation values for the play bar stub
+const STUB_HIDDEN_TRANSLATION = -96 // 20 //-96
+// Hide the drawer when the keyboard is down
+const DRAWER_KEYBOARD_UP = 50
+
+// Fraction of swipe up to fade (1 / FADE_FRACTION_DENOMINATOR)
+const FADE_FRACTION_DENOMINATOR = 2
+
+// Cut off where an open is considered an open
+const OPEN_CUTOFF = 0.2
+// Cut off where a close is considered a close
+const CLOSE_CUTOFF = 0.7
+// Cut off where velocity trumps open/close cut offs
+const VELOCITY_CUTOFF = 0.5
+
+// Controls the amount of friction in swiping when overflowing up or down
+const OVERFLOW_FRICTION = 4
+
+const wobble = {
+  mass: 1,
+  tension: 250,
+  friction: 25
+}
+const stiff = {
+  mass: 1,
+  tension: 215,
+  friction: 40
+}
+
+const fast = {
+  mass: 1,
+  tension: 300,
+  friction: 40
+}
+
+// Interpolates a single y-value into a string translate3d
+const interpY = (y: number) => `translate3d(0, ${y}px, 0)`
+
+type DrawerProps = {
+  isOpen: boolean
+  keyboardVisible: boolean
+  shouldClose: boolean
+}
+
+const Drawer = ({ isOpen, keyboardVisible, shouldClose }: DrawerProps) => {
+  // Stores whether or not the drawer is "open"
+  const [height, setHeight] = useInstanceVar(0)
+
+  const contentRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (contentRef.current) {
+      setHeight(contentRef.current.getBoundingClientRect().height)
+    }
+  }, [contentRef, setHeight])
+
+  // Stores the initial translation of the drawer
+  const [initialTranslation, setInitialTranslation] = useInstanceVar(0)
+  // Stores the last transition
+  const [currentTranslation, setCurrentTranslation] = useInstanceVar(0)
+
+  const [drawerSlideProps, setDrawerSlideProps] = useSpring(() => ({
+    to: {
+      y: -1 * height()
+    },
+    config: wobble,
+    onFrame(frame: any) {
+      setCurrentTranslation(frame.y)
+    }
+  }))
+  // setInterval(() => {
+  //   // @ts-ignore
+  //   console.log(drawerSlideProps.y.value)
+  // }, 500)
+
+  const [contentFadeProps, setContentFadeProps] = useSpring(() => ({
+    to: {
+      opacity: 1
+    },
+    config: stiff
+  }))
+
+  useEffect(() => {
+    if (isOpen) {
+      const newY = -1 * height()
+      setDrawerSlideProps({
+        to: {
+          y: newY
+        },
+        config: wobble
+      })
+    }
+  }, [setDrawerSlideProps, setInitialTranslation, height, isOpen])
+
+  // useEffect(() => {
+  //   window.onresize = () => {
+  //     // const diff = Math.abs(height - window.innerHeight)
+  //     const drawer = document.getElementById('now-playing-drawer')
+  //     if (drawer) {
+  //       const h = window.innerHeight
+  //       setHeight(h)
+  //       // @ts-ignore
+  //       drawer.style.height = `${h}px`
+  //       // @ts-ignore
+  //       drawer.style.bottom = `-${h}px`
+  //     }
+  //   }
+  //   // @ts-ignore
+  //   window.onresize()
+  // }, [setHeight])
+
+  const open = () => {
+    console.log('open')
+    new DisablePullToRefreshMessage().send()
+    setDrawerSlideProps({
+      to: {
+        y: -1 * height()
+      },
+      immediate: false,
+      config: wobble
+    })
+    setContentFadeProps({
+      to: {
+        opacity: 1
+      },
+      immediate: false,
+      config: stiff
+    })
+  }
+
+  const close = useCallback(() => {
+    console.log('close', initialTranslation())
+    new EnablePullToRefreshMessage(true).send()
+    setDrawerSlideProps({
+      to: {
+        y: initialTranslation()
+      },
+      immediate: false,
+      config: wobble
+    })
+    setContentFadeProps({
+      to: {
+        opacity: 1
+      },
+      immediate: false,
+      config: stiff
+    })
+  }, [initialTranslation, setDrawerSlideProps, setContentFadeProps])
+
+  // Handle the "controlled" component
+  useEffect(() => {
+    if (shouldClose) {
+      close()
+    }
+  }, [shouldClose, close])
+
+  useEffect(() => {
+    const drawerY = keyboardVisible ? DRAWER_KEYBOARD_UP : -1 * height()
+
+    setDrawerSlideProps({
+      to: {
+        y: drawerY
+      },
+      immediate: false,
+      config: fast
+    })
+  }, [keyboardVisible, setDrawerSlideProps, height])
+
+  const bind = useDrag(
+    ({
+      last,
+      first,
+      vxvy: [, vy],
+      movement: [, my],
+      memo = currentTranslation()
+    }) => {
+      if (!contentRef.current) return
+      const height = contentRef.current.getBoundingClientRect().height
+
+      let newY = memo + my
+
+      // Overflow dragging up: the height of the drawer drag is > window height
+      // Add friction
+      const topOverflow = Math.abs(newY) - height
+      if (topOverflow > 0) {
+        newY = -1 * height - topOverflow / OVERFLOW_FRICTION
+      }
+
+      // Overflow dragging down: the height of the drawer < playbar height
+      // Add friction
+      const bottomOverflow = newY
+      if (bottomOverflow > 0) {
+        newY = STUB_HIDDEN_TRANSLATION + bottomOverflow / OVERFLOW_FRICTION
+      }
+
+      if (last) {
+        console.log('result', newY, vy, height)
+        // If this is the last touch event, potentially open or close the drawer
+        if (vy === 0) {
+          if (Math.abs(newY) > height * OPEN_CUTOFF) {
+            open()
+          } else {
+            close()
+          }
+          // Click, do nothing
+        } else if (vy < 0) {
+          // swipe up
+          if (
+            Math.abs(newY) > height * OPEN_CUTOFF ||
+            Math.abs(vy) > VELOCITY_CUTOFF
+          ) {
+            open()
+          } else {
+            close()
+          }
+        } else {
+          // swipe down
+          if (Math.abs(newY) < height * CLOSE_CUTOFF || vy > VELOCITY_CUTOFF) {
+            close()
+          } else {
+            open()
+          }
+        }
+      } else if (!first) {
+        // Otherwise track the touch events with the drawer
+        setDrawerSlideProps({
+          to: {
+            y: newY
+          },
+          immediate: true,
+          config: stiff
+        })
+        console.log(
+          newY,
+          height,
+          1 -
+            (height / FADE_FRACTION_DENOMINATOR - Math.abs(newY)) /
+              (height / FADE_FRACTION_DENOMINATOR)
+        )
+        let newFade
+        if (Math.abs(newY) > height / FADE_FRACTION_DENOMINATOR) {
+          newFade = 1
+        } else {
+          newFade =
+            1 -
+            (height / FADE_FRACTION_DENOMINATOR - Math.abs(newY)) /
+              (height / FADE_FRACTION_DENOMINATOR)
+        }
+        setContentFadeProps({
+          to: {
+            // Animate from opacity 1 to 0 at 1/4th the height
+            opacity: Math.max(0, newFade)
+          },
+          immediate: true,
+          config: stiff
+        })
+      }
+      return memo
+    }
+  )
+
+  return (
+    <>
+      <animated.div
+        className={cn(styles.drawer, {
+          // [styles.native]: NATIVE_MOBILE
+        })}
+        // id='test-drawer'
+        {...bind()}
+        style={{
+          // @ts-ignore
+          transform: drawerSlideProps.y.interpolate(interpY)
+        }}
+      >
+        <animated.div className={styles.playBar} style={contentFadeProps}>
+          <div ref={contentRef}>
+            <p>p1</p>
+            <p>p2</p>
+            <p>p3</p>
+            <p>p4</p>
+          </div>
+        </animated.div>
+      </animated.div>
+    </>
+  )
+}
+
+export default Drawer

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -15,8 +15,6 @@ import { useClickOutside } from '@audius/stems'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
-// Translation values for the play bar stub
-const STUB_HIDDEN_TRANSLATION = -96
 // Hide the drawer when the keyboard is down
 const DRAWER_KEYBOARD_UP = 50
 
@@ -188,7 +186,7 @@ const Drawer = ({
       // Add friction
       const bottomOverflow = newY
       if (bottomOverflow > 0) {
-        newY = STUB_HIDDEN_TRANSLATION + bottomOverflow / OVERFLOW_FRICTION
+        newY = bottomOverflow / OVERFLOW_FRICTION
       }
 
       if (last) {
@@ -238,7 +236,7 @@ const Drawer = ({
         }
         setContentFadeProps({
           to: {
-            // Animate from opacity 1 to 0 at 1/4th the height
+            // Animate from opacity 1 to 0 at 1/FADE_FRACTION_DENOMINATOR the height
             opacity: Math.max(0, newFade)
           },
           immediate: true,

--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useCallback, useRef, ReactNode } from 'react'
+import cn from 'classnames'
 
 import styles from './Drawer.module.css'
 
@@ -11,6 +12,8 @@ import {
 } from 'services/native-mobile-interface/android/pulltorefresh'
 import { usePortal } from 'hooks/usePortal'
 import { useClickOutside } from '@audius/stems'
+
+const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
 // Translation values for the play bar stub
 const STUB_HIDDEN_TRANSLATION = -96
@@ -252,7 +255,9 @@ const Drawer = ({
     <Portal>
       <animated.div
         ref={clickOutsideRef}
-        className={styles.drawer}
+        className={cn(styles.drawer, {
+          [styles.native]: NATIVE_MOBILE
+        })}
         {...bind()}
         style={{
           // @ts-ignore

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -143,6 +143,7 @@ import ExploreCollectionsPage from './explore-page/ExploreCollectionsPage'
 import ConfirmerPreview from 'containers/confirmer-preview/ConfirmerPreview'
 import Notice from './notice/Notice'
 import SignOn from 'containers/sign-on/SignOn'
+import Drawer from 'components/drawer/Drawer'
 
 const MOBILE_BANNER_LOCAL_STORAGE_KEY = 'dismissMobileAppBanner'
 
@@ -814,6 +815,7 @@ class App extends Component {
 
         {/* Mobile-only */}
         {isMobileClient && <ConnectedReachabilityBar />}
+        {isMobileClient && <Drawer />}
 
         {shouldShowPopover && isMobileClient && !NATIVE_MOBILE && (
           <AppRedirectPopover

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -143,7 +143,6 @@ import ExploreCollectionsPage from './explore-page/ExploreCollectionsPage'
 import ConfirmerPreview from 'containers/confirmer-preview/ConfirmerPreview'
 import Notice from './notice/Notice'
 import SignOn from 'containers/sign-on/SignOn'
-import Drawer from 'components/drawer/Drawer'
 
 const MOBILE_BANNER_LOCAL_STORAGE_KEY = 'dismissMobileAppBanner'
 
@@ -815,7 +814,6 @@ class App extends Component {
 
         {/* Mobile-only */}
         {isMobileClient && <ConnectedReachabilityBar />}
-        {isMobileClient && <Drawer />}
 
         {shouldShowPopover && isMobileClient && !NATIVE_MOBILE && (
           <AppRedirectPopover

--- a/src/containers/mobile-upload-drawer/MobileUploadDrawer.module.css
+++ b/src/containers/mobile-upload-drawer/MobileUploadDrawer.module.css
@@ -1,0 +1,46 @@
+.drawer {
+  height: 460px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  padding: 40px 36px;
+}
+
+.iconUpload {
+  width: 66px;
+  height: 66px;
+}
+
+.cta {
+  font-weight: var(--font-heavy);
+  font-size: 28px;
+  line-height: 34px;
+  text-align: center;
+  user-select: none;
+  background-image: var(--page-header-gradient);
+
+  -webkit-text-fill-color: transparent;
+  -webkit-background-clip: text;
+}
+
+.visit {
+  font-weight: var(--font-medium);
+  font-size: var(--font-2xl);
+  line-height: 29px;
+  text-align: center;
+  margin-top: 4px;
+}
+
+.bottom {
+  margin-bottom: 16px;
+}
+
+.action {
+  font-weight: var(--font-bold);
+  font-size: var(--font-2xl);
+  line-height: 40px;
+}
+
+.action i {
+  margin-right: 16px;
+}

--- a/src/containers/mobile-upload-drawer/MobileUploadDrawer.tsx
+++ b/src/containers/mobile-upload-drawer/MobileUploadDrawer.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+
+import { getIsOpen } from './store/selectors'
+import { getKeyboardVisibility } from 'store/application/ui/mobileKeyboard/selectors'
+
+import Drawer from 'components/drawer/Drawer'
+import styles from './MobileUploadDrawer.module.css'
+import { ReactComponent as IconUpload } from 'assets/img/iconGradientUpload.svg'
+
+const messages = {
+  start: 'Start Uploading',
+  visit: 'Visit audius.co from a desktop browser',
+  unlimited: 'Unlimited Uploads',
+  exclusive: 'Exclusive Content',
+  clear: 'Crystal Clear 320kbps'
+}
+
+const MobileUploadDrawer = ({ onClose }: { onClose: () => void }) => {
+  const isOpen = useSelector(getIsOpen)
+  const keyboardVisible = useSelector(getKeyboardVisibility)
+  return (
+    <Drawer isOpen={isOpen} keyboardVisible={keyboardVisible} onClose={onClose}>
+      <div className={styles.drawer}>
+        <div className={styles.top}>
+          <div className={styles.cta}>
+            <IconUpload className={styles.iconUpload} />
+            <div>{messages.start}</div>
+          </div>
+          <div className={styles.visit}>{messages.visit}</div>
+        </div>
+        <div className={styles.bottom}>
+          <div className={styles.action}>
+            <i className='emoji large white-heavy-check-mark' />
+            {messages.unlimited}
+          </div>
+          <div className={styles.action}>
+            <i className='emoji large white-heavy-check-mark' />
+            {messages.clear}
+          </div>
+          <div className={styles.action}>
+            <i className='emoji large white-heavy-check-mark' />
+            {messages.exclusive}
+          </div>
+        </div>
+      </div>
+    </Drawer>
+  )
+}
+
+export default MobileUploadDrawer

--- a/src/containers/mobile-upload-drawer/store/selectors.ts
+++ b/src/containers/mobile-upload-drawer/store/selectors.ts
@@ -1,0 +1,4 @@
+import { AppState } from 'store/types'
+
+export const getIsOpen = (state: AppState) =>
+  state.application.ui.mobileUploadDrawer.isOpen

--- a/src/containers/mobile-upload-drawer/store/slice.ts
+++ b/src/containers/mobile-upload-drawer/store/slice.ts
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+type MobileUploadDrawerState = {
+  isOpen: boolean
+}
+
+const initialState: MobileUploadDrawerState = {
+  isOpen: false
+}
+
+const slice = createSlice({
+  name: 'mobile-upload-drawer',
+  initialState,
+  reducers: {
+    show: state => {
+      state.isOpen = true
+    },
+    hide: state => {
+      state.isOpen = false
+    }
+  }
+})
+
+export const { show, hide } = slice.actions
+
+export default slice.reducer

--- a/src/containers/now-playing/NowPlayingDrawer.tsx
+++ b/src/containers/now-playing/NowPlayingDrawer.tsx
@@ -398,6 +398,7 @@ const NowPlayingDrawer = ({
         <div className={styles.nowPlaying}>
           <NowPlaying onClose={close} />
         </div>
+        {/* "Bottom padding" so over drags upwards of the drawer are white */}
         <div className={styles.skirt} />
       </animated.div>
 

--- a/src/containers/profile-page/components/mobile/ProfileHeader.tsx
+++ b/src/containers/profile-page/components/mobile/ProfileHeader.tsx
@@ -35,6 +35,7 @@ import SubscribeButton from 'components/general/SubscribeButton'
 import { verifiedHandleWhitelist } from 'utils/handleWhitelist'
 import { make, useRecord } from 'store/analytics/actions'
 import { Name } from 'services/analytics'
+import UploadButton from './UploadButton'
 
 const messages = {
   tracks: 'Tracks',
@@ -454,6 +455,7 @@ const ProfileHeader = ({
           ) : null}
         </div>
       )}
+      {mode === 'owner' && !isEditing && <UploadButton />}
     </div>
   )
 }

--- a/src/containers/profile-page/components/mobile/UploadButton.module.css
+++ b/src/containers/profile-page/components/mobile/UploadButton.module.css
@@ -1,0 +1,22 @@
+.buttonContainer {
+  padding: 8px 12px;
+}
+
+.button {
+  width: 100%;
+  box-shadow: 0px 2px 5px rgba(133, 129, 153, 0.15);
+  border-color: var(--neutral-light-7);
+  height: 40px !important;
+}
+
+.button:hover {
+  transform: none;
+}
+
+.buttonText {
+  color: var(--neutral-light-2) !important;
+}
+
+.icon path {
+  fill: var(--neutral-light-2) !important;
+}

--- a/src/containers/profile-page/components/mobile/UploadButton.tsx
+++ b/src/containers/profile-page/components/mobile/UploadButton.tsx
@@ -1,0 +1,39 @@
+import React, { useCallback } from 'react'
+import { Button, ButtonType, IconUpload } from '@audius/stems'
+
+import MobileUploadDrawer from 'containers/mobile-upload-drawer/MobileUploadDrawer'
+import { useDispatch } from 'react-redux'
+import {
+  show as showUploadDrawer,
+  hide as hideUploadDrawer
+} from 'containers/mobile-upload-drawer/store/slice'
+import styles from './UploadButton.module.css'
+
+const UploadButton = () => {
+  const dispatch = useDispatch()
+  const onClickUpload = useCallback(() => {
+    dispatch(showUploadDrawer())
+  }, [dispatch])
+  const onCloseUpload = useCallback(() => {
+    dispatch(hideUploadDrawer())
+  }, [dispatch])
+
+  return (
+    <>
+      <div className={styles.buttonContainer}>
+        <Button
+          className={styles.button}
+          textClassName={styles.buttonText}
+          onClick={onClickUpload}
+          text='Upload Track'
+          type={ButtonType.COMMON_ALT}
+          leftIcon={<IconUpload />}
+          iconClassName={styles.icon}
+        />
+      </div>
+      <MobileUploadDrawer onClose={onCloseUpload} />
+    </>
+  )
+}
+
+export default UploadButton

--- a/src/hooks/usePortal.ts
+++ b/src/hooks/usePortal.ts
@@ -1,0 +1,44 @@
+import { ReactNode, useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+/**
+ * Hook for better interaction with portals. Accepts an optional container element
+ * to portal into. Otherwise, creates a portal into the document body.
+ *
+ * In your component...
+ * ```
+ *    const MyComponent = () => {
+ *      const Portal = usePortal()
+ *      return (
+ *        <Portal>
+ *          <div>some content</div>
+ *        </Portal>
+ *      )
+ *    }
+ * ```
+ *
+ * @param container
+ */
+export const usePortal = ({ container }: { container?: HTMLDivElement }) => {
+  const [portalContainer, setPortalContainer] = useState<
+    HTMLDivElement | undefined
+  >(container)
+
+  // Initialize the portal container if necessary
+  useEffect(() => {
+    if (!container) {
+      const el = document.createElement('div')
+      document.body.appendChild(el)
+      setPortalContainer(el)
+    }
+  }, [container, setPortalContainer])
+
+  // Export the portal component memoized based on the portal container.
+  // Users of Portal may wish to write their own effects with [Portal] in the dep array.
+  const Portal = useMemo(
+    () => ({ children }: { children: ReactNode }) =>
+      portalContainer ? createPortal(children, portalContainer!) : null,
+    [portalContainer]
+  )
+  return Portal
+}

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -45,6 +45,7 @@ import firstUploadModal from 'containers/first-upload-modal/store/slice'
 import remixSettingsModal from 'containers/remix-settings-modal/store/slice'
 import remoteConfig from 'containers/remote-config/slice'
 import musicConfetti from 'containers/music-confetti/store/slice'
+import mobileUploadDrawer from 'containers/mobile-upload-drawer/store/slice'
 
 import account from 'store/account/reducer'
 import tracksReducer from 'store/cache/tracks/reducer'
@@ -132,7 +133,8 @@ const createRootReducer = routeHistory =>
         remixSettingsModal,
         stemsUpload,
         appCTAModal,
-        musicConfetti
+        musicConfetti,
+        mobileUploadDrawer
       }),
       pages: combineReducers({
         explore,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -27,6 +27,7 @@ import PlayerReducer from 'store/player/slice'
 import QueueReducer from 'store/queue/slice'
 import { PasswordResetState } from 'containers/password-reset/store/types'
 import MusicConfetti from 'containers/music-confetti/store/slice'
+import MobileUploadDrawer from 'containers/mobile-upload-drawer/store/slice'
 import AccountReducer from 'store/account/reducer'
 import tokenDashboard from 'store/token-dashboard/slice'
 
@@ -111,6 +112,7 @@ export type AppState = {
       stemsUpload: ReturnType<typeof StemsUploadReducer>
       appCTAModal: ReturnType<typeof AppCTAModalReducer>
       musicConfetti: ReturnType<typeof MusicConfetti>
+      mobileUploadDrawer: ReturnType<typeof MobileUploadDrawer>
     }
     pages: {
       explore: ExplorePageState


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/Clro3f9J/1692-upload-from-desktop-button-on-mobile

### Description
Add a button to your own profile page on mobile for upload. Clicking the button triggers a drawer to appear (copy pasta from now playing drawer) with a call to action to visit audius.co on web. Swipe down or tapping outside cause the drawer to dismiss.

<img width="479" alt="Screen Shot 2020-11-30 at 6 48 30 PM" src="https://user-images.githubusercontent.com/2731362/100691023-a5f0ad00-333c-11eb-911c-88d0881cf093.png">

<img width="439" alt="Screen Shot 2020-11-30 at 6 52 30 PM" src="https://user-images.githubusercontent.com/2731362/100691295-3a5b0f80-333d-11eb-8650-cfb690567a0b.png">


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Nope

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Locally on mobile web + ngrok ios app.
