### PR TITLE
Reduce sentry notification polling errors

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1596,11 +1596,20 @@ class AudiusBackend {
             [AuthHeaders.Signature]: signature
           }
         }
-      ).then(res => res.json())
+      ).then(res => {
+        if (res.status !== 200) {
+          return {
+            success: false,
+            error: new Error('Invalid Server Response'),
+            isRequestError: true
+          }
+        }
+        return res.json()
+      })
       return notifications
     } catch (e) {
       console.error(e)
-      return { success: false, error: e }
+      return { success: false, error: e, isRequestError: true }
     }
   }
 


### PR DESCRIPTION
### Description
Only report the errors where the server doesn't return a 200 status code
- This should stop error when the client in unable to make a request (ie. background)
Also check for an account before continuing the notification flow. 
Seems like there are cases where the user is not signed in but tries to fetch notifications?

### Dragons
Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
none

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
ran locally and simulated no internet and a bad response to test that it hit the correct code path on each
