### PR TITLE
Bump libs to v1.1.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
       }
     },
     "@audius/libs": {
-      "version": "1.1.20",
+      "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.20.tgz",
       "integrity": "sha512-yDjo0LnN6DOotSoEA4RKW3cPGuxXbL3rfT2OLufrARWgW9veWDQSqx+FDJ8loZ8f+IZ/NMGb7xFjbawW/QsKzA==",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.9",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.1.20",
+    "@audius/libs": "1.1.21",
     "@audius/stems": "0.3.7",
     "@optimizely/optimizely-sdk": "^4.0.0",
     "@reduxjs/toolkit": "^1.3.2",


### PR DESCRIPTION
### Description
Bump libs in v1.1.21

### Dragons
Shouldn't be any

### How Has This Been Tested?
Each commit in libs has been tested against client pointed to stage/prod