### PR TITLE
Break playlist title name on mobile

### DIFF
--- a/src/components/collection/mobile/CollectionHeader.module.css
+++ b/src/components/collection/mobile/CollectionHeader.module.css
@@ -45,6 +45,7 @@
   line-height: 25px;
   text-align: center;
   margin-bottom: 15px;
+  word-break: break-all;
 }
 
 .artist {


### PR DESCRIPTION
### Description
Prevent overflow of text on mobile playlist name

Fixes AUD-475


![Screen Shot 2021-04-07 at 1 19 20 PM](https://user-images.githubusercontent.com/7064122/113908107-2c624300-97a4-11eb-8759-0699389d8add.png)

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
ran locally
