### PR TITLE
Wrap track tile for smaller screens

### DIFF
--- a/src/components/track/GiantTrackTile.module.css
+++ b/src/components/track/GiantTrackTile.module.css
@@ -14,6 +14,7 @@
 .topSection {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   position: relative;
   background-color: var(--neutral-light-10);
 
@@ -22,6 +23,7 @@
 }
 
 .infoSection {
+  flex: 1 0 338px;
   padding-left: 22px;
   flex-direction: column;
   width: 100%;


### PR DESCRIPTION
### Description
Wraps the giant track tile for smaller screens on desktop. 
NOTE: the 338px is the width of the image on the left, so it wraps after the right side is smaller than the image on the left. 

Screenshot of the min size before wrapping
![Screen Shot 2021-04-08 at 10 14 55 AM](https://user-images.githubusercontent.com/7064122/114042800-bddcbe00-9853-11eb-9fd3-2d614d9134e4.png)
![Screen Shot 2021-04-08 at 10 15 06 AM](https://user-images.githubusercontent.com/7064122/114042804-be755480-9853-11eb-988d-bb4f4308091d.png)

Fixes AUD-454

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
ran locally
