### PR TITLE
Fix twitter uuid

### DIFF
--- a/src/store/account/sagas.js
+++ b/src/store/account/sagas.js
@@ -282,11 +282,11 @@ export function* unsubscribeBrowserPushNotifcations() {
 }
 
 function* associateTwitterAccount(action) {
-  const { twitterId, profile } = action
+  const { uuid, profile } = action.payload
   try {
     const userId = yield select(getUserId)
     const handle = yield select(getUserHandle)
-    yield call(AudiusBackend.associateTwitterAccount, twitterId, userId, handle)
+    yield call(AudiusBackend.associateTwitterAccount, uuid, userId, handle)
 
     const account = yield select(getAccountUser)
     const { verified } = profile


### PR DESCRIPTION
### Description

I believe `twitterId` is not the name of the action value. It should be uuid. This must have changed with instagram auth.

See https://github.com/AudiusProject/audius-client/blob/ea04a6ef7dfd20156aa889280f2c932658890985/src/containers/settings-page/SettingsPageProvider.tsx#L243

Broken in this commit:
https://github.com/AudiusProject/audius-client-old/pull/1119

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.


