### PR TITLE
Prevent pull to refresh if confirming

### DIFF
--- a/src/containers/profile-page/ProfilePageProvider.tsx
+++ b/src/containers/profile-page/ProfilePageProvider.tsx
@@ -4,7 +4,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom'
 import { push as pushRoute, replace } from 'connected-react-router'
 import moment from 'moment'
 import { UnregisterCallback } from 'history'
-import { AppState, Status } from 'store/types'
+import { AppState, Kind, Status } from 'store/types'
 import { Dispatch } from 'redux'
 import { Tabs, FollowType, TracksSortMode } from './store/types'
 import { ID, UID } from 'models/common/Identifiers'
@@ -46,6 +46,8 @@ import { make, TrackEvent } from 'store/analytics/actions'
 import { Name, FollowSource, ShareSource } from 'services/analytics'
 import { parseUserRoute } from 'utils/route/userRouteParser'
 import { verifiedHandleWhitelist } from 'utils/handleWhitelist'
+import { makeKindId } from 'utils/uid'
+import { getIsDone } from 'store/confirmer/selectors'
 
 const INITIAL_UPDATE_FIELDS = {
   updatedName: null,
@@ -828,6 +830,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     const mobileProps = {
       trackIsActive: !!currentQueueItem,
       onConfirmUnfollow: this.props.onConfirmUnfollow,
+      isUserConfirming: this.props.isUserConfirming,
       hasMadeEdit:
         updatedName !== null ||
         updatedBio !== null ||
@@ -889,7 +892,10 @@ function makeMapStateToProps() {
     currentQueueItem: getCurrentQueueItem(state),
     playing: getPlaying(state),
     buffering: getBuffering(state),
-    pathname: getLocationPathname(state)
+    pathname: getLocationPathname(state),
+    isUserConfirming: !getIsDone(state, {
+      uid: makeKindId(Kind.USERS, getAccountUser(state)?.user_id)
+    })
   })
   return mapStateToProps
 }

--- a/src/containers/profile-page/components/mobile/ProfilePage.tsx
+++ b/src/containers/profile-page/components/mobile/ProfilePage.tsx
@@ -76,6 +76,7 @@ export type ProfilePageProps = {
   onClickMobileOverflow: (userId: ID, overflowActions: OverflowAction[]) => void
   stats: Array<{ number: number; title: string; key: string }>
   trackIsActive: boolean
+  isUserConfirming: boolean
 
   profile: ProfileUser | null
   albums: Collection[] | null
@@ -188,6 +189,7 @@ const ProfilePage = g(
     playlists,
     artistTracks,
     userFeed,
+    isUserConfirming,
     getLineupProps,
     loadMoreArtistTracks,
     loadMoreUserFeed,
@@ -555,7 +557,7 @@ const ProfilePage = g(
             fetchContent={asyncRefresh}
             shouldPad={false}
             overImage
-            isDisabled={isEditing}
+            isDisabled={isEditing || isUserConfirming}
           >
             <ProfileHeader
               name={name}


### PR DESCRIPTION
### Description
On mobile, if the user edits their profile and pulls down to refresh, the old state is displayed. 
This change prevents the user from pulling to refresh if the user's profile is confirming. 

Closes AUD-213

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran this locally, ngroked and on my phone edited my profile, and made sure that I could not pull to refresh while it was confirming. 