### PR TITLE
Dropdown fix

### DIFF
--- a/src/components/data-entry/FormTile.js
+++ b/src/components/data-entry/FormTile.js
@@ -111,6 +111,7 @@ const BasicForm = props => {
           <div className={styles.categorization}>
             <DropdownInput
               placeholder='Pick a Genre'
+              mount='parent'
               menu={{ items: GENRES }}
               defaultValue={getCannonicalName(props.defaultFields.genre) || ''}
               isRequired={props.requiredFields.genre}
@@ -125,6 +126,7 @@ const BasicForm = props => {
             />
             <DropdownInput
               placeholder='Pick a Mood'
+              mount='parent'
               menu={{ items: MOODS }}
               defaultValue={props.defaultFields.mood || ''}
               isRequired={props.requiredFields.mood}


### PR DESCRIPTION
### Trello Card Link
https://trello.com/c/hXkQmKzV/1740-editing-track-genre-broken-on-staging-because-of-modal-work

### Description
Fixes edit track dropdown by changing dropdown input to be parent mounted inside form tile. This allows "clickOutside" to work properly in the stems modal

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested both edit track change genre as well as upload track change genre
