### PR TITLE
Add more in playlist component to playlist tile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,9 +91,9 @@
       }
     },
     "@audius/stems": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.5.tgz",
-      "integrity": "sha512-5zArFwcRHKO5sKjPVwDZjk5sL9cMMuym3xn58LmdgjKSFYpyCifzR5BxWKmToDPP8QAHM0b9HZ7NaV3T1aYzIw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.6.tgz",
+      "integrity": "sha512-vMMzfHs9AGsMf911ssYsbZQFQb8aps6dAUVu3CFBT93lLuyxh2jsdIamEpYMXy4gaJ0rV4DpYAnuZRgMXvNZeA==",
       "requires": {
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",

--- a/src/components/track/desktop/ConnectedPlaylistTile.module.css
+++ b/src/components/track/desktop/ConnectedPlaylistTile.module.css
@@ -13,6 +13,10 @@
   opacity: 0.5;
 }
 
+.loading .tracksContainer {
+  padding-bottom: 24px;
+}
+
 .tracksContainer :global(.simplebar-scrollbar:before) {
   width: 6px;
 }

--- a/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -142,7 +142,8 @@ const ConnectedPlaylistTile = memo(
       followee_reposts: followeeReposts,
       followee_saves: followeeSaves,
       has_current_user_reposted: isReposted,
-      has_current_user_saved: isFavorited
+      has_current_user_saved: isFavorited,
+      track_count: trackCount
     } = getCollectionWithFallback(collection)
 
     const { name, handle, is_creator: isCreator } = getUserWithFallback(user)
@@ -497,6 +498,7 @@ const ConnectedPlaylistTile = memo(
         tileClassName={cn(styles.trackTile)}
         tracksContainerClassName={cn(styles.tracksContainer)}
         trackList={trackList}
+        trackCount={trackCount}
         isTrending={isTrending}
         showRankIcon={showRankIcon}
       />

--- a/src/components/track/desktop/PlaylistTile.module.css
+++ b/src/components/track/desktop/PlaylistTile.module.css
@@ -6,16 +6,46 @@
   border-radius: 8px;
   transition: all ease-in-out .18s;
 }
+
 .container.large, .container.medium {
   margin-bottom: 16px;
 }
+
 .container.small {
   margin-bottom: 8px;
 }
+
 .container:not(.disabled):hover {
   box-shadow: 0 1px 5px 1px var(--tile-shadow-1-alt), 0 1px 0 0 var(--tile-shadow-2), 0 2px 10px -2px var(--tile-shadow-3);
   transform: scale(1.005);
 }
+
 .container:not(.disabled):active {
   box-shadow: 0 0 1px 0 var(--tile-shadow-1), 0 2px 3px -2px var(--tile-shadow-3);
+}
+
+.moreTracks {
+  background: var(--white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--neutral-light-4);
+  font-size: 12px;
+  font-weight: 500;
+  height: 27px;
+  cursor: pointer;
+}
+
+.moreTracks:hover {
+  background: var(--neutral-light-9);
+}
+
+.moreArrow {
+  margin-left: 4px;
+  height: 16x;
+  width: 16px;
+}
+
+.moreArrow path {
+  fill: var(--neutral-light-4);
 }

