### PR TITLE
Fix verification modal width

### DIFF
--- a/src/containers/settings-page/components/desktop/VerificationModal.module.css
+++ b/src/containers/settings-page/components/desktop/VerificationModal.module.css
@@ -4,6 +4,7 @@
 }
 
 .modalBodyStyle {
+  width: 736px;
   max-width: 736px;
 }
 


### PR DESCRIPTION
### Description
Fixes a set value to verification modal width. Weird behavior where this looks fine locally, but not on a built version of the dapp

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

