### PR TITLE
Wrap redirect to signup on authenticated route only if non-native

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -294,7 +294,10 @@ class App extends Component {
     ) {
       if (prevProps.accountStatus === Status.LOADING) {
         this.pushWithToken(TRENDING_PAGE)
-        this.props.openSignOn(true, SignOnPages.SIGNIN)
+        // If native mobile, a saga watches for fetch account failure to push route
+        if (!NATIVE_MOBILE) {
+          this.props.openSignOn(true, SignOnPages.SIGNIN)
+        }
         this.props.updateRouteOnSignUpCompletion(this.state.entryRoute)
       } else {
         this.pushWithToken(TRENDING_PAGE)


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/Ubt497ux/1719-noticed-a-bug-on-mobile-i-dont-think-caused-by-anything-recently-but-if-you-try-typing-into-sign-in-immediately-after-the-app-lo

### Description
On native mobile, on load and the user is not signed in, the signin page will appear for a second then switch to the sign up page. 

What happening is that on load of the react native app, the webview is directed to http://localhost:3000. There is no route associated with this pathname, so the react router redirect is hit, pushing the /feed route. This is an authenticated route that can only load if the user is signed in. There is logic in /src/containers/App.js that checks for the page being unauthenticated and the user not being signed in and redirects to the /signin route. Additionally, there is a mobile only saga that is triggered on fetch account failure that redirects the app to the /signup page. 

This race condition / differing source of logic (onComponentDidUpdate vs in saga) is the cause of this error. 
My solution - is to wrap the componentDidUpdate logic to push the /signin route with a check for is the app is not native. If it is native it will always be pushed from the saga.  

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
None.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the app locally and checked that the signin page did not appear. 
