### PR TITLE
[AUD-13] Fix profile completion meter

### DIFF
--- a/src/store/cache/collections/utils/addUsersFromCollections.ts
+++ b/src/store/cache/collections/utils/addUsersFromCollections.ts
@@ -2,15 +2,30 @@ import { makeUid } from 'utils/uid'
 import { UserCollection } from 'models/Collection'
 import { Kind } from 'store/types'
 import { reformat as reformatUser } from 'store/cache/users/utils'
-import { put } from 'redux-saga/effects'
+import { put, select } from 'redux-saga/effects'
 import * as cacheActions from 'store/cache/actions'
+import { getAccountUser } from 'store/account/selectors'
+import { uniqBy } from 'lodash'
 
+/**
+ * Adds users from collection metadata to cache.
+ * Dedupes users and removes self.
+ * @param metadataArray
+ */
 export function* addUsersFromCollections(metadataArray: Array<UserCollection>) {
-  const users = metadataArray.map(m => ({
+  const accountUser: ReturnType<typeof getAccountUser> = yield select(
+    getAccountUser
+  )
+  const currentUserId = accountUser?.user_id
+  let users = metadataArray.map(m => ({
     id: m.user.user_id,
     uid: makeUid(Kind.USERS, m.user.user_id),
     metadata: reformatUser(m.user)
   }))
+
+  // Removes duplicates and self
+  users = uniqBy(users, 'id')
+  users = users.filter(user => !(currentUserId && user.id === currentUserId))
 
   yield put(
     cacheActions.add(Kind.USERS, users, /* replace */ false, /* persist */ true)

--- a/src/store/cache/tracks/utils/helpers.ts
+++ b/src/store/cache/tracks/utils/helpers.ts
@@ -1,19 +1,26 @@
 import { TrackMetadata } from 'models/Track'
 import User from 'models/User'
 import { Kind } from 'store/types'
-import { put } from 'redux-saga/effects'
+import { put, select } from 'redux-saga/effects'
 import * as cacheActions from 'store/cache/actions'
 import { reformat as reformatUser } from 'store/cache/users/utils'
 import { makeUid } from 'utils/uid'
+import { getAccountUser } from 'store/account/selectors'
+import { uniqBy } from 'lodash'
 
 /**
  * Adds users from track metadata to cache.
+ * Dedupes and removes self.
  * @param metadataArray
  */
 export function* addUsersFromTracks<T extends TrackMetadata & { user?: User }>(
   metadataArray: T[]
 ) {
-  const users = metadataArray
+  const accountUser: ReturnType<typeof getAccountUser> = yield select(
+    getAccountUser
+  )
+  const currentUserId = accountUser?.user_id
+  let users = metadataArray
     .filter(m => m.user)
     .map(m => {
       const track = m as TrackMetadata & { user: User }
@@ -25,6 +32,11 @@ export function* addUsersFromTracks<T extends TrackMetadata & { user?: User }>(
     })
 
   if (!users.length) return
+
+  // Don't add duplicate users or self
+  users = uniqBy(users, 'id')
+  users = users.filter(user => !(currentUserId && user.id === currentUserId))
+
   yield put(
     cacheActions.add(Kind.USERS, users, /* replace */ false, /* persist */ true)
   )


### PR DESCRIPTION
### Trello Card Link

https://trello.com/c/HFeIWwAf

### Description
Profile completion meter broken for two reasons:
- Updates to profile weren't synced to local storage, so we could hit 5 followees but when we load up again, the old profile with 4th followees is cached
- Visiting your Profile Page loads the cached account user embedded into your tracks + collections into the redux store. This profile is potentially out of date from your local redux state, so you have a bug where you go follow the 5th person, confirm, go the profile page, add user with 4 follows into the store, write that out to local storage, and then reload and still see 4

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
- Cache changes

### How Has This Been Tested?

Tested locally with profile completion meter

