### PR TITLE
[AUD-14] Fix stale buffering state

### DIFF
--- a/src/audio/AudioStream.test.js
+++ b/src/audio/AudioStream.test.js
@@ -103,12 +103,16 @@ describe('load native hls', () => {
   it('sets up event listeners', () => {
     const onEnd = jest.fn()
     audioStream.load(segments, onEnd)
+    const onBufferingChange = jest.fn()
+    audioStream.onBufferingChange = onBufferingChange
 
     audioStream.audio.dispatchEvent(new Event('waiting'))
     expect(audioStream.buffering).toEqual(true)
+    expect(onBufferingChange).toBeCalledWith(true)
 
     audioStream.audio.dispatchEvent(new Event('canplay'))
     expect(audioStream.buffering).toEqual(false)
+    expect(onBufferingChange).toBeCalledWith(false)
 
     audioStream.audio.dispatchEvent(new Event('ended'))
     expect(onEnd).toBeCalled()

--- a/src/audio/AudioStream.ts
+++ b/src/audio/AudioStream.ts
@@ -76,6 +76,7 @@ class AudioStream {
   duration: number
   bufferingTimeout: ReturnType<typeof setTimeout> | null
   buffering: boolean
+  onBufferingChange: (isBuffering: boolean) => void
   concatBufferInterval: ReturnType<typeof setInterval> | null
   nextBufferIndex: number
   loadCounter: number
@@ -101,8 +102,11 @@ class AudioStream {
     // outside source. Audio.duration returns Infinity until all the streams are
     // concatenated together.
     this.duration = 0
+
     this.bufferingTimeout = null
     this.buffering = false
+    // Callback fired when buffering status changes
+    this.onBufferingChange = isBuffering => {}
 
     this.concatBufferInterval = null
     this.nextBufferIndex = 0
@@ -142,6 +146,7 @@ class AudioStream {
 
       clearTimeout(this.bufferingTimeout!)
       this.buffering = false
+      this.onBufferingChange(this.buffering)
     })
 
     this.audio.onerror = e => {
@@ -274,6 +279,7 @@ class AudioStream {
     this.waitingListener = () => {
       this.bufferingTimeout = setTimeout(() => {
         this.buffering = true
+        this.onBufferingChange(this.buffering)
       }, BUFFERING_DELAY_MILLISECONDS)
     }
     this.audio.addEventListener('waiting', this.waitingListener)

--- a/src/containers/play-bar/desktop/PlayBar.js
+++ b/src/containers/play-bar/desktop/PlayBar.js
@@ -19,7 +19,8 @@ import {
   getAudio,
   getPlaying,
   getCounter,
-  getUid as getPlayingUid
+  getUid as getPlayingUid,
+  getBuffering
 } from 'store/player/selectors'
 import { makeGetCurrent } from 'store/queue/selectors'
 import { getLineupSelectorForRoute } from 'store/lineup/lineupForRoute'
@@ -82,13 +83,13 @@ class PlayBar extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { audio, playing, playCounter } = this.props
-    if (!playing) {
+    const { audio, isPlaying, playCounter } = this.props
+    if (!isPlaying) {
       clearInterval(this.seekInterval)
       this.seekInterval = null
     }
 
-    if (playing && !this.seekInterval) {
+    if (isPlaying && !this.seekInterval) {
       this.seekInterval = setInterval(() => {
         const trackPosition = audio.getPosition()
         this.setState({ trackPosition })
@@ -147,13 +148,13 @@ class PlayBar extends Component {
     const {
       currentQueueItem: { track },
       audio,
-      playing,
+      isPlaying,
       play,
       pause,
       record
     } = this.props
 
-    if (audio && playing) {
+    if (audio && isPlaying) {
       pause()
       record(
         make(Name.PLAYBACK_PAUSE, {
@@ -238,7 +239,8 @@ class PlayBar extends Component {
       currentQueueItem: { uid, track, user },
       playCounter,
       audio,
-      playing,
+      isPlaying,
+      isBuffering,
       userId,
       theme
     } = this.props
@@ -271,9 +273,9 @@ class PlayBar extends Component {
     }
 
     let playButtonStatus
-    if (audio?.isBuffering()) {
+    if (isBuffering) {
       playButtonStatus = 'load'
-    } else if (playing) {
+    } else if (isPlaying) {
       playButtonStatus = 'pause'
     } else {
       playButtonStatus = 'play'
@@ -301,7 +303,7 @@ class PlayBar extends Component {
             <div className={styles.timeControls}>
               <Scrubber
                 mediaKey={`${uid}${playCounter}`}
-                isPlaying={playing && !audio?.isBuffering()}
+                isPlaying={isPlaying && !isBuffering}
                 isDisabled={!uid}
                 includeTimestamps
                 elapsedSeconds={audio?.getPosition()}
@@ -388,7 +390,8 @@ const makeMapStateToProps = () => {
     currentQueueItem: getCurrentQueueItem(state),
     playCounter: getCounter(state),
     audio: getAudio(state),
-    playing: getPlaying(state),
+    isPlaying: getPlaying(state),
+    isBuffering: getBuffering(state),
     playingUid: getPlayingUid(state),
     lineupHasTracks: getLineupHasTracks(
       getLineupSelectorForRoute(state),

--- a/src/containers/play-bar/mobile/PlayBar.tsx
+++ b/src/containers/play-bar/mobile/PlayBar.tsx
@@ -13,7 +13,12 @@ import {
 import { AppState } from 'store/types'
 
 import PlayButton from 'components/play-bar/PlayButton'
-import { getAudio, getCounter, getPlaying } from 'store/player/selectors'
+import {
+  getAudio,
+  getBuffering,
+  getCounter,
+  getPlaying
+} from 'store/player/selectors'
 import { makeGetCurrent } from 'store/queue/selectors'
 
 import styles from './PlayBar.module.css'
@@ -33,7 +38,6 @@ const SEEK_INTERVAL = 200
 
 type OwnProps = {
   audio: AudioState
-  playing: boolean
   onClickInfo: () => void
 }
 
@@ -44,7 +48,8 @@ type PlayBarProps = OwnProps &
 const PlayBar = ({
   currentQueueItem,
   audio,
-  playing,
+  isPlaying,
+  isBuffering,
   play,
   pause,
   save,
@@ -81,16 +86,16 @@ const PlayBar = ({
   const { name } = user
 
   let playButtonStatus
-  if (audio.isBuffering()) {
+  if (isBuffering) {
     playButtonStatus = PlayButtonStatus.LOAD
-  } else if (playing) {
+  } else if (isPlaying) {
     playButtonStatus = PlayButtonStatus.PAUSE
   } else {
     playButtonStatus = PlayButtonStatus.PLAY
   }
 
   const togglePlay = () => {
-    if (playing) {
+    if (isPlaying) {
       pause()
       record(
         make(Name.PLAYBACK_PAUSE, {
@@ -175,7 +180,8 @@ function makeMapStateToProps() {
     currentQueueItem: getCurrentQueueItem(state),
     playCounter: getCounter(state),
     audio: getAudio(state),
-    playing: getPlaying(state)
+    isPlaying: getPlaying(state),
+    isBuffering: getBuffering(state)
   })
   return mapStateToProps
 }

--- a/src/store/player/sagas.ts
+++ b/src/store/player/sagas.ts
@@ -8,6 +8,7 @@ import {
   playSucceeded,
   pause,
   stop,
+  setBuffering,
   reset,
   resetSuceeded,
   seek,
@@ -169,6 +170,17 @@ export function* setAudioListeners() {
   }
 }
 
+export function* handleAudioBuffering() {
+  const audioStream = yield call(waitForValue, getAudio)
+  const chan = eventChannel(emitter => {
+    audioStream.onBufferingChange = (isBuffering: boolean) => {
+      emitter(setBuffering({ buffering: isBuffering }))
+    }
+    return () => {}
+  })
+  yield spawn(actionChannelDispatcher, chan)
+}
+
 export function* handleAudioErrors() {
   // Watch for audio errors and emit an error saga dispatching action
   const audioStream = yield call(waitForValue, getAudio)
@@ -242,6 +254,7 @@ const sagas = () => {
     watchSeek,
     setAudioListeners,
     handleAudioErrors,
+    handleAudioBuffering,
     recordListenWorker,
     errorSagas
   ]

--- a/src/store/player/selectors.ts
+++ b/src/store/player/selectors.ts
@@ -11,8 +11,7 @@ export const getAudio = (state: AppState) => state.player.audio
 export const getPlaying = (state: AppState) => state.player.playing
 export const getPaused = (state: AppState) => !state.player.playing
 export const getCounter = (state: AppState) => state.player.counter
-export const getBuffering = (state: AppState) =>
-  state.player.audio?.isBuffering() ?? false
+export const getBuffering = (state: AppState) => state.player.buffering
 
 export const getCurrentTrack = (state: AppState) =>
   getTrack(state, { id: getTrackId(state) })

--- a/src/store/player/slice.ts
+++ b/src/store/player/slice.ts
@@ -16,6 +16,10 @@ type State = {
   // object to allow components to subscribe to changes.
   playing: boolean
 
+  // Keep 'buffering' in the store separately from the audio
+  // object to allow components to subscribe to changes.
+  buffering: boolean
+
   // Unique integer that increments every time something is "played."
   // E.g. replaying a track doesn't change uid or trackId, but counter changes.
   counter: number
@@ -30,6 +34,7 @@ export const initialState: State = {
   audio: NATIVE_MOBILE ? new NativeMobileAudio() : null,
 
   playing: false,
+  buffering: false,
   counter: 0
 }
 
@@ -56,6 +61,10 @@ type PausePayload = {
 }
 
 type StopPayload = {}
+
+type SetBufferingPayload = {
+  buffering: boolean
+}
 
 type SetPayload = {
   uid: UID
@@ -99,6 +108,10 @@ const slice = createSlice({
     pause: (state, action: PayloadAction<PausePayload>) => {
       state.playing = false
     },
+    setBuffering: (state, action: PayloadAction<SetBufferingPayload>) => {
+      const { buffering } = action.payload
+      state.buffering = buffering
+    },
     stop: (state, action: PayloadAction<StopPayload>) => {
       state.playing = false
       state.uid = null
@@ -130,6 +143,7 @@ export const {
   playSucceeded,
   pause,
   stop,
+  setBuffering,
   set,
   reset,
   resetSuceeded,


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/dy9UrJ9J/1732-fix-bug-where-spinner-shows-on-track-tile-despite-playing

### Description
Track tiles can incorrectly show buffering because buffering state is is pulled directly off of the audio object vs. from a proper state mutation that triggers a re-render. Add buffering to the player state so that components can use selectors to pull buffering directly.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

1. Updated unit test for the callback
2. Reproduced bug by playing tracks before they finish prefetching to trigger bad buffering state. Tested with bugfixes on web + mobile web.
