### PR TITLE
Fix tracklist missing prop on mobile history pg

### DIFF
--- a/src/containers/history-page/components/mobile/HistoryPage.tsx
+++ b/src/containers/history-page/components/mobile/HistoryPage.tsx
@@ -7,6 +7,7 @@ import NavContext, { LeftPreset } from 'containers/nav/store/context'
 import MobilePageContainer from 'components/general/MobilePageContainer'
 import { TrackItemAction } from 'components/track/mobile/TrackListItem'
 import { TRENDING_PAGE } from 'utils/route'
+import { LineupTrack } from 'models/Track'
 
 import styles from './HistoryPage.module.css'
 import Spin from 'antd/lib/spin'
@@ -24,7 +25,7 @@ export type HistoryPageProps = {
   title: string
   description: string
   userId: ID
-  entries: any
+  entries: LineupTrack[]
   playing: boolean
   isEmpty: boolean
   loading: boolean
@@ -54,14 +55,16 @@ const HistoryPage = ({
     setRight(null)
   }, [setLeft, setCenter, setRight])
 
-  const tracks = entries.map((track: any, index: number) => {
+  const tracks = entries.map((track: LineupTrack, index: number) => {
     const isActive = track.uid === currentQueueItem.uid
     return {
       isLoading: loading,
+      isReposted: track.has_current_user_reposted,
       isSaved: track.has_current_user_saved,
       isActive,
       isPlaying: isActive && playing,
       artistName: track.user.name,
+      artistHandle: track.user.handle,
       trackTitle: track.title,
       trackId: track.track_id,
       uid: track.uid,
@@ -70,7 +73,7 @@ const HistoryPage = ({
     }
   })
 
-  const onClickEmtpy = useCallback(() => {
+  const onClickEmpty = useCallback(() => {
     goToRoute(TRENDING_PAGE)
   }, [goToRoute])
 
@@ -87,23 +90,26 @@ const HistoryPage = ({
             type={ButtonType.SECONDARY}
             className={styles.btn}
             textClassName={styles.btnText}
-            onClick={onClickEmtpy}
+            onClick={onClickEmpty}
             text={messages.empty.cta}
           />
         </div>
       ) : (
         <div className={styles.trackListContainer}>
-          {loading && <Spin size='large' className={styles.spin} />}
-          <TrackList
-            containerClassName={styles.containerClassName}
-            tracks={tracks}
-            itemClassName={styles.itemClassNamew}
-            showDivider
-            showBorder
-            onSave={onToggleSave}
-            togglePlay={onTogglePlay}
-            trackItemAction={TrackItemAction.Overflow}
-          />
+          {loading ? (
+            <Spin size='large' className={styles.spin} />
+          ) : (
+            <TrackList
+              containerClassName={styles.containerClassName}
+              tracks={tracks}
+              itemClassName={styles.itemClassName}
+              showDivider
+              showBorder
+              onSave={onToggleSave}
+              togglePlay={onTogglePlay}
+              trackItemAction={TrackItemAction.Overflow}
+            />
+          )}
         </div>
       )}
     </MobilePageContainer>


### PR DESCRIPTION
### Description
Closes AUD-56
Bug: On the mobile listening history page, when you reposted a song, it would not show up as reposted. This was caused by a missing prop. 

Solution: add the isReposted prop!

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Ran the dapp locally against staging w/ the desktop browser set to mobile width. Then went to the mobile listening history page and reposted a track and checked that it was reposted and the option said unrepost after. 
