### PR TITLE
[AUD-281] Fix drawer pos on safari

### DIFF
--- a/src/components/drawer/Drawer.module.css
+++ b/src/components/drawer/Drawer.module.css
@@ -27,10 +27,17 @@
   bottom: 0;
 }
 
-/* Fixes positioning on ios Safari */
+/*
+ * Fixes positioning on ios Safari due to the navigation
+ * bar that appears while scrolling up / down.
+ * When testing this, make sure to test Safari embedded inside Twitter.
+ */
 @supports (-webkit-overflow-scrolling: touch) {
   .drawer:not(.native).isOpen {
     top: calc(100vh - 100px);
+  }
+  .drawer:not(.native):not(.isOpen) {
+    top: calc(100vh + 100px);
   }
 }
 


### PR DESCRIPTION
### Description

Token info drawer shows when scrolling down on audius.co inside Twitter. 100px padding here fixes that. Could not repro the other half of the ticket, but lmk if you know what the repro is (i forgot).

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
n/a

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Ngrokked link via tweet
