### PR TITLE
[AUD-28] Bust web3 provider cache on balance of

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.5.tgz",
-      "integrity": "sha512-jU9E0jFeI/JXBWIp3G1Cl85QYH5s9LdPHkrV7WB3ByG8y8nKk7+KguG/cq+QW/Ei+T8/4Tu9fqGwZmrvSwpPpw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.6.tgz",
+      "integrity": "sha512-Yd9ieZsEnzM0otT5sLe5ArnGi5CL2rkGP6kFehuNGHKnvWByVPjapbZDCjsUriLOS2tSplcqaukm322b9ZZazA==",
       "requires": {
         "@audius/hedgehog": "^1.0.8",
         "@ethersproject/solidity": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.23.1",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.1.5",
+    "@audius/libs": "1.1.6",
     "@audius/stems": "0.3.2",
     "@optimizely/optimizely-sdk": "^4.0.0",
     "@reduxjs/toolkit": "^1.3.2",

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -2099,7 +2099,7 @@ class AudiusBackend {
    * Make a request to check if the user has already claimed
    * @returns {Promise<BN>} doesHaveClaim
    */
-  static async getBalance() {
+  static async getBalance(bustCache = false) {
     await waitForLibsInit()
     const wallet = audiusLibs.web3Manager.getWalletAddress()
     if (!wallet) return
@@ -2107,6 +2107,9 @@ class AudiusBackend {
     try {
       const ethWeb3 = audiusLibs.ethWeb3Manager.getWeb3()
       const checksumWallet = ethWeb3.utils.toChecksumAddress(wallet)
+      if (bustCache) {
+        audiusLibs.ethContracts.AudiusTokenClient.bustCache()
+      }
       const balance = await audiusLibs.ethContracts.AudiusTokenClient.balanceOf(
         checksumWallet
       )

--- a/src/services/wallet-client/WalletClient.ts
+++ b/src/services/wallet-client/WalletClient.ts
@@ -17,9 +17,9 @@ const BN_ZERO = new BN('0') as BNWei
 class WalletClient {
   init() {}
 
-  async getCurrentBalance(): Promise<BNWei> {
+  async getCurrentBalance(bustCache = false): Promise<BNWei> {
     try {
-      const balance = await AudiusBackend.getBalance()
+      const balance = await AudiusBackend.getBalance(bustCache)
       return balance as BNWei
     } catch (err) {
       console.log(err)

--- a/src/store/wallet/sagas.ts
+++ b/src/store/wallet/sagas.ts
@@ -18,7 +18,7 @@ import {
   weiToString,
   BNWei,
   StringWei,
-  getLocalBalanceChange
+  getLocalBalanceDidChange
 } from 'store/wallet/slice'
 import { fetchAccountSucceeded } from 'store/account/reducer'
 import walletClient from 'services/wallet-client/WalletClient'
@@ -114,7 +114,9 @@ function* getWalletBalanceAndClaim() {
 }
 
 function* fetchBalanceAsync() {
-  const localBalanceChange = yield select(getLocalBalanceChange)
+  const localBalanceChange: ReturnType<typeof getLocalBalanceDidChange> = yield select(
+    getLocalBalanceDidChange
+  )
   const currentBalance: BNWei = yield call(() =>
     walletClient.getCurrentBalance(/* bustCache */ localBalanceChange)
   )

--- a/src/store/wallet/sagas.ts
+++ b/src/store/wallet/sagas.ts
@@ -17,7 +17,8 @@ import {
   stringWeiToBN,
   weiToString,
   BNWei,
-  StringWei
+  StringWei,
+  getLocalBalanceChange
 } from 'store/wallet/slice'
 import { fetchAccountSucceeded } from 'store/account/reducer'
 import walletClient from 'services/wallet-client/WalletClient'
@@ -113,13 +114,10 @@ function* getWalletBalanceAndClaim() {
 }
 
 function* fetchBalanceAsync() {
-  const oldBalance: ReturnType<typeof getAccountBalance> = yield select(
-    getAccountBalance
-  )
+  const localBalanceChange = yield select(getLocalBalanceChange)
   const currentBalance: BNWei = yield call(() =>
-    walletClient.getCurrentBalance()
+    walletClient.getCurrentBalance(/* bustCache */ localBalanceChange)
   )
-  if (oldBalance?.eq(currentBalance)) return
   yield put(setBalance({ balance: weiToString(currentBalance) }))
 }
 

--- a/src/store/wallet/slice.ts
+++ b/src/store/wallet/slice.ts
@@ -20,13 +20,13 @@ export type WalletAddress = string
 type WalletState = {
   balance: Nullable<StringWei>
   pendingClaimBalance: Nullable<StringWei>
-  localBalanceChange: boolean
+  localBalanceDidChange: boolean
 }
 
 const initialState: WalletState = {
   balance: null,
   pendingClaimBalance: null,
-  localBalanceChange: false
+  localBalanceDidChange: false
 }
 
 const slice = createSlice({
@@ -38,7 +38,7 @@ const slice = createSlice({
       { payload: { balance } }: PayloadAction<{ balance: StringWei }>
     ) => {
       state.balance = balance
-      state.localBalanceChange = false
+      state.localBalanceDidChange = false
     },
     increaseBalance: (
       state,
@@ -49,7 +49,7 @@ const slice = createSlice({
       state.balance = existingBalance
         .add(new BN(amount))
         .toString() as StringWei
-      state.localBalanceChange = true
+      state.localBalanceDidChange = true
     },
     decreaseBalance: (
       state,
@@ -60,7 +60,7 @@ const slice = createSlice({
       state.balance = existingBalance
         .sub(new BN(amount))
         .toString() as StringWei
-      state.localBalanceChange = true
+      state.localBalanceDidChange = true
     },
     setClaim: (
       state,
@@ -167,8 +167,8 @@ export const getAccountBalance = (state: AppState): Nullable<BNWei> => {
   return stringWeiToBN(balance)
 }
 
-export const getLocalBalanceChange = (state: AppState): boolean => {
-  return state.wallet.localBalanceChange
+export const getLocalBalanceDidChange = (state: AppState): boolean => {
+  return state.wallet.localBalanceDidChange
 }
 
 export const {

--- a/src/store/wallet/slice.ts
+++ b/src/store/wallet/slice.ts
@@ -20,11 +20,13 @@ export type WalletAddress = string
 type WalletState = {
   balance: Nullable<StringWei>
   pendingClaimBalance: Nullable<StringWei>
+  localBalanceChange: boolean
 }
 
 const initialState: WalletState = {
   balance: null,
-  pendingClaimBalance: null
+  pendingClaimBalance: null,
+  localBalanceChange: false
 }
 
 const slice = createSlice({
@@ -36,6 +38,7 @@ const slice = createSlice({
       { payload: { balance } }: PayloadAction<{ balance: StringWei }>
     ) => {
       state.balance = balance
+      state.localBalanceChange = false
     },
     increaseBalance: (
       state,
@@ -46,6 +49,7 @@ const slice = createSlice({
       state.balance = existingBalance
         .add(new BN(amount))
         .toString() as StringWei
+      state.localBalanceChange = true
     },
     decreaseBalance: (
       state,
@@ -56,6 +60,7 @@ const slice = createSlice({
       state.balance = existingBalance
         .sub(new BN(amount))
         .toString() as StringWei
+      state.localBalanceChange = true
     },
     setClaim: (
       state,
@@ -160,6 +165,10 @@ export const getAccountBalance = (state: AppState): Nullable<BNWei> => {
   const balance = state.wallet.balance
   if (!balance) return null
   return stringWeiToBN(balance)
+}
+
+export const getLocalBalanceChange = (state: AppState): boolean => {
+  return state.wallet.localBalanceChange
 }
 
 export const {


### PR DESCRIPTION
### Description
Invalidates the cache after local state changes to claim amt and balance.

Currently the web3 provider can cache requests to your current balance and if we poll for your balance and get a cached value right after a local state change, the value can toggle back to what it was before your local state change.

The AudiusTokenClient .bustCache method invalidates the cache by adding a nonce query param -- this feature could be extended to the ContractClient.js class in libs at some point if we need this behavior more than for fetching balance

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Nah

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Ran against prod & issued a claim. Ensured that numbers were consistent.
