### PR TITLE
Add wallet link as provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6828,6 +6828,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bind-decorator": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/bind-decorator/-/bind-decorator-1.0.11.tgz",
+      "integrity": "sha1-5BvAah9l3ZzsR2yRxdrzl4SIJS8="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -7963,6 +7968,11 @@
       "requires": {
         "mimic-response": "^1.0.0"
       }
+    },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "4.6.0",
@@ -25604,6 +25614,38 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "walletlink": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/walletlink/-/walletlink-2.0.3.tgz",
+      "integrity": "sha512-fl8LmelFpgVITdGxGkoGhCn9coIcV/8ubg2kT96DaqGi2N4BNvUjlmgOsXMuHvVUMg4kGVZeq2XKaChXBC9ySA==",
+      "requires": {
+        "bind-decorator": "^1.0.11",
+        "bn.js": "^5.1.1",
+        "clsx": "^1.1.0",
+        "preact": "^10.5.9",
+        "rxjs": "^6.6.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "preact": {
+          "version": "10.5.13",
+          "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.13.tgz",
+          "integrity": "sha512-q/vlKIGNwzTLu+jCcvywgGrt+H/1P/oIRSD6mV4ln3hmlC+Aa34C7yfPI4+5bzW8pONyVXYS7SvXosy2dKKtWQ=="
+        },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        }
       }
     },
     "warning": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "simplebar-react": "^2.0.5",
     "simplebar-react-legacy": "npm:simplebar-react@^1.0.0",
     "typesafe-actions": "^5.1.0",
+    "walletlink": "^2.0.3",
     "web-vitals": "^0.2.0",
     "web3modal": "^1.9.3",
     "webgl-context": "^2.2.0"

