### PR TITLE
Fix playlist reorder breaking

### DIFF
--- a/src/containers/collection-page/CollectionPageProvider.tsx
+++ b/src/containers/collection-page/CollectionPageProvider.tsx
@@ -176,11 +176,12 @@ class CollectionPage extends Component<
     // update (initialOrder should contain ALL of the uids, so it suffices to check the first one).
     const newInitialOrder = tracks.entries.map(track => track.uid)
     const noInitialOrder = !initialOrder && tracks.entries.length > 0
+    const entryIds = new Set(newInitialOrder)
     const newUids =
       Array.isArray(initialOrder) &&
       initialOrder.length > 0 &&
       newInitialOrder.length > 0 &&
-      !newInitialOrder.includes(initialOrder[0])
+      !initialOrder.every(id => entryIds.has(id))
 
     if (noInitialOrder || newUids) {
       this.setState({


### PR DESCRIPTION
### Description
Fix playlist reorder
The playlist reordering was breaking because if the lineup was reloaded ie. on adding a new track, the uid of the track might be different. Then, if you attempted to re-order the tracks, it would then differ from the internal state of uids for reordering for the tracks and error on line 524 here https://github.com/AudiusProject/audius-client/blob/3fdc376d4aacc8fdeb6223503e05b587599b13e3/src/containers/collection-page/CollectionPageProvider.tsx#L516-L526 

The fix is to update the component's order uid ordering to reflect changes in the lineup track entry uids

Fixes AUD-468

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
I ran it locally and tried to reproduce the eror. 
