### PR TITLE
Remove optimizely trending bool

### DIFF
--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -28,12 +28,6 @@ export enum IntKeys {
 }
 
 export enum BooleanKeys {
-  /**
-   * If the optimized trending track ids endpoint should be used for badges
-   * else the trending tracks endpoint will be used
-   */
-  OPTIMIZED_TRENDING_BADGE_ENDPOINT = 'OPTIMIZED_TRENDING_BADGE_ENDPOINT',
-
   /*
    * Boolean to show instagram verification.
    */

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -26,6 +26,5 @@ export const remoteConfigDoubleDefaults: {
 export const remoteConfigBooleanDefaults: {
   [key in BooleanKeys]: boolean | null
 } = {
-  [BooleanKeys.OPTIMIZED_TRENDING_BADGE_ENDPOINT]: false,
   [BooleanKeys.DISPLAY_INSTAGRAM_VERIFICATION]: true
 }


### PR DESCRIPTION
### Description
Removes the optimizely boolean value `OPTIMIZED_TRENDING_BADGE_ENDPOINT`
We introduced this remote config value to wait for all discprovs to have a new endpoint before consuming it on the client.
The nodes running the current version of discprov 0.3.28 (check [dashboard](https://dashboard.audius.org/services/discovery-node) - 17/18 Discovery nodes) have this endpoint. 

Closes AUD-256

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?  
The remote config value was already flipped from false to true and the client was working as intended. 
This change removes the now, unused code path.
I ran the client against prod locally after the changes and still saw the trending badges