--- a/src/assets/img/wallet-link.svg
+++ b/src/assets/img/wallet-link.svg
@@ -1,0 +1,31 @@
+<svg width="383" height="383" viewBox="0 0 383 383" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<g filter="url(#filter0_dd)">
+<path d="M0.998047 0.572266L382.78 0.572266V382.354H0.998047L0.998047 0.572266Z" fill="url(#paint0_linear)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M59.1074 191.572C59.1074 264.966 118.605 324.463 191.998 324.463C265.392 324.463 324.889 264.966 324.889 191.572C324.889 118.179 265.392 58.6816 191.998 58.6816C118.605 58.6816 59.1074 118.179 59.1074 191.572ZM158.037 148.752C153.144 148.752 149.178 152.718 149.178 157.611V225.533C149.178 230.426 153.144 234.393 158.037 234.393H225.959C230.852 234.393 234.818 230.426 234.818 225.533V157.611C234.818 152.718 230.852 148.752 225.959 148.752H158.037Z" fill="white"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_dd" x="-23.002" y="-7.42773" width="429.782" height="429.782" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="16"/>
+<feGaussianBlur stdDeviation="12"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.06 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="4"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear" x1="191.889" y1="0.572266" x2="191.889" y2="382.354" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2E66F8"/>
+<stop offset="1" stop-color="#124ADB"/>
+</linearGradient>
+<clipPath id="clip0">
+<rect width="381.782" height="381.782" fill="white" transform="translate(0.998047 0.572266)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/services/remote-config/RemoteConfig.ts
+++ b/src/services/remote-config/RemoteConfig.ts
@@ -54,6 +54,10 @@ export enum BooleanKeys {
    */
   DISPLAY_WEB3_PROVIDER_BITSKI = 'DISPLAY_WEB3_PROVIDER_BITSKI',
   /*
+   * Boolean to show wallet link as an option for associating wallets
+   */
+  DISPLAY_WEB3_PROVIDER_WALLET_LINK = 'DISPLAY_WEB3_PROVIDER_WALLET_LINK',
+  /*
    * Boolean to show instagram verification on mobile.
    */
   DISPLAY_INSTAGRAM_VERIFICATION = 'DISPLAY_INSTAGRAM_VERIFICATION',

--- a/src/services/remote-config/defaults.ts
+++ b/src/services/remote-config/defaults.ts
@@ -43,5 +43,6 @@ export const remoteConfigBooleanDefaults: {
   [BooleanKeys.DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP]: true,
   [BooleanKeys.DISPLAY_WEB3_PROVIDER_WALLET_CONNECT]: true,
   [BooleanKeys.DISPLAY_WEB3_PROVIDER_BITSKI]: true,
+  [BooleanKeys.DISPLAY_WEB3_PROVIDER_WALLET_LINK]: true,
   [BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK]: false
 }

--- a/src/services/web3-modal/index.ts
+++ b/src/services/web3-modal/index.ts
@@ -1,5 +1,6 @@
 import Web3Modal, { IProviderOptions } from 'web3modal'
-
+import walletLinkSvg from 'assets/img/wallet-link.svg'
+const CHAIN_ID = process.env.REACT_APP_ETH_NETWORK_ID
 const BITSKI_CLIENT_ID = process.env.REACT_APP_BITSKI_CLIENT_ID
 const BITSKI_CALLBACK_URL = process.env.REACT_APP_BITSKI_CALLBACK_URL
 const WEB3_NETWORK_ID = parseInt(process.env.REACT_APP_ETH_NETWORK_ID || '')
@@ -10,6 +11,7 @@ const ETH_PROVIDER_URLS = (process.env.REACT_APP_ETH_PROVIDER_URL || '').split(
 type Config = {
   isBitkiEnabled: boolean
   isWalletConnectEnabled: boolean
+  isWalletLinkEnabled: boolean
 }
 
 export const loadWalletConnect = async () => {
@@ -24,12 +26,18 @@ export const loadBitski = async () => {
   return Bitski
 }
 
+export const loadWalletLink = async () => {
+  const { WalletLink } = await import('walletlink')
+  return WalletLink
+}
+
 export const createSession = async (config: Config): Promise<any> => {
   try {
     const Web3 = window.Web3
 
     const WalletConnectProvider = await loadWalletConnect()
     const Bitski = await loadBitski()
+    const WalletLink = await loadWalletLink()
 
     const providerOptions: IProviderOptions = {}
     if (config.isBitkiEnabled && BITSKI_CLIENT_ID && BITSKI_CALLBACK_URL) {
@@ -51,15 +59,30 @@ export const createSession = async (config: Config): Promise<any> => {
         }
       }
     }
-
-    // Other provider options
-    // torus: {
-    //   package: Torus, // required
-    //   options: {}
-    // },
-    // frame: {
-    //   package: ethProvider // required
-    // },
+    if (config.isWalletLinkEnabled) {
+      providerOptions['custom-walletlink'] = {
+        display: {
+          logo: walletLinkSvg,
+          name: 'WalletLink',
+          description: 'Scan with WalletLink to connect'
+        },
+        options: {
+          appName: 'Audius',
+          networkUrl: ETH_PROVIDER_URLS[0],
+          chainId: CHAIN_ID
+        },
+        package: WalletLink,
+        connector: async (_, options) => {
+          const { appName, networkUrl, chainId } = options
+          const walletLink = new WalletLink({
+            appName
+          })
+          const provider = walletLink.makeWeb3Provider(networkUrl, chainId)
+          await provider.enable()
+          return provider
+        }
+      }
+    }
 
     const web3Modal = new Web3Modal({ providerOptions })
 

--- a/src/services/web3-modal/index.ts
+++ b/src/services/web3-modal/index.ts
@@ -9,7 +9,7 @@ const ETH_PROVIDER_URLS = (process.env.REACT_APP_ETH_PROVIDER_URL || '').split(
 )
 
 type Config = {
-  isBitkiEnabled: boolean
+  isBitSkiEnabled: boolean
   isWalletConnectEnabled: boolean
   isWalletLinkEnabled: boolean
 }
@@ -40,7 +40,7 @@ export const createSession = async (config: Config): Promise<any> => {
     const WalletLink = await loadWalletLink()
 
     const providerOptions: IProviderOptions = {}
-    if (config.isBitkiEnabled && BITSKI_CLIENT_ID && BITSKI_CALLBACK_URL) {
+    if (config.isBitSkiEnabled && BITSKI_CLIENT_ID && BITSKI_CALLBACK_URL) {
       providerOptions.bitski = {
         package: Bitski, // required
         options: {

--- a/src/store/token-dashboard/sagas.ts
+++ b/src/store/token-dashboard/sagas.ts
@@ -179,8 +179,6 @@ function* connectWallet() {
       isWalletConnectEnabled,
       isWalletLinkEnabled
     })
-    // @ts-ignore
-    window.w3inst = web3Instance
 
     if (!web3Instance) {
       yield put(


### PR DESCRIPTION
### Description
Adds walletLink as a provider to web3modal.
Note that on disconnect of the walletLink provider it calls a page reload. I couldn't find clean a way around this, so after confirming wallet, it reloads the page if using walletLink as a provider. We disconnect so that the next time you try to connect with walletLink, it shows the QR code instead of using the last cached linked wallet.

![Screen Shot 2021-04-09 at 10 41 29 AM](https://user-images.githubusercontent.com/7064122/114197278-2db87a80-9920-11eb-9570-b9f8acac9226.png)
![Screen Shot 2021-04-09 at 10 41 34 AM](https://user-images.githubusercontent.com/7064122/114197281-2db87a80-9920-11eb-867b-330bb22c96bf.png)

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Ran locally against staging to connect wallets with walletLink and the iOS wallet app.
