### PR TITLE
Fix mobile saved page lineup - currently playing

### DIFF
--- a/src/containers/saved-page/store/lineups/tracks/sagas.js
+++ b/src/containers/saved-page/store/lineups/tracks/sagas.js
@@ -16,7 +16,7 @@ import moment from 'moment'
 import { Kind } from 'store/types'
 import { makeUid } from 'utils/uid'
 import { retrieveTracks } from 'store/cache/tracks/utils'
-
+import { getUid as getPlayerUid } from 'store/player/selectors'
 const getSavedTracks = state => state.saved.tracks
 
 function* getTracks() {
@@ -124,15 +124,20 @@ function* watchUnsave() {
   yield takeEvery(UNSAVE_TRACK, function* (action) {
     const { trackId } = action
     const localSaveUid = yield select(getLocalSave, { id: trackId })
+    const playerUid = yield select(getPlayerUid)
     yield put(saveActions.removeLocalSave(action.trackId))
     if (localSaveUid) {
       yield put(savedTracksActions.remove(Kind.TRACKS, localSaveUid))
-      yield put(queueActions.remove({ uid: localSaveUid }))
+      if (localSaveUid !== playerUid) {
+        yield put(queueActions.remove({ uid: localSaveUid }))
+      }
     }
     const lineupSaveUid = yield select(getSavedTracksLineupUid, { id: trackId })
     if (lineupSaveUid) {
       yield put(savedTracksActions.remove(Kind.TRACKS, lineupSaveUid))
-      yield put(queueActions.remove({ uid: lineupSaveUid }))
+      if (lineupSaveUid !== playerUid) {
+        yield put(queueActions.remove({ uid: lineupSaveUid }))
+      }
     }
   })
 }


### PR DESCRIPTION
### Description
Closes AUD-55
Issue: When on the mobile favorites page, if you play a track, the lineup updates the queue. If you remove a track on the favorites page, it's removed from the queue as well and the Now Playing overlay uses the queue to display the track information, but since it's missing, it displays nothing. Note, at this point the player in redux still has the information so the track still plays. 

My solution was to do a simple check on un-save for if it's the currently playing track and if so, do not remove from queue. 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
No

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the dapp on my browser with mobile width. 
