### PR TITLE
Fix deeplink into collection on mobile

### DIFF
--- a/src/containers/collection-page/CollectionPageProvider.tsx
+++ b/src/containers/collection-page/CollectionPageProvider.tsx
@@ -259,8 +259,15 @@ class CollectionPage extends Component<
 
   componentWillUnmount() {
     if (this.unlisten) this.unlisten()
-    if (this.props.smartCollection || !this.props.isMobile)
+    // If we're on mobile, account for transition delay before
+    // resetting collection
+    if (this.props.isMobile) {
+      setTimeout(() => {
+        this.resetCollection()
+      }, 300)
+    } else {
       this.resetCollection()
+    }
   }
 
   playListContentsEqual(
@@ -287,7 +294,6 @@ class CollectionPage extends Component<
     if (params) {
       const { handle, collectionId } = params
       if (forceFetch || collectionId !== this.state.playlistId) {
-        this.resetCollection()
         this.setState({ playlistId: collectionId as number })
         this.props.fetchCollection(handle, collectionId as number)
         this.props.fetchTracks()


### PR DESCRIPTION
### Trello Card Link

https://trello.com/c/6wa2YJ7y

### Description

Reset race condition that would break deeplinking into collections on mobile. Solution is to reset on Collection page unmount, rather than during mount.

### Dragons

Probably not


### How Has This Been Tested?

Tested in simulator and browser, still trying to test on device...

