### PR TITLE
Add spacing to desktop settings btn

### DIFF
--- a/src/containers/settings-page/components/desktop/SettingsPage.module.css
+++ b/src/containers/settings-page/components/desktop/SettingsPage.module.css
@@ -94,3 +94,7 @@
 .settingButtonText {
   font-size: var(--font-l) !important;
 }
+
+.cardButton {
+  margin-left: 16px;
+}

--- a/src/containers/settings-page/components/desktop/SettingsPage.tsx
+++ b/src/containers/settings-page/components/desktop/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import cn from 'classnames'
 import {
   Modal,
   Button,
@@ -201,7 +202,7 @@ class SettingsPage extends Component<SettingsPageProps, SettingsPageState> {
             >
               <Button
                 onClick={this.downloadDesktopApp}
-                className={styles.downloadButton}
+                className={cn(styles.cardButton, styles.downloadButton)}
                 textClassName={styles.settingButtonText}
                 type={ButtonType.COMMON_ALT}
                 text='Get App'
@@ -227,7 +228,7 @@ class SettingsPage extends Component<SettingsPageProps, SettingsPageState> {
             >
               <Button
                 onClick={this.showEmailToast}
-                className={styles.resetButton}
+                className={cn(styles.cardButton, styles.resetButton)}
                 textClassName={styles.settingButtonText}
                 iconClassName={styles.resetButtonIcon}
                 type={ButtonType.COMMON_ALT}
@@ -265,7 +266,7 @@ class SettingsPage extends Component<SettingsPageProps, SettingsPageState> {
           >
             <Button
               onClick={this.showNotificationSettings}
-              className={styles.resetButton}
+              className={cn(styles.cardButton, styles.resetButton)}
               textClassName={styles.settingButtonText}
               type={ButtonType.COMMON_ALT}
               text='Review'


### PR DESCRIPTION
### Description
Adds margin-left to the buttons on the desktop settings page 

![Screen Shot 2021-01-15 at 10 58 00 AM](https://user-images.githubusercontent.com/7064122/104749284-9f699980-5720-11eb-8db4-39d0d3ab38ee.png)

Closes AUD-136

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
no

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
ran it locally!