### PR TITLE
Add content node block list

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -459,13 +459,36 @@ class AudiusBackend {
   }
 
   static async autoSelectCreatorNodes() {
+    let contentNodeBlockList = getRemoteVar(StringKeys.CONTENT_NODE_BLOCK_LIST)
+    if (contentNodeBlockList) {
+      try {
+        contentNodeBlockList = new Set(contentNodeBlockList.split(','))
+      } catch (e) {
+        console.error(e)
+        contentNodeBlockList = null
+      }
+    }
     return audiusLibs.ServiceProvider.autoSelectCreatorNodes(
-      /* numberOfNodes */ 3
+      /* numberOfNodes */ 3,
+      /* whitelist */ null,
+      /* blacklist */ contentNodeBlockList
     )
   }
 
   static async getSelectableCreatorNodes() {
-    return audiusLibs.ServiceProvider.getSelectableCreatorNodes()
+    let contentNodeBlockList = getRemoteVar(StringKeys.CONTENT_NODE_BLOCK_LIST)
+    if (contentNodeBlockList) {
+      try {
+        contentNodeBlockList = new Set(contentNodeBlockList.split(','))
+      } catch (e) {
+        console.error(e)
+        contentNodeBlockList = null
+      }
+    }
+    return audiusLibs.ServiceProvider.getSelectableCreatorNodes(
+      /* whitelist */ null,
+      /* blacklist */ contentNodeBlockList
+    )
   }
 
   static async getAccount(fromSource = false) {

--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -68,7 +68,12 @@ export enum StringKeys {
   /**
    * Blocks content
    */
-  CONTENT_BLOCK_LIST = 'CONTENT_BLOCK_LIST'
+  CONTENT_BLOCK_LIST = 'CONTENT_BLOCK_LIST',
+
+  /**
+   * Blocks content nodes from selection
+   */
+  CONTENT_NODE_BLOCK_LIST = 'CONTENT_NODE_BLOCK_LIST'
 }
 
 export type AllRemoteConfigKeys =

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -17,7 +17,8 @@ export const remoteConfigStringDefaults: {
   [StringKeys.AUDIUS_LOGO_VARIANT_CLICK_TARGET]: null,
   [StringKeys.APP_WIDE_NOTICE_TEXT]: null,
   [StringKeys.ETH_PROVIDER_URLS]: ETH_PROVIDER_URLS,
-  [StringKeys.CONTENT_BLOCK_LIST]: null
+  [StringKeys.CONTENT_BLOCK_LIST]: null,
+  [StringKeys.CONTENT_NODE_BLOCK_LIST]: null
 }
 export const remoteConfigDoubleDefaults: {
   [key in DoubleKeys]: number | null


### PR DESCRIPTION
### Description
Adds ability to use remote config to disallow clients from waiting for a particular content node to resolve. Discovery node needs more plumbing, unfortunately.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Nope

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Ran against prod, manually blocked https://content-gru02.audius.hashbeam.com and made sure everything worked
