### PR TITLE
Fix ellipsis on mobile track title

### DIFF
--- a/src/components/track/mobile/TrackTile.module.css
+++ b/src/components/track/mobile/TrackTile.module.css
@@ -162,6 +162,7 @@
   min-height: 20px;
   align-items: center;
   position: relative;
+  width: 100%;
 }
 
 .title:active {


### PR DESCRIPTION
### Description
Fix mobile track tile to have ellipsis in title

![Screen Shot 2021-04-05 at 11 52 00 AM](https://user-images.githubusercontent.com/7064122/113594586-e53e4b80-9605-11eb-9805-6d3eb765ea85.png)

Fixes AUD-431

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
ran locally in browser mobile view
