### PR TITLE
Fix limited lineup end point calculation

### DIFF
--- a/src/store/lineup/reducer.js
+++ b/src/store/lineup/reducer.js
@@ -71,12 +71,15 @@ export const actionsMap = {
 
     // Hack alert:
     // For lineups with max entries (such as trending playlists) and deleted content,
-    // manually set hasMore
-    if (
-      newState.maxEntries !== null &&
-      newState.entries.length + action.entries.length + action.deleted >=
-        newState.maxEntries
-    ) {
+    // manually set hasMore.
+    //
+    // Total entries is existing entries + deleted from both lineup & action
+    const totalEntries =
+      newState.entries.length +
+      action.entries.length +
+      newState.deleted +
+      action.deleted
+    if (newState.maxEntries !== null && totalEntries >= newState.maxEntries) {
       newState.hasMore = false
     }
 


### PR DESCRIPTION
### Description
We forgot to deal with newState.deleted. This fixes infinite loading for playlist trending on mobile. Mobile would fetch a smaller page size (2) and get stuck before hitting our conditional.

### Dragons

Nah


### How Has This Been Tested?

Tested mobile + desktop, 27 results each

