### PR TITLE
[AUD-129] Fix profile pic not loading

### DIFF
--- a/src/store/cache/users/sagas.js
+++ b/src/store/cache/users/sagas.js
@@ -149,7 +149,7 @@ const pruneBlobValues = user => {
   if (returned._cover_photo_sizes) {
     Object.keys(returned._cover_photo_sizes).forEach(size => {
       if (returned._cover_photo_sizes[size].startsWith('blob')) {
-        returned._cover_photo_sizes[size] = 'pokemon'
+        delete returned._cover_photo_sizes[size]
       }
     })
   }

--- a/src/store/cache/users/sagas.js
+++ b/src/store/cache/users/sagas.js
@@ -16,7 +16,7 @@ import { retrieve } from 'store/cache/sagas'
 import { DefaultSizes } from 'models/common/ImageSizes'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
 import { getAccountUser, getUserId } from 'store/account/selectors'
-import { reformat } from './utils'
+import { pruneBlobValues, reformat } from './utils'
 import {
   getAudiusAccountUser,
   setAudiusAccountUser
@@ -127,33 +127,6 @@ function* watchAdd() {
       )
     }
   })
-}
-
-/**
- * Prunes blob url values off of a user.
- * @param {User} user
- */
-const pruneBlobValues = user => {
-  const returned = {
-    ...user,
-    _profile_picture_sizes: { ...user._profile_picture_sizes },
-    _cover_photo_sizes: { ...user._cover_photo_sizes }
-  }
-  if (returned._profile_picture_sizes) {
-    Object.keys(returned._profile_picture_sizes).forEach(size => {
-      if (returned._profile_picture_sizes[size].startsWith('blob')) {
-        delete returned._profile_picture_sizes[size]
-      }
-    })
-  }
-  if (returned._cover_photo_sizes) {
-    Object.keys(returned._cover_photo_sizes).forEach(size => {
-      if (returned._cover_photo_sizes[size].startsWith('blob')) {
-        delete returned._cover_photo_sizes[size]
-      }
-    })
-  }
-  return returned
 }
 
 // For updates and adds, sync the account user to local storage.

--- a/src/store/cache/users/utils/index.ts
+++ b/src/store/cache/users/utils/index.ts
@@ -1,2 +1,3 @@
 export { reformat } from './reformat'
 export { processAndCacheUsers } from './processAndCacheUsers'
+export { pruneBlobValues } from './pruneBlobValues'

--- a/src/store/cache/users/utils/pruneBlobValues.ts
+++ b/src/store/cache/users/utils/pruneBlobValues.ts
@@ -1,0 +1,33 @@
+import { SquareSizes, WidthSizes } from 'models/common/ImageSizes'
+import User from 'models/User'
+
+/**
+ * Prunes blob url values off of a user.
+ * @param {User} user
+ */
+export const pruneBlobValues = (user: User) => {
+  const returned = {
+    ...user,
+    _profile_picture_sizes: { ...user._profile_picture_sizes },
+    _cover_photo_sizes: { ...user._cover_photo_sizes }
+  }
+  if (returned._profile_picture_sizes) {
+    ;(Object.keys(returned._profile_picture_sizes) as SquareSizes[]).forEach(
+      size => {
+        if (returned._profile_picture_sizes[size].startsWith('blob')) {
+          delete returned._profile_picture_sizes[size]
+        }
+      }
+    )
+  }
+  if (returned._cover_photo_sizes) {
+    ;(Object.keys(returned._cover_photo_sizes) as WidthSizes[]).forEach(
+      size => {
+        if (returned._cover_photo_sizes[size].startsWith('blob')) {
+          delete returned._cover_photo_sizes[size]
+        }
+      }
+    )
+  }
+  return returned
+}


### PR DESCRIPTION
### Description
Sometimes the user's profile pic does not load in the nav column. This is a race condition that is manifested by us caching _profilePictureSizes on the user object in local storage and that user not getting updated with a fresh image before the image is rendered by the useImageSize hook.

The reason it's bad to cache _profilePictureSizes in local storage is that our image references are sometimes blob references (e.g. blob:audius.co/xxx-yyy-zzz), a side effect of how fetchCID needs to work. These references are no longer valid on a new session, but there's a chance we could read the (outdated) local storage ones before having refetched.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Able to reproduce the bug by visiting my own profile repeatedly and delaying image fetch requests so the race condition manifests more easily (the image has to be pulled from the object in local storage *before* being fetched by the nav column component).
