### PR TITLE
Fix profile page pull to refresh

### DIFF
--- a/src/containers/profile-page/store/reducer.js
+++ b/src/containers/profile-page/store/reducer.js
@@ -49,12 +49,17 @@ const initialState = {
 
 const actionsMap = {
   [FETCH_PROFILE](state, action) {
-    return {
+    const newState = {
       ...state,
-      handle: action.handle,
-      userId: action.userId,
       status: action.shouldSetLoading ? Status.LOADING : state.status
     }
+    if (action.handle) {
+      newState.handle = action.handle
+    }
+    if (action.userId) {
+      newState.userId = action.userId
+    }
+    return newState
   },
   [FETCH_PROFILE_SUCCEEDED](state, action) {
     return {

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -121,10 +121,8 @@ function* fetchProfileAsync(action) {
 }
 
 function* fetchUserSocials(handle) {
-  console.log('fetch socials', handle)
   const user = yield call(waitForValue, getUser, { handle })
   const socials = yield call(AudiusBackend.getCreatorSocialHandle, user.handle)
-  console.log('got socials', socials)
   yield put(
     cacheActions.update(Kind.USERS, [
       {

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -52,7 +52,6 @@ function* fetchProfileAsync(action) {
   try {
     let user
     if (action.handle) {
-      yield fork(fetchUserSocials, action.handle)
       user = yield call(
         fetchUserByHandle,
         action.handle,
@@ -79,7 +78,12 @@ function* fetchProfileAsync(action) {
       return
     }
     yield put(profileActions.fetchProfileSucceeded(user.handle, user.user_id))
+
+    // Fetch user socials and collections after fetching the user itself
+    yield fork(fetchUserSocials, action.handle)
     yield fork(fetchUserCollections, user.user_id)
+
+    // Get current user notification & subscription status
     const isSubscribed = yield call(
       AudiusBackend.getUserSubscribed,
       user.user_id
@@ -117,8 +121,10 @@ function* fetchProfileAsync(action) {
 }
 
 function* fetchUserSocials(handle) {
+  console.log('fetch socials', handle)
   const user = yield call(waitForValue, getUser, { handle })
   const socials = yield call(AudiusBackend.getCreatorSocialHandle, user.handle)
+  console.log('got socials', socials)
   yield put(
     cacheActions.update(Kind.USERS, [
       {


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/wNWX6xxN/1707-refresh-causes-the-page-content-to-disappear-on-profiles-video-link-in-description

### Description
Fix pull to refresh on profile pages on mobile. Currently it flashes an empty screen.
Breakage caused by https://github.com/AudiusProject/audius-client/commit/21766e952cc197f0753f2195bef4b5e72cc975b8
Because that PR added a line to allow fetching by user id rather than handle alone, fetching by handle alone unsets the user id and causes the profile page selector to think there was no page loaded at all.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

* Ran local iOS app pointed at local build & verified the blank screen behavior is gone
* Verified that on desktop (local build), you can go from one profile page to another w/o issues.
