### PR TITLE
Fix associated wallet override

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -34,6 +34,7 @@ import {
 } from './remote-config/Provider'
 import { monitoringCallbacks } from './serviceMonitoring'
 import { isElectron } from 'utils/clientUtil'
+import { getCreatorNodeIPFSGateways } from 'utils/gatewayUtil'
 
 export const IDENTITY_SERVICE = process.env.REACT_APP_IDENTITY_SERVICE
 export const USER_NODE = process.env.REACT_APP_USER_NODE
@@ -936,8 +937,31 @@ class AudiusBackend {
     }
   }
 
+  static async fetchUserAssociatedWallets(user) {
+    const gateways = getCreatorNodeIPFSGateways(user.creator_node_endpoint)
+    const cid = user?.metadata_multihash ?? null
+    if (cid) {
+      const metadata = await fetchCID(
+        cid,
+        gateways,
+        /* cache */ false,
+        /* asUrl */ false
+      )
+      if (metadata?.associated_wallets) {
+        return metadata.associated_wallets
+      }
+    }
+    return null
+  }
+
   static async updateCreator(metadata, id) {
     let newMetadata = { ...metadata }
+    const associatedWallets = await AudiusBackend.fetchUserAssociatedWallets(
+      metadata
+    )
+    newMetadata.associated_wallets =
+      newMetadata.associated_wallets || associatedWallets
+
     try {
       if (newMetadata.updatedProfilePicture) {
         const resp = await audiusLibs.File.uploadImage(

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -937,6 +937,11 @@ class AudiusBackend {
     }
   }
 
+  /**
+   * Retrieves the user's associated wallets from IPFS using the user's metadata CID and creator node endpoints
+   * @param {Object} user The user metadata which contains the CID for the metadata multihash
+   * @returns Object The associated wallets mapping of address to nested signature
+   */
   static async fetchUserAssociatedWallets(user) {
     const gateways = getCreatorNodeIPFSGateways(user.creator_node_endpoint)
     const cid = user?.metadata_multihash ?? null


### PR DESCRIPTION
### Description
The user metadata w/ associated wallet was being overriden with null when not updating the associated wallets field in the metadata directly. This was due to an oversite in fetching the user's ipfs metadata before re-writing to it. The associated wallet metadata (ie. signature) is not passed as part of the DP response, so we must request the user's ipfs metadata to update it before posting a new version.  

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Ran locally w/ users that have associated wallets and w/out associated wallet to ensure the flow works are expected. 
Also ran updates to the associated wallets metadata to ensure that those were also updated correctly and not over-riden by later updates.
