### PR TITLE
[AUD-462] Throttle upload relays for collections

### DIFF
--- a/src/containers/upload-page/store/sagas.js
+++ b/src/containers/upload-page/store/sagas.js
@@ -45,6 +45,7 @@ import { trackNewRemixEvent } from 'store/cache/tracks/sagas'
 import { reportSuccessAndFailureEvents } from './utils/sagaHelpers'
 
 const MAX_CONCURRENT_UPLOADS = 4
+const MAX_CONCURRENT_REGISTRATIONS = 4
 const MAX_CONCURRENT_TRACK_SIZE_BYTES = 40 /* MB */ * 1024 * 1024
 const UPLOAD_TIMEOUT_MILLIS = 60 /* min */ * 60 /* sec */ * 1000 /* ms */
 
@@ -526,10 +527,43 @@ export function* handleUploads({
       console.debug(
         `Attempting to register tracks: ${JSON.stringify(sortedMetadata)}`
       )
-      // Send it off to get our trackIDs
-      const { trackIds, error } = yield AudiusBackend.registerUploadedTracks(
-        sortedMetadata
-      )
+
+      // Send the tracks off to chain to get our trackIDs
+      //
+      // We want to limit the number of concurrent requests to chain here, as tons and tons of
+      // tracks lead to a lot of metadata being colocated on the same block and discovery nodes
+      // can have a hard time keeping up. [see AUD-462]. So, chunk the registration into "rounds."
+      //
+      // Multi-track upload does not have the same issue because we write to chain immediately
+      // after each upload succeeds and those fire on a rolling window.
+      // Realistically, with a higher throughput system, this should be a non-issue.
+      let trackIds = []
+      let error = null
+      for (
+        let i = 0;
+        i < sortedMetadata.length;
+        i += MAX_CONCURRENT_REGISTRATIONS
+      ) {
+        const concurrentMetadata = sortedMetadata.slice(
+          i,
+          i + MAX_CONCURRENT_REGISTRATIONS
+        )
+        const {
+          trackIds: roundTrackIds,
+          error: roundHadError
+        } = yield AudiusBackend.registerUploadedTracks(concurrentMetadata)
+
+        // Any errors should break out
+        if (roundHadError) {
+          error = roundHadError
+          break
+        }
+
+        trackIds = trackIds.concat(roundTrackIds)
+        console.debug(
+          `Finished registering: ${roundTrackIds}, Registered so far: ${trackIds}`
+        )
+      }
 
       if (error) {
         console.error('Something went wrong registering tracks!')

--- a/src/containers/upload-page/store/sagas.js
+++ b/src/containers/upload-page/store/sagas.js
@@ -553,16 +553,17 @@ export function* handleUploads({
           error: roundHadError
         } = yield AudiusBackend.registerUploadedTracks(concurrentMetadata)
 
-        // Any errors should break out
-        if (roundHadError) {
-          error = roundHadError
-          break
-        }
-
         trackIds = trackIds.concat(roundTrackIds)
         console.debug(
           `Finished registering: ${roundTrackIds}, Registered so far: ${trackIds}`
         )
+
+        // Any errors should break out, but we need to record the associated tracks first
+        // so that we can delete the orphaned ones.
+        if (roundHadError) {
+          error = roundHadError
+          break
+        }
       }
 
       if (error) {


### PR DESCRIPTION
### Description
Throttles the maximum number of concurrent /relay requests on collection uploads.
<img width="434" alt="Screen Shot 2021-03-24 at 6 45 14 PM" src="https://user-images.githubusercontent.com/2731362/112407990-3aa85d80-8cd4-11eb-8526-d4a7bbbfd08f.png">

As it stands today (in the above screen shot) we wait until all uploads for a collection happen and then we spam the relay endpoint. For 200 concurrent tracks, we would send 200x concurrency leading to too many tracks in the same block and discovery struggles to index.

After this change, we bundle the relays & track posts into groups and collate any errors.
<img width="552" alt="Screen Shot 2021-03-24 at 7 05 52 PM" src="https://user-images.githubusercontent.com/2731362/112408054-53187800-8cd4-11eb-8677-0503de1a01b3.png">


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Touches core playlist/album upload flow

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Uploaded playlist of 28 tracks on staging
- Multi upload of 8 tracks (not collection -- should be unimpacted)
- Single track upload (not collection -- should be unimpacted)