### PR TITLE
Fix collectibles white tile and asset not displaying bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "audius-client",
-  "version": "0.24.12",
+  "version": "0.24.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Audius",
   "description": "The Audius decentralized application",
   "author": "Audius",
-  "version": "0.24.12",
+  "version": "0.24.13",
   "private": true,
   "dependencies": {
     "@audius/libs": "1.1.23",

--- a/src/components/preload-image/PreloadImage.tsx
+++ b/src/components/preload-image/PreloadImage.tsx
@@ -7,11 +7,11 @@ import styles from './PreloadImage.module.css'
 /** Super simple PreloadImage component to be used for fading in an image */
 const PreloadImage = ({
   src,
-  alt,
+  alt = '',
   className
 }: {
   src: string
-  alt: string
+  alt?: string
   className: string
 }) => {
   const [isLoaded, setIsLoaded] = useState(false)

--- a/src/containers/collectibles/components/CollectibleRow.tsx
+++ b/src/containers/collectibles/components/CollectibleRow.tsx
@@ -3,7 +3,6 @@ import styles from 'containers/collectibles/components/CollectiblesPage.module.c
 import cn from 'classnames'
 import Tooltip from 'components/tooltip/Tooltip'
 import { formatDate } from 'utils/timeUtil'
-import { Nullable } from 'utils/typeUtils'
 import { ReactComponent as IconDrag } from 'assets/img/iconDrag.svg'
 import { ReactComponent as IconShow } from 'assets/img/iconMultiselectAdd.svg'
 import { ReactComponent as IconHide } from 'assets/img/iconRemoveTrack.svg'
@@ -11,10 +10,11 @@ import {
   collectibleMessages,
   editTableContainerClass
 } from 'containers/collectibles/components/CollectiblesPage'
-import { getCollectibleImage } from 'containers/collectibles/helpers'
-import { Collectible } from 'containers/collectibles/components/types'
+import {
+  Collectible,
+  CollectibleType
+} from 'containers/collectibles/components/types'
 import { findAncestor } from 'utils/domUtils'
-import useInstanceVar from 'hooks/useInstanceVar'
 
 // @ts-ignore
 export const VisibleCollectibleRow = props => {
@@ -26,17 +26,7 @@ export const VisibleCollectibleRow = props => {
     handleProps,
     ...otherProps
   } = props
-  const { name, isOwned, dateCreated } = collectible
-
-  const [image, setImage] = useState<Nullable<string>>(null)
-
-  const [getHasFetchedImage, setHasFetchedImage] = useInstanceVar(false)
-  useEffect(() => {
-    if (!getHasFetchedImage()) {
-      setHasFetchedImage(true)
-      getCollectibleImage(collectible).then(frame => setImage(frame))
-    }
-  }, [collectible, getHasFetchedImage, setHasFetchedImage])
+  const { name, isOwned, dateCreated, type, frameUrl, videoUrl } = collectible
 
   const dragRef = useRef<HTMLDivElement>(null)
   const [tableElement, setTableElement] = useState<HTMLDivElement | null>(null)
@@ -77,12 +67,22 @@ export const VisibleCollectibleRow = props => {
         <IconHide onClick={onHideClick} />
       </Tooltip>
       <div className={styles.verticalDivider} />
-      {image ? (
+      {frameUrl ? (
         <div>
           <img
             className={styles.editMedia}
-            src={image}
+            src={frameUrl}
             alt={collectibleMessages.visibleThumbnail}
+          />
+        </div>
+      ) : type === CollectibleType.VIDEO ? (
+        <div>
+          <video
+            muted={true}
+            autoPlay={false}
+            controls={false}
+            style={{ height: '40px', width: '40px' }}
+            src={videoUrl!}
           />
         </div>
       ) : (
@@ -114,17 +114,8 @@ export const HiddenCollectibleRow: React.FC<{
   onShowClick: () => void
 }> = props => {
   const { collectible, onShowClick } = props
-  const { name, isOwned, dateCreated } = collectible
+  const { name, isOwned, dateCreated, type, frameUrl, videoUrl } = collectible
 
-  const [image, setImage] = useState<Nullable<string>>(null)
-
-  const [getHasFetchedImage, setHasFetchedImage] = useInstanceVar(false)
-  useEffect(() => {
-    if (!getHasFetchedImage()) {
-      setHasFetchedImage(true)
-      getCollectibleImage(collectible).then(frame => setImage(frame))
-    }
-  }, [collectible, getHasFetchedImage, setHasFetchedImage])
   return (
     <div className={cn(styles.editRow, styles.editHidden)}>
       <Tooltip
@@ -134,12 +125,22 @@ export const HiddenCollectibleRow: React.FC<{
         <IconShow onClick={onShowClick} />
       </Tooltip>
       <div className={styles.verticalDivider} />
-      {image ? (
+      {frameUrl ? (
         <div>
           <img
             className={styles.editMedia}
-            src={image}
+            src={frameUrl}
             alt={collectibleMessages.hiddenThumbnail}
+          />
+        </div>
+      ) : type === CollectibleType.VIDEO ? (
+        <div>
+          <video
+            muted={true}
+            autoPlay={false}
+            controls={false}
+            style={{ height: '40px', width: '40px' }}
+            src={videoUrl!}
           />
         </div>
       ) : (

--- a/src/containers/collectibles/components/CollectiblesPage.module.css
+++ b/src/containers/collectibles/components/CollectiblesPage.module.css
@@ -109,10 +109,14 @@
   fill: #fffa;
 }
 
+.imageWrapper {
+  position: relative;
+}
+
 .stamp {
   position: absolute;
-  top: 182px;
-  left: 20px;
+  bottom: 18px;
+  left: 12px;
   z-index: 10000;
   font-size: var(--font-2xs);
   color: var(--white);
@@ -244,6 +248,7 @@
   max-width: 50vw;
   max-height: 70vh;
   overflow: hidden;
+  border-radius: 8px;
 }
 
 .detailsMediaWrapper img {
@@ -254,7 +259,6 @@
 
 .detailsMediaWrapper video {
   width: 100%;
-  border-radius: 8px;
   box-sizing: border-box;
   background-size: cover;
   background-position: center;
@@ -530,10 +534,6 @@
 .mobile .media {
   width: 80vw;
   height: 80vw;
-}
-
-.mobile .stamp {
-  top: calc(80vw - 20px);
 }
 
 .mobile .detailsStamp {

--- a/src/containers/collectibles/components/CollectiblesPage.module.css
+++ b/src/containers/collectibles/components/CollectiblesPage.module.css
@@ -193,6 +193,7 @@
   align-items: center;
   color: var(--secondary);
   text-decoration: underline !important;
+  margin-bottom: 16px;
 }
 
 .link:hover {

--- a/src/containers/collectibles/components/CollectiblesPage.tsx
+++ b/src/containers/collectibles/components/CollectiblesPage.tsx
@@ -10,7 +10,6 @@ import {
 import cn from 'classnames'
 import styles from 'containers/collectibles/components/CollectiblesPage.module.css'
 import PerspectiveCard from 'components/perspective-card/PerspectiveCard'
-import DynamicImage from 'components/dynamic-image/DynamicImage'
 import UserBadges from 'containers/user-badges/UserBadges'
 import {
   DragDropContext,
@@ -33,6 +32,7 @@ import {
   VisibleCollectibleRow
 } from 'containers/collectibles/components/CollectibleRow'
 import useInstanceVar from 'hooks/useInstanceVar'
+import PreloadImage from 'components/preload-image/PreloadImage'
 
 export const editTableContainerClass = 'editTableContainer'
 
@@ -120,7 +120,7 @@ const CollectibleDetails: React.FC<{
         {type === CollectibleType.GIF ||
         (type === CollectibleType.VIDEO && frameUrl) ? (
           <div className={styles.imageWrapper}>
-            <DynamicImage image={frameUrl!} wrapperClassName={styles.media} />
+            <PreloadImage src={frameUrl!} className={styles.media} />
             <IconPlay className={styles.playIcon} />
             <div className={styles.stamp}>
               {collectible.isOwned ? (
@@ -158,7 +158,7 @@ const CollectibleDetails: React.FC<{
           </div>
         ) : type === CollectibleType.IMAGE ? (
           <div className={styles.imageWrapper}>
-            <DynamicImage image={frameUrl!} wrapperClassName={styles.media} />
+            <PreloadImage src={frameUrl!} className={styles.media} />
             <div className={styles.stamp}>
               {collectible.isOwned ? (
                 <span className={styles.owned}>

--- a/src/containers/collectibles/components/CollectiblesPage.tsx
+++ b/src/containers/collectibles/components/CollectiblesPage.tsx
@@ -119,7 +119,7 @@ const CollectibleDetails: React.FC<{
       >
         {type === CollectibleType.GIF ||
         (type === CollectibleType.VIDEO && frameUrl) ? (
-          <div>
+          <div className={styles.imageWrapper}>
             <DynamicImage image={frameUrl!} wrapperClassName={styles.media} />
             <IconPlay className={styles.playIcon} />
             <div className={styles.stamp}>

--- a/src/containers/collectibles/components/CollectiblesPage.tsx
+++ b/src/containers/collectibles/components/CollectiblesPage.tsx
@@ -135,7 +135,7 @@ const CollectibleDetails: React.FC<{
             </div>
           </div>
         ) : type === CollectibleType.VIDEO ? (
-          <div className={styles.media}>
+          <div className={cn(styles.media, styles.imageWrapper)}>
             <IconPlay className={styles.playIcon} />
             <video
               muted={true}
@@ -157,7 +157,7 @@ const CollectibleDetails: React.FC<{
             </div>
           </div>
         ) : type === CollectibleType.IMAGE ? (
-          <div>
+          <div className={styles.imageWrapper}>
             <DynamicImage image={frameUrl!} wrapperClassName={styles.media} />
             <div className={styles.stamp}>
               {collectible.isOwned ? (
@@ -239,6 +239,18 @@ const CollectibleDetails: React.FC<{
               <a
                 className={styles.link}
                 href={collectible.externalLink}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <IconLink className={styles.linkIcon} />
+                {new URL(collectible.externalLink).hostname}
+              </a>
+            )}
+
+            {collectible.permaLink && (
+              <a
+                className={styles.link}
+                href={collectible.permaLink}
                 target='_blank'
                 rel='noopener noreferrer'
               >

--- a/src/containers/collectibles/components/CollectiblesPage.tsx
+++ b/src/containers/collectibles/components/CollectiblesPage.tsx
@@ -321,6 +321,17 @@ const CollectibleDetails: React.FC<{
                 {collectibleMessages.linkToCollectible}
               </a>
             )}
+            {collectible.permaLink && (
+              <a
+                className={styles.link}
+                href={collectible.permaLink}
+                target='_blank'
+                rel='noopener noreferrer'
+              >
+                <IconLink className={styles.linkIcon} />
+                {collectibleMessages.linkToCollectible}
+              </a>
+            )}
           </div>
         </div>
       </Drawer>

--- a/src/containers/collectibles/components/types.ts
+++ b/src/containers/collectibles/components/types.ts
@@ -24,4 +24,5 @@ export type Collectible = {
   dateCreated: Nullable<string>
   dateLastTransferred: Nullable<string>
   externalLink: Nullable<string>
+  permaLink: Nullable<string>
 }

--- a/src/containers/collectibles/components/types.ts
+++ b/src/containers/collectibles/components/types.ts
@@ -16,13 +16,10 @@ export type Collectible = {
   name: Nullable<string>
   description: Nullable<string>
   type: CollectibleType
+  frameUrl: Nullable<string>
   imageUrl: Nullable<string>
-  imagePreviewUrl: Nullable<string>
-  imageThumbnailUrl: Nullable<string>
-  imageOriginalUrl: Nullable<string>
-  animationUrl: Nullable<string>
-  animationOriginalUrl: Nullable<string>
-  youtubeUrl: Nullable<string>
+  gifUrl: Nullable<string>
+  videoUrl: Nullable<string>
   isOwned: boolean
   dateCreated: Nullable<string>
   dateLastTransferred: Nullable<string>

--- a/src/containers/collectibles/helpers.ts
+++ b/src/containers/collectibles/helpers.ts
@@ -5,26 +5,64 @@ import {
 } from 'containers/collectibles/components/types'
 import { gifPreview } from 'utils/imageProcessingUtil'
 
+/**
+ * extensions based on OpenSea metadata standards
+ * https://docs.opensea.io/docs/metadata-standards
+ */
+const OPENSEA_VIDEO_EXTENSIONS = [
+  'gltf',
+  'glb',
+  'webm',
+  'mp4',
+  'm4v',
+  'ogv',
+  'ogg'
+]
 const OPENSEA_AUDIO_EXTENSIONS = ['mp3', 'wav', 'oga']
+
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const isAssetImage = (asset: OpenSeaAsset) => {
-  return (
-    !!asset.image_url ||
-    !!asset.image_original_url ||
-    !!asset.image_preview_url ||
-    !!asset.image_thumbnail_url
-  )
+  const nonImageExtensions = [
+    ...OPENSEA_VIDEO_EXTENSIONS,
+    ...OPENSEA_AUDIO_EXTENSIONS
+  ]
+  return [
+    asset.image_url,
+    asset.image_original_url,
+    asset.image_preview_url,
+    asset.image_thumbnail_url
+  ].some(url => url && nonImageExtensions.every(ext => !url.endsWith(ext)))
 }
 
-const isAssetAudio = (asset: OpenSeaAsset) => {
-  return OPENSEA_AUDIO_EXTENSIONS.some(extension =>
-    asset.animation_url?.endsWith(extension)
-  )
+const isAudio = (url: string) => {
+  return OPENSEA_AUDIO_EXTENSIONS.some(extension => url.endsWith(extension))
 }
 
 const isAssetVideo = (asset: OpenSeaAsset) => {
-  return !!asset.animation_url && !isAssetAudio(asset)
+  const {
+    animation_url,
+    animation_original_url,
+    image_url,
+    image_original_url,
+    image_preview_url,
+    image_thumbnail_url
+  } = asset
+  if (isAudio(animation_url || '') || isAudio(animation_original_url || '')) {
+    return false
+  }
+  return (
+    !!animation_url ||
+    !!animation_original_url ||
+    [
+      image_url,
+      image_original_url,
+      image_preview_url,
+      image_thumbnail_url
+    ].some(
+      url => url && OPENSEA_VIDEO_EXTENSIONS.some(ext => url.endsWith(ext))
+    )
+  )
 }
 
 const isAssetGif = (asset: OpenSeaAsset) => {
@@ -40,23 +78,94 @@ export const isAssetValid = (asset: OpenSeaAsset) => {
   return isAssetVideo(asset) || isAssetImage(asset) || isAssetGif(asset)
 }
 
-export const assetToCollectible = (asset: OpenSeaAsset): Collectible => {
-  let type = CollectibleType.IMAGE
-  if (isAssetVideo(asset)) type = CollectibleType.VIDEO
-  if (isAssetGif(asset)) type = CollectibleType.GIF
+export const assetToCollectible = async (
+  asset: OpenSeaAsset
+): Promise<Collectible> => {
+  let type: CollectibleType
+  let frameUrl = null
+  let imageUrl = null
+  let videoUrl = null
+  let gifUrl = null
+
+  const { animation_url, animation_original_url, name } = asset
+  const imageUrlsHighToLowRes = [
+    asset.image_url,
+    asset.image_original_url,
+    asset.image_preview_url,
+    asset.image_thumbnail_url
+  ]
+  const imageUrlsLowToHighRes = [
+    asset.image_thumbnail_url,
+    asset.image_preview_url,
+    asset.image_url,
+    asset.image_original_url
+  ]
+
+  if (isAssetGif(asset)) {
+    type = CollectibleType.GIF
+    const urlForFrame = imageUrlsLowToHighRes.find(url =>
+      url?.endsWith('.gif')
+    )!
+    frameUrl = await getFrameFromGif(urlForFrame, name || '')
+    gifUrl = imageUrlsHighToLowRes.find(url => url?.endsWith('.gif'))!
+  } else if (isAssetVideo(asset)) {
+    type = CollectibleType.VIDEO
+    frameUrl =
+      imageUrlsLowToHighRes.find(
+        url => url && OPENSEA_VIDEO_EXTENSIONS.every(ext => !url.endsWith(ext))
+      ) ?? null
+
+    /**
+     * make sure frame url is not a video
+     * if it is avideo, unset frame url so that component will use a video url instead
+     */
+    if (frameUrl) {
+      const res = await fetch(frameUrl, { method: 'HEAD' })
+      const isVideo = OPENSEA_VIDEO_EXTENSIONS.some(ext =>
+        res.headers.get('Content-Type')?.includes(ext)
+      )
+      if (isVideo) {
+        frameUrl = null
+      }
+    }
+
+    videoUrl =
+      [animation_url, animation_original_url].find(
+        url => url && !isAudio(url)
+      ) ?? null
+    if (!videoUrl) {
+      videoUrl = imageUrlsHighToLowRes.find(
+        url => url && OPENSEA_VIDEO_EXTENSIONS.some(ext => url.endsWith(ext))
+      )!
+    }
+  } else {
+    type = CollectibleType.IMAGE
+    frameUrl = imageUrlsLowToHighRes.find(url => !!url)!
+    const res = await fetch(frameUrl, { method: 'HEAD' })
+    const isGif = res.headers.get('Content-Type')?.includes('gif')
+    const isVideo = res.headers.get('Content-Type')?.includes('video')
+    if (isGif) {
+      type = CollectibleType.GIF
+      frameUrl = await getFrameFromGif(frameUrl, name || '')
+      gifUrl = imageUrlsHighToLowRes.find(url => !!url)!
+    } else if (isVideo) {
+      type = CollectibleType.VIDEO
+      frameUrl = null
+      videoUrl = imageUrlsHighToLowRes.find(url => !!url)!
+    } else {
+      imageUrl = imageUrlsHighToLowRes.find(url => !!url)!
+    }
+  }
 
   return {
     id: asset.token_id,
     name: asset.name,
     description: asset.description,
     type,
-    imageUrl: asset.image_url,
-    imagePreviewUrl: asset.image_preview_url,
-    imageThumbnailUrl: asset.image_thumbnail_url,
-    imageOriginalUrl: asset.image_original_url,
-    animationUrl: asset.animation_url,
-    animationOriginalUrl: asset.animation_original_url,
-    youtubeUrl: asset.youtube_url,
+    frameUrl,
+    imageUrl,
+    videoUrl,
+    gifUrl,
     isOwned: true,
     dateCreated: null,
     dateLastTransferred: null,
@@ -64,26 +173,30 @@ export const assetToCollectible = (asset: OpenSeaAsset): Collectible => {
   }
 }
 
-export const creationEventToCollectible = (
+export const creationEventToCollectible = async (
   event: OpenSeaEvent
-): Collectible => {
+): Promise<Collectible> => {
   const { asset, created_date } = event
 
+  const collectible = await assetToCollectible(asset)
+
   return {
-    ...assetToCollectible(asset),
+    ...collectible,
     dateCreated: created_date,
     isOwned: false
   }
 }
 
-export const transferEventToCollectible = (
+export const transferEventToCollectible = async (
   event: OpenSeaEvent,
   isOwned = true
-): Collectible => {
+): Promise<Collectible> => {
   const { asset, created_date } = event
 
+  const collectible = await assetToCollectible(asset)
+
   return {
-    ...assetToCollectible(asset),
+    ...collectible,
     isOwned,
     dateLastTransferred: created_date
   }
@@ -117,35 +230,4 @@ const getFrameFromGif = async (url: string, name: string) => {
   }
 
   return URL.createObjectURL(preview)
-}
-
-export const getCollectibleImage = async (collectible: Collectible) => {
-  const {
-    imageUrl,
-    imageOriginalUrl,
-    imagePreviewUrl,
-    imageThumbnailUrl,
-    name
-  } = collectible
-  if (imageThumbnailUrl?.endsWith('.gif')) {
-    return await getFrameFromGif(imageThumbnailUrl, name || '')
-  }
-  if (imagePreviewUrl?.endsWith('.gif')) {
-    return await getFrameFromGif(imagePreviewUrl, name || '')
-  }
-  if (imageUrl?.endsWith('.gif')) {
-    return await getFrameFromGif(imageUrl, name || '')
-  }
-  if (imageOriginalUrl?.endsWith('.gif')) {
-    return await getFrameFromGif(imageOriginalUrl, name || '')
-  }
-  const foundImage =
-    imageUrl || imageThumbnailUrl || imagePreviewUrl || imageOriginalUrl
-  if (foundImage) {
-    const res = await fetch(foundImage)
-    if (res.headers.get('Content-Type')?.includes('gif')) {
-      return await getFrameFromGif(foundImage, name || '')
-    }
-  }
-  return foundImage
 }

--- a/src/containers/collectibles/helpers.ts
+++ b/src/containers/collectibles/helpers.ts
@@ -208,10 +208,12 @@ export const isNotFromNullAddress = (event: OpenSeaEvent) => {
 
 const getFrameFromGif = async (url: string, name: string) => {
   const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1
+  const isSafariMobile =
+    navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)
   let preview
   try {
     // Firefox does not handle partial gif rendering well
-    if (isFirefox) {
+    if (isFirefox || isSafariMobile) {
       throw new Error('partial gif not supported')
     }
     const req = await fetch(url, {

--- a/src/containers/collectibles/helpers.ts
+++ b/src/containers/collectibles/helpers.ts
@@ -95,10 +95,9 @@ export const assetToCollectible = async (
     asset.image_thumbnail_url
   ]
   const imageUrlsLowToHighRes = [
-    asset.image_preview_url,
     asset.image_url,
     asset.image_original_url,
-    // Put thumbnail last because it's too low res for use
+    asset.image_preview_url,
     asset.image_thumbnail_url
   ]
 

--- a/src/containers/collectibles/helpers.ts
+++ b/src/containers/collectibles/helpers.ts
@@ -95,10 +95,11 @@ export const assetToCollectible = async (
     asset.image_thumbnail_url
   ]
   const imageUrlsLowToHighRes = [
-    asset.image_thumbnail_url,
     asset.image_preview_url,
     asset.image_url,
-    asset.image_original_url
+    asset.image_original_url,
+    // Put thumbnail last because it's too low res for use
+    asset.image_thumbnail_url
   ]
 
   if (isAssetGif(asset)) {

--- a/src/services/opensea-client/OpenSeaClient.ts
+++ b/src/services/opensea-client/OpenSeaClient.ts
@@ -98,21 +98,27 @@ class OpenSeaClient {
     )
   }
 
-  async getAllCollectibles(wallets: string[], imageAndVideoOnly = true) {
+  async getAllCollectibles(wallets: string[]) {
     return Promise.all([
       client.getCollectiblesForMultipleWallets(wallets),
       client.getCreatedCollectiblesForMultipleWallets(wallets),
       client.getTransferredCollectiblesForMultipleWallets(wallets)
-    ]).then(([assets, creationEvents, transferEvents]) => {
-      const collectiblesMap: { [key: string]: Collectible } = assets
-        .filter(asset => asset && isAssetValid(asset))
-        .reduce(
-          (acc, curr) => ({
-            ...acc,
-            [curr.token_id]: assetToCollectible(curr)
-          }),
-          {}
-        )
+    ]).then(async ([assets, creationEvents, transferEvents]) => {
+      const filteredAssets = assets.filter(
+        asset => asset && isAssetValid(asset)
+      )
+      const collectibles = await Promise.all(
+        filteredAssets.map(async asset => await assetToCollectible(asset))
+      )
+      const collectiblesMap: {
+        [key: string]: Collectible
+      } = collectibles.reduce(
+        (acc, curr) => ({
+          ...acc,
+          [curr.id]: curr
+        }),
+        {}
+      )
       const ownedCollectibleKeySet = new Set(Object.keys(collectiblesMap))
 
       // Handle transfers from NullAddress as if they were created events
@@ -135,7 +141,7 @@ class OpenSeaClient {
             [curr.asset.token_id]: curr
           }
         }, {})
-      Object.values(firstOwnershipTransferEvents).forEach(event => {
+      for (const event of Object.values(firstOwnershipTransferEvents)) {
         if (ownedCollectibleKeySet.has(event.asset.token_id)) {
           collectiblesMap[event.asset.token_id] = {
             ...collectiblesMap[event.asset.token_id],
@@ -143,23 +149,22 @@ class OpenSeaClient {
           }
         } else {
           ownedCollectibleKeySet.add(event.asset.token_id)
-          collectiblesMap[event.asset.token_id] = transferEventToCollectible(
-            event,
-            false
-          )
+          collectiblesMap[
+            event.asset.token_id
+          ] = await transferEventToCollectible(event, false)
         }
-      })
+      }
 
       // Handle created events
-      creationEvents
-        .filter(event => event && isAssetValid(event.asset))
-        .forEach(event => {
-          const tokenId = event.asset.token_id
-          if (!ownedCollectibleKeySet.has(tokenId)) {
-            collectiblesMap[tokenId] = creationEventToCollectible(event)
-            ownedCollectibleKeySet.add(tokenId)
-          }
-        })
+      for (const event of creationEvents.filter(
+        event => event && isAssetValid(event.asset)
+      )) {
+        const tokenId = event.asset.token_id
+        if (!ownedCollectibleKeySet.has(tokenId)) {
+          collectiblesMap[tokenId] = await creationEventToCollectible(event)
+          ownedCollectibleKeySet.add(tokenId)
+        }
+      }
 
       // Handle transfers
       const latestTransferEventsMap = transferEvents
@@ -181,7 +186,7 @@ class OpenSeaClient {
             [curr.asset.token_id]: curr
           }
         }, {})
-      Object.values(latestTransferEventsMap).forEach(event => {
+      for (const event of Object.values(latestTransferEventsMap)) {
         if (ownedCollectibleKeySet.has(event.asset.token_id)) {
           collectiblesMap[event.asset.token_id] = {
             ...collectiblesMap[event.asset.token_id],
@@ -189,11 +194,11 @@ class OpenSeaClient {
           }
         } else if (wallets.includes(event.to_account.address)) {
           ownedCollectibleKeySet.add(event.asset.token_id)
-          collectiblesMap[event.asset.token_id] = transferEventToCollectible(
-            event
-          )
+          collectiblesMap[
+            event.asset.token_id
+          ] = await transferEventToCollectible(event)
         }
-      })
+      }
 
       return Object.values(collectiblesMap)
     })

--- a/src/services/opensea-client/types.ts
+++ b/src/services/opensea-client/types.ts
@@ -36,6 +36,7 @@ export type OpenSeaAsset = {
   name: string | null
   description: string | null
   external_link: string | null
+  permalink: string | null
   image_url: string | null
   image_preview_url: string | null
   image_thumbnail_url: string | null


### PR DESCRIPTION
### Description
Fix bug where white tiles e.g. on /boysnoize/collectibles and collectible not displaying on click e.g. /3lau/collectibles

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?
Tested locally with prod build and went to

/boysnoize/collectibles
/3lau/collectibles
/rac/collectibles
/coopahtroopa/collectibles

Also ran a staging build to test sort modal image/video behavior. looked good too
