### PR TITLE
Add correct playlist id from temp

### DIFF
--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -182,6 +182,7 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
         const reformattedPlaylist = {
           ...reformat(confirmedPlaylist),
           ...movedCollection,
+          playlist_id: confirmedPlaylist.playlist_id,
           _temp: false
         }
 


### PR DESCRIPTION
### Description
On temp playlist creation and confirmation, the wrong playlist id is added to the confirmed new playlist and prevents playlist  editing.

Fixes AUD-370

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
ran locally
