### PR TITLE
[AUD-26] Playlist fixes

### DIFF
--- a/src/components/create-playlist/CreatePlaylistModal.js
+++ b/src/components/create-playlist/CreatePlaylistModal.js
@@ -27,19 +27,22 @@ const CreatePlaylistModal = props => {
 
   const { visible, metadata, editMode } = props
 
-  // On modal open (similar to componentDidMount, but this component is mounted before being displayed)
+  // On receiving new, defined metadata, set the form fields
   useEffect(() => {
-    if (visible) {
+    if (metadata) {
       setFormFields(_ => ({
         artwork: {},
         ...schemas.newCollectionMetadata(metadata)
       }))
+    }
+  }, [metadata])
 
-      return () => {
-        if (!editMode) {
-          setFormFields(initialFormFields)
-        }
-        setErrors({})
+  // On becoming invisible, hide errors and reset form fields
+  useEffect(() => {
+    if (!visible) {
+      setErrors({})
+      if (!editMode) {
+        setFormFields(initialFormFields)
       }
     }
   }, [visible, metadata, editMode, setErrors])

--- a/src/containers/collection-page/CollectionPageProvider.tsx
+++ b/src/containers/collection-page/CollectionPageProvider.tsx
@@ -259,13 +259,11 @@ class CollectionPage extends Component<
 
   componentWillUnmount() {
     if (this.unlisten) this.unlisten()
-    // If we're on mobile, account for transition delay before
-    // resetting collection
-    if (this.props.isMobile) {
-      setTimeout(() => {
-        this.resetCollection()
-      }, 300)
-    } else {
+    // On mobile, because the transitioning-out collection page unmounts
+    // after the transitioning-in collection page mounts, we do not want to reset
+    // the collection in unmount. That would end up clearing the content AFTER
+    // new content is loaded.
+    if (!this.props.isMobile) {
       this.resetCollection()
     }
   }

--- a/src/containers/collection-page/CollectionPageProvider.tsx
+++ b/src/containers/collection-page/CollectionPageProvider.tsx
@@ -79,6 +79,7 @@ import {
 import { SmartCollection } from 'models/Collection'
 import DeletedPage from 'containers/deleted-page/DeletedPage'
 import { parseCollectionRoute } from 'utils/route/collectionRouteParser'
+import { getLocationPathname } from 'store/routing/selectors'
 
 type OwnProps = {
   type: CollectionsPageType
@@ -148,7 +149,7 @@ class CollectionPage extends Component<
       collection: { userUid, metadata, status, user },
       smartCollection,
       tracks,
-      location: { pathname },
+      pathname,
       fetchCollectionSucceeded
     } = this.props
 
@@ -230,16 +231,14 @@ class CollectionPage extends Component<
             ? albumPage(user!.handle, metadata.playlist_name, collectionId)
             : playlistPage(user!.handle, metadata.playlist_name, collectionId)
           this.props.replaceRoute(newPath)
-        } else if (
-          // Check that the collection name hasn't changed. If so, update url.
-          prevMetadata &&
-          metadata.playlist_name !== prevMetadata.playlist_name &&
-          title &&
-          newCollectionName !== title &&
-          collectionId === metadata.playlist_id
-        ) {
-          const newPath = pathname.replace(title, newCollectionName)
-          this.props.replaceRoute(newPath)
+        } else {
+          // Check that the playlist name hasn't changed. If so, update url.
+          if (collectionId === metadata.playlist_id && title) {
+            if (newCollectionName !== title) {
+              const newPath = pathname.replace(title, newCollectionName)
+              this.props.replaceRoute(newPath)
+            }
+          }
         }
       }
     }
@@ -791,7 +790,8 @@ function makeMapStateToProps() {
       userPlaylists: getAccountCollections(state, {}),
       currentQueueItem: getCurrentQueueItem(state),
       playing: getPlaying(state),
-      buffering: getBuffering(state)
+      buffering: getBuffering(state),
+      pathname: getLocationPathname(state)
     }
   }
   return mapStateToProps

--- a/src/containers/edit-playlist/mobile/EditPlaylistPage.tsx
+++ b/src/containers/edit-playlist/mobile/EditPlaylistPage.tsx
@@ -175,6 +175,11 @@ const EditPlaylistPage = g(
     }
 
     const onSave = useCallback(() => {
+      // Sanitize description field. Description is required to be present, but can be null
+      if (formFields.description === undefined) {
+        formFields.description = null
+      }
+
       if (metadata && formFields.playlist_id) {
         // Edit playlist
         if (hasReordered) {

--- a/src/containers/profile-page/components/desktop/ProfilePage.module.css
+++ b/src/containers/profile-page/components/desktop/ProfilePage.module.css
@@ -191,9 +191,6 @@
   width: 100%;
   margin-top: 4px;
   min-height: 500px;
-}
-
-.tiles {
   padding: 0px 16px;
 }
 

--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -122,11 +122,15 @@ function* createPlaylistAsync(action) {
     })
   )
   yield put(collectionActions.createPlaylistSucceeded())
+
+  const collectionIds = (user._collectionIds || [])
+    .filter(c => c.uid !== uid)
+    .concat(uid)
   yield put(
     cacheActions.update(Kind.USERS, [
       {
         id: userId,
-        metadata: { _collectionIds: (user._collectionIds || []).concat(uid) }
+        metadata: { _collectionIds: collectionIds }
       }
     ])
   )
@@ -153,15 +157,33 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
         } else {
           check = playlist => some([playlist], toConfirm)
         }
-        return yield call(pollPlaylist, playlistId, userId, check)
-      },
-      function* (confirmedPlaylist) {
+        const confirmedPlaylist = yield call(
+          pollPlaylist,
+          playlistId,
+          userId,
+          check
+        )
+
+        // Immediately after confirming the playlist,
+        // create a new playlist reference and mark the temporary one as moved.
+        // This will trigger the page to refresh, etc. with the new ID url.
+        // Even if there are other actions confirming for this particular
+        // playlist, those will just file in afterwards.
+
         const subscribedUid = makeUid(
           Kind.COLLECTIONS,
           confirmedPlaylist.playlist_id,
           'account'
         )
         const movedCollection = yield select(getCollection, { id: uid })
+
+        // The reformatted playlist is the combination of the results we get back
+        // from the confirmation, plus any writes that may be in the confirmer still.
+        const reformattedPlaylist = {
+          ...reformat(confirmedPlaylist),
+          ...movedCollection,
+          _temp: false
+        }
 
         // On playlist creation, copy over all fields from the temp collection
         // to retain optimistically set fields.
@@ -170,11 +192,7 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
             {
               id: confirmedPlaylist.playlist_id,
               uid: subscribedUid,
-              metadata: {
-                ...movedCollection,
-                ...reformat(confirmedPlaylist),
-                _temp: false
-              }
+              metadata: reformattedPlaylist
             }
           ])
         )
