### PR TITLE
Fix various search issues

### DIFF
--- a/src/components/general/Page.module.css
+++ b/src/components/general/Page.module.css
@@ -39,6 +39,8 @@
 
 .frosted {
   backdrop-filter: blur(10px);
+  position: relative;
+  z-index: 10;
 }
 
 .headerBoxShadow {

--- a/src/components/search/SearchBar.js
+++ b/src/components/search/SearchBar.js
@@ -301,6 +301,7 @@ class SearchBar extends Component {
                   defaultImage={opt.defaultImage}
                   secondary={opt.secondary}
                   isVerifiedUser={opt.isVerifiedUser}
+                  tier={opt.tier}
                 />
               </Option>
             ))}

--- a/src/components/search/SearchBar.module.css
+++ b/src/components/search/SearchBar.module.css
@@ -163,18 +163,21 @@
   border-radius: 4px;
 }
 
-.searchBox :global(.ant-select-dropdown-menu-item.ant-select-dropdown-menu-item-active),
+/**
+ * To make this bg color work with both hover & keyboard selection, we set bg color in the ant
+ * active state, AND unset bg color in the ant built in hover state. Active state must take precedence (!important),
+ * otherwise unsetting in hover will unset us everywhere.
+ */
+.searchBox :global(.ant-select-dropdown-menu-item.ant-select-dropdown-menu-item-active) {
+  background-color: var(--secondary) !important;
+}
 .searchBox :global(.ant-select-dropdown-menu-item:hover) {
-  background-color: var(--secondary);
+  background-color: unset;
 }
 
 .searchBox :global(.ant-select-dropdown-menu-item.ant-select-dropdown-menu-item-active) > div > div > .resultText,
-.searchBox :global(.ant-select-dropdown-menu-item:hover) > div > div > .resultText {
+.searchBox :global(.ant-select-dropdown-menu-item.ant-select-dropdown-menu-item-active) > div > div > div > .resultText {
   color: var(--static-white);
-}
-.searchBox :global(.ant-select-dropdown-menu-item.ant-select-dropdown-menu-item-active) > div > div > div > .resultText,
-.searchBox :global(.ant-select-dropdown-menu-item:hover) > div > div > div > .resultText {
-    color: var(--static-white);
 }
 
 .allResultsOptionWrapper {

--- a/src/components/search/SearchBarResult.js
+++ b/src/components/search/SearchBarResult.js
@@ -60,7 +60,8 @@ const SearchBarResult = memo(props => {
     creatorNodeEndpoint,
     size,
     defaultImage,
-    isVerifiedUser
+    isVerifiedUser,
+    tier
   } = props
   const isUser = kind === Kind.USERS
 
@@ -87,6 +88,7 @@ const SearchBarResult = memo(props => {
               userId={userId}
               badgeSize={10}
               isVerifiedOverride={isVerifiedUser}
+              overrideTier={tier}
             />
           )}
         </span>
@@ -103,6 +105,8 @@ const SearchBarResult = memo(props => {
                 className={styles.verified}
                 userId={userId}
                 badgeSize={8}
+                isVerifiedOverride={isVerifiedUser}
+                overrideTier={tier}
               />
             )}
           </span>

--- a/src/containers/search-bar/SearchBar.js
+++ b/src/containers/search-bar/SearchBar.js
@@ -60,11 +60,12 @@ class SearchBar extends Component {
       this.setState({ value: '' })
       return
     }
+    const decodedValue = decodeURIComponent(value)
 
     if (!this.isTagSearch() && fetch) {
-      this.props.fetchSearch(value)
+      this.props.fetchSearch(decodedValue)
     }
-    this.setState({ value })
+    this.setState({ value: decodedValue })
   }
 
   onSubmit = value => {
@@ -220,6 +221,7 @@ class SearchBar extends Component {
       0
     )
     const { status, searchText } = this.props.search
+    console.log({ searchText, val: this.state.value })
     return (
       <div className={styles.search}>
         <Bar

--- a/src/containers/search-bar/SearchBar.js
+++ b/src/containers/search-bar/SearchBar.js
@@ -22,6 +22,7 @@ import placeholderArt from 'assets/img/imageBlank2x.png'
 import profilePicEmpty from 'assets/img/imageProfilePicEmpty2X.png'
 
 import Bar from 'components/search/SearchBar'
+import { getTierForUser } from 'containers/user-badges/utils'
 
 class SearchBar extends Component {
   state = {
@@ -140,7 +141,8 @@ class SearchBar extends Component {
                 : null,
               creatorNodeEndpoint: user.creator_node_endpoint,
               defaultImage: profilePicEmpty,
-              isVerifiedUser: user.is_verified
+              isVerifiedUser: user.is_verified,
+              tier: getTierForUser(user)
             }
           })
         },
@@ -160,7 +162,9 @@ class SearchBar extends Component {
               creatorNodeEndpoint: track.user
                 ? track.user.creator_node_endpoint
                 : '',
-              defaultImage: placeholderArt
+              defaultImage: placeholderArt,
+              isVerifiedUser: track.user.is_verified,
+              tier: getTierForUser(track.user)
             }
           })
         },
@@ -186,7 +190,9 @@ class SearchBar extends Component {
               defaultImage: placeholderArt,
               creatorNodeEndpoint: playlist.user
                 ? playlist.user.creator_node_endpoint
-                : ''
+                : '',
+              isVerifiedUser: playlist.user.is_verified,
+              tier: getTierForUser(playlist.user)
             }
           })
         },
