### PR TITLE
Remove track from profile lineup when deleted

### DIFF
--- a/src/containers/profile-page/store/lineups/tracks/sagas.js
+++ b/src/containers/profile-page/store/lineups/tracks/sagas.js
@@ -11,6 +11,7 @@ import {
 } from 'containers/profile-page/store/selectors'
 import { LineupSagas } from 'store/lineup/sagas'
 import { getTrack } from 'store/cache/tracks/selectors'
+import { DELETE_TRACK } from 'store/cache/tracks/actions'
 import { tracksActions as lineupActions } from './actions'
 import { SET_ARTIST_PICK } from 'store/social/tracks/actions'
 import { retrieveTracks } from 'store/cache/tracks/utils'
@@ -20,6 +21,7 @@ import { retrieveUserTracks } from './retrieveUserTracks'
 import { waitForValue } from 'utils/sagaHelpers'
 import { getUser } from 'store/cache/users/selectors'
 import { TracksSortMode } from '../../types'
+import { Kind } from 'store/types'
 
 function* getTracks({ offset, limit, payload }) {
   const handle = yield select(getProfileUserHandle)
@@ -129,7 +131,18 @@ function* watchSetArtistPick() {
   })
 }
 
+function* watchDeleteTrack() {
+  yield takeEvery(DELETE_TRACK, function* (action) {
+    const { trackId } = action
+    const lineup = yield select(getProfileTracksLineup)
+    const trackLineupEntry = lineup.entries.find(entry => entry.id === trackId)
+    if (trackLineupEntry) {
+      yield put(tracksActions.remove(Kind.TRACKS, trackLineupEntry.uid))
+    }
+  })
+}
+
 export default function sagas() {
   const trackSagas = new TracksSagas().getSagas()
-  return trackSagas.concat([watchSetArtistPick])
+  return trackSagas.concat([watchSetArtistPick, watchDeleteTrack])
 }


### PR DESCRIPTION
### Description
Closes AUD-113
If on the user profile page and a track is deleted, it should be removed from the page. 


### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
nope

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the dapp locally against staging and removed a track on the profile page. 
