### PR TITLE
Fix repeat and shuffle

### DIFF
--- a/src/services/native-mobile-interface/queue.ts
+++ b/src/services/native-mobile-interface/queue.ts
@@ -17,13 +17,31 @@ type TrackInfo = {
 export type Tracks = TrackInfo[]
 
 export class PersistQueueMessage extends NativeMobileMessage {
-  constructor(tracks: Tracks, index: number) {
-    super(MessageType.PERSIST_QUEUE, { tracks, index })
+  constructor(
+    tracks: Tracks,
+    index: number,
+    shuffle: boolean,
+    shuffleIndex: number,
+    shuffleOrder: number[]
+  ) {
+    super(MessageType.PERSIST_QUEUE, {
+      tracks,
+      index,
+      shuffle,
+      shuffleIndex,
+      shuffleOrder
+    })
   }
 }
 
 export class RepeatModeMessage extends NativeMobileMessage {
   constructor(repeatMode: RepeatMode) {
     super(MessageType.SET_REPEAT_MODE, { repeatMode })
+  }
+}
+
+export class ShuffleMessage extends NativeMobileMessage {
+  constructor(shuffle: boolean, shuffleIndex: number, shuffleOrder: number[]) {
+    super(MessageType.SHUFFLE, { shuffle, shuffleIndex, shuffleOrder })
   }
 }

--- a/src/services/native-mobile-interface/types.ts
+++ b/src/services/native-mobile-interface/types.ts
@@ -7,6 +7,7 @@ export enum MessageType {
   SET_INFO = 'set-info',
   PERSIST_QUEUE = 'persist-queue',
   SET_REPEAT_MODE = 'set-repeat-mode',
+  SHUFFLE = 'shuffle',
 
   // Linking
   OPEN_LINK = 'open-link',


### PR DESCRIPTION
### Description
On native mobile shuffle and repeat were broken 🙃 
This should fix both. 
* Shuffle was never implemented
* Repeat broken when we switched to using redux toolkit and forgot to destruct the action's content from the new `payload` body of the action vs getting the value directly 

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Yes, this is dangerous as it touched playing on native mobile. 
Please take some time to play around and test it 🙏 

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran the client locally against a simulator and tested w/ a playlist to ensure it was shuffling and repeating correctly. 
