### PR TITLE
Fix trending badge

### DIFF
--- a/src/containers/track-page/store/retrieveTrending.ts
+++ b/src/containers/track-page/store/retrieveTrending.ts
@@ -15,7 +15,7 @@ import { AppState } from 'store/types'
 
 type RetrieveTrendingArgs = {
   timeRange: TimeRange
-  genre?: string
+  genre: string | null
   offset: number
   limit: number
   currentUserId: ID | null

--- a/src/containers/track-page/store/retrieveTrending.ts
+++ b/src/containers/track-page/store/retrieveTrending.ts
@@ -12,13 +12,14 @@ import apiClient from 'services/audius-api-client/AudiusAPIClient'
 import { getTracks } from 'store/cache/tracks/selectors'
 import { processAndCacheTracks } from 'store/cache/tracks/utils'
 import { AppState } from 'store/types'
+import { Nullable } from 'utils/typeUtils'
 
 type RetrieveTrendingArgs = {
   timeRange: TimeRange
-  genre: string | null
+  genre: Nullable<string>
   offset: number
   limit: number
-  currentUserId: ID | null
+  currentUserId: Nullable<ID>
 }
 
 export function* retrieveTrending({

--- a/src/containers/track-page/store/sagas.js
+++ b/src/containers/track-page/store/sagas.js
@@ -29,17 +29,20 @@ function* watchTrackBadge() {
       call(retrieveTrending, {
         timeRange: TimeRange.WEEK,
         offset: 0,
-        limit: TRENDING_LIMIT
+        limit: TRENDING_LIMIT,
+        genre: null
       }),
       call(retrieveTrending, {
         timeRange: TimeRange.MONTH,
         offset: 0,
-        limit: TRENDING_LIMIT
+        limit: TRENDING_LIMIT,
+        genre: null
       }),
       call(retrieveTrending, {
         timeRange: TimeRange.YEAR,
         offset: 0,
-        limit: TRENDING_LIMIT
+        limit: TRENDING_LIMIT,
+        genre: null
       })
     ])
 

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -71,7 +71,7 @@ type GetTrendingArgs = {
   offset?: number
   limit?: number
   currentUserId: Nullable<ID>
-  genre?: string
+  genre: string | null
 }
 
 type GetFollowingArgs = {
@@ -238,7 +238,7 @@ class AudiusAPIClient {
       limit,
       offset,
       user_id: encodedCurrentUserId || undefined,
-      genre
+      genre: genre || undefined
     }
 
     const trendingResponse: Nullable<APIResponse<

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -71,7 +71,7 @@ type GetTrendingArgs = {
   offset?: number
   limit?: number
   currentUserId: Nullable<ID>
-  genre: string | null
+  genre: Nullable<string>
 }
 
 type GetFollowingArgs = {


### PR DESCRIPTION
### Trello Card Link
na

### Description
FIxes the trending badge on the track page.

The error was that this [line in retrieveTrending](https://github.com/AudiusProject/audius-client/blob/079c4d34a2475f55a8bc8ffc850be679f3a16b9d/src/containers/track-page/store/retrieveTrending.ts#L60) was comparing null and undefined and thought that they were different genres. 

It now only expects a string or null so it can strictly compare the values. 

![Screen Shot 2020-12-09 at 12 06 24 PM](https://user-images.githubusercontent.com/7064122/101662004-f63fcd00-3a16-11eb-8776-32864dfa2620.png)


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the dapp locally against staging. 
