### PR TITLE
[AUD-111] Prevent touch actions on nav and bottom bar

### DIFF
--- a/src/components/bottom-bar/BottomBar.module.css
+++ b/src/components/bottom-bar/BottomBar.module.css
@@ -15,4 +15,5 @@
   display: flex;
   align-items: center;
   justify-content: space-evenly;
+  touch-action: none;
 }

--- a/src/containers/nav/mobile/NavBar.module.css
+++ b/src/containers/nav/mobile/NavBar.module.css
@@ -12,6 +12,7 @@
   position: relative;
   min-width: var(--mobile-min-width);
   user-select: none;
+  touch-action: none;
 }
 
 .leftElement {


### PR DESCRIPTION
### Description
A bug exists where you can lose the ability to scroll on the edit playlist page.

Really what this boils down to is you creating a scroll focus on the nav/play bar and scrolling accidentally (which triggers inertial scrolling on the window/document). If you then try to immediately scroll the edit playlist page, since the window/document hasn't lost scroll focus, you continue to scroll it. The user then gets frustrated and scrolls much more aggressively which creates more inertia and it takes a while to regain scroll focus where you want it.

Touch action none is supported pretty widely and from my testing I believe this prevents the issue:
https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

iOS simulator
