### PR TITLE
[AUD-62] Fix unconfirmed reposted tracks not appearing on profile

### DIFF
--- a/src/containers/profile-page/store/lineups/feed/sagas.js
+++ b/src/containers/profile-page/store/lineups/feed/sagas.js
@@ -12,17 +12,31 @@ import {
 import { LineupSagas } from 'store/lineup/sagas'
 import { getUserId } from 'store/account/selectors'
 import { retrieveUserReposts } from './retrieveUserReposts'
+import { getTracks } from 'store/cache/tracks/selectors'
 
 function* getReposts({ offset, limit, payload }) {
   const handle = yield select(getProfileUserHandle)
+  const profileId = yield select(getProfileUserId)
   const currentUserId = yield select(getUserId)
-
   const reposts = yield call(retrieveUserReposts, {
     handle,
     currentUserId,
     offset,
     limit
   })
+
+  // If we're on our own profile, add any
+  // tracks that haven't confirmed yet
+  if (profileId === currentUserId) {
+    const repostIds = new Set(reposts.map(r => r.track_id).filter(Boolean))
+    const tracks = yield select(getTracks)
+    for (const track of Object.values(tracks)) {
+      if (track.has_current_user_reposted && !repostIds.has(track.track_id)) {
+        reposts.push(track)
+      }
+    }
+  }
+
   return reposts
 }
 


### PR DESCRIPTION
### Description

We weren't accounting for uncofirmed reposts on the profile page reposts lineup.

This is a linear scan that adds about 1ms to profile page load.
 
### Dragons

None

### How Has This Been Tested?

Tested locally

