### PR TITLE
[AUD-54] Fix flickering drop shadow in nav column

### DIFF
--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -65,6 +65,7 @@ import { make, useRecord } from 'store/analytics/actions'
 import { Name, CreatePlaylistSource } from 'services/analytics'
 import { Variant } from 'models/Collection'
 import { getClaimableBalance } from 'store/wallet/slice'
+import { getAverageColor } from 'store/application/ui/average-color/slice'
 
 const NavColumn = ({
   account,
@@ -90,7 +91,8 @@ const NavColumn = ({
   goToRoute,
   goToSignUp: routeToSignup,
   goToUpload,
-  pendingClaim
+  pendingClaim,
+  averageRGBColor
 }) => {
   const record = useRecord()
   const goToSignUp = useCallback(
@@ -446,7 +448,7 @@ const NavColumn = ({
             (currentQueueItem?.user?.handle ?? null) ===
             (account?.handle ?? undefined)
           }
-          coverArtColor={currentQueueItem.track?._cover_art_color ?? null}
+          coverArtColor={averageRGBColor}
           coverArtSizes={currentQueueItem.track?._cover_art_sizes ?? null}
           draggableLink={getTrackPageLink()}
           onClick={onClickArtwork}
@@ -458,18 +460,29 @@ const NavColumn = ({
 
 const makeMapStateToProps = () => {
   const getCurrentQueueItem = makeGetCurrent()
-  const mapStateToProps = state => ({
-    currentQueueItem: getCurrentQueueItem(state),
-    account: getAccountUser(state),
-    accountStatus: getAccountStatus(state),
-    playlists: getAccountPlaylists(state),
-    dragging: getIsDragging(state),
-    notificationCount: getNotificationUnreadCount(state),
-    notificationPanelIsOpen: getNotificationPanelIsOpen(state),
-    upload: state.upload,
-    showCreatePlaylistModal: getIsOpen(state),
-    pendingClaim: getClaimableBalance(state)
-  })
+  const mapStateToProps = state => {
+    const currentQueueItem = getCurrentQueueItem(state)
+    return {
+      currentQueueItem,
+      account: getAccountUser(state),
+      accountStatus: getAccountStatus(state),
+      playlists: getAccountPlaylists(state),
+      dragging: getIsDragging(state),
+      notificationCount: getNotificationUnreadCount(state),
+      notificationPanelIsOpen: getNotificationPanelIsOpen(state),
+      upload: state.upload,
+      showCreatePlaylistModal: getIsOpen(state),
+      pendingClaim: getClaimableBalance(state),
+      averageRGBColor: currentQueueItem.track
+        ? getAverageColor(state, {
+            multihash:
+              currentQueueItem.track.cover_art_sizes ??
+              currentQueueItem.track.cover_art ??
+              ''
+          })
+        : null
+    }
+  }
   return mapStateToProps
 }
 

--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -477,8 +477,7 @@ const makeMapStateToProps = () => {
         ? getAverageColor(state, {
             multihash:
               currentQueueItem.track.cover_art_sizes ??
-              currentQueueItem.track.cover_art ??
-              ''
+              currentQueueItem.track.cover_art
           })
         : null
     }

--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -65,7 +65,7 @@ import { make, useRecord } from 'store/analytics/actions'
 import { Name, CreatePlaylistSource } from 'services/analytics'
 import { Variant } from 'models/Collection'
 import { getClaimableBalance } from 'store/wallet/slice'
-import { getAverageColor } from 'store/application/ui/average-color/slice'
+import { getAverageColorByTrack } from 'store/application/ui/average-color/slice'
 
 const NavColumn = ({
   account,
@@ -473,13 +473,9 @@ const makeMapStateToProps = () => {
       upload: state.upload,
       showCreatePlaylistModal: getIsOpen(state),
       pendingClaim: getClaimableBalance(state),
-      averageRGBColor: currentQueueItem.track
-        ? getAverageColor(state, {
-            multihash:
-              currentQueueItem.track.cover_art_sizes ??
-              currentQueueItem.track.cover_art
-          })
-        : null
+      averageRGBColor: getAverageColorByTrack(state, {
+        track: currentQueueItem.track
+      })
     }
   }
   return mapStateToProps

--- a/src/containers/now-playing/NowPlaying.tsx
+++ b/src/containers/now-playing/NowPlaying.tsx
@@ -66,6 +66,7 @@ import { useRecord, make } from 'store/analytics/actions'
 import { AudioState } from 'store/player/types'
 import { withNullGuard } from 'utils/withNullGuard'
 import CoSign, { Size } from 'components/co-sign/CoSign'
+import { getAverageColor } from 'store/application/ui/average-color/slice'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
@@ -121,7 +122,8 @@ const NowPlaying = g(
     clickOverflow,
     goToRoute,
     isCasting,
-    castMethod
+    castMethod,
+    averageRGBColor
   }) => {
     const { uid } = currentQueueItem
     const { track, user } = currentQueueItem
@@ -298,16 +300,15 @@ const NowPlaying = g(
       }
     }
 
-    const artworkAverageColor =
-      track && track._cover_art_color
-        ? {
-            boxShadow: `0 1px 15px -2px rgba(
-          ${track._cover_art_color.r},
-          ${track._cover_art_color.g},
-          ${track._cover_art_color.b}
+    const artworkAverageColor = averageRGBColor
+      ? {
+          boxShadow: `0 1px 15px -2px rgba(
+          ${averageRGBColor.r},
+          ${averageRGBColor.g},
+          ${averageRGBColor.b}
           , 0.5)`
-          }
-        : {}
+        }
+      : {}
 
     return (
       <div
@@ -432,15 +433,24 @@ function makeMapStateToProps() {
   const getCurrentQueueItem = makeGetCurrent()
 
   const mapStateToProps = (state: AppState) => {
+    const currentQueueItem = getCurrentQueueItem(state)
     return {
-      currentQueueItem: getCurrentQueueItem(state),
+      currentQueueItem,
       currentUserId: getUserId(state),
       playCounter: getCounter(state),
       audio: getAudio(state),
       isPlaying: getPlaying(state),
       isBuffering: getBuffering(state),
       isCasting: getIsCasting(state),
-      castMethod: getCastMethod(state)
+      castMethod: getCastMethod(state),
+      averageRGBColor: currentQueueItem.track
+        ? getAverageColor(state, {
+            multihash:
+              currentQueueItem.track.cover_art_sizes ??
+              currentQueueItem.track.cover_art ??
+              ''
+          })
+        : null
     }
   }
   return mapStateToProps

--- a/src/containers/now-playing/NowPlaying.tsx
+++ b/src/containers/now-playing/NowPlaying.tsx
@@ -447,8 +447,7 @@ function makeMapStateToProps() {
         ? getAverageColor(state, {
             multihash:
               currentQueueItem.track.cover_art_sizes ??
-              currentQueueItem.track.cover_art ??
-              ''
+              currentQueueItem.track.cover_art
           })
         : null
     }

--- a/src/containers/now-playing/NowPlaying.tsx
+++ b/src/containers/now-playing/NowPlaying.tsx
@@ -66,7 +66,7 @@ import { useRecord, make } from 'store/analytics/actions'
 import { AudioState } from 'store/player/types'
 import { withNullGuard } from 'utils/withNullGuard'
 import CoSign, { Size } from 'components/co-sign/CoSign'
-import { getAverageColor } from 'store/application/ui/average-color/slice'
+import { getAverageColorByTrack } from 'store/application/ui/average-color/slice'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
@@ -443,13 +443,9 @@ function makeMapStateToProps() {
       isBuffering: getBuffering(state),
       isCasting: getIsCasting(state),
       castMethod: getCastMethod(state),
-      averageRGBColor: currentQueueItem.track
-        ? getAverageColor(state, {
-            multihash:
-              currentQueueItem.track.cover_art_sizes ??
-              currentQueueItem.track.cover_art
-          })
-        : null
+      averageRGBColor: getAverageColorByTrack(state, {
+        track: currentQueueItem.track
+      })
     }
   }
   return mapStateToProps

--- a/src/models/Track.ts
+++ b/src/models/Track.ts
@@ -1,4 +1,3 @@
-import Color from 'models/common/Color'
 import { CID, ID, UID } from 'models/common/Identifiers'
 import { CoverArtSizes } from 'models/common/ImageSizes'
 import Repost from 'models/Repost'
@@ -104,7 +103,6 @@ export type ComputedTrackProperties = {
   _cover_art_sizes: CoverArtSizes
   _first_segment?: string
   _followees?: Followee[]
-  _cover_art_color?: Color
   _marked_deleted?: boolean
   _is_publishing?: boolean
   _stems?: Stem[]

--- a/src/store/application/ui/average-color/slice.ts
+++ b/src/store/application/ui/average-color/slice.ts
@@ -1,0 +1,35 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import Color from 'models/common/Color'
+import { CID } from 'models/common/Identifiers'
+import { AppState } from 'store/types'
+
+const initialState: { colors: { [multihash: string]: Color } } = {
+  colors: {}
+}
+
+/**
+ * This slice tracks computed average colors for a given track art CID.
+ * Colors is a map of art cid -> Color
+ */
+const slice = createSlice({
+  name: 'application/ui/averageColor',
+  initialState,
+  reducers: {
+    setColor: (
+      state,
+      action: PayloadAction<{ multihash: string; color: Color }>
+    ) => {
+      const { multihash, color } = action.payload
+      state.colors[multihash] = color
+    }
+  }
+})
+
+export const { setColor } = slice.actions
+
+export const getAverageColor = (
+  state: AppState,
+  { multihash }: { multihash: CID }
+): Color | undefined => state.application.ui.averageColor.colors[multihash]
+
+export default slice.reducer

--- a/src/store/application/ui/average-color/slice.ts
+++ b/src/store/application/ui/average-color/slice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import Color from 'models/common/Color'
 import { CID } from 'models/common/Identifiers'
+import Track from 'models/Track'
 import { AppState } from 'store/types'
 import { Nullable } from 'utils/typeUtils'
 
@@ -33,5 +34,14 @@ export const getAverageColor = (
   { multihash }: { multihash: Nullable<CID> }
 ): Nullable<Color> =>
   (multihash && state.application.ui.averageColor.colors[multihash]) || null
+
+export const getAverageColorByTrack = (
+  state: AppState,
+  { track }: { track: Nullable<Track> }
+): Nullable<Color> => {
+  const multihash = track?.cover_art_sizes ?? track?.cover_art
+  if (!multihash) return null
+  return state.application.ui.averageColor.colors[multihash] ?? null
+}
 
 export default slice.reducer

--- a/src/store/application/ui/average-color/slice.ts
+++ b/src/store/application/ui/average-color/slice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import Color from 'models/common/Color'
 import { CID } from 'models/common/Identifiers'
 import { AppState } from 'store/types'
+import { Nullable } from 'utils/typeUtils'
 
 const initialState: { colors: { [multihash: string]: Color } } = {
   colors: {}
@@ -29,7 +30,8 @@ export const { setColor } = slice.actions
 
 export const getAverageColor = (
   state: AppState,
-  { multihash }: { multihash: CID }
-): Color | undefined => state.application.ui.averageColor.colors[multihash]
+  { multihash }: { multihash: Nullable<CID> }
+): Nullable<Color> =>
+  (multihash && state.application.ui.averageColor.colors[multihash]) || null
 
 export default slice.reducer

--- a/src/store/cache/tracks/sagas.js
+++ b/src/store/cache/tracks/sagas.js
@@ -37,6 +37,7 @@ import { Name } from 'services/analytics'
 import { getTrack } from 'store/cache/tracks/selectors'
 import { waitForValue } from 'utils/sagaHelpers'
 import { makeKindId } from 'utils/uid'
+import { setColor } from 'store/application/ui/average-color/slice'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
@@ -395,9 +396,10 @@ function* watchFetchCoverArt() {
 
       const rgb = yield call(averageRgb, url)
       yield put(
-        cacheActions.update(Kind.TRACKS, [
-          { id: trackId, metadata: { _cover_art_color: rgb } }
-        ])
+        setColor({
+          multihash,
+          color: rgb
+        })
       )
     } catch (e) {
       console.error(`Unable to fetch cover art for track ${trackId}`)

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -69,6 +69,7 @@ import mobileKeyboard from 'store/application/ui/mobileKeyboard/reducer'
 import userListModal from 'store/application/ui/userListModal/slice'
 import stemsUpload from 'store/application/ui/stemsUpload/slice'
 import appCTAModal from 'store/application/ui/app-cta-modal/slice'
+import averageColor from 'store/application/ui/average-color/slice'
 
 import wallet from 'store/wallet/slice'
 
@@ -136,7 +137,8 @@ const createRootReducer = routeHistory =>
         appCTAModal,
         musicConfetti,
         mobileUploadDrawer,
-        enablePushNotificationsDrawer
+        enablePushNotificationsDrawer,
+        averageColor
       }),
       pages: combineReducers({
         explore,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -63,6 +63,7 @@ import RemoteConfigReducer from 'containers/remote-config/slice'
 import StemsUploadReducer from 'store/application/ui/stemsUpload/slice'
 import AppCTAModalReducer from 'store/application/ui/app-cta-modal/slice'
 import ServiceSelectionReducer from 'containers/service-selection/store/slice'
+import averageColor from 'store/application/ui/average-color/slice'
 
 import wallet from 'store/wallet/slice'
 
@@ -117,6 +118,7 @@ export type AppState = {
       enablePushNotificationsDrawer: ReturnType<
         typeof EnablePushNotificationsDrawer
       >
+      averageColor: ReturnType<typeof averageColor>
     }
     pages: {
       explore: ExplorePageState


### PR DESCRIPTION
### Description

Switching between tracks with the same artwork would cause the dropshadow to do an ugly flicker (highly visible here: https://audius.co/mrcarmack/album/blu-ep-154) because when we load the new track, we haven't calculated the averageRGB yet, so we briefly display the placeholder while calculating the new one.

This fix pulls the averageRGB info out of the track model and into a new redux slice that maps the image CID -> averageRGB to allow us to reuse the average color info for tracks with the same artwork.

### Dragons

Nah


### How Has This Been Tested?

Tested on desktop + mobile browser

