### PR TITLE
Pulling property off undefined object throws error in creator node autoselect

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -452,7 +452,7 @@ class AudiusBackend {
   }
 
   static async autoSelectCreatorNodes() {
-    return audiusLibs.ServiceProvider.autoSelectCreatorNodes()
+    return audiusLibs.ServiceProvider.autoSelectCreatorNodes({})
   }
 
   static async getSelectableCreatorNodes() {


### PR DESCRIPTION
### Description
The autoselect function expects an object and since nothing is passed in, the function is trying to pull properties off undefined and it errors. This change just passes an empty object so the default properties get pulled off in the autoselect and fixes the error.

<img width="1680" alt="Upload_•_Audius" src="https://user-images.githubusercontent.com/295938/108437062-9174d000-721a-11eb-9a34-e477af075470.png">

This is only a problem in the old user metadata -> creator flow. New users created via libs don't face this issue because libs correctly passes in an object
### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Ran the client pointed against prod and verified replica set is assigned

<img width="1680" alt="Upload_•_Audius" src="https://user-images.githubusercontent.com/295938/108437093-a0f41900-721a-11eb-8353-19020008f3be.png">



