### PR TITLE
[AUD-118] Fix web3 race on mobile init

### DIFF
--- a/src/containers/sign-on/components/desktop/MetaMaskModal.js
+++ b/src/containers/sign-on/components/desktop/MetaMaskModal.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react'
 import cn from 'classnames'
 import PropTypes from 'prop-types'
-import { Utils } from '@audius/libs'
 import { Button, ButtonType } from '@audius/stems'
 import Tooltip from 'antd/lib/tooltip'
+import { Utils } from 'services/AudiusBackend'
 
 import styles from './MetaMaskModal.module.css'
+import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 
 const WEB3_NETWORK_ID = process.env.REACT_APP_WEB3_NETWORK_ID
 
@@ -31,6 +32,7 @@ class MetaMaskModal extends Component {
   componentDidMount() {
     const checkWeb3ConfigInterval = setInterval(async () => {
       try {
+        await waitForLibsInit()
         const configured = await Utils.configureWeb3(
           window.web3.currentProvider,
           WEB3_NETWORK_ID

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -70,7 +70,7 @@ export const waitForWeb3 = async () => {
 }
 
 let AudiusLibs = null
-let Utils = null
+export let Utils = null
 let SanityChecks = null
 
 let audiusLibs = null


### PR DESCRIPTION
### Description
Fixes race condition on window.Web3 on initial load.

The reason this was happening is because the metamask sign in component was importing Utils directly from libs. Utils, in turn, imports libs/src/Web3.js which checks to see if Web3 is provided by the window or whether requiring it is necessary. In order to do that check in libs/src/Web3.js, Web3 must be already present on the window object. Since Web3 itself is lazy loaded in the client, directly importing Utils from libs is not safe.

Doing so through AudiusBackend as done in this PR is though because the correct ordering enforced --
1. Web3 is lazy loaded
2. Libs is lazy loaded
3. Metamask can use libs utils

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

1. Created an account (bleh) using metamask
2. Verified that race condition for web3 doesn't occur on mobile local dev any longer
