### PR TITLE
Fix styling on public site footer links

### DIFF
--- a/src/components/public-site/Footer.module.css
+++ b/src/components/public-site/Footer.module.css
@@ -97,7 +97,6 @@
   font-family: Gilroy !important;
   font-size: var(--font-s);
   line-height: 24px;
-  margin-right: 48px;
   text-decoration-color: var(--static-neutral) !important;
 }
 
@@ -239,10 +238,12 @@
 
 .isMobile .siteLinksContainer {
   margin-bottom: 0px;
+  width: 100%;
 }
 
 .isMobile .siteLinksRowContainer {
   height: 32px;
+  max-width: 100%;
 }
 
 .isMobile .linksContainer {


### PR DESCRIPTION
### Description
Fix the footer, it was previously wrapping the text on `Hot & New`

Updated footer in desktop and mobile
![Screen Shot 2021-01-07 at 5 18 07 PM](https://user-images.githubusercontent.com/7064122/103951257-5441fc00-510c-11eb-8728-a78a1444fc47.png)
![Screen Shot 2021-01-07 at 5 17 57 PM](https://user-images.githubusercontent.com/7064122/103951259-54da9280-510c-11eb-9016-7bd4bf1d43ed.png)

Closes AUD-49


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the dapp with these changes
