### PR TITLE
[AUD-110] Fix Unfollow from Desktop User List

### DIFF
--- a/src/components/artist/ArtistPopover.tsx
+++ b/src/components/artist/ArtistPopover.tsx
@@ -18,6 +18,7 @@ import { FollowSource } from 'services/analytics'
 import { useUserCoverPhoto, useUserProfilePicture } from 'hooks/useImageSize'
 import { WidthSizes, SquareSizes } from 'models/common/ImageSizes'
 import { MountPlacement } from 'components/types'
+import { setNotificationSubscription } from 'containers/profile-page/store/actions'
 
 enum Placement {
   Top = 'top',
@@ -154,8 +155,10 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   goToRoute: (route: string) => dispatch(pushRoute(route)),
   onFollow: (userId: ID) =>
     dispatch(socialActions.followUser(userId, FollowSource.HOVER_TILE)),
-  onUnfollow: (userId: ID) =>
+  onUnfollow: (userId: ID) => {
     dispatch(socialActions.unfollowUser(userId, FollowSource.HOVER_TILE))
+    dispatch(setNotificationSubscription(userId, false, true))
+  }
 })
 
 ArtistPopover.defaultProps = {

--- a/src/components/general/FollowButton.js
+++ b/src/components/general/FollowButton.js
@@ -15,8 +15,7 @@ import styles from './FollowButton.module.css'
 const messages = {
   follow: 'FOLLOW',
   following: 'FOLLOWING',
-  unfollow: 'UNFOLLOW',
-  unfollowed: 'UNFOLLOWED'
+  unfollow: 'UNFOLLOW'
 }
 
 const FollowButton = props => {

--- a/src/components/general/FollowButton.js
+++ b/src/components/general/FollowButton.js
@@ -15,7 +15,8 @@ import styles from './FollowButton.module.css'
 const messages = {
   follow: 'FOLLOW',
   following: 'FOLLOWING',
-  unfollow: 'UNFOLLOW'
+  unfollow: 'UNFOLLOW',
+  unfollowed: 'UNFOLLOWED'
 }
 
 const FollowButton = props => {
@@ -63,7 +64,7 @@ const FollowButton = props => {
     text = messages.unfollow
   } else if (!props.following && isHoveringClicked) {
     icon = <IconUnfollow />
-    text = messages.unfollow
+    text = messages.unfollowed
   }
 
   if (!props.showIcon) icon = null

--- a/src/components/general/FollowButton.js
+++ b/src/components/general/FollowButton.js
@@ -63,8 +63,8 @@ const FollowButton = props => {
     icon = <IconUnfollow />
     text = messages.unfollow
   } else if (!props.following && isHoveringClicked) {
-    icon = <IconUnfollow />
-    text = messages.unfollowed
+    icon = <IconFollow />
+    text = messages.follow
   }
 
   if (!props.showIcon) icon = null

--- a/src/containers/user-list/UserList.tsx
+++ b/src/containers/user-list/UserList.tsx
@@ -15,6 +15,7 @@ import { getUsers } from 'store/cache/users/selectors'
 import User from 'models/User'
 import { isMobile } from 'utils/clientUtil'
 import { FollowSource } from 'services/analytics'
+import { setNotificationSubscription } from 'containers/profile-page/store/actions'
 
 type ConnectedUserListOwnProps = {
   // A tag uniquely identifying this particular instance of a UserList in the store.
@@ -103,11 +104,18 @@ function mapDispatchToProps(
   dispatch: Dispatch,
   ownProps: ConnectedUserListOwnProps
 ) {
+  const mobile = isMobile()
   return {
     onFollow: (userId: ID) =>
       dispatch(socialActions.followUser(userId, FollowSource.USER_LIST)),
-    onUnfollow: (userId: ID) =>
-      dispatch(unfollowConfirmationActions.setOpen(userId)),
+    onUnfollow: (userId: ID) => {
+      if (mobile) {
+        dispatch(unfollowConfirmationActions.setOpen(userId))
+      } else {
+        dispatch(socialActions.unfollowUser(userId, FollowSource.USER_LIST))
+        dispatch(setNotificationSubscription(userId, false, true))
+      }
+    },
     onClickArtistName: (handle: string) =>
       dispatch(pushRoute(profilePage(handle))),
     loadMore: () => dispatch(loadMore(ownProps.tag)),


### PR DESCRIPTION
### Description

- Changes follow button to immediately show 'follow' after unfollowing, as per discussion w product and design
- Fixes unfollow from userlist broken on desktop
- Looks like we were missing unsubscribe when unfollow on a few buttons, following the behavior on mobile here. Not 100% sure this is necessary?

### Dragons

None


### How Has This Been Tested?

Locally

