### PR TITLE
Remove visualizer component from app.js

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -81,7 +81,6 @@ import SomethingWrong from 'containers/something-wrong/SomethingWrong'
 import RequiresUpdate from 'containers/requires-update/RequiresUpdate'
 import PlayBarProvider from 'containers/play-bar/PlayBarProvider'
 import UploadType from 'containers/upload-page/components/uploadType'
-import Visualizer from 'containers/visualizer/Visualizer'
 import { Pages as SignOnPages } from 'containers/sign-on/store/types'
 import {
   incrementScrollCount as incrementScrollCountAction,
@@ -843,7 +842,6 @@ class App extends Component {
         {/* Non-mobile */}
         {!isMobileClient && <Konami />}
         {!isMobileClient && <ConfirmerPreview />}
-        {!isMobileClient && <Visualizer />}
         {!isMobileClient && <PinnedTrackConfirmation />}
 
         {/* Mobile-only */}


### PR DESCRIPTION
### Description
**This is just a speculative pull request and assumes that the visualizer isn't in use at the moment.** I was unable to figure out how to trigger it on web or mobile but noticed that it had a decent affect on our first boot time.

On my device (2.4 GHz 8-Core Intel Core i9) it added around ~400ms of parsing time. I also suspect but haven't proved that the webgl libs it uses might cause us to switch to the discrete GPU (where available) for web acceleration.

<img width="735" alt="visualizer-timing" src="https://user-images.githubusercontent.com/505986/112101711-365c4180-8bfb-11eb-9424-de4d75a36f14.png">


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
If we are still using the visualizer I can rework this to use react suspense or something similar and only load when triggered.

### How Has This Been Tested?
Tried triggering the visualizer / reading through the code to find where it was used. Removed the code paths and tested the app without finding any issues.