@@ -185,7 +203,7 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
               id: userId,
               metadata: {
                 _collectionIds: (user._collectionIds || [])
-                  .filter(cId => cId !== uid)
+                  .filter(cId => cId !== uid && confirmedPlaylist.playlist_id)
                   .concat(confirmedPlaylist.playlist_id)
               }
             }
@@ -199,9 +217,9 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
         yield put(accountActions.removeAccountPlaylist({ collectionId: uid }))
         yield put(
           accountActions.addAccountPlaylist({
-            id: confirmedPlaylist.playlist_id,
-            name: confirmedPlaylist.playlist_name,
-            isAlbum: confirmedPlaylist.is_album,
+            id: reformattedPlaylist.playlist_id,
+            name: reformattedPlaylist.playlist_name,
+            isAlbum: reformattedPlaylist.is_album,
             user: {
               id: user.user_id,
               handle: user.handle
@@ -214,7 +232,9 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
           status: 'success'
         })
         yield put(event)
+        return confirmedPlaylist
       },
+      function* () {},
       function* ({ error, timeout, message }) {
         const event = make(Name.PLAYLIST_COMPLETE_CREATE, {
           source,

--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -217,9 +217,11 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
         yield put(accountActions.removeAccountPlaylist({ collectionId: uid }))
         yield put(
           accountActions.addAccountPlaylist({
-            id: reformattedPlaylist.playlist_id,
+            id: confirmedPlaylist.playlist_id,
+            // Take playlist name from the "local" state because the user
+            // may have edited the name before we got the confirmed result back.
             name: reformattedPlaylist.playlist_name,
-            isAlbum: reformattedPlaylist.is_album,
+            isAlbum: confirmedPlaylist.is_album,
             user: {
               id: user.user_id,
               handle: user.handle


### PR DESCRIPTION
### Description
Fixes a few playlist issues & can be reviewed commit by commit, but they were all discovered trying to fix AUD-26.

AUD-26 has more description about the actual bug that the last commit fixes. The gist was that our confirmation process for playlists was kind of broken.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Touches playlist creation flow. Worth serious QA.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

On both desktop & mobile -- 
1. Created a playlist and waited for confirmation on the playlist page
2. Created a playlist from a track and waited for confirmation on the playlist page
3. Created a playlist, went to profile page and waited for confirmation
4. Created a playlist, edited the playlist, and waited for confirmation on the playlist page
5. Created a playlist, edited the playlist, and waited for confirmation on the profile page
