### PR TITLE
Fix race condition in AudiusAPIClient

### DIFF
--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -870,13 +870,11 @@ class AudiusAPIClient {
       return response.json()
     } catch (e) {
       // Something went wrong with the request and we should wait for the libs
-      // initialization state
+      // initialization state if needed before retrying
       if (this.initializationState.type === 'manual') {
         await waitForLibsInit()
-        return this._getResponse(path, sanitizedParams, retry)
       }
-      // Something is just broken, propagate the error out
-      throw e
+      return this._getResponse(path, sanitizedParams, retry)
     }
   }
 


### PR DESCRIPTION
### Description

Bug:
- If we're in eager mode and a request fails, we would always wait for libs to init before doing the libs route. However, libs might have already initted in this time, causing us to never retry the request. 

### Dragons

None


### How Has This Been Tested?

Careful console logging of the control flow here, before and after the fix. I can get 500s now and the client still works as expected. 

