### PR TITLE
Fix profile image empty state

### DIFF
--- a/src/components/dynamic-image/DynamicImage.tsx
+++ b/src/components/dynamic-image/DynamicImage.tsx
@@ -62,7 +62,7 @@ const fadeIn = (
     // Set default background color for static images (transparent background defaults)
     if (image.includes('/static')) {
       ref.current.style.backgroundColor = 'var(--neutral-light-5)'
-    } else {
+    } else if (!image.startsWith('data:image/png')) {
       ref.current.style.backgroundColor = 'unset'
     }
     // Allow gradient values for 'image' in addition to URIs


### PR DESCRIPTION
### Description
<img width="249" alt="Screen Shot 2021-04-15 at 12 35 43 AM" src="https://user-images.githubusercontent.com/2731362/114832377-4511c080-9d83-11eb-8724-7f2fa94db6e2.png">
<img width="236" alt="Screen Shot 2021-04-15 at 12 35 41 AM" src="https://user-images.githubusercontent.com/2731362/114832379-45aa5700-9d83-11eb-90ed-fe05e9812ea7.png">
<img width="291" alt="Screen Shot 2021-04-15 at 12 35 36 AM" src="https://user-images.githubusercontent.com/2731362/114832380-4642ed80-9d83-11eb-839f-11ca62be0b6c.png">

This broke because somehow our default image placeholder is being base64 encoded as a data uri instead of as something in /static. Not really sure how this changed, but this fix seems reasonable to me & i've hit a bunch of dynamic image spots to see if there's any impact

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