--- a/src/components/track/desktop/PlaylistTile.tsx
+++ b/src/components/track/desktop/PlaylistTile.tsx
@@ -62,7 +62,7 @@ const PlaylistTile = memo(
     )
 
     const renderMoreTracks = useCallback(() => {
-      const hasMoreTracks = trackCount && trackCount > trackList.length
+      const hasMoreTracks = trackCount ? trackCount > trackList.length : null
       return (
         !isLoading &&
         hasMoreTracks && (

--- a/src/components/track/desktop/PlaylistTile.tsx
+++ b/src/components/track/desktop/PlaylistTile.tsx
@@ -62,7 +62,7 @@ const PlaylistTile = memo(
     )
 
     const renderMoreTracks = useCallback(() => {
-      const hasMoreTracks = trackCount ? trackCount > trackList.length : null
+      const hasMoreTracks = trackCount ? trackCount > trackList.length : false
       return (
         !isLoading &&
         hasMoreTracks && (

--- a/src/components/track/desktop/PlaylistTile.tsx
+++ b/src/components/track/desktop/PlaylistTile.tsx
@@ -64,6 +64,7 @@ const PlaylistTile = memo(
     const renderMoreTracks = useCallback(() => {
       const hasMoreTracks = trackCount && trackCount > trackList.length
       return (
+        !isLoading &&
         hasMoreTracks && (
           <div onClick={onClickTitle} className={styles.moreTracks}>
             {`${trackCount - trackList.length} More Tracks`}
@@ -71,7 +72,7 @@ const PlaylistTile = memo(
           </div>
         )
       )
-    }, [trackCount, trackList, onClickTitle])
+    }, [trackCount, trackList, onClickTitle, isLoading])
 
     return (
       <div

--- a/src/components/track/desktop/PlaylistTile.tsx
+++ b/src/components/track/desktop/PlaylistTile.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactChildren } from 'react'
+import React, { memo, ReactChildren, useCallback } from 'react'
 
 import TrackTile from './TrackTile'
 import cn from 'classnames'
@@ -8,6 +8,7 @@ import {
   DesktopPlaylistTileProps as PlaylistTileProps
 } from 'components/track/types'
 import styles from './PlaylistTile.module.css'
+import { IconArrow } from '@audius/stems'
 
 const DefaultTileContainer = ({ children }: { children: ReactChildren }) =>
   children
@@ -42,19 +43,35 @@ const PlaylistTile = memo(
     onClickShare,
     onTogglePlay,
     trackList,
+    trackCount,
     isTrending,
     showRankIcon,
     TileTrackContainer = DefaultTileContainer
   }: PlaylistTileProps) => {
-    const bar = (
-      <SimpleBar
-        className={cn(styles.playlistTracks, {
-          [tracksContainerClassName!]: !!tracksContainerClassName
-        })}
-      >
-        {trackList}
-      </SimpleBar>
+    const renderTracks = useCallback(
+      () => (
+        <SimpleBar
+          className={cn(styles.playlistTracks, {
+            [tracksContainerClassName!]: !!tracksContainerClassName
+          })}
+        >
+          {trackList}
+        </SimpleBar>
+      ),
+      [tracksContainerClassName, trackList]
     )
+
+    const renderMoreTracks = useCallback(() => {
+      const hasMoreTracks = trackCount && trackCount > trackList.length
+      return (
+        hasMoreTracks && (
+          <div onClick={onClickTitle} className={styles.moreTracks}>
+            {`${trackCount - trackList.length} More Tracks`}
+            <IconArrow className={styles.moreArrow} />
+          </div>
+        )
+      )
+    }, [trackCount, trackList, onClickTitle])
 
     return (
       <div
@@ -96,7 +113,8 @@ const PlaylistTile = memo(
             isTrending={isTrending}
           />
         </TileTrackContainer>
-        {bar}
+        {renderTracks()}
+        {renderMoreTracks()}
       </div>
     )
   }

--- a/src/components/track/helpers.ts
+++ b/src/components/track/helpers.ts
@@ -36,6 +36,7 @@ export const getCollectionWithFallback = (collection: Collection | null) => {
       repost_count: 0,
       save_count: 0,
       track_ids: [],
+      track_count: 0,
       followee_reposts: [],
       followee_saves: [],
       has_current_user_reposted: false,

--- a/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -233,7 +233,6 @@ const ConnectedPlaylistTile = memo(
       goToRoute(FAVORITING_USERS_ROUTE)
     }
 
-    console.log({ collection })
     return (
       <PlaylistTile
         uid={uid}
@@ -258,6 +257,7 @@ const ConnectedPlaylistTile = memo(
           0
         )}
         tracks={tracks}
+        trackCount={collection.track_count}
         size={size}
         repostCount={collection.repost_count}
         saveCount={collection.save_count}

--- a/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -233,6 +233,7 @@ const ConnectedPlaylistTile = memo(
       goToRoute(FAVORITING_USERS_ROUTE)
     }
 
+    console.log({ collection })
     return (
       <PlaylistTile
         uid={uid}

--- a/src/components/track/mobile/PlaylistTile.tsx
+++ b/src/components/track/mobile/PlaylistTile.tsx
@@ -60,6 +60,7 @@ type TrackListProps = {
   goToCollectionPage: (e: React.MouseEvent<HTMLElement>) => void
   isLoading?: boolean
   numLoadingSkeletonRows?: number
+  trackCount?: number
 }
 
 const TrackList = ({
@@ -67,7 +68,8 @@ const TrackList = ({
   activeTrackUid,
   goToCollectionPage,
   isLoading,
-  numLoadingSkeletonRows
+  numLoadingSkeletonRows,
+  trackCount
 }: TrackListProps) => {
   if (!tracks.length && isLoading && numLoadingSkeletonRows) {
     return (
@@ -89,11 +91,11 @@ const TrackList = ({
           track={track}
         />
       ))}
-      {tracks.length > 5 && (
+      {trackCount && trackCount > 5 && (
         <>
           <div className={styles.trackItemDivider}></div>
           <div className={cn(styles.trackItem, styles.trackItemMore)}>
-            {`+${tracks.length - DISPLAY_TRACK_COUNT} more tracks`}
+            {`+${trackCount - tracks.length} more tracks`}
           </div>
         </>
       )}
@@ -127,7 +129,8 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
     showSkeleton,
     numLoadingSkeletonRows,
     isTrending,
-    showRankIcon
+    showRankIcon,
+    trackCount
   } = props
   const [artworkLoaded, setArtworkLoaded] = useState(false)
   useEffect(() => {
@@ -247,6 +250,7 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
             tracks={props.tracks}
             isLoading={showSkeleton}
             numLoadingSkeletonRows={numLoadingSkeletonRows}
+            trackCount={trackCount}
           />
         }
         <div className={cn(fadeIn)}>

--- a/src/components/track/types.ts
+++ b/src/components/track/types.ts
@@ -275,7 +275,7 @@ export type DesktopPlaylistTileProps = {
   /** The list of tracks to be rendered under the tracktile  */
   trackList: ReactNode[]
 
-  /** The fll track count for the playlist (may include tracks not rendered) */
+  /** The full track count for the playlist (may include tracks not rendered) */
   trackCount: number
 
   /** The wrapper react compoenent for the track tile - can be used for drag and drop */

--- a/src/components/track/types.ts
+++ b/src/components/track/types.ts
@@ -73,6 +73,7 @@ export type PlaylistTileProps = TileProps & {
   activeTrackUid: UID | null
   saveCount: number
   tracks: LineupTrack[]
+  trackCount: number
   showArtworkIcon?: boolean
   showSkeleton?: boolean
   pauseTrack: () => void
@@ -273,6 +274,9 @@ export type DesktopPlaylistTileProps = {
 
   /** The list of tracks to be rendered under the tracktile  */
   trackList: ReactNode[]
+
+  /** The fll track count for the playlist (may include tracks not rendered) */
+  trackCount: number
 
   /** The wrapper react compoenent for the track tile - can be used for drag and drop */
   TileTrackContainer?: any

--- a/src/containers/collection-page/store/sagas.js
+++ b/src/containers/collection-page/store/sagas.js
@@ -13,10 +13,13 @@ function* watchFetchCollection() {
   yield takeLatest(collectionActions.FETCH_COLLECTION, function* (action) {
     const collectionId = action.id
 
-    const {
-      collections,
-      uids: collectionUids
-    } = yield call(retrieveCollections, null, [collectionId])
+    const { collections, uids: collectionUids } = yield call(
+      retrieveCollections,
+      null,
+      [collectionId],
+      false,
+      true
+    )
 
     if (Object.values(collections).length === 0) {
       yield put(collectionActions.fetchCollectionFailed())

--- a/src/containers/collection-page/store/sagas.js
+++ b/src/containers/collection-page/store/sagas.js
@@ -17,8 +17,8 @@ function* watchFetchCollection() {
       retrieveCollections,
       null,
       [collectionId],
-      false,
-      true
+      /* fetchTracks */ false,
+      /* requiresAllTracks */ true
     )
 
     if (Object.values(collections).length === 0) {

--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -64,7 +64,6 @@ import NavHeader from './NavHeader'
 import { make, useRecord } from 'store/analytics/actions'
 import { Name, CreatePlaylistSource } from 'services/analytics'
 import { Variant } from 'models/Collection'
-import { getClaimableBalance } from 'store/wallet/slice'
 import { getAverageColorByTrack } from 'store/application/ui/average-color/slice'
 import UserBadges from 'containers/user-badges/UserBadges'
 
@@ -92,7 +91,6 @@ const NavColumn = ({
   goToRoute,
   goToSignUp: routeToSignup,
   goToUpload,
-  pendingClaim,
   averageRGBColor
 }) => {
   const record = useRecord()
@@ -218,8 +216,6 @@ const NavColumn = ({
   const navLoaded =
     accountStatus === Status.SUCCESS || accountStatus === Status.ERROR
 
-  const isPendingClaim = pendingClaim && !pendingClaim.isZero()
-
   return (
     <nav id='navColumn' className={styles.navColumn}>
       {isElectron && <RouteNav />}
@@ -230,7 +226,6 @@ const NavColumn = ({
         toggleNotificationPanel={onClickToggleNotificationPanel}
         goToRoute={goToRoute}
         isElectron={isElectron}
-        pendingClaim={isPendingClaim}
       />
       <div className={cn(styles.navContent, { [styles.show]: navLoaded })}>
         <SimpleBar className={styles.scrollable}>
@@ -478,7 +473,6 @@ const makeMapStateToProps = () => {
       notificationPanelIsOpen: getNotificationPanelIsOpen(state),
       upload: state.upload,
       showCreatePlaylistModal: getIsOpen(state),
-      pendingClaim: getClaimableBalance(state),
       averageRGBColor: getAverageColorByTrack(state, {
         track: currentQueueItem.track
       })

--- a/src/models/Collection.ts
+++ b/src/models/Collection.ts
@@ -31,6 +31,7 @@ export type CollectionMetadata = {
     track_ids: Array<{ time: number; track: ID; uid?: UID }>
   }
   tracks?: UserTrackMetadata[]
+  track_count: number
   playlist_id: ID
   cover_art: CID | null
   playlist_name: string

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -46,7 +46,6 @@ const ETH_REGISTRY_ADDRESS = process.env.REACT_APP_ETH_REGISTRY_ADDRESS
 const ETH_TOKEN_ADDRESS = process.env.REACT_APP_ETH_TOKEN_ADDRESS
 const ETH_OWNER_WALLET = process.env.REACT_APP_ETH_OWNER_WALLET
 const ETH_PROVIDER_URLS = process.env.REACT_APP_ETH_PROVIDER_URL.split(',')
-const COMSTOCK_URL = process.env.REACT_APP_COMSTOCK_URL
 const CLAIM_DISTRIBUTION_CONTRACT_ADDRESS =
   process.env.REACT_APP_CLAIM_DISTRIBUTION_CONTRACT_ADDRESS
 const RECAPTCHA_SITE_KEY = process.env.REACT_APP_RECAPTCHA_SITE_KEY
@@ -386,7 +385,6 @@ class AudiusBackend {
           contentNodeBlockList,
           monitoringCallbacks.contentNode
         ),
-        comstockConfig: AudiusLibs.configComstock(COMSTOCK_URL),
         // Electron cannot use captcha until it serves its assets from
         // a "domain" (e.g. localhost) rather than the file system itself.
         // i.e. there is no way to instruct captcha that the domain is "file://"

--- a/src/services/audius-api-client/ResponseAdapter.ts
+++ b/src/services/audius-api-client/ResponseAdapter.ts
@@ -220,6 +220,7 @@ export const makePlaylist = (
   const repost_count = 'repost_count' in playlist ? playlist.repost_count : 0
   const total_play_count =
     'total_play_count' in playlist ? playlist.total_play_count : 0
+  const track_count = 'track_count' in playlist ? playlist.track_count : 0
 
   const playlistContents = {
     track_ids: playlist.added_timestamps
@@ -256,6 +257,7 @@ export const makePlaylist = (
     has_current_user_saved,
     save_count,
     repost_count,
+    track_count,
     total_play_count,
     playlist_contents: playlistContents,
 

--- a/src/services/audius-api-client/types.ts
+++ b/src/services/audius-api-client/types.ts
@@ -165,6 +165,7 @@ export type APIPlaylist = {
   is_private: boolean
   added_timestamps: APIPlaylistAddedTimestamp[]
   tracks: APITrack[]
+  track_count: number
   cover_art: Nullable<string>
   cover_art_sies: Nullable<string>
 }

--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -93,7 +93,13 @@ export enum StringKeys {
   /**
    * Instagram Profile API url. Must contain $USERNAME$
    */
-  INSTAGRAM_API_PROFILE_URL = 'INSTAGRAM_API_PROFILE_URL'
+  INSTAGRAM_API_PROFILE_URL = 'INSTAGRAM_API_PROFILE_URL',
+
+  /**
+   * User ids omitted from trending playlists (used to omit Audius from rewards).
+   * Comma-separated.
+   */
+  TRENDING_PLAYLIST_OMITTED_USER_IDS = 'TRENDING_PLAYLIST_OMITTED_USER_IDS'
 }
 
 export type AllRemoteConfigKeys =

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -23,7 +23,9 @@ export const remoteConfigStringDefaults: {
   [StringKeys.CONTENT_NODE_BLOCK_LIST]: null,
   [StringKeys.DISCOVERY_NODE_BLOCK_LIST]: null,
   [StringKeys.INSTAGRAM_API_PROFILE_URL]:
-    'https://instagram.com/$USERNAME$/?__a=1'
+    'https://instagram.com/$USERNAME$/?__a=1',
+  // Audius user id
+  [StringKeys.TRENDING_PLAYLIST_OMITTED_USER_IDS]: '51'
 }
 export const remoteConfigDoubleDefaults: {
   [key in DoubleKeys]: number | null

--- a/src/store/cache/collections/utils/retrieveCollections.ts
+++ b/src/store/cache/collections/utils/retrieveCollections.ts
@@ -91,6 +91,15 @@ function* retrieveCollection(playlistId: ID) {
   return playlists
 }
 
+/**
+ * Retrieves collections from the cache or from source
+ * @param userId optional owner of collections to fetch (TODO: to be removed)
+ * @param collectionIds ids to retrieve
+ * @param fetchTracks whether or not to fetch the tracks inside the playlist
+ * @param requiresAllTracks whether or not fetching this collection requires it to havhe all its tracks.
+ * In the case where a collection is already cached with partial tracks, use this flag to refetch from source.
+ * @returns
+ */
 export function* retrieveCollections(
   userId: ID | null,
   collectionIds: ID[],
@@ -107,8 +116,9 @@ export function* retrieveCollections(
         const keys = Object.keys(res) as any
         keys.forEach((collectionId: number) => {
           const fullTrackCount = res[collectionId].track_count
-          const currentTrackCount = res[collectionId]?.tracks?.length ?? 0
-          if (fullTrackCount > currentTrackCount) {
+          const currentTrackCount = res[collectionId].tracks?.length ?? 0
+          if (currentTrackCount < fullTrackCount) {
+            // Remove the collection from the res so retrieve knows to get it from source
             delete res[collectionId]
           }
         })

--- a/src/store/cache/collections/utils/retrieveCollections.ts
+++ b/src/store/cache/collections/utils/retrieveCollections.ts
@@ -96,7 +96,7 @@ function* retrieveCollection(playlistId: ID) {
  * @param userId optional owner of collections to fetch (TODO: to be removed)
  * @param collectionIds ids to retrieve
  * @param fetchTracks whether or not to fetch the tracks inside the playlist
- * @param requiresAllTracks whether or not fetching this collection requires it to havhe all its tracks.
+ * @param requiresAllTracks whether or not fetching this collection requires it to have all its tracks.
  * In the case where a collection is already cached with partial tracks, use this flag to refetch from source.
  * @returns
  */

--- a/src/store/wallet/sagas.ts
+++ b/src/store/wallet/sagas.ts
@@ -119,8 +119,8 @@ function* claimAsync() {
   }
 }
 
-function* getWalletBalanceAndClaim() {
-  yield all([put(getClaim()), put(getBalance())])
+function* getWalletBalance() {
+  yield put(getBalance())
 }
 
 function* fetchBalanceAsync() {
@@ -159,7 +159,7 @@ function* watchGetClaims() {
 function* watchFetchAccountSucceeded() {
   try {
     yield all([take(fetchAccountSucceeded.type), take(SETUP_BACKEND_SUCCEEDED)])
-    yield getWalletBalanceAndClaim()
+    yield getWalletBalance()
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
### Description
- Add a button for navigating to the additional tracks in a playlist that aren't displayed on the playlist tile
- Make sure that when navigating to a collection page from a collection tile that if we have fetched partial tracks, we go refetch them all
- Remove some dead claim code (reduces startup work + comstock request)
- Add optimizely var for omitting playlists from a certain user id

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally against staging on top of piazz-rewards
* Trending playlist -> playlist page shows all tracks
* Mobile trending playlist page -> playlist page shows all tracks

Unrelated I think, but i noticed a bug where if you navigate from trending playlist to a playlist and then click back, an exception is thrown. Let me know if you already have any thoughts on that
