### PR TITLE
[AUD-133] Fix instagram/twitter handles on profiles

### DIFF
--- a/src/containers/profile-page/ProfilePageProvider.tsx
+++ b/src/containers/profile-page/ProfilePageProvider.tsx
@@ -45,6 +45,7 @@ import {
 import { make, TrackEvent } from 'store/analytics/actions'
 import { Name, FollowSource, ShareSource } from 'services/analytics'
 import { parseUserRoute } from 'utils/route/userRouteParser'
+import { verifiedHandleWhitelist } from 'utils/handleWhitelist'
 
 const INITIAL_UPDATE_FIELDS = {
   updatedName: null,
@@ -704,11 +705,15 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     const twitterHandle = profile
       ? updatedTwitterHandle !== null
         ? updatedTwitterHandle
+        : profile.twitterVerified && !verifiedHandleWhitelist.has(handle)
+        ? profile.handle
         : profile.twitter_handle || ''
       : ''
     const instagramHandle = profile
       ? updatedInstagramHandle !== null
         ? updatedInstagramHandle
+        : profile.instagramVerified
+        ? profile.handle
         : profile.instagram_handle || ''
       : ''
     const website = profile

--- a/src/containers/profile-page/components/desktop/ProfileWrapping.js
+++ b/src/containers/profile-page/components/desktop/ProfileWrapping.js
@@ -22,7 +22,6 @@ import { formatCount, squashNewLines } from 'utils/formatUtil'
 
 import styles from './ProfilePage.module.css'
 import { ReactComponent as BadgeArtist } from 'assets/img/badgeArtist.svg'
-import { verifiedHandleWhitelist } from 'utils/handleWhitelist'
 
 const Tags = props => {
   const { tags, goToRoute } = props
@@ -170,11 +169,7 @@ const ProfileWrapping = props => {
         </div>
         <div className={styles.editField}>
           <SocialLinkInput
-            defaultValue={
-              props.verified
-                ? props.handle.replace('@', '')
-                : props.twitterHandle
-            }
+            defaultValue={props.twitterHandle}
             isDisabled={!!props.twitterVerified}
             className={styles.twitterInput}
             type={Type.TWITTER}
@@ -223,11 +218,7 @@ const ProfileWrapping = props => {
           {props.twitterHandle && (
             <SocialLink
               type={Type.TWITTER}
-              link={
-                props.verified && !verifiedHandleWhitelist.has(props.handle)
-                  ? props.handle.replace('@', '')
-                  : props.twitterHandle
-              }
+              link={props.twitterHandle}
               onClick={onClickTwitter}
             />
           )}

--- a/src/containers/profile-page/components/mobile/ProfileHeader.tsx
+++ b/src/containers/profile-page/components/mobile/ProfileHeader.tsx
@@ -32,7 +32,6 @@ import FollowButton from 'components/general/FollowButton'
 import GrowingCoverPhoto from './GrowingCoverPhoto'
 import UploadStub from './UploadStub'
 import SubscribeButton from 'components/general/SubscribeButton'
-import { verifiedHandleWhitelist } from 'utils/handleWhitelist'
 import { make, useRecord } from 'store/analytics/actions'
 import { Name } from 'services/analytics'
 import UploadButton from './UploadButton'
@@ -217,20 +216,17 @@ const ProfileHeader = ({
     )
     if (win) win.focus()
   }, [record, instagramHandle, handle])
+
   const onGoToTwitter = useCallback(() => {
-    const linkHandle =
-      verified && !verifiedHandleWhitelist.has(handle)
-        ? handle.replace('@', '')
-        : twitterHandle
     record(
       make(Name.PROFILE_PAGE_CLICK_TWITTER, {
-        handle: linkHandle,
+        handle: handle.replace('@', ''),
         twitterHandle
       })
     )
-    const win = window.open(`https://twitter.com/${linkHandle}`, '_blank')
+    const win = window.open(`https://twitter.com/${twitterHandle}`, '_blank')
     if (win) win.focus()
-  }, [record, verified, twitterHandle, handle])
+  }, [record, twitterHandle, handle])
 
   const onExternalLinkClick = useCallback(
     event => {

--- a/src/utils/handleWhitelist.ts
+++ b/src/utils/handleWhitelist.ts
@@ -1,9 +1,9 @@
-// These handles represent a list of accounts that are in a
+// These Audius handles represent a list of accounts that are in a
 // messed up state (they were able to change their handle) but oauth
 // with twitter, which ends up forcing them to show the wrong twitter
 // link on their profile.
 export const verifiedHandleWhitelist = new Set([
-  '@miquela',
-  '@JodyBreeze',
-  '@masego'
+  'miquela',
+  'JodyBreeze',
+  'masego'
 ])


### PR DESCRIPTION
### Description
Fixes instagram/twitter handles on profiles according to verif status

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Nope

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Visited these profile in prod context and made sure on both desktop & mobile the twitter/ig links are correct:
audius.co/miquela
audius.co/JodyBreeze
audius.co/masego
audius.co/rayjacobson
audius.co/riotmusic

Then, manually set AudiusBackend to tell us that my account was verified on both twitter & ig and made sure the links were right and i could not update my handles.
