### PR TITLE
Add optimizely for legacy track trending rank badge

### DIFF
--- a/src/containers/track-page/store/sagas.js
+++ b/src/containers/track-page/store/sagas.js
@@ -70,6 +70,7 @@ function* watchTrackBadge() {
         /**
          * Use the legacy get trending track ranks if the optimizely
          * flag OPTIMIZED_TRENDING_BADGE_ENDPOINT is set to false
+         * Relies on Protocol changes https://github.com/AudiusProject/audius-protocol/pull/1137
          */
         const trendingRanks = useOptimizedTrendingIds
           ? yield apiClient.getTrendingIds({

--- a/src/containers/track-page/store/sagas.js
+++ b/src/containers/track-page/store/sagas.js
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { fork, call, put, select, takeEvery } from 'redux-saga/effects'
+import { all, fork, call, put, select, takeEvery } from 'redux-saga/effects'
 
 import tracksSagas from 'containers/track-page/store/lineups/tracks/sagas'
 import * as trackPageActions from './actions'
@@ -14,8 +14,49 @@ import { retrieveTracks } from 'store/cache/tracks/utils'
 import { NOT_FOUND_PAGE, trackRemixesPage } from 'utils/route'
 import { getUsers } from 'store/cache/users/selectors'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
+import TimeRange from 'models/TimeRange'
+import { retrieveTrending } from 'containers/track-page/store/retrieveTrending'
+import { getRemoteVar, BooleanKeys } from 'services/remote-config'
 
 export const TRENDING_BADGE_LIMIT = 10
+
+/**
+ * Get the trending track ranks by requesting trending for
+ * each time frame
+ */
+function* legacyGetTrendingTrackBadges() {
+  yield call(waitForBackendSetup)
+  const [
+    weeklyTrendingTracks,
+    monthlyTrendingTracks,
+    yearlyTrendingTracks
+  ] = yield all([
+    call(retrieveTrending, {
+      timeRange: TimeRange.WEEK,
+      offset: 0,
+      limit: TRENDING_BADGE_LIMIT,
+      genre: null
+    }),
+    call(retrieveTrending, {
+      timeRange: TimeRange.MONTH,
+      offset: 0,
+      limit: TRENDING_BADGE_LIMIT,
+      genre: null
+    }),
+    call(retrieveTrending, {
+      timeRange: TimeRange.YEAR,
+      offset: 0,
+      limit: TRENDING_BADGE_LIMIT,
+      genre: null
+    })
+  ])
+  const mapTrackToId = track => track.track_id
+  return {
+    week: weeklyTrendingTracks.map(mapTrackToId),
+    month: monthlyTrendingTracks.map(mapTrackToId),
+    year: yearlyTrendingTracks.map(mapTrackToId)
+  }
+}
 
 function* watchTrackBadge() {
   yield takeEvery(trackPageActions.GET_TRACK_RANKS, function* (action) {
@@ -23,9 +64,19 @@ function* watchTrackBadge() {
       yield call(waitForBackendSetup)
       let trendingTrackRanks = yield select(getTrendingTrackRanks)
       if (!trendingTrackRanks) {
-        const trendingRanks = yield apiClient.getTrendingIds({
-          limit: TRENDING_BADGE_LIMIT
-        })
+        const useOptimizedTrendingIds = getRemoteVar(
+          BooleanKeys.OPTIMIZED_TRENDING_BADGE_ENDPOINT
+        )
+        /**
+         * Use the legacy get trending track ranks if the optimizely
+         * flag OPTIMIZED_TRENDING_BADGE_ENDPOINT is set to false
+         */
+        const trendingRanks = useOptimizedTrendingIds
+          ? yield apiClient.getTrendingIds({
+              limit: TRENDING_BADGE_LIMIT
+            })
+          : yield call(legacyGetTrendingTrackBadges)
+
         yield put(trackPageActions.setTrackTrendingRanks(trendingRanks))
         trendingTrackRanks = yield select(getTrendingTrackRanks)
       }

--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -27,7 +27,13 @@ export enum IntKeys {
   NOTIFICATION_POLLING_FREQ_MS = 'NOTIFICATION_POLLING_FREQ_MS'
 }
 
-export enum BooleanKeys {}
+export enum BooleanKeys {
+  /**
+   * If the optimized trending track ids endpoint should be used for badges
+   * else the trending tracks endpoint will be used
+   */
+  OPTIMIZED_TRENDING_BADGE_ENDPOINT = 'OPTIMIZED_TRENDING_BADGE_ENDPOINT'
+}
 
 export enum DoubleKeys {}
 

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -24,4 +24,6 @@ export const remoteConfigDoubleDefaults: {
 } = {}
 export const remoteConfigBooleanDefaults: {
   [key in BooleanKeys]: boolean | null
-} = {}
+} = {
+  OPTIMIZED_TRENDING_BADGE_ENDPOINT: false
+}


### PR DESCRIPTION
### Trello Card Link
na

### Description
Add back the old method for retrieving the trending track badge by calling the trending tracks endpoint. 
This is added behind an optimizely flag which defaults to the old method. 
Reference #154 for the changes to the updated endpoint.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran it against staging with the flag set to both true and false and saw the badge in both cases. 
