### PR TITLE
Prevent a route switch if already on login/signup

### DIFF
--- a/src/store/account/mobileSagas.ts
+++ b/src/store/account/mobileSagas.ts
@@ -11,6 +11,8 @@ export const ENTROPY_KEY = 'hedgehog-entropy-key'
 
 function* watchFetchAccountFailed() {
   yield takeEvery(accountActions.fetchAccountFailed.type, function* () {
+    // Do not push route if the user is already on the signup or signin page
+    // or else it will toggle the UI page.
     if (!doesMatchRoute(SIGN_IN_PAGE) && !doesMatchRoute(SIGN_UP_PAGE)) {
       yield put(pushRoute(SIGN_UP_PAGE))
     }

--- a/src/store/account/mobileSagas.ts
+++ b/src/store/account/mobileSagas.ts
@@ -1,7 +1,7 @@
 import { takeEvery, put } from 'redux-saga/effects'
 import * as accountActions from 'store/account/reducer'
 import { push as pushRoute } from 'connected-react-router'
-import { SIGN_UP_PAGE } from 'utils/route'
+import { SIGN_UP_PAGE, SIGN_IN_PAGE, doesMatchRoute } from 'utils/route'
 import { MessageType } from 'services/native-mobile-interface/types'
 import { setNeedsAccountRecovery } from './reducer'
 import { ReloadMessage } from 'services/native-mobile-interface/linking'
@@ -11,7 +11,9 @@ export const ENTROPY_KEY = 'hedgehog-entropy-key'
 
 function* watchFetchAccountFailed() {
   yield takeEvery(accountActions.fetchAccountFailed.type, function* () {
-    yield put(pushRoute(SIGN_UP_PAGE))
+    if (!doesMatchRoute(SIGN_IN_PAGE) && !doesMatchRoute(SIGN_UP_PAGE)) {
+      yield put(pushRoute(SIGN_UP_PAGE))
+    }
   })
 }
 


### PR DESCRIPTION
### Description
If you load in the signin page or the signup page and quickly switch to the signup page, it goes back to the signup page. 
This is because a saga re-routes to the signup page if fetch account fails.
The fix is to check if the user is already on either and not push route if the user is on signup or signin. 

Closes AUD-121

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
nope

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I loaded the signup page and quickly switched to the signin page and it didn't switch back. 
I loaded the signin page and it didn't switch to the signup page
