### PR TITLE
Fix tab slider

### DIFF
--- a/src/containers/settings-page/components/desktop/SettingsPage.tsx
+++ b/src/containers/settings-page/components/desktop/SettingsPage.tsx
@@ -179,6 +179,7 @@ class SettingsPage extends Component<SettingsPageProps, SettingsPageState> {
           options={options}
           selected={theme || Theme.DEFAULT}
           onSelectOption={option => toggleTheme(option)}
+          key={`tab-slider-${options.length}`}
         />
       </SettingsCard>
     )

--- a/src/containers/settings-page/components/mobile/SettingsPage.tsx
+++ b/src/containers/settings-page/components/mobile/SettingsPage.tsx
@@ -197,6 +197,7 @@ const SettingsPage = (props: SettingsPageProps) => {
         options={options}
         selected={theme || Theme.DEFAULT}
         onSelectOption={option => toggleTheme(option)}
+        key={`tab-slider-${options.length}`}
       />
     )
   }


### PR DESCRIPTION
### Description

Fixes tab slider crashes when:
- Matrix mode is set but gold is lost
- Gold tier is gained when on settings page

### Dragons

None


### How Has This Been Tested?

Locally