@@ -210,7 +216,9 @@ class SearchBar extends Component {
               defaultImage: placeholderArt,
               creatorNodeEndpoint: album.user
                 ? album.user.creator_node_endpoint
-                : ''
+                : '',
+              isVerifiedUser: album.user.is_verified,
+              tier: getTierForUser(album.user)
             }
           })
         }

--- a/src/containers/search-bar/SearchBar.js
+++ b/src/containers/search-bar/SearchBar.js
@@ -229,7 +229,6 @@ class SearchBar extends Component {
       0
     )
     const { status, searchText } = this.props.search
-    console.log({ searchText, val: this.state.value })
     return (
       <div className={styles.search}>
         <Bar

--- a/src/containers/search-bar/SearchBar.js
+++ b/src/containers/search-bar/SearchBar.js
@@ -61,7 +61,13 @@ class SearchBar extends Component {
       this.setState({ value: '' })
       return
     }
-    const decodedValue = decodeURIComponent(value)
+
+    // decodeURIComponent can fail with searches that include
+    // a % sign (malformed URI), so wrap this in a try catch
+    let decodedValue = value
+    try {
+      decodedValue = decodeURIComponent(value)
+    } catch {}
 
     if (!this.isTagSearch() && fetch) {
       this.props.fetchSearch(decodedValue)

--- a/src/containers/user-badges/UserBadges.tsx
+++ b/src/containers/user-badges/UserBadges.tsx
@@ -44,6 +44,7 @@ type UserBadgesProps = {
   // badges off of the store. The override allows for it to be used
   // in a controlled context where the desired store state is not available.
   isVerifiedOverride?: boolean
+  overrideTier?: BadgeTier
 }
 
 const UserBadges: React.FC<UserBadgesProps> = ({
@@ -52,9 +53,11 @@ const UserBadges: React.FC<UserBadgesProps> = ({
   className,
   useSVGTiers = false,
   inline = false,
-  isVerifiedOverride
+  isVerifiedOverride,
+  overrideTier
 }) => {
-  const { tier, isVerified } = useSelectTierInfo(userId)
+  let { tier, isVerified } = useSelectTierInfo(userId)
+  tier = overrideTier || tier
   const tierMap = useSVGTiers ? audioTierMapSVG : audioTierMapPng
   const audioBadge = tierMap[tier]
 

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -816,7 +816,7 @@ class AudiusAPIClient {
       emptySearchResponse
 
     const adapted = adapter.adaptSearchResponse(searchResponse)
-    return processSearchResults({ searchText: query, ...adapted })
+    return processSearchResults(adapted)
   }
 
   async getSearchAutocomplete({
@@ -841,7 +841,6 @@ class AudiusAPIClient {
       emptySearchResponse
     const adapted = adapter.adaptSearchAutocompleteResponse(searchResponse)
     return processSearchResults({
-      searchText: query,
       isAutocomplete: true,
       ...adapted
     })

--- a/src/services/audius-api-client/helper.ts
+++ b/src/services/audius-api-client/helper.ts
@@ -3,7 +3,6 @@ import { UserCollectionMetadata } from 'models/Collection'
 import { UserMetadata } from 'models/User'
 import * as adapter from './ResponseAdapter'
 import { APIResponse, APISearch } from './types'
-import { trimToAlphaNumeric } from 'utils/formatUtil'
 import { removeNullable } from 'utils/typeUtils'
 
 const SEARCH_MAX_SAVED_RESULTS = 10
@@ -91,7 +90,6 @@ export const processSearchResults = async ({
   saved_albums: savedAlbums = [],
   saved_playlists: savedPlaylists = [],
   followed_users: followedUsers = [],
-  searchText = null,
   isAutocomplete = false
 }: ProcessSearchResultsArgs) => {
   const maxSaved = isAutocomplete
@@ -128,22 +126,6 @@ export const processSearchResults = async ({
     maxSaved,
     maxTotal
   )
-
-  // Move any exact handle or name matches to the front of our returned users list
-  const compSearchText = trimToAlphaNumeric(searchText).toLowerCase()
-  const foundIndex = combinedUsers.findIndex(user => {
-    if (!user.name) return -1
-    return (
-      trimToAlphaNumeric(user.name).toLowerCase() === compSearchText ||
-      trimToAlphaNumeric(user.handle_lc) === compSearchText
-    )
-  })
-
-  if (foundIndex !== -1) {
-    const user = combinedUsers[foundIndex]
-    combinedUsers.splice(foundIndex, 1)
-    combinedUsers.unshift(user)
-  }
 
   return {
     tracks: combinedTracks,


### PR DESCRIPTION
### Description
Fixes a bunch of things:
- Adds badges in autocomplete search
- Removes %20 in search bar if you search for multiple words (pressing enter, full search)
- Stops sorting exact handle matches to top on client, since DP is smart now
- Fix bug where if you hover over an autocomplete option and then press arrow key down, two opts show selected (go see this one on prod)
- Fix bug where a 5px dropshadow from the header would steal focus as you scrolled through autocomplete results (a @forrestb find)

Had to break up the selectors for badge stuff a bit, but no logic changes.

### Dragons

Nah


### How Has This Been Tested?

Locally against DP1

