### PR TITLE
Send theme change messages to native layer

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -145,6 +145,7 @@ import ConfirmerPreview from 'containers/confirmer-preview/ConfirmerPreview'
 import Notice from './notice/Notice'
 import SignOn from 'containers/sign-on/SignOn'
 import EnablePushNotificationsDrawer from './enable-push-notifications-drawer/EnablePushNotificationsDrawer'
+import { ThemeChangeMessage } from 'services/native-mobile-interface/theme'
 
 const MOBILE_BANNER_LOCAL_STORAGE_KEY = 'dismissMobileAppBanner'
 
@@ -287,9 +288,7 @@ class App extends Component {
       }
     }
 
-    if (this.props.theme === null) {
-      this.props.setTheme(getSystemTheme() || Theme.DEFAULT)
-    }
+    this.handleTheme()
   }
 
   componentDidUpdate(prevProps) {
@@ -344,6 +343,10 @@ class App extends Component {
     ) {
       this.props.setConnectivityFailure(this.props.firstLoadConnectivityFailure)
     }
+
+    if (prevProps.theme !== this.props.theme) {
+      this.handleTheme()
+    }
   }
 
   componentWillUnmount() {
@@ -354,6 +357,22 @@ class App extends Component {
     if (client === Client.ELECTRON) {
       this.ipc.removeAllListeners('updateDownloaded')
       this.ipc.removeAllListeners('updateAvailable')
+    }
+  }
+
+  handleTheme() {
+    // Set local theme
+    if (this.props.theme === null) {
+      this.props.setTheme(getSystemTheme() || Theme.DEFAULT)
+    }
+
+    // If we're on native mobile, dispatch
+    // a message to the native layer so it can properly
+    // set it's status bar color.
+    if (NATIVE_MOBILE) {
+      const theme = this.props.theme || Theme.DEFAULT
+      const themeMessage = new ThemeChangeMessage(theme)
+      themeMessage.send()
     }
   }
 

--- a/src/services/native-mobile-interface/theme.ts
+++ b/src/services/native-mobile-interface/theme.ts
@@ -1,0 +1,12 @@
+import Theme from 'models/Theme'
+import { NativeMobileMessage } from './helpers'
+import { MessageType } from './types'
+
+/**
+ * Notifies the Mobile Client that the theme has changed
+ */
+export class ThemeChangeMessage extends NativeMobileMessage {
+  constructor(theme: Theme) {
+    super(MessageType.THEME_CHANGE, { theme })
+  }
+}

--- a/src/services/native-mobile-interface/types.ts
+++ b/src/services/native-mobile-interface/types.ts
@@ -71,7 +71,10 @@ export enum MessageType {
   ANALYTICS_SCREEN = 'analytics-screen',
 
   // Logging
-  LOGGING = 'logging'
+  LOGGING = 'logging',
+
+  // Theme
+  THEME_CHANGE = 'theme-change'
 }
 
 export interface Message {

--- a/src/store/application/ui/theme/sagas.ts
+++ b/src/store/application/ui/theme/sagas.ts
@@ -7,6 +7,7 @@ import { SET_THEME, ThemeActions, setTheme as setThemeAction } from './actions'
 import Theme from 'models/Theme'
 import { PrefersColorSchemeMessage } from 'services/native-mobile-interface/android/theme'
 import { getIsIOS } from 'utils/browser'
+import { ThemeChangeMessage } from 'services/native-mobile-interface/theme'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
@@ -38,12 +39,15 @@ function* watchNativeTheme() {
 
 export function* watchSetTheme() {
   yield takeEvery(SET_THEME, function* (action: ThemeActions) {
-    setTheme(action.theme)
+    const { theme } = action
+    setTheme(theme)
+    const message = new ThemeChangeMessage(theme)
+    message.send()
 
     // If the user switches to auto, add a media query listener that
     // updates their theme setting again if the OS theme preference changes
     if (mql && mqlListener) mql.removeListener(mqlListener)
-    if (action.theme === Theme.AUTO && mql) {
+    if (theme === Theme.AUTO && mql) {
       const channel = eventChannel(emitter => {
         mqlListener = () => {
           emitter(setThemeAction(Theme.AUTO))
@@ -54,7 +58,7 @@ export function* watchSetTheme() {
       yield spawn(actionChannelDispatcher, channel)
     }
 
-    if (action.theme === Theme.AUTO && NATIVE_MOBILE && !getIsIOS()) {
+    if (theme === Theme.AUTO && NATIVE_MOBILE && !getIsIOS()) {
       yield spawn(watchNativeTheme)
     }
   })

--- a/src/store/application/ui/theme/sagas.ts
+++ b/src/store/application/ui/theme/sagas.ts
@@ -41,8 +41,10 @@ export function* watchSetTheme() {
   yield takeEvery(SET_THEME, function* (action: ThemeActions) {
     const { theme } = action
     setTheme(theme)
-    const message = new ThemeChangeMessage(theme)
-    message.send()
+    if (NATIVE_MOBILE) {
+      const message = new ThemeChangeMessage(theme)
+      message.send()
+    }
 
     // If the user switches to auto, add a media query listener that
     // updates their theme setting again if the OS theme preference changes


### PR DESCRIPTION
### Description

This & native layer code fixes two bugs:
- Manually setting the theme in the app wouldn't change the StatusBar color - so if your phone was in dark mode and you set the theme to light, your status bar is invisible. 
- Our react-native-webview package has an evil default where it manages the StatusBar color unless you tell it otherwise, and it has weird behavior (randomly changing the color to be white when it shouldn't be, etc). https://github.com/react-native-webview/react-native-webview/issues/735

### Dragons

Native change did update the Webview package. But seems fine.


### How Has This Been Tested?

On physical iOS device

