### PR TITLE
[AUD-126] Fix failure to update photos on repeated changes

### DIFF
--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -324,7 +324,7 @@ function* confirmUpdateProfile(userId, metadata) {
         // Store the update in local storage so it is correct upon reload
         yield setAudiusAccountUser(confirmedUser)
         // Update the cached user so it no longer contains image upload artifacts
-        // and contains updated profile picture sizes if any
+        // and contains updated profile picture / cover photo sizes if any
         const newMetadata = {
           updatedProfilePicture: null,
           updatedCoverPhoto: null

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -324,14 +324,23 @@ function* confirmUpdateProfile(userId, metadata) {
         // Store the update in local storage so it is correct upon reload
         yield setAudiusAccountUser(confirmedUser)
         // Update the cached user so it no longer contains image upload artifacts
+        // and contains updated profile picture sizes if any
+        const newMetadata = {
+          updatedProfilePicture: null,
+          updatedCoverPhoto: null
+        }
+        if (metadata.updatedCoverPhoto) {
+          newMetadata.cover_photo_sizes = confirmedUser.cover_photo_sizes
+        }
+        if (metadata.updatedProfilePicture) {
+          newMetadata.profile_picture_sizes =
+            confirmedUser.profile_picture_sizes
+        }
         yield put(
           cacheActions.update(Kind.USERS, [
             {
               id: confirmedUser.user_id,
-              metadata: {
-                updatedProfilePicture: null,
-                updatedCoverPhoto: null
-              }
+              metadata: newMetadata
             }
           ])
         )


### PR DESCRIPTION
### Description
Repeated updates to profile picture/cover photo end up erroneous because local state is not updated after the confirmer finishes.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

1. Repeated full steps in AUD-126 description
2. Repeated minimal repro steps in AUD-126 description
3. Verified that multiple attempts to modify profile picture before the first attempt has been confirmed works as intended (both displaying the latest update as well as actually writing the correct metadata for the most recent update)
