### PR TITLE
Fix broken scroll on edit playlist mobile

### DIFF
--- a/src/containers/nav/mobile/TopLevelPage.tsx
+++ b/src/containers/nav/mobile/TopLevelPage.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import cn from 'classnames'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
-import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 import { AppState } from 'store/types'
 import { getIsOpen as getIsCreatePlaylistModalOpen } from 'store/application/ui/createPlaylistModal/selectors'
@@ -12,6 +11,7 @@ import EditPlaylistPage from 'containers/edit-playlist/mobile/EditPlaylistPage'
 import AddToPlaylistPage from 'containers/add-to-playlist/mobile/AddToPlaylist'
 
 import styles from './TopLevelPage.module.css'
+import useScrollLock from 'hooks/useScrollLock'
 
 type TopLevelPageProps = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>
@@ -23,15 +23,8 @@ const TopLevelPage = ({
   showAddToPlaylist
 }: TopLevelPageProps) => {
   const showPage = showCreatePlaylist || showAddToPlaylist
-
-  useEffect(() => {
-    if (showPage && rootElement) {
-      disableBodyScroll(rootElement)
-    }
-    if (!showPage) {
-      clearAllBodyScrollLocks()
-    }
-  }, [showPage])
+  const isLocked = !!(showPage && rootElement)
+  useScrollLock(isLocked)
 
   let page = null
   if (showCreatePlaylist) {

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -1,18 +1,12 @@
-import { useState, useRef, useEffect } from 'react'
 import { useDispatch } from 'react-redux'
+import { useScrollLock as stemsScrollLock } from '@audius/stems'
 import {
   incrementScrollCount,
   decrementScrollCount
 } from 'store/application/ui/scrollLock/actions'
 
 /**
- * `useScrollLock` will prevent the root app div from scrolling. This is useful for modals, or for presenting
- * full screen pages on top of the existing app (e.g. in SignOn).
- *
- * Beacuse useScrollLock may be called from multiple components simultaneously, in order to prevent brittle code
- * and race conditions we use the Redux store to keep a count of attempts to lock vs unlock,
- * and only lock the app when the count > 0.
- *
+ * Wraps Stems `useScrollLock` passing in increment and decrement store functions.
  */
 const useScrollLock = (
   lock: boolean,
@@ -20,40 +14,9 @@ const useScrollLock = (
   decrement?: () => void
 ) => {
   const dispatch = useDispatch()
-  if (!increment) {
-    increment = () => dispatch(incrementScrollCount())
-  }
-  if (!decrement) {
-    decrement = () => dispatch(decrementScrollCount())
-  }
-  const isLocked = useRef(lock)
-  const [previousLockVal, setPreviousLockVal] = useState<boolean | null>(null)
-
-  const isNewLockVal = lock !== previousLockVal && previousLockVal !== null
-  const isFirstLock = lock && previousLockVal === null
-
-  if (isNewLockVal || isFirstLock) {
-    setPreviousLockVal(lock)
-
-    if (lock) {
-      increment()
-    } else {
-      decrement()
-    }
-  }
-
-  useEffect(() => {
-    isLocked.current = lock
-  }, [lock])
-
-  useEffect(
-    () => () => {
-      if (isLocked.current && decrement) {
-        decrement()
-      }
-    },
-    [decrement]
-  )
+  increment = increment ?? (() => dispatch(incrementScrollCount()))
+  decrement = decrement ?? (() => dispatch(decrementScrollCount()))
+  stemsScrollLock(lock, increment, decrement)
 }
 
 export default useScrollLock

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -1,4 +1,9 @@
 import { useState, useRef, useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import {
+  incrementScrollCount,
+  decrementScrollCount
+} from 'store/application/ui/scrollLock/actions'
 
 /**
  * `useScrollLock` will prevent the root app div from scrolling. This is useful for modals, or for presenting
@@ -11,9 +16,16 @@ import { useState, useRef, useEffect } from 'react'
  */
 const useScrollLock = (
   lock: boolean,
-  increment: () => void,
-  decrement: () => void
+  increment?: () => void,
+  decrement?: () => void
 ) => {
+  const dispatch = useDispatch()
+  if (!increment) {
+    increment = () => dispatch(incrementScrollCount())
+  }
+  if (!decrement) {
+    decrement = () => dispatch(decrementScrollCount())
+  }
   const isLocked = useRef(lock)
   const [previousLockVal, setPreviousLockVal] = useState<boolean | null>(null)
 
@@ -36,7 +48,7 @@ const useScrollLock = (
 
   useEffect(
     () => () => {
-      if (isLocked.current) {
+      if (isLocked.current && decrement) {
         decrement()
       }
     },


### PR DESCRIPTION
### Trello Card Link

https://trello.com/c/s04A5Jac

### Description
- Scrolling on edit playlist page was broken (would get stuck). Moved to using our native scroll lock solution to handle this instead of body-scroll-lock npm package.
- Improved useScrollLock ergonomics

### Dragons

None


### How Has This Been Tested?

Tested in iOS simulator safari

