### PR TITLE
Hide recaptcha always with custom render

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -83,7 +83,15 @@
     <!-- end Google Analytics -->
 
     <!-- start reCAPTCHA -->
-    <!-- <script src="https://www.google.com/recaptcha/api.js?render=6LfVR-0ZAAAAADFcqNM1P1IafKwQwN0E_l-gxQ9q"></script> -->
+    <script>
+      onRecaptchaLoad = () => grecaptcha.render('recaptcha-hidden', {
+        'sitekey' : '6LfVR-0ZAAAAADFcqNM1P1IafKwQwN0E_l-gxQ9q',
+        'size': 'invisible',
+        'expired-callback': () => null,
+        'expired-callback': () => null
+      })
+    </script>
+    <script src="https://www.google.com/recaptcha/api.js?onload=onRecaptchaLoad&render=explicit"></script>
     <!-- end reCAPTCHA -->
 
     <!-- start Segment -->
@@ -156,5 +164,6 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
+    <div id="recaptcha-hidden" style='display: none;'></div>
   </body>
 </html>

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -40,7 +40,7 @@ const ETH_PROVIDER_URLS = process.env.REACT_APP_ETH_PROVIDER_URL.split(',')
 const COMSTOCK_URL = process.env.REACT_APP_COMSTOCK_URL
 const CLAIM_DISTRIBUTION_CONTRACT_ADDRESS =
   process.env.REACT_APP_CLAIM_DISTRIBUTION_CONTRACT_ADDRESS
-// const RECAPTCHA_SITE_KEY = process.env.REACT_APP_RECAPTCHA_SITE_KEY
+const RECAPTCHA_SITE_KEY = process.env.REACT_APP_RECAPTCHA_SITE_KEY
 
 const SEARCH_MAX_SAVED_RESULTS = 10
 const SEARCH_MAX_TOTAL_RESULTS = 50
@@ -366,7 +366,7 @@ class AudiusBackend {
           monitoringCallbacks.contentNode
         ),
         comstockConfig: AudiusLibs.configComstock(COMSTOCK_URL),
-        // captchaConfig: { siteKey: RECAPTCHA_SITE_KEY },
+        captchaConfig: { siteKey: RECAPTCHA_SITE_KEY },
         isServer: false
       })
       await audiusLibs.init()


### PR DESCRIPTION
### Description
High level of confidence that this will make the captcha error message never show.
I believe the outer div is where the text got added -- effectively it replaced the contents of the outer div in this screenshot:
<img width="1680" alt="Screen Shot 2021-03-10 at 3 34 40 PM" src="https://user-images.githubusercontent.com/2731362/110714196-f7b89700-81b7-11eb-9b43-2a5dcfc6b817.png">

<img width="1271" alt="Screen Shot 2021-03-10 at 3 52 15 PM" src="https://user-images.githubusercontent.com/2731362/110714610-980ebb80-81b8-11eb-8b9f-8f7e7e4dd555.png">

By choosing where to render recaptcha (inside of the ghost div, that should take care of things)

<img width="1644" alt="Screen Shot 2021-03-10 at 3 53 29 PM" src="https://user-images.githubusercontent.com/2731362/110714706-c55b6980-81b8-11eb-9c17-cc07b85281c5.png">


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

touches index.html 

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Against staging
