### PR TITLE
Bump to libs 1.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.17.tgz",
-      "integrity": "sha512-WfsmauPn6xPfmo7Q6M6lv9PaAYTyDQQCgx73m5hlfFcWk1wdzLkXKoCvtajgJENgSyeWtkOcLDCsNYh/3FAdzA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.18.tgz",
+      "integrity": "sha512-j7qjBY6ZY7/JZKbU0IjfBqN3wAQLFrdoQOIpQruqGZ79IdViM9Fb9iZCxjMeKxRuILDhE9OzBOtPlXuNMHAF3w==",
       "requires": {
         "@audius/hedgehog": "^1.0.8",
         "@ethersproject/solidity": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.8",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.1.17",
+    "@audius/libs": "1.1.18",
     "@audius/stems": "0.3.5",
     "@optimizely/optimizely-sdk": "^4.0.0",
     "@reduxjs/toolkit": "^1.3.2",


### PR DESCRIPTION
### Description
Update libs to 1.1.18. No user-facing changes, but includes multi wallet / collectibles libs support, URSM client changes, and updated listen method for content node use.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

