### PR TITLE
GIF fixes

### DIFF
--- a/src/containers/collectibles/components/CollectibleRow.tsx
+++ b/src/containers/collectibles/components/CollectibleRow.tsx
@@ -14,6 +14,7 @@ import {
 import { getCollectibleImage } from 'containers/collectibles/helpers'
 import { Collectible } from 'containers/collectibles/components/types'
 import { findAncestor } from 'utils/domUtils'
+import useInstanceVar from 'hooks/useInstanceVar'
 
 // @ts-ignore
 export const VisibleCollectibleRow = props => {
@@ -29,9 +30,13 @@ export const VisibleCollectibleRow = props => {
 
   const [image, setImage] = useState<Nullable<string>>(null)
 
+  const [getHasFetchedImage, setHasFetchedImage] = useInstanceVar(false)
   useEffect(() => {
-    getCollectibleImage(collectible).then(frame => setImage(frame))
-  }, [collectible])
+    if (!getHasFetchedImage()) {
+      setHasFetchedImage(true)
+      getCollectibleImage(collectible).then(frame => setImage(frame))
+    }
+  }, [collectible, getHasFetchedImage, setHasFetchedImage])
 
   const dragRef = useRef<HTMLDivElement>(null)
   const [tableElement, setTableElement] = useState<HTMLDivElement | null>(null)
@@ -113,10 +118,13 @@ export const HiddenCollectibleRow: React.FC<{
 
   const [image, setImage] = useState<Nullable<string>>(null)
 
+  const [getHasFetchedImage, setHasFetchedImage] = useInstanceVar(false)
   useEffect(() => {
-    getCollectibleImage(collectible).then(frame => setImage(frame))
-  }, [collectible])
-
+    if (!getHasFetchedImage()) {
+      setHasFetchedImage(true)
+      getCollectibleImage(collectible).then(frame => setImage(frame))
+    }
+  }, [collectible, getHasFetchedImage, setHasFetchedImage])
   return (
     <div className={cn(styles.editRow, styles.editHidden)}>
       <Tooltip

--- a/src/containers/collectibles/components/CollectiblesPage.tsx
+++ b/src/containers/collectibles/components/CollectiblesPage.tsx
@@ -96,9 +96,13 @@ const CollectibleDetails: React.FC<{
   const [isMuted, setIsMuted] = useState<boolean>(true)
   const [image, setImage] = useState<Nullable<string>>(null)
 
+  const [getHasFetchedImage, setHasFetchedImage] = useInstanceVar(false)
   useEffect(() => {
-    getCollectibleImage(collectible).then(frame => setImage(frame))
-  }, [collectible])
+    if (!getHasFetchedImage()) {
+      setHasFetchedImage(true)
+      getCollectibleImage(collectible).then(frame => setImage(frame))
+    }
+  }, [collectible, getHasFetchedImage, setHasFetchedImage])
 
   const handleItemClick = useCallback(() => {
     if (isMobile) {

--- a/src/containers/collectibles/helpers.ts
+++ b/src/containers/collectibles/helpers.ts
@@ -3,8 +3,7 @@ import {
   Collectible,
   CollectibleType
 } from 'containers/collectibles/components/types'
-import { resizeImage } from 'utils/imageProcessingUtil'
-import { preload } from 'utils/image'
+import { gifPreview } from 'utils/imageProcessingUtil'
 
 const OPENSEA_AUDIO_EXTENSIONS = ['mp3', 'wav', 'oga']
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -95,12 +94,25 @@ export const isNotFromNullAddress = (event: OpenSeaEvent) => {
 }
 
 const getFrameFromGif = async (url: string, name: string) => {
-  const imageBlob = await fetch(url).then(r => r.blob())
-  const imageFile = new File([imageBlob], name, {
-    type: 'image/jpeg'
-  })
-  const resized = await resizeImage(imageFile, 200, true, name)
-  return URL.createObjectURL(resized)
+  let preview
+  try {
+    const req = await fetch(url, {
+      headers: {
+        // Extremely heuristic 200KB. This should contain the first frame
+        // and then some. Rendering this out into an <img tag won't allow
+        // animation to play. Some gifs may not load if we do this, so we
+        // can try-catch it.
+        Range: 'bytes=0-200000'
+      }
+    })
+    const ab = await req.arrayBuffer()
+    const uint8arr = new Uint8Array(ab)
+    preview = new Blob([uint8arr.slice(0, 100000)])
+  } catch (e) {
+    preview = await gifPreview(url)
+  }
+
+  return URL.createObjectURL(preview)
 }
 
 export const getCollectibleImage = async (collectible: Collectible) => {
@@ -111,20 +123,23 @@ export const getCollectibleImage = async (collectible: Collectible) => {
     imageThumbnailUrl,
     name
   } = collectible
+  if (imageThumbnailUrl?.endsWith('.gif')) {
+    return await getFrameFromGif(imageThumbnailUrl, name || '')
+  }
+  if (imagePreviewUrl?.endsWith('.gif')) {
+    return await getFrameFromGif(imagePreviewUrl, name || '')
+  }
   if (imageUrl?.endsWith('.gif')) {
     return await getFrameFromGif(imageUrl, name || '')
   }
   if (imageOriginalUrl?.endsWith('.gif')) {
     return await getFrameFromGif(imageOriginalUrl, name || '')
   }
-  if (imagePreviewUrl?.endsWith('.gif')) {
-    return await getFrameFromGif(imagePreviewUrl, name || '')
-  }
-  if (imageThumbnailUrl?.endsWith('.gif')) {
-    return await getFrameFromGif(imageThumbnailUrl, name || '')
-  }
   if (imageUrl) {
-    await preload(imageUrl)
+    const res = await fetch(imageUrl)
+    if (res.headers.get('Content-Type')?.includes('gif')) {
+      return await getFrameFromGif(imageUrl, name || '')
+    }
   }
   return imageUrl
 }

--- a/src/containers/collectibles/helpers.ts
+++ b/src/containers/collectibles/helpers.ts
@@ -135,11 +135,13 @@ export const getCollectibleImage = async (collectible: Collectible) => {
   if (imageOriginalUrl?.endsWith('.gif')) {
     return await getFrameFromGif(imageOriginalUrl, name || '')
   }
-  if (imageUrl) {
-    const res = await fetch(imageUrl)
+  const foundImage =
+    imageUrl || imageThumbnailUrl || imagePreviewUrl || imageOriginalUrl
+  if (foundImage) {
+    const res = await fetch(foundImage)
     if (res.headers.get('Content-Type')?.includes('gif')) {
-      return await getFrameFromGif(imageUrl, name || '')
+      return await getFrameFromGif(foundImage, name || '')
     }
   }
-  return imageUrl
+  return foundImage
 }

--- a/src/utils/imageProcessingUtil.js
+++ b/src/utils/imageProcessingUtil.js
@@ -1,8 +1,10 @@
 import WebWorker from 'services/WebWorker'
 import resizeImageWorkerFile from 'workers/resizeImage.worker.js'
 import averageRgbWorkerFile from 'workers/averageRgb.worker.js'
+import gifPreviewWorkerFile from 'workers/gifPreview.worker.js'
 
 const averageRgbWorker = new WebWorker(averageRgbWorkerFile, false)
+const gifPreviewWorker = new WebWorker(gifPreviewWorkerFile, false)
 
 const ALLOWED_IMAGE_FILE_TYPES = [
   'image/jpeg',
@@ -31,4 +33,9 @@ export const resizeImage = async (
 export const averageRgb = async (imageUrl, chunkSize = 100) => {
   averageRgbWorker.call({ imageUrl, chunkSize }, imageUrl)
   return averageRgbWorker.getResult(imageUrl)
+}
+
+export const gifPreview = async imageUrl => {
+  gifPreviewWorker.call({ imageUrl }, imageUrl)
+  return gifPreviewWorker.getResult(imageUrl)
 }

--- a/src/workers/gifPreview.worker.js
+++ b/src/workers/gifPreview.worker.js
@@ -1,0 +1,40 @@
+/* globals Jimp */
+
+export default () => {
+  const script = '/scripts/jimp.min.js'
+  // eslint-disable-next-line
+  importWorkerScript(script)
+
+  /**
+   * Returns a jpeg of a gif
+   * @param {string} key identifies this computation
+   * @param {string} imageUrl url of the image to use
+   */
+  const gifPreview = ({ key, imageUrl }) => {
+    Jimp.read({
+      url: imageUrl
+    })
+      .then(img => {
+        // eslint-disable-next-line
+        self.console.log(imageUrl, img)
+        const mimeType = 'image/jpeg'
+        img.getBufferAsync(mimeType).then(buffer => {
+          // eslint-disable-next-line
+          let convertedBlob = new self.Blob([buffer], { type: mimeType })
+          // eslint-disable-next-line
+          postMessage({key, result: convertedBlob})
+        })
+      })
+      .catch(err => {
+        console.error(imageUrl, err)
+        // eslint-disable-next-line
+        postMessage({key, result: new Blob()})
+      })
+  }
+
+  // eslint-disable-next-line
+  self.addEventListener('message', e => {
+    if (!e) return
+    gifPreview(JSON.parse(e.data))
+  })
+}


### PR DESCRIPTION
### Description
1. try preview / thumbnails first just in case they are there--they will be smaller
2. try Range request uber hack (works most of the time) 
3. write faster gif worker to be used instead of resize worker (we just need to read into a jpeg which JIMP will do). also use same model as average rgb worker since that keeps a persistent worker up & running

4*. additional change to `getCollectibleImage` to instead of preloading, use fetch and use Content-Type to determine gif. There are currently some gifs that will not be treated as such because there is no extension in the URL. This stops them from autoplaying in the collectible detail -- but it also doesn't show the play button. We should do this check earlier in the stack, per our other convo today about restructuring when we determine gif.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

ray.audius.co
/matthewchaim/collectibles
/coopahtroopa/collectibles
/rayjacobson/collectibles
/rac/collectibles
