### PR TITLE
Fix drag unlisted track bug

### DIFF
--- a/src/containers/nav/desktop/CurrentlyPlaying.tsx
+++ b/src/containers/nav/desktop/CurrentlyPlaying.tsx
@@ -11,6 +11,7 @@ import styles from './CurrentlyPlaying.module.css'
 
 type CurrentlyPlayingProps = {
   isOwner: boolean
+  isUnlisted: boolean
   trackId: number
   trackTitle: string
   coverArtSizes: CoverArtSizes
@@ -30,6 +31,7 @@ type WrapperStyle = {
 
 const CurrentlyPlaying = ({
   isOwner,
+  isUnlisted,
   trackId,
   trackTitle,
   coverArtSizes,
@@ -75,7 +77,7 @@ const CurrentlyPlaying = ({
 
   return (
     <Draggable
-      isDisabled={!trackId}
+      isDisabled={!trackId || isUnlisted}
       text={trackTitle}
       kind='track'
       id={trackId}

--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -444,6 +444,7 @@ const NavColumn = ({
         <CurrentlyPlaying
           trackId={currentQueueItem.track?.track_id ?? null}
           trackTitle={currentQueueItem.track?.title ?? null}
+          isUnlisted={currentQueueItem.track?.is_unlisted ?? false}
           isOwner={
             // Note: if neither are defined, it should eval to false, so setting default to different values
             (currentQueueItem?.user?.handle ?? null) ===

--- a/src/containers/play-bar/desktop/PlayBar.js
+++ b/src/containers/play-bar/desktop/PlayBar.js
@@ -257,6 +257,7 @@ class PlayBar extends Component {
     let reposted = false
     let favorited = false
     let isOwner = false
+    let isTrackUnlisted = false
 
     if (uid && track && user) {
       trackTitle = track.title
@@ -271,6 +272,7 @@ class PlayBar extends Component {
       trackId = track.track_id
       reposted = track.has_current_user_reposted
       favorited = track.has_current_user_saved || false
+      isTrackUnlisted = track.is_unlisted
     }
 
     let playButtonStatus
@@ -297,6 +299,7 @@ class PlayBar extends Component {
               artistHandle={artistHandle}
               artistUserId={artistUserId}
               isVerified={isVerified}
+              isTrackUnlisted={isTrackUnlisted}
               onClickTrackTitle={this.goToTrackPage}
               onClickArtistName={this.goToArtistPage}
             />

--- a/src/containers/play-bar/desktop/components/PlayingTrackInfo.tsx
+++ b/src/containers/play-bar/desktop/components/PlayingTrackInfo.tsx
@@ -18,6 +18,7 @@ interface PlayingTrackInfoProps {
   trackTitle: string
   profilePictureSizes: ProfilePictureSizes
   isVerified: boolean
+  isTrackUnlisted: boolean
   artistUserId: ID
   artistName: string
   artistHandle: string
@@ -42,7 +43,8 @@ const PlayingTrackInfo: React.FC<PlayingTrackInfoProps> = ({
   artistHandle,
   onClickTrackTitle,
   onClickArtistName,
-  isVerified
+  isVerified,
+  isTrackUnlisted
 }) => {
   const [artistSpringProps, setArtistSpringProps] = useSpring(() => springProps)
   const [trackSpringProps, setTrackSpringProps] = useSpring(() => springProps)
@@ -76,7 +78,7 @@ const PlayingTrackInfo: React.FC<PlayingTrackInfoProps> = ({
       </div>
       <div className={styles.text}>
         <Draggable
-          isDisabled={!trackTitle}
+          isDisabled={!trackTitle || isTrackUnlisted}
           text={trackTitle}
           isOwner={isOwner}
           kind='track'


### PR DESCRIPTION
### Description
Disallow dragging a private track into a playlist on desktop from the currently playing image and now playing track name

Fixes AUD-544

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Ran the client locally and checked that dragging public track still worked and private tracks no longer work from the currently playing image and now playing track name.
