### PR TITLE
Ability to skip rolloverNodes sanity check with a config

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -311,9 +311,9 @@ class AudiusBackend {
     })
   }
 
-  static async sanityChecks(audiusLibs) {
+  static async sanityChecks(audiusLibs, options) {
     try {
-      const sanityChecks = new SanityChecks(audiusLibs)
+      const sanityChecks = new SanityChecks(audiusLibs, options)
       await sanityChecks.run()
     } catch (e) {
       console.error(`Sanity checks failed: ${e}`)

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -16,6 +16,7 @@ import {
   IntKeys,
   getRemoteVar,
   StringKeys,
+  BooleanKeys,
   FeatureFlags
 } from 'services/remote-config'
 import {
@@ -399,7 +400,10 @@ class AudiusBackend {
       const event = new CustomEvent(LIBS_INITTED_EVENT)
       window.dispatchEvent(event)
 
-      AudiusBackend.sanityChecks(audiusLibs)
+      const sanityCheckOptions = {
+        skipRollover: getRemoteVar(BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK)
+      }
+      AudiusBackend.sanityChecks(audiusLibs, sanityCheckOptions)
     } catch (err) {
       libsError = err.message
     }

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -311,9 +311,12 @@ class AudiusBackend {
     })
   }
 
-  static async sanityChecks(audiusLibs, options) {
+  static async sanityChecks(audiusLibs) {
     try {
-      const sanityChecks = new SanityChecks(audiusLibs, options)
+      const sanityCheckOptions = {
+        skipRollover: getRemoteVar(BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK)
+      }
+      const sanityChecks = new SanityChecks(audiusLibs, sanityCheckOptions)
       await sanityChecks.run()
     } catch (e) {
       console.error(`Sanity checks failed: ${e}`)
@@ -400,10 +403,7 @@ class AudiusBackend {
       const event = new CustomEvent(LIBS_INITTED_EVENT)
       window.dispatchEvent(event)
 
-      const sanityCheckOptions = {
-        skipRollover: getRemoteVar(BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK)
-      }
-      AudiusBackend.sanityChecks(audiusLibs, sanityCheckOptions)
+      AudiusBackend.sanityChecks(audiusLibs)
     } catch (err) {
       libsError = err.message
     }

--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -47,7 +47,12 @@ export enum BooleanKeys {
   /*
    * Boolean to show instagram verification on web + desktop.
    */
-  DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP = 'DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP'
+  DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP = 'DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP',
+
+  /**
+   * Boolean to skip the rollover nodes sanity check.
+   */
+  SKIP_ROLLOVER_NODES_SANITY_CHECK = 'SKIP_ROLLOVER_NODES_SANITY_CHECK'
 }
 
 export enum DoubleKeys {}

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -38,5 +38,6 @@ export const remoteConfigBooleanDefaults: {
   [key in BooleanKeys]: boolean | null
 } = {
   [BooleanKeys.DISPLAY_INSTAGRAM_VERIFICATION]: true,
-  [BooleanKeys.DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP]: true
+  [BooleanKeys.DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP]: true,
+  [BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK]: false
 }


### PR DESCRIPTION
### Description
Ability to turn the rolloverNode sanity check off with a config flag. The libs side of this PR is here https://github.com/AudiusProject/audius-protocol/pull/1355

### Dragons
Shouldn't be any.


### How Has This Been Tested?
Testing and pics here https://github.com/AudiusProject/audius-protocol/pull/1355
