### PR TITLE
Close notification popup on user select

### DIFF
--- a/src/containers/browser-push-confirmation-modal/BrowserPushConfirmationModal.tsx
+++ b/src/containers/browser-push-confirmation-modal/BrowserPushConfirmationModal.tsx
@@ -60,7 +60,7 @@ const ConnectedBrowserPushConfirmationModal = ({
         if (permission === Permission.GRANTED) onClose()
       } else if (isSafariPushAvailable) {
         // NOTE: The request browser permission must be done directly
-        // b/c safari requires the user action to trigger the premission request
+        // b/c safari requires the user action to trigger the permission request
         if (permission === Permission.GRANTED) {
           subscribeBrowserPushNotifications()
         } else {
@@ -83,6 +83,7 @@ const ConnectedBrowserPushConfirmationModal = ({
         }
       }
     }
+    onClose()
     return () => {
       cancelled = true
     }


### PR DESCRIPTION
### Description
Closes AUD-66
On sign-in and sign-up the user is presented a popup modal the asks if they want to turn on browser notifications. 
If the user is in incognito mode or if they have previously declined notifications and click turn on notifications, nothing happens. The modal only closes if the browser permissions are changed or they close close. 

This PR closes the modal on user action even if it doesn't succeed. 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the dapp locally against staging and signed in on incognito and in normal browsing mode. I clicked enable notifications and expected it to always close. 
