### PR TITLE
Fix edit playlist overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,9 +91,9 @@
       }
     },
     "@audius/stems": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.2.tgz",
-      "integrity": "sha512-gLIA+imd9nUF0kdaM9NQCylfs1bDvSHKxtg0NIhEf2R1AMT64g7INJ4OpyMNGggVP4mJGWW2cskuaLhkTNC7og==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.3.tgz",
+      "integrity": "sha512-brm6za5f+zcNCyFWVXMR3j6l45cuMefPqMLK4rwbKlm7R9Tze+Cq3/MSLnWoGx2wP0+WBMYzr00QQL5MPWk+ZQ==",
       "requires": {
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@audius/libs": "1.1.8",
-    "@audius/stems": "0.3.2",
+    "@audius/stems": "0.3.3",
     "@optimizely/optimizely-sdk": "^4.0.0",
     "@reduxjs/toolkit": "^1.3.2",
     "@sentry/browser": "^5.10.2",

--- a/src/components/actions-tab/ActionsTab.js
+++ b/src/components/actions-tab/ActionsTab.js
@@ -188,7 +188,8 @@ export class ActionsTab extends PureComponent {
       currentUserSaved,
       currentUserReposted,
       isArtistPick,
-      isPublic
+      isPublic,
+      includeEdit
     } = this.props
 
     const overflowMenu = {
@@ -212,6 +213,7 @@ export class ActionsTab extends PureComponent {
       overflowMenu.menu.playlistName = playlistName
       overflowMenu.menu.includeAddToPlaylist = false
       overflowMenu.menu.isPublic = isPublic
+      overflowMenu.menu.includeEdit = includeEdit
     }
 
     return (
@@ -247,6 +249,7 @@ ActionsTab.propTypes = {
   minimized: PropTypes.bool,
   standalone: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  includeEdit: PropTypes.bool,
   direction: PropTypes.oneOf(['vertical', 'horizontal']),
   variant: PropTypes.oneOf(['track', 'playlist', 'album']),
   containerStyles: PropTypes.string,

--- a/src/components/card/desktop/Card.tsx
+++ b/src/components/card/desktop/Card.tsx
@@ -183,6 +183,7 @@ const Card = ({
           currentUserReposted={isReposted}
           currentUserSaved={isSaved}
           isPublic={isPublic}
+          includeEdit
         />
       </div>
     )

--- a/src/components/create-playlist/CreatePlaylistModal.js
+++ b/src/components/create-playlist/CreatePlaylistModal.js
@@ -193,7 +193,6 @@ CreatePlaylistModal.propTypes = {
   onSave: PropTypes.func,
   // When the delete button is clicked
   onDelete: PropTypes.func,
-  // When the delete button is clicked
   zIndex: PropTypes.number
 }
 

--- a/src/components/create-playlist/CreatePlaylistModal.js
+++ b/src/components/create-playlist/CreatePlaylistModal.js
@@ -25,7 +25,7 @@ const CreatePlaylistModal = props => {
     artwork: false
   })
 
-  const { visible, metadata, editMode } = props
+  const { zIndex, visible, metadata, editMode } = props
 
   // On modal open (similar to componentDidMount, but this component is mounted before being displayed)
   useEffect(() => {
@@ -119,6 +119,7 @@ const CreatePlaylistModal = props => {
       titleClassName={styles.modalTitle}
       isOpen={props.visible}
       onClose={onCancel}
+      zIndex={zIndex}
     >
       <div className={styles.createPlaylist}>
         <UploadArtwork
@@ -191,7 +192,9 @@ CreatePlaylistModal.propTypes = {
   // When the save button is clicked
   onSave: PropTypes.func,
   // When the delete button is clicked
-  onDelete: PropTypes.func
+  onDelete: PropTypes.func,
+  // When the delete button is clicked
+  zIndex: PropTypes.number
 }
 
 CreatePlaylistModal.defaultProps = {

--- a/src/components/track/EditTrackModal.js
+++ b/src/components/track/EditTrackModal.js
@@ -10,6 +10,7 @@ import FormTile from 'components/data-entry/FormTile'
 import styles from './EditTrackModal.module.css'
 import { useTrackCoverArt } from 'hooks/useImageSize'
 import { SquareSizes } from 'models/common/ImageSizes'
+import zIndex from 'utils/zIndex'
 
 const EditTrackModal = ({
   visible,
@@ -97,7 +98,7 @@ const EditTrackModal = ({
       isOpen={visible}
       onClose={onClose}
       // Antd modal default value, behind antd DropdownInput
-      zIndex={1000}
+      zIndex={zIndex.EDIT_TRACK_MODAL}
       bodyClassName={styles.modalBody}
       titleClassName={styles.modalTitle}
       headerContainerClassName={styles.modalHeader}

--- a/src/containers/Modals.tsx
+++ b/src/containers/Modals.tsx
@@ -11,6 +11,7 @@ import ConnectedUserListModal from 'containers/user-list-modal/ConnectedUserList
 import BrowserPushConfirmationModal from './browser-push-confirmation-modal/BrowserPushConfirmationModal'
 import FirstUploadModal from 'containers/first-upload-modal/FirstUploadModal'
 import UnloadDialog from 'containers/unload-dialog/UnloadDialog'
+import EditPlaylistModal from 'containers/edit-playlist/desktop/EditPlaylistModal'
 
 import { getClient } from 'utils/clientUtil'
 import Client from 'models/Client'
@@ -31,6 +32,7 @@ const Modals = () => {
       <UnloadDialog />
 
       {!isMobileClient && <EmbedModal />}
+      {!isMobileClient && <EditPlaylistModal />}
       {!isMobileClient && <ConnectedUserListModal />}
       {!NATIVE_MOBILE && client !== Client.ELECTRON && (
         <BrowserPushConfirmationModal />

--- a/src/containers/collection-page/components/desktop/CollectionPage.tsx
+++ b/src/containers/collection-page/components/desktop/CollectionPage.tsx
@@ -23,16 +23,10 @@ const messages = {
       'Find a track you want to add and click the ••• button to add it to your playlist',
     visitor: 'This Playlist is Empty...'
   },
-  title: {
-    playlist: 'PLAYLIST',
-    album: 'ALBUM'
-  },
   type: {
     playlist: 'Playlist',
     album: 'Album'
   },
-  edit: 'EDIT',
-  delete: 'DELETE',
   remove: 'Remove from this'
 }
 

--- a/src/containers/collection-page/components/desktop/CollectionPage.tsx
+++ b/src/containers/collection-page/components/desktop/CollectionPage.tsx
@@ -4,8 +4,6 @@ import { Status } from 'store/types'
 
 import Page from 'components/general/Page'
 import CollectionHeader from 'components/collection/desktop/CollectionHeader'
-import CreatePlaylistModal from 'components/create-playlist/CreatePlaylistModal'
-import DeleteConfirmationModal from 'components/delete-confirmation/DeleteConfirmationModal'
 import { ID } from 'models/common/Identifiers'
 import Collection, { SmartCollection, Variant } from 'models/Collection'
 import TracksTable from 'components/tracks-table/TracksTable'
@@ -53,8 +51,6 @@ export type CollectionPageProps = {
   title: string
   description: string
   canonicalUrl: string
-  showEditPlaylist: boolean
-  showDeleteConfirmation: boolean
   playlistId: ID
   playing: boolean
   getPlayingUid: () => string | null
@@ -94,11 +90,6 @@ export type CollectionPageProps = {
     uid: string,
     timestamp: number
   ) => void
-  onSaveEdit: (formField: any) => void
-  onDeletePlaylist: () => void
-  onCancelEditPlaylist: () => void
-  onDelete: () => void
-  onCancelDelete: () => void
   onFollow: () => void
   onUnfollow: () => void
   onClickReposts: () => void
@@ -110,8 +101,6 @@ const CollectionPage = ({
   title,
   description: pageDescription,
   canonicalUrl,
-  showEditPlaylist,
-  showDeleteConfirmation,
   playlistId,
   allowReordering,
   playing,
@@ -138,11 +127,6 @@ const CollectionPage = ({
   onSortTracks,
   onReorderTracks,
   onClickRemove,
-  onDeletePlaylist,
-  onSaveEdit,
-  onCancelEditPlaylist,
-  onDelete,
-  onCancelDelete,
   onFollow,
   onUnfollow,
   onClickReposts,
@@ -283,28 +267,6 @@ const CollectionPage = ({
             )}
           </div>
         )}
-        <CreatePlaylistModal
-          key={playlistId}
-          title={`${messages.edit} ${
-            isAlbum ? messages.title.album : messages.title.playlist
-          }`}
-          isAlbum={isAlbum}
-          visible={showEditPlaylist}
-          metadata={metadata}
-          editMode
-          onDelete={onDeletePlaylist}
-          onSave={onSaveEdit}
-          onCancel={onCancelEditPlaylist}
-        />
-        <DeleteConfirmationModal
-          title={`${messages.delete} ${
-            isAlbum ? messages.title.album : messages.title.playlist
-          }`}
-          entity={isAlbum ? messages.type.album : messages.type.playlist}
-          visible={showDeleteConfirmation}
-          onDelete={onDelete}
-          onCancel={onCancelDelete}
-        />
       </div>
     </Page>
   )

--- a/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -56,7 +56,7 @@ const EditPlaylistModal = ({
     onClose()
     deletePlaylist(playlistId!)
     const playlistRoute = playlistPage(handle, title, playlistId!)
-    // If on the playlist page, direct user to teed
+    // If on the playlist page, direct user to feed
     if (location.pathname === playlistRoute) goToRoute(FEED_PAGE)
   }
   const onSaveEdit = (formFields: any) => {

--- a/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react'
+import { connect } from 'react-redux'
+import { AppState } from 'store/types'
+import { Dispatch } from 'redux'
+import CreatePlaylistModal from 'components/create-playlist/CreatePlaylistModal'
+import DeleteConfirmationModal from 'components/delete-confirmation/DeleteConfirmationModal'
+import { withRouter, RouteComponentProps } from 'react-router-dom'
+import {
+  getCollectionAndUser,
+  getIsOpen
+} from 'store/application/ui/editPlaylistModal/selectors'
+import { close } from 'store/application/ui/editPlaylistModal/slice'
+import { editPlaylist, deletePlaylist } from 'store/cache/collections/actions'
+import { ID } from 'models/common/Identifiers'
+import { push as pushRoute } from 'connected-react-router'
+import { FEED_PAGE, playlistPage } from 'utils/route'
+import zIndex from 'utils/zIndex'
+
+const messages = {
+  edit: 'EDIT',
+  delete: 'DELETE',
+  title: {
+    playlist: 'PLAYLIST',
+    album: 'ALBUM'
+  },
+  type: {
+    playlist: 'Playlist',
+    album: 'Album'
+  }
+}
+
+type OwnProps = {}
+type EditPlaylistModalProps = OwnProps &
+  RouteComponentProps &
+  ReturnType<typeof mapStateToProps> &
+  ReturnType<typeof mapDispatchToProps>
+
+const EditPlaylistModal = ({
+  isOpen,
+  collection,
+  user,
+  location,
+  onClose,
+  editPlaylist,
+  deletePlaylist,
+  goToRoute
+}: EditPlaylistModalProps) => {
+  const { playlist_id: playlistId, is_album: isAlbum, playlist_name: title } =
+    collection || {}
+  const { handle } = user || {}
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+  const onClickDelete = () => setShowDeleteConfirmation(true)
+  const onCancelDelete = () => setShowDeleteConfirmation(false)
+  const onDelete = () => {
+    setShowDeleteConfirmation(false)
+    onClose()
+    deletePlaylist(playlistId!)
+    const playlistRoute = playlistPage(handle, title, playlistId!)
+    // If on the playlist page, direct user to teed
+    if (location.pathname === playlistRoute) goToRoute(FEED_PAGE)
+  }
+  const onSaveEdit = (formFields: any) => {
+    editPlaylist(playlistId!, formFields)
+    onClose()
+  }
+
+  if (!collection) return null
+  return (
+    <>
+      <CreatePlaylistModal
+        key={playlistId}
+        title={`${messages.edit} ${
+          isAlbum ? messages.title.album : messages.title.playlist
+        }`}
+        isAlbum={isAlbum}
+        visible={isOpen}
+        metadata={collection}
+        editMode
+        onDelete={onClickDelete}
+        onSave={onSaveEdit}
+        onCancel={onClose}
+        zIndex={zIndex.EDIT_PLAYLIST_MODAL}
+      />
+      <DeleteConfirmationModal
+        title={`${messages.delete} ${
+          isAlbum ? messages.title.album : messages.title.playlist
+        }`}
+        entity={isAlbum ? messages.type.album : messages.type.playlist}
+        visible={showDeleteConfirmation}
+        onDelete={onDelete}
+        onCancel={onCancelDelete}
+      />
+    </>
+  )
+}
+
+const mapStateToProps = (state: AppState) => {
+  return {
+    isOpen: getIsOpen(state),
+    ...getCollectionAndUser(state)
+  }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onClose: () => dispatch(close()),
+  goToRoute: (route: string) => dispatch(pushRoute(route)),
+  editPlaylist: (playlistId: ID, formFields: any) =>
+    dispatch(editPlaylist(playlistId, formFields)),
+  deletePlaylist: (playlistId: ID) => dispatch(deletePlaylist(playlistId))
+})
+
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(EditPlaylistModal)
+)

--- a/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -6,9 +6,10 @@ import CreatePlaylistModal from 'components/create-playlist/CreatePlaylistModal'
 import DeleteConfirmationModal from 'components/delete-confirmation/DeleteConfirmationModal'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
 import {
-  getCollectionAndUser,
-  getIsOpen
+  getIsOpen,
+  getCollectionId
 } from 'store/application/ui/editPlaylistModal/selectors'
+import { getCollectionWithUser } from 'store/cache/collections/selectors'
 import { close } from 'store/application/ui/editPlaylistModal/slice'
 import { editPlaylist, deletePlaylist } from 'store/cache/collections/actions'
 import { ID } from 'models/common/Identifiers'
@@ -38,15 +39,18 @@ type EditPlaylistModalProps = OwnProps &
 const EditPlaylistModal = ({
   isOpen,
   collection,
-  user,
   location,
   onClose,
   editPlaylist,
   deletePlaylist,
   goToRoute
 }: EditPlaylistModalProps) => {
-  const { playlist_id: playlistId, is_album: isAlbum, playlist_name: title } =
-    collection || {}
+  const {
+    playlist_id: playlistId,
+    is_album: isAlbum,
+    playlist_name: title,
+    user
+  } = collection || {}
   const { handle } = user || {}
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const onClickDelete = () => setShowDeleteConfirmation(true)
@@ -95,9 +99,10 @@ const EditPlaylistModal = ({
 }
 
 const mapStateToProps = (state: AppState) => {
+  const collectionId = getCollectionId(state)
   return {
     isOpen: getIsOpen(state),
-    ...getCollectionAndUser(state)
+    collection: getCollectionWithUser(state, { id: collectionId || undefined })
   }
 }
 

--- a/src/containers/edit-track/EditTrackModal.tsx
+++ b/src/containers/edit-track/EditTrackModal.tsx
@@ -200,11 +200,6 @@ const EditTrackModal = ({
         onAddStems={onAddStems}
       />
       <DeleteConfirmationModal
-        // Need to re-key this whenever it changes visibility state,
-        // so that it always recreates a new modal thus preserving z-index
-        // ordering between EditTrackModal and DeleteConfirmationModal
-        // (DeleteConfirmationModal should be on top)
-        key={isOpen ? 'isOpen' : 'isClosed'}
         title={messages.deleteTrack}
         entity='Track'
         visible={showDeleteConfirmation}

--- a/src/containers/menu/CollectionMenu.tsx
+++ b/src/containers/menu/CollectionMenu.tsx
@@ -6,6 +6,7 @@ import { albumPage, playlistPage, profilePage } from 'utils/route'
 
 import * as socialActions from 'store/social/collections/actions'
 import * as embedModalActions from 'containers/embed-modal/store/actions'
+import { open as openEditCollectionModal } from 'store/application/ui/editPlaylistModal/slice'
 
 import CascadingMenu from 'components/navigation/CascadingMenu'
 import { ShareSource, FavoriteSource, RepostSource } from 'services/analytics'
@@ -25,6 +26,7 @@ export type OwnProps = {
   isArtist: boolean
   isPublic: boolean
   playlistId: PlaylistId
+  includeEdit?: boolean
   includeShare: boolean
   includeRepost: boolean
   includeFavorite: boolean
@@ -48,6 +50,7 @@ const messages = {
 
 const CollectionMenu: React.FC<CollectionMenuProps> = props => {
   const getMenu = () => {
+    const includeEdit = true
     const {
       type,
       handle,
@@ -56,6 +59,7 @@ const CollectionMenu: React.FC<CollectionMenuProps> = props => {
       isOwner,
       isFavorited,
       isReposted,
+      // includeEdit,
       includeShare,
       includeRepost,
       includeFavorite,
@@ -66,6 +70,7 @@ const CollectionMenu: React.FC<CollectionMenuProps> = props => {
       onShare,
       goToRoute,
       openEmbedModal,
+      editCollection,
       shareCollection,
       saveCollection,
       unsaveCollection,
@@ -113,6 +118,11 @@ const CollectionMenu: React.FC<CollectionMenuProps> = props => {
       onClick: () => goToRoute(routePage(handle, playlistName, playlistId))
     }
 
+    const editCollectionMenuItem = {
+      text: `Edit ${typeName}`,
+      onClick: () => editCollection(playlistId)
+    }
+
     const embedMenuItem = {
       text: messages.embed,
       onClick: () =>
@@ -140,6 +150,9 @@ const CollectionMenu: React.FC<CollectionMenuProps> = props => {
     }
     if (includeEmbed && isPublic) {
       menu.items.push(embedMenuItem)
+    }
+    if (includeEdit && isOwner) {
+      menu.items.push(editCollectionMenuItem)
     }
 
     return menu
@@ -173,6 +186,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     goToRoute: (route: string) => dispatch(pushRoute(route)),
     shareCollection: (playlistId: PlaylistId) =>
       dispatch(socialActions.shareCollection(playlistId, ShareSource.OVERFLOW)),
+    editCollection: (playlistId: ID) =>
+      dispatch(openEditCollectionModal(playlistId)),
     saveCollection: (playlistId: PlaylistId) =>
       dispatch(
         socialActions.saveCollection(playlistId, FavoriteSource.OVERFLOW)

--- a/src/containers/menu/CollectionMenu.tsx
+++ b/src/containers/menu/CollectionMenu.tsx
@@ -50,7 +50,6 @@ const messages = {
 
 const CollectionMenu: React.FC<CollectionMenuProps> = props => {
   const getMenu = () => {
-    const includeEdit = true
     const {
       type,
       handle,
@@ -59,7 +58,7 @@ const CollectionMenu: React.FC<CollectionMenuProps> = props => {
       isOwner,
       isFavorited,
       isReposted,
-      // includeEdit,
+      includeEdit,
       includeShare,
       includeRepost,
       includeFavorite,

--- a/src/store/application/ui/editPlaylistModal/selectors.ts
+++ b/src/store/application/ui/editPlaylistModal/selectors.ts
@@ -1,6 +1,4 @@
 import { AppState } from 'store/types'
-import { getCollection as getCollectionById } from 'store/cache/collections/selectors'
-import { getUser as getUserById } from 'store/cache/users/selectors'
 
 const getBase = (state: AppState) => state.application.ui.editPlaylistModal
 export const getIsOpen = (state: AppState) => {
@@ -9,12 +7,4 @@ export const getIsOpen = (state: AppState) => {
 
 export const getCollectionId = (state: AppState) => {
   return getBase(state).collectionId
-}
-
-export const getCollectionAndUser = (state: AppState) => {
-  const collectionId = getBase(state).collectionId
-  const collection = getCollectionById(state, { id: collectionId })
-  const userId = collection?.playlist_owner_id
-  const user = getUserById(state, { id: userId })
-  return { collection, user }
 }

--- a/src/store/application/ui/editPlaylistModal/selectors.ts
+++ b/src/store/application/ui/editPlaylistModal/selectors.ts
@@ -1,0 +1,20 @@
+import { AppState } from 'store/types'
+import { getCollection as getCollectionById } from 'store/cache/collections/selectors'
+import { getUser as getUserById } from 'store/cache/users/selectors'
+
+const getBase = (state: AppState) => state.application.ui.editPlaylistModal
+export const getIsOpen = (state: AppState) => {
+  return getBase(state).isOpen
+}
+
+export const getCollectionId = (state: AppState) => {
+  return getBase(state).collectionId
+}
+
+export const getCollectionAndUser = (state: AppState) => {
+  const collectionId = getBase(state).collectionId
+  const collection = getCollectionById(state, { id: collectionId })
+  const userId = collection?.playlist_owner_id
+  const user = getUserById(state, { id: userId })
+  return { collection, user }
+}

--- a/src/store/application/ui/editPlaylistModal/slice.ts
+++ b/src/store/application/ui/editPlaylistModal/slice.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { ID } from 'models/common/Identifiers'
+
+export type EditPlaylistModalState = {
+  isOpen: boolean
+  collectionId: ID | null
+}
+
+const initialState: EditPlaylistModalState = {
+  isOpen: false,
+  collectionId: null
+}
+
+type OpenPayload = ID
+
+const slice = createSlice({
+  name: 'application/ui/editPlaylistModal',
+  initialState,
+  reducers: {
+    open: (state, action: PayloadAction<OpenPayload>) => {
+      state.isOpen = true
+      state.collectionId = action.payload
+    },
+    close: state => {
+      state.isOpen = false
+      state.collectionId = null
+    }
+  }
+})
+
+export const { open, close } = slice.actions
+
+export default slice.reducer

--- a/src/store/cache/collections/selectors.ts
+++ b/src/store/cache/collections/selectors.ts
@@ -1,7 +1,7 @@
 import { getEntry, getAllEntries } from 'store/cache/selectors'
 import { Kind, AppState, Status } from 'store/types'
-import { getTracks } from '../tracks/selectors'
-import { getUsers } from '../users/selectors'
+import { getTracks } from 'store/cache/tracks/selectors'
+import { getUsers, getUser as getUserById } from 'store/cache/users/selectors'
 import { Uid } from 'utils/uid'
 import { ID, UID } from 'models/common/Identifiers'
 import Collection from 'models/Collection'
@@ -103,4 +103,21 @@ export const getTracksFromCollection = (
       user: users[tracks[t.track].owner_id]
     }
   })
+}
+
+type EnhancedCollection = Collection & { user: User }
+export const getCollectionWithUser = (
+  state: AppState,
+  props: { id?: ID }
+): EnhancedCollection | null => {
+  const collection = getCollection(state, { id: props.id })
+  const userId = collection?.playlist_owner_id
+  const user = getUserById(state, { id: userId })
+  if (collection && user) {
+    return {
+      user,
+      ...collection
+    }
+  }
+  return null
 }

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -60,6 +60,7 @@ import tokenDashboard from 'store/token-dashboard/slice'
 import setAsArtistPickConfirmation from 'store/application/ui/setAsArtistPickConfirmation/reducer'
 import browserPushPermissionConfirmation from 'store/application/ui/browserPushPermissionConfirmation/reducer'
 import createPlaylistModal from 'store/application/ui/createPlaylistModal/reducer'
+import editPlaylistModal from 'store/application/ui/editPlaylistModal/slice'
 import editTrackModal from 'store/application/ui/editTrackModal/reducer'
 import theme from 'store/application/ui/theme/reducer'
 import scrollLock from 'store/application/ui/scrollLock/reducer'
@@ -118,6 +119,7 @@ const createRootReducer = routeHistory =>
 
     application: combineReducers({
       ui: combineReducers({
+        editPlaylistModal,
         createPlaylistModal,
         editTrackModal,
         embedModal,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -17,6 +17,7 @@ import { UploadPageState } from 'containers/upload-page/store/types'
 import VisualizerReducer from 'containers/visualizer/store/slice'
 import { ThemeState } from './application/ui/theme/types'
 import { CreatePlaylistModalState } from './application/ui/createPlaylistModal/types'
+import { EditPlaylistModalState } from './application/ui/editPlaylistModal/slice'
 import { CookieBannerState } from './application/ui/cookieBanner/types'
 import { ScrollLockState } from './application/ui/scrollLock/types'
 import { SetAsArtistPickConfirmationState } from './application/ui/setAsArtistPickConfirmation/types'
@@ -97,6 +98,7 @@ export type AppState = {
   application: {
     ui: {
       createPlaylistModal: CreatePlaylistModalState
+      editPlaylistModal: EditPlaylistModalState
       editTrackModal: EditTrackModalState
       theme: ThemeState
       scrollLock: ScrollLockState

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -1,10 +1,11 @@
 /**
  * Standardize the use of zIndex across the application
  *
- * Reference: https://www.notion.so/audiusproject/Client-Modal-Design-cc9d722f2aed4a0abf14fb44f97c246e
+ * NOTE: default modal zIndex is 10,000 and the modal bg is 9,999
  */
 
 export enum zIndex {
+  // Set to 1000 to account for nested modals inside, which take a higher z-index
   EDIT_TRACK_MODAL = 1000,
   EDIT_PLAYLIST_MODAL = 1000
 }

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -1,0 +1,12 @@
+/**
+ * Standardize the use of zIndex across the application
+ *
+ * Reference: https://www.notion.so/audiusproject/Client-Modal-Design-cc9d722f2aed4a0abf14fb44f97c246e
+ */
+
+export enum zIndex {
+  EDIT_TRACK_MODAL = 1000,
+  EDIT_PLAYLIST_MODAL = 1000
+}
+
+export default zIndex


### PR DESCRIPTION
### Description
* Update stems from 0.3.2 -> 0.3.3
* Adds an Edit Playlist Modal component - it reuses the ui of the create playlist component, but is added at the root level to the Modals container. 
* Adds an edit playlist option to the dropdown of the playlist card.
* Updates the edit playlist modal in the playlist page to use the new component.
* Added a zIndex file to collect all z-indices used in the app. 
* Removed toggle key in edit track modal

Closes AUD-84

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
**Yes**: I updated stems from 0.3.2 -> 0.3.3 which has the modal style changes.
I played around with the modals and they seemed to be working fine. 

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the dapp against staging. I clicked edit playlist and tried all the options from the overflow menu as well as from the playlist/album page and it all worked as intended.  
