### PR TITLE
Update fetch trending track ids to updated endpoint

### DIFF
--- a/src/containers/track-page/store/actions.js
+++ b/src/containers/track-page/store/actions.js
@@ -3,6 +3,7 @@ export const GET_TRACK_RANKS = 'TRACK_PAGE/GET_TRACK_RANKS'
 export const RESET = 'TRACK_PAGE/RESET'
 export const SET_TRACK_ID = 'TRACK_PAGE/SET_TRACK_ID'
 export const MAKE_TRACK_PUBLIC = 'TRACK_PAGE/MAKE_TRACK_PUBLIC'
+export const SET_TRACK_TRENDING_RANKS = 'TRACK_PAGE/SET_TRACK_TRENDING_RANKS'
 
 export const FETCH_TRACK = 'TRACK_PAGE/FETCH_TRACK'
 export const FETCH_TRACK_SUCCEEDED = 'TRACK_PAGE/FETCH_TRACK_SUCCEEDED'
@@ -48,4 +49,9 @@ export const goToRemixesOfParentPage = parentTrackId => ({
  */
 export const refetchLineup = () => ({
   type: REFETCH_LINEUP
+})
+
+export const setTrackTrendingRanks = trendingTrackRanks => ({
+  type: SET_TRACK_TRENDING_RANKS,
+  trendingTrackRanks
 })

--- a/src/containers/track-page/store/reducer.js
+++ b/src/containers/track-page/store/reducer.js
@@ -1,11 +1,21 @@
 import { asLineup } from 'store/lineup/reducer'
 import tracksReducer from 'containers/track-page/store/lineups/tracks/reducer'
 import { PREFIX as tracksPrefix } from './lineups/tracks/actions'
-import { SET_TRACK_ID, RESET, SET_TRACK_RANK } from './actions'
+import {
+  SET_TRACK_ID,
+  RESET,
+  SET_TRACK_RANK,
+  SET_TRACK_TRENDING_RANKS
+} from './actions'
 
 const initialState = {
   trackId: null,
   rank: {
+    week: null,
+    month: null,
+    year: null
+  },
+  trendingTrackRanks: {
     week: null,
     month: null,
     year: null
@@ -25,6 +35,15 @@ const actionsMap = {
       rank: {
         ...state.rank,
         [action.duration]: action.rank
+      }
+    }
+  },
+  [SET_TRACK_TRENDING_RANKS](state, action) {
+    return {
+      ...state,
+      trendingTrackRanks: {
+        ...state.trendingTrackRanks,
+        ...action.trendingTrackRanks
       }
     }
   },

--- a/src/containers/track-page/store/sagas.js
+++ b/src/containers/track-page/store/sagas.js
@@ -19,44 +19,48 @@ export const TRENDING_BADGE_LIMIT = 10
 
 function* watchTrackBadge() {
   yield takeEvery(trackPageActions.GET_TRACK_RANKS, function* (action) {
-    yield call(waitForBackendSetup)
-    let trendingTrackRanks = yield select(getTrendingTrackRanks)
-    if (trendingTrackRanks.week === null) {
-      const trendingRanks = yield apiClient.getTrendingIds({
-        limit: TRENDING_BADGE_LIMIT
-      })
-      yield put(trackPageActions.setTrackTrendingRanks(trendingRanks))
-      trendingTrackRanks = yield select(getTrendingTrackRanks)
+    try {
+      yield call(waitForBackendSetup)
+      let trendingTrackRanks = yield select(getTrendingTrackRanks)
+      if (!trendingTrackRanks) {
+        const trendingRanks = yield apiClient.getTrendingIds({
+          limit: TRENDING_BADGE_LIMIT
+        })
+        yield put(trackPageActions.setTrackTrendingRanks(trendingRanks))
+        trendingTrackRanks = yield select(getTrendingTrackRanks)
+      }
+
+      const weeklyTrackIndex = trendingTrackRanks.week.findIndex(
+        trackId => trackId === action.trackId
+      )
+      const monthlyTrackIndex = trendingTrackRanks.month.findIndex(
+        trackId => trackId === action.trackId
+      )
+      const yearlyTrackIndex = trendingTrackRanks.year.findIndex(
+        trackId => trackId === action.trackId
+      )
+
+      yield put(
+        trackPageActions.setTrackRank(
+          'week',
+          weeklyTrackIndex !== -1 ? weeklyTrackIndex + 1 : null
+        )
+      )
+      yield put(
+        trackPageActions.setTrackRank(
+          'month',
+          monthlyTrackIndex !== -1 ? monthlyTrackIndex + 1 : null
+        )
+      )
+      yield put(
+        trackPageActions.setTrackRank(
+          'year',
+          yearlyTrackIndex !== -1 ? yearlyTrackIndex + 1 : null
+        )
+      )
+    } catch (error) {
+      console.error(`Unable to fetch track badge: ${error.message}`)
     }
-
-    const weeklyTrackIndex = trendingTrackRanks.week.findIndex(
-      trackId => trackId === action.trackId
-    )
-    const monthlyTrackIndex = trendingTrackRanks.month.findIndex(
-      trackId => trackId === action.trackId
-    )
-    const yearlyTrackIndex = trendingTrackRanks.year.findIndex(
-      trackId => trackId === action.trackId
-    )
-
-    yield put(
-      trackPageActions.setTrackRank(
-        'week',
-        weeklyTrackIndex !== -1 ? weeklyTrackIndex + 1 : null
-      )
-    )
-    yield put(
-      trackPageActions.setTrackRank(
-        'month',
-        monthlyTrackIndex !== -1 ? monthlyTrackIndex + 1 : null
-      )
-    )
-    yield put(
-      trackPageActions.setTrackRank(
-        'year',
-        yearlyTrackIndex !== -1 ? yearlyTrackIndex + 1 : null
-      )
-    )
   })
 }
 

--- a/src/containers/track-page/store/sagas.js
+++ b/src/containers/track-page/store/sagas.js
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { all, fork, call, put, select, takeEvery } from 'redux-saga/effects'
+import { fork, call, put, select, takeEvery } from 'redux-saga/effects'
 
 import tracksSagas from 'containers/track-page/store/lineups/tracks/sagas'
 import * as trackPageActions from './actions'
@@ -8,52 +8,35 @@ import { tracksActions } from './lineups/tracks/actions'
 import { waitForBackendSetup } from 'store/backend/sagas'
 import { getIsReachable } from 'store/reachability/selectors'
 import { getTrack as getCachedTrack } from 'store/cache/tracks/selectors'
-import { getTrack, getUser } from './selectors'
-import TimeRange from 'models/TimeRange'
+import { getTrack, getTrendingTrackRanks, getUser } from './selectors'
 import { push as pushRoute } from 'connected-react-router'
 import { retrieveTracks } from 'store/cache/tracks/utils'
 import { NOT_FOUND_PAGE, trackRemixesPage } from 'utils/route'
 import { getUsers } from 'store/cache/users/selectors'
-import { retrieveTrending } from 'containers/track-page/store/retrieveTrending'
+import apiClient from 'services/audius-api-client/AudiusAPIClient'
 
 export const TRENDING_BADGE_LIMIT = 10
 
 function* watchTrackBadge() {
   yield takeEvery(trackPageActions.GET_TRACK_RANKS, function* (action) {
     yield call(waitForBackendSetup)
-    const [
-      weeklyTrendingTracks,
-      monthlyTrendingTracks,
-      yearlyTrendingTracks
-    ] = yield all([
-      call(retrieveTrending, {
-        timeRange: TimeRange.WEEK,
-        offset: 0,
-        limit: TRENDING_BADGE_LIMIT,
-        genre: null
-      }),
-      call(retrieveTrending, {
-        timeRange: TimeRange.MONTH,
-        offset: 0,
-        limit: TRENDING_BADGE_LIMIT,
-        genre: null
-      }),
-      call(retrieveTrending, {
-        timeRange: TimeRange.YEAR,
-        offset: 0,
-        limit: TRENDING_BADGE_LIMIT,
-        genre: null
+    let trendingTrackRanks = yield select(getTrendingTrackRanks)
+    if (trendingTrackRanks.week === null) {
+      const trendingRanks = yield apiClient.getTrendingIds({
+        limit: TRENDING_BADGE_LIMIT
       })
-    ])
+      yield put(trackPageActions.setTrackTrendingRanks(trendingRanks))
+      trendingTrackRanks = yield select(getTrendingTrackRanks)
+    }
 
-    const weeklyTrackIndex = weeklyTrendingTracks.findIndex(
-      ({ track_id: trackId }) => trackId === action.trackId
+    const weeklyTrackIndex = trendingTrackRanks.week.findIndex(
+      trackId => trackId === action.trackId
     )
-    const monthlyTrackIndex = monthlyTrendingTracks.findIndex(
-      ({ track_id: trackId }) => trackId === action.trackId
+    const monthlyTrackIndex = trendingTrackRanks.month.findIndex(
+      trackId => trackId === action.trackId
     )
-    const yearlyTrackIndex = yearlyTrendingTracks.findIndex(
-      ({ track_id: trackId }) => trackId === action.trackId
+    const yearlyTrackIndex = trendingTrackRanks.year.findIndex(
+      trackId => trackId === action.trackId
     )
 
     yield put(

--- a/src/containers/track-page/store/selectors.ts
+++ b/src/containers/track-page/store/selectors.ts
@@ -32,7 +32,10 @@ export const getStatus = (state: AppState) =>
 
 export const getLineup = (state: AppState) => getBaseState(state).tracks
 export const getTrackRank = (state: AppState) => getBaseState(state).rank
-export const getTrendingTrackRanks = (state: AppState) =>
-  getBaseState(state).trendingTrackRanks
+export const getTrendingTrackRanks = (state: AppState) => {
+  const ranks = getBaseState(state).trendingTrackRanks
+  if (!ranks.week && !ranks.month && !ranks.year) return null
+  return ranks
+}
 export const getSourceSelector = (state: AppState) =>
   `${PREFIX}:${getTrackId(state)}`

--- a/src/containers/track-page/store/selectors.ts
+++ b/src/containers/track-page/store/selectors.ts
@@ -32,5 +32,7 @@ export const getStatus = (state: AppState) =>
 
 export const getLineup = (state: AppState) => getBaseState(state).tracks
 export const getTrackRank = (state: AppState) => getBaseState(state).rank
+export const getTrendingTrackRanks = (state: AppState) =>
+  getBaseState(state).trendingTrackRanks
 export const getSourceSelector = (state: AppState) =>
   `${PREFIX}:${getTrackId(state)}`

--- a/src/containers/track-page/store/types.ts
+++ b/src/containers/track-page/store/types.ts
@@ -8,5 +8,10 @@ export default interface TrackPageState {
     month: number | null
     year: number | null
   }
+  trendingTrackRanks: {
+    week: ID[] | null
+    month: ID[] | null
+    year: ID[] | null
+  }
   tracks: LineupState<{ id: ID }>
 }

--- a/src/services/audius-api-client/ResponseAdapter.ts
+++ b/src/services/audius-api-client/ResponseAdapter.ts
@@ -1,4 +1,5 @@
 import Favorite from 'models/Favorite'
+import { ID } from 'models/common/Identifiers'
 import Repost from 'models/Repost'
 import { Remix, StemTrackMetadata, UserTrackMetadata } from 'models/Track'
 import { UserCollectionMetadata, Variant } from 'models/Collection'
@@ -174,6 +175,14 @@ export const makeTrack = (
   delete marshalled.favorite_count
 
   return marshalled
+}
+
+export const makeTrackId = (track: { id: string }): ID | undefined => {
+  const decodedTrackId = decodeHashId(track.id)
+  if (!decodedTrackId) {
+    return undefined
+  }
+  return decodedTrackId
 }
 
 export const makePlaylist = (


### PR DESCRIPTION
Closes AUD-27

### Description
Updates the trending track badge on the track page to be sourced from the new DP endpoint - [created in this protocol pr](https://github.com/AudiusProject/audius-protocol/pull/1137)

Caches the trending tracks id results as to not make subsequent request on multiple track pages

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the client locally and hard coded the DP to be the locally running DP against a staging RDS instance. 
