### PR TITLE
Confirm transactions using block has and block number

### DIFF
--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -367,10 +367,11 @@ function* confirmUpdateProfile(userId, metadata) {
           )
         }
         const currentUserId = yield select(getUserId)
-        return apiClient.getUser({
+        const users = yield apiClient.getUser({
           userId,
           currentUserId
         })
+        return users[0]
       },
       function* (confirmedUser) {
         // Store the update in local storage so it is correct upon reload

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -8,7 +8,6 @@ import {
   takeEvery,
   takeLatest
 } from 'redux-saga/effects'
-import { pick, some } from 'lodash'
 
 import * as profileActions from './actions'
 import { waitForBackendSetup } from 'store/backend/sagas'
@@ -16,7 +15,7 @@ import * as cacheActions from 'store/cache/actions'
 import { Kind } from 'store/types'
 import * as confirmerActions from 'store/confirmer/actions'
 import AudiusBackend, { fetchCID } from 'services/AudiusBackend'
-import { pollUser } from 'store/confirmer/sagas'
+import { confirmTransaction, pollUser } from 'store/confirmer/sagas'
 import { getUserId } from 'store/account/selectors'
 import {
   getProfileUserId,
@@ -353,28 +352,21 @@ function* confirmUpdateProfile(userId, metadata) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.USERS, userId),
       function* () {
+        let response
         if (metadata.creator_node_endpoint) {
-          yield call(AudiusBackend.updateCreator, metadata, userId)
+          response = yield call(AudiusBackend.updateCreator, metadata, userId)
         } else {
-          yield call(AudiusBackend.updateUser, metadata, userId)
+          response = yield call(AudiusBackend.updateUser, metadata, userId)
         }
-        const toConfirm = pick(metadata, ['name', 'bio', 'location'])
-        // If the user is trying to upload a new profile picture or cover photo, check that it gets changed
-        let coverPhotoCheck = user => user
-        let profilePictureCheck = user => user
-        if (metadata.updatedCoverPhoto) {
-          coverPhotoCheck = user =>
-            user.cover_photo_sizes !== metadata.cover_photo_sizes
+        const { blockHash, blockNumber } = response
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm update profile for user id ${userId}`
+          )
         }
-        if (metadata.updatedProfilePicture) {
-          profilePictureCheck = user =>
-            user.profile_picture_sizes !== metadata.profile_picture_sizes
-        }
-        const checks = user =>
-          some([user], toConfirm) &&
-          coverPhotoCheck(user) &&
-          profilePictureCheck(user)
-        return yield call(pollUser, userId, checks)
+        return yield call(pollUser, userId)
       },
       function* (confirmedUser) {
         // Store the update in local storage so it is correct upon reload

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -15,7 +15,7 @@ import * as cacheActions from 'store/cache/actions'
 import { Kind } from 'store/types'
 import * as confirmerActions from 'store/confirmer/actions'
 import AudiusBackend, { fetchCID } from 'services/AudiusBackend'
-import { confirmTransaction, pollUser } from 'store/confirmer/sagas'
+import { confirmTransaction } from 'store/confirmer/sagas'
 import { getUserId } from 'store/account/selectors'
 import {
   getProfileUserId,
@@ -366,7 +366,11 @@ function* confirmUpdateProfile(userId, metadata) {
             `Could not confirm update profile for user id ${userId}`
           )
         }
-        return yield call(pollUser, userId)
+        const currentUserId = yield select(getUserId)
+        return apiClient.getUser({
+          userId,
+          currentUserId
+        })
       },
       function* (confirmedUser) {
         // Store the update in local storage so it is correct upon reload

--- a/src/containers/upload-page/store/sagas.js
+++ b/src/containers/upload-page/store/sagas.js
@@ -18,7 +18,11 @@ import * as confirmerActions from 'store/confirmer/actions'
 import * as cacheActions from 'store/cache/actions'
 import * as tracksActions from 'store/cache/tracks/actions'
 import * as accountActions from 'store/account/reducer'
-import { getAccountUser, getUserHandle } from 'store/account/selectors'
+import {
+  getAccountUser,
+  getUserHandle,
+  getUserId
+} from 'store/account/selectors'
 import {
   getSelectedServices,
   getStatus
@@ -27,7 +31,7 @@ import { getUser } from 'store/cache/users/selectors'
 import AudiusBackend from 'services/AudiusBackend'
 import { waitForBackendSetup } from 'store/backend/sagas'
 import UploadType from 'containers/upload-page/components/uploadType'
-import { pollTrack, pollPlaylist } from 'store/confirmer/sagas'
+import { confirmTransaction } from 'store/confirmer/sagas'
 import { actionChannelDispatcher, waitForValue } from 'utils/sagaHelpers'
 import { Kind, Status } from 'store/types'
 import { makeUid } from 'utils/uid'
@@ -43,6 +47,8 @@ import { getStems } from 'containers/upload-page/store/selectors'
 import { updateAndFlattenStems } from 'containers/upload-page/store/utils/stems'
 import { trackNewRemixEvent } from 'store/cache/tracks/sagas'
 import { reportSuccessAndFailureEvents } from './utils/sagaHelpers'
+
+import apiClient from 'services/audius-api-client/AudiusAPIClient'
 
 const MAX_CONCURRENT_UPLOADS = 4
 const MAX_CONCURRENT_REGISTRATIONS = 4
@@ -181,7 +187,7 @@ function* uploadWorker(requestChan, respChan, progressChan) {
       console.debug(
         `Beginning non-collection upload for track: ${metadata.title}`
       )
-      const { trackId, error, phase } = yield call(
+      const { blockHash, blockNumber, trackId, error, phase } = yield call(
         AudiusBackend.uploadTrack,
         track.file,
         artwork,
@@ -206,8 +212,13 @@ function* uploadWorker(requestChan, respChan, progressChan) {
       }
 
       console.debug(`Got new ID ${trackId} for track ${metadata.title}}`)
-      const handle = yield select(getUserHandle)
-      yield call(pollTrack, trackId, formatUrlName(metadata.title), handle)
+
+      const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+      if (!confirmed) {
+        throw new Error(
+          `Could not confirm track upload for track id ${trackId}`
+        )
+      }
       return trackId
     }
   }
@@ -681,7 +692,7 @@ function* uploadCollection(tracks, userId, collectionMetadata, isAlbum) {
         console.debug('Creating playlist')
         // Uploaded collections are always public
         const isPrivate = false
-        const { playlistId, error } = yield call(
+        const { blockHash, blockNumber, playlistId, error } = yield call(
           AudiusBackend.createPlaylist,
           userId,
           collectionMetadata,
@@ -699,20 +710,21 @@ function* uploadCollection(tracks, userId, collectionMetadata, isAlbum) {
             // created the playlist but adding tracks to it failed. So we must delete the playlist
             yield call(AudiusBackend.deletePlaylist, playlistId)
             console.debug('Playlist deleted successfully')
+          } else {
+            // I think this is what we want
+            yield put(uploadActions.createPlaylistErrorNoId(error))
           }
-
-          yield put(uploadActions.createPlaylistErrorIDExists())
           // Throw to trigger the fail callback
           throw new Error('Playlist creation error')
         }
-        return yield call(
-          pollPlaylist,
-          playlistId,
-          userId,
-          playlist =>
-            playlist &&
-            (!collectionMetadata.artwork || playlist.cover_art_sizes)
-        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm playlist creation for playlist id ${playlistId}`
+          )
+        }
+        return (yield call(AudiusBackend.getPlaylists, userId, [playlistId]))[0]
       },
       function* (confirmedPlaylist) {
         yield put(
@@ -785,8 +797,12 @@ function* uploadCollection(tracks, userId, collectionMetadata, isAlbum) {
             trackIds
           )}`
         )
-        yield all(trackIds.map(id => AudiusBackend.deleteTrack(id)))
-        console.debug('Deleted tracks.')
+        try {
+          yield all(trackIds.map(id => AudiusBackend.deleteTrack(id)))
+          console.debug('Deleted tracks.')
+        } catch (err) {
+          console.debug(`Could not delete all tracks: ${err}`)
+        }
         yield put(pushRoute(ERROR_PAGE))
       }
     )
@@ -823,7 +839,7 @@ function* uploadSingleTrack(track) {
     confirmerActions.requestConfirmation(
       `${track.metadata.title}`,
       function* () {
-        const { trackId, error, phase } = yield call(
+        const { blockHash, blockNumber, trackId, error, phase } = yield call(
           AudiusBackend.uploadTrack,
           track.file,
           track.metadata.artwork.file,
@@ -847,13 +863,21 @@ function* uploadSingleTrack(track) {
           throw new Error(error)
         }
 
+        const userId = yield select(getUserId)
         const handle = yield select(getUserHandle)
-        return yield call(
-          pollTrack,
-          trackId,
-          formatUrlName(track.metadata.title),
-          handle
-        )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(`Could not confirm upload single track ${trackId}`)
+        }
+
+        return apiClient.getTrack({
+          id: trackId,
+          currentUserId: userId,
+          unlistedArgs: {
+            urlTitle: formatUrlName(track.metadata.title),
+            handle
+          }
+        })
       },
       function* (confirmedTrack) {
         yield call(responseChan.put, { confirmedTrack })

--- a/src/containers/upload-page/store/sagas.js
+++ b/src/containers/upload-page/store/sagas.js
@@ -870,7 +870,7 @@ function* uploadSingleTrack(track) {
           throw new Error(`Could not confirm upload single track ${trackId}`)
         }
 
-        return apiClient.getTrack({
+        return yield apiClient.getTrack({
           id: trackId,
           currentUserId: userId,
           unlistedArgs: {

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -854,13 +854,12 @@ class AudiusBackend {
   // Uploads a single track
   // Returns { trackId, error, phase }
   static async uploadTrack(trackFile, coverArtFile, metadata, onProgress) {
-    const uploadTrackResponse = await audiusLibs.Track.uploadTrack(
+    return await audiusLibs.Track.uploadTrack(
       trackFile,
       coverArtFile,
       metadata,
       onProgress
     )
-    return uploadTrackResponse
   }
 
   // Used to upload multiple tracks as part of an album/playlist
@@ -899,8 +898,7 @@ class AudiusBackend {
       const resp = await audiusLibs.File.uploadImage(metadata.artwork.file)
       cleanedMetadata.cover_art_sizes = resp.dirCID
     }
-    const update = await audiusLibs.Track.updateTrack(cleanedMetadata)
-    return update
+    return await audiusLibs.Track.updateTrack(cleanedMetadata)
   }
 
   static async getCreators(ids) {
@@ -1009,11 +1007,12 @@ class AudiusBackend {
 
       newMetadata = schemas.newUserMetadata(newMetadata, true)
 
-      const idVal = await audiusLibs.User.updateCreator(
-        newMetadata.user_id,
-        newMetadata
-      )
-      return idVal
+      const {
+        blockHash,
+        blockNumber,
+        userId
+      } = await audiusLibs.User.updateCreator(newMetadata.user_id, newMetadata)
+      return { blockHash, blockNumber, userId }
     } catch (err) {
       console.error(err.message)
       return false
@@ -1061,11 +1060,14 @@ class AudiusBackend {
 
       newMetadata = schemas.newUserMetadata(newMetadata, true)
 
-      await audiusLibs.User.updateUser(id, newMetadata)
-      return true
+      const { blockHash, blockNumber } = await audiusLibs.User.updateUser(
+        id,
+        newMetadata
+      )
+      return { blockHash, blockNumber }
     } catch (err) {
       console.error(err.message)
-      return false
+      throw err
     }
   }
 
@@ -1081,7 +1083,7 @@ class AudiusBackend {
 
   static async followUser(followeeUserId) {
     try {
-      await audiusLibs.User.addUserFollow(followeeUserId)
+      return await audiusLibs.User.addUserFollow(followeeUserId)
     } catch (err) {
       console.error(err.message)
       throw err
@@ -1090,7 +1092,7 @@ class AudiusBackend {
 
   static async unfollowUser(followeeUserId) {
     try {
-      await audiusLibs.User.deleteUserFollow(followeeUserId)
+      return await audiusLibs.User.deleteUserFollow(followeeUserId)
     } catch (err) {
       console.error(err.message)
       throw err
@@ -1152,32 +1154,53 @@ class AudiusBackend {
     if (isAlbum) isPrivate = false
 
     try {
-      const { playlistId, error } = await audiusLibs.Playlist.createPlaylist(
+      const response = await audiusLibs.Playlist.createPlaylist(
         userId,
         playlistName,
         isPrivate,
         isAlbum,
         trackIds
       )
+      let { blockHash, blockNumber, playlistId, error } = response
 
       if (error) return { playlistId, error }
 
+      const updatePromises = []
+
       // If this playlist is being created from an existing cover art, use it.
       if (metadata.cover_art_sizes) {
-        await audiusLibs.contracts.PlaylistFactoryClient.updatePlaylistCoverPhoto(
-          playlistId,
-          Utils.formatOptionalMultihash(metadata.cover_art_sizes)
+        updatePromises.push(
+          audiusLibs.contracts.PlaylistFactoryClient.updatePlaylistCoverPhoto(
+            playlistId,
+            Utils.formatOptionalMultihash(metadata.cover_art_sizes)
+          )
         )
       } else if (coverArt) {
-        await audiusLibs.Playlist.updatePlaylistCoverPhoto(playlistId, coverArt)
-      }
-      if (description) {
-        await audiusLibs.Playlist.updatePlaylistDescription(
-          playlistId,
-          description
+        updatePromises.push(
+          audiusLibs.Playlist.updatePlaylistCoverPhoto(playlistId, coverArt)
         )
       }
-      return { playlistId, error: false }
+      if (description) {
+        updatePromises.push(
+          audiusLibs.Playlist.updatePlaylistDescription(playlistId, description)
+        )
+      }
+
+      /**
+       * find the latest transaction i.e. latest block number among the return transaction receipts
+       * and return that block number along with its corresponding block hash
+       */
+      if (updatePromises.length > 0) {
+        const latestReceipt = (
+          await Promise.all(updatePromises)
+        ).sort((receipt1, receipt2) =>
+          receipt1.blockNumber < receipt2.blockNumber ? 1 : -1
+        )[0]
+        blockHash = latestReceipt.blockHash
+        blockNumber = latestReceipt.blockNumber
+      }
+
+      return { blockHash, blockNumber, playlistId }
     } catch (err) {
       // This code path should never execute
       console.error(err.message)
@@ -1191,22 +1214,39 @@ class AudiusBackend {
     const description = metadata.description
 
     try {
+      let blockHash, blockNumber
+      const promises = []
       if (playlistName) {
-        await audiusLibs.Playlist.updatePlaylistName(playlistId, playlistName)
+        promises.push(
+          audiusLibs.Playlist.updatePlaylistName(playlistId, playlistName)
+        )
       }
       if (coverPhoto) {
-        await audiusLibs.Playlist.updatePlaylistCoverPhoto(
-          playlistId,
-          coverPhoto
+        promises.push(
+          audiusLibs.Playlist.updatePlaylistCoverPhoto(playlistId, coverPhoto)
         )
       }
       if (description) {
-        await audiusLibs.Playlist.updatePlaylistDescription(
-          playlistId,
-          description
+        promises.push(
+          audiusLibs.Playlist.updatePlaylistDescription(playlistId, description)
         )
       }
-      return { error: false }
+
+      /**
+       * find the latest transaction i.e. latest block number among the return transaction receipts
+       * and return that block number along with its corresponding block hash
+       */
+      if (promises.length > 0) {
+        const latestReceipt = (
+          await Promise.all(promises)
+        ).sort((receipt1, receipt2) =>
+          receipt1.blockNumber < receipt2.blockNumber ? 1 : -1
+        )[0]
+        blockHash = latestReceipt.blockHash
+        blockNumber = latestReceipt.blockNumber
+      }
+
+      return { blockHash, blockNumber }
     } catch (error) {
       console.error(error.message)
       return { error }
@@ -1215,12 +1255,15 @@ class AudiusBackend {
 
   static async orderPlaylist(playlistId, trackIds, retries) {
     try {
-      await audiusLibs.Playlist.orderPlaylistTracks(
+      const {
+        blockHash,
+        blockNumber
+      } = await audiusLibs.Playlist.orderPlaylistTracks(
         playlistId,
         trackIds,
         retries
       )
-      return { error: false }
+      return { blockHash, blockNumber }
     } catch (error) {
       console.error(error.message)
       return { error }
@@ -1229,8 +1272,11 @@ class AudiusBackend {
 
   static async publishPlaylist(playlistId) {
     try {
-      await audiusLibs.Playlist.updatePlaylistPrivacy(playlistId, false)
-      return { error: false }
+      const {
+        blockHash,
+        blockNumber
+      } = await audiusLibs.Playlist.updatePlaylistPrivacy(playlistId, false)
+      return { blockHash, blockNumber }
     } catch (error) {
       console.error(error.message)
       return { error }
@@ -1239,8 +1285,11 @@ class AudiusBackend {
 
   static async addPlaylistTrack(playlistId, trackId) {
     try {
-      await audiusLibs.Playlist.addPlaylistTrack(playlistId, trackId)
-      return { error: false }
+      const {
+        blockHash,
+        blockNumber
+      } = await audiusLibs.Playlist.addPlaylistTrack(playlistId, trackId)
+      return { blockHash, blockNumber }
     } catch (error) {
       console.error(error.message)
       return { error }
@@ -1249,13 +1298,16 @@ class AudiusBackend {
 
   static async deletePlaylistTrack(playlistId, trackId, timestamp, retries) {
     try {
-      await audiusLibs.Playlist.deletePlaylistTrack(
+      const {
+        blockHash,
+        blockNumber
+      } = await audiusLibs.Playlist.deletePlaylistTrack(
         playlistId,
         trackId,
         timestamp,
         retries
       )
-      return { error: false }
+      return { blockHash, blockNumber }
     } catch (error) {
       console.error(error.message)
       return { error }
@@ -1293,8 +1345,11 @@ class AudiusBackend {
 
   static async deletePlaylist(playlistId) {
     try {
-      await audiusLibs.Playlist.deletePlaylist(playlistId)
-      return { error: false }
+      const { txReceipt } = await audiusLibs.Playlist.deletePlaylist(playlistId)
+      return {
+        blockHash: txReceipt.blockHash,
+        blockNumber: txReceipt.blockNumber
+      }
     } catch (error) {
       console.error(error.message)
       return { error }
@@ -1314,8 +1369,18 @@ class AudiusBackend {
       const playlistDeletionPromise = audiusLibs.Playlist.deletePlaylist(
         playlistId
       )
-      await Promise.all(trackDeletionPromises.concat(playlistDeletionPromise))
-      return { error: false }
+      const results = await Promise.all(
+        trackDeletionPromises.concat(playlistDeletionPromise)
+      )
+      const deleteTrackReceipts = results.slice(0, -1).map(r => r.txReceipt)
+      const deletePlaylistReceipt = results.slice(-1)[0].txReceipt
+
+      const { blockHash, blockNumber } = deleteTrackReceipts
+        .concat(deletePlaylistReceipt)
+        .sort((receipt1, receipt2) =>
+          receipt1.blockNumber < receipt2.blockNumber ? 1 : -1
+        )[0]
+      return { blockHash, blockNumber }
     } catch (error) {
       console.error(error.message)
       return { error }
@@ -1384,10 +1449,14 @@ class AudiusBackend {
 
   static async deleteTrack(trackId) {
     try {
-      return await audiusLibs.Track.deleteTrack(trackId)
+      const { txReceipt } = await audiusLibs.Track.deleteTrack(trackId)
+      return {
+        blockHash: txReceipt.blockHash,
+        blockNumber: txReceipt.blockNumber
+      }
     } catch (err) {
       console.error(err.message)
-      return false
+      throw err
     }
   }
 

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1191,11 +1191,9 @@ class AudiusBackend {
        * and return that block number along with its corresponding block hash
        */
       if (updatePromises.length > 0) {
-        const latestReceipt = (
+        const latestReceipt = this.getLatestTxReceipt(
           await Promise.all(updatePromises)
-        ).sort((receipt1, receipt2) =>
-          receipt1.blockNumber < receipt2.blockNumber ? 1 : -1
-        )[0]
+        )
         blockHash = latestReceipt.blockHash
         blockNumber = latestReceipt.blockNumber
       }
@@ -1237,11 +1235,9 @@ class AudiusBackend {
        * and return that block number along with its corresponding block hash
        */
       if (promises.length > 0) {
-        const latestReceipt = (
+        const latestReceipt = this.getLatestTxReceipt(
           await Promise.all(promises)
-        ).sort((receipt1, receipt2) =>
-          receipt1.blockNumber < receipt2.blockNumber ? 1 : -1
-        )[0]
+        )
         blockHash = latestReceipt.blockHash
         blockNumber = latestReceipt.blockNumber
       }
@@ -1375,11 +1371,9 @@ class AudiusBackend {
       const deleteTrackReceipts = results.slice(0, -1).map(r => r.txReceipt)
       const deletePlaylistReceipt = results.slice(-1)[0].txReceipt
 
-      const { blockHash, blockNumber } = deleteTrackReceipts
-        .concat(deletePlaylistReceipt)
-        .sort((receipt1, receipt2) =>
-          receipt1.blockNumber < receipt2.blockNumber ? 1 : -1
-        )[0]
+      const { blockHash, blockNumber } = this.getLatestTxReceipt(
+        deleteTrackReceipts.concat(deletePlaylistReceipt)
+      )
       return { blockHash, blockNumber }
     } catch (error) {
       console.error(error.message)
@@ -2344,6 +2338,18 @@ class AudiusBackend {
   static async getSignature(data) {
     await waitForLibsInit()
     return audiusLibs.web3Manager.sign(data)
+  }
+
+  /**
+   * Get latest transaction receipt based on block number
+   * Used by confirmer
+   */
+
+  static getLatestTxReceipt(receipts) {
+    if (!receipts.length) return {}
+    return receipts.sort((receipt1, receipt2) =>
+      receipt1.blockNumber < receipt2.blockNumber ? 1 : -1
+    )[0]
   }
 }
 

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -55,6 +55,7 @@ const FULL_ENDPOINT_MAP = {
     `/playlists/${playlistId}/reposts`,
   playlistFavoriteUsers: (playlistId: OpaqueID) =>
     `/playlists/${playlistId}/favorites`,
+  getUser: (userId: OpaqueID) => `/users/${userId}`,
   userByHandle: (handle: OpaqueID) => `/users/handle/${handle}`,
   userTracksByHandle: (handle: OpaqueID) => `/users/handle/${handle}/tracks`,
   userFavoritedTracks: (userId: OpaqueID) =>
@@ -156,6 +157,11 @@ type GetPlaylistFavoriteUsersArgs = {
   currentUserId: Nullable<ID>
   limit?: number
   offset?: number
+}
+
+type GetUserArgs = {
+  userId: ID
+  currentUserId: Nullable<ID>
 }
 
 type GetUserByHandleArgs = {
@@ -689,6 +695,25 @@ class AudiusAPIClient {
 
     const tracks = remixingResponse.data.map(adapter.makeTrack)
     return tracks
+  }
+
+  async getUser({ userId, currentUserId }: GetUserArgs) {
+    const encodedUserId = this._encodeOrThrow(userId)
+    const encodedCurrentUserId = encodeHashId(currentUserId)
+    this._assertInitialized()
+    const params = {
+      user_id: encodedCurrentUserId || undefined
+    }
+
+    const response: Nullable<APIResponse<APIUser[]>> = await this._getResponse(
+      FULL_ENDPOINT_MAP.getUser(encodedUserId),
+      params
+    )
+
+    if (!response) return []
+
+    const adapted = response.data.map(adapter.makeUser).filter(removeNullable)
+    return adapted
   }
 
   async getUserByHandle({ handle, currentUserId }: GetUserByHandleArgs) {

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -986,7 +986,6 @@ class AudiusAPIClient {
       true,
       PathType.RootPath
     )
-    console.log('block confirmation response', response)
     if (!response) return {}
     return response.data
   }

--- a/src/services/audius-api-client/types.ts
+++ b/src/services/audius-api-client/types.ts
@@ -214,6 +214,11 @@ export type APISearchAutocomplete = {
   saved_albums?: APISearchPlaylist[]
 }
 
+export type APIBlockConfirmation = {
+  block_found: boolean
+  block_passed: boolean
+}
+
 export type APIResponse<T> = {
   data: T
 }

--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -1,36 +1,31 @@
 import {
-  call,
-  put,
   all,
+  call,
+  fork,
+  put,
   select,
-  takeLatest,
   takeEvery,
-  fork
+  takeLatest
 } from 'redux-saga/effects'
-import { pick, some } from 'lodash'
 
 import * as collectionActions from 'store/cache/collections/actions'
 import * as confirmerActions from 'store/confirmer/actions'
 import * as cacheActions from 'store/cache/actions'
 import * as accountActions from 'store/account/reducer'
-import {
-  getUserId,
-  getUserHandle,
-  getAccountUser
-} from 'store/account/selectors'
+import { getAccountUser, getUserId } from 'store/account/selectors'
 import { getUser } from 'store/cache/users/selectors'
 import { getCollection } from 'store/cache/collections/selectors'
-import { getTrack, getTracks } from 'store/cache/tracks/selectors'
+import { getTrack } from 'store/cache/tracks/selectors'
 import AudiusBackend from 'services/AudiusBackend'
 import { waitForBackendSetup } from 'store/backend/sagas'
-import { pollPlaylist, pollTrack } from 'store/confirmer/sagas'
+import { confirmTransaction, pollPlaylist } from 'store/confirmer/sagas'
 import { Kind } from 'store/types'
-import { makeUid, makeKindId } from 'utils/uid'
+import { makeKindId, makeUid } from 'utils/uid'
 import { getCreatorNodeIPFSGateways } from 'utils/gatewayUtil'
 import { fetchUsers } from 'store/cache/users/sagas'
 import * as signOnActions from 'containers/sign-on/store/actions'
 import { DefaultSizes } from 'models/common/ImageSizes'
-import { squashNewLines, formatUrlName } from 'utils/formatUtil'
+import { squashNewLines } from 'utils/formatUtil'
 import { make } from 'store/analytics/actions'
 import { Name } from 'services/analytics'
 import watchTrackErrors from './errorSagas'
@@ -141,28 +136,26 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, uid),
       function* () {
-        const { playlistId, error } = yield call(
+        const { blockHash, blockNumber, playlistId, error } = yield call(
           AudiusBackend.createPlaylist,
           userId,
           formFields
         )
+
         if (error || !playlistId) throw new Error('Unable to create playlist')
-        const toConfirm = pick(formFields, ['playlist_name', 'description'])
-        let check
-        // If the user is trying to upload artwork, check that an artwork gets set.
-        if (formFields.artwork && formFields.artwork.file) {
-          check = playlist =>
-            some([playlist], toConfirm) &&
-            playlist.playlist_image_sizes_multihash
-        } else {
-          check = playlist => some([playlist], toConfirm)
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm playlist creation for playlist id ${playlistId}`
+          )
         }
-        const confirmedPlaylist = yield call(
-          pollPlaylist,
-          playlistId,
+
+        const confirmedPlaylist = (yield call(
+          AudiusBackend.getPlaylists,
           userId,
-          check
-        )
+          [playlistId]
+        ))[0]
 
         // Immediately after confirming the playlist,
         // create a new playlist reference and mark the temporary one as moved.
@@ -308,27 +301,26 @@ function* confirmEditPlaylist(playlistId, userId, formFields) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, playlistId),
       function* (confirmedPlaylistId) {
-        const { error } = yield call(
+        const { blockHash, blockNumber, error } = yield call(
           AudiusBackend.updatePlaylist,
           confirmedPlaylistId,
-          { ...formFields }
-        )
-        if (error) throw error
-        const toConfirm = pick(formFields, ['playlist_name', 'description'])
-        let check
-        // If the user is trying to upload a new album artwork, check for a new CID in confirmation.
-        if (formFields.artwork.file) {
-          check = playlist => {
-            return (
-              some([playlist], toConfirm) &&
-              playlist.playlist_image_sizes_multihash !==
-                formFields.cover_art_sizes
-            )
+          {
+            ...formFields
           }
-        } else {
-          check = playlist => some([playlist], toConfirm)
+        )
+
+        if (error) throw error
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm playlist edition for playlist id ${playlistId}`
+          )
         }
-        return yield call(pollPlaylist, confirmedPlaylistId, userId, check)
+
+        return (yield call(AudiusBackend.getPlaylists, userId, [
+          confirmedPlaylistId
+        ]))[0]
       },
       function* (confirmedPlaylist) {
         // Update the cached collection so it no longer contains image upload artifacts
@@ -429,19 +421,23 @@ function* confirmAddTrackToPlaylist(userId, playlistId, trackId, count) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, playlistId),
       function* (confirmedPlaylistId) {
-        const { error } = yield call(
+        const { blockHash, blockNumber, error } = yield call(
           AudiusBackend.addPlaylistTrack,
           confirmedPlaylistId,
           trackId
         )
         if (error) throw error
-        return yield call(
-          pollPlaylist,
-          confirmedPlaylistId,
-          userId,
-          playlist =>
-            countTrackIds(playlist.playlist_contents, trackId) >= count
-        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm add playlist track for playlist id ${playlistId} and track id ${trackId}`
+          )
+        }
+
+        return (yield call(AudiusBackend.getPlaylists, userId, [
+          confirmedPlaylistId
+        ]))[0]
       },
       function* (confirmedPlaylist) {
         yield put(
@@ -561,7 +557,7 @@ function* confirmRemoveTrackFromPlaylist(
       function* (confirmedPlaylistId) {
         // NOTE: In an attempt to fix playlists in a corrupted state, only attempt the delete playlist track once,
         // if it fails, check if the playlist is in a corrupted state and if so fix it before re-attempting to delete track from playlist
-        const { error } = yield call(
+        let { blockHash, blockNumber, error } = yield call(
           AudiusBackend.deletePlaylistTrack,
           confirmedPlaylistId,
           trackId,
@@ -589,22 +585,28 @@ function* confirmRemoveTrackFromPlaylist(
               countTrackIds(updatedPlaylist.playlist_contents, trackId) <= count
             if (isTrackRemoved) return updatedPlaylist
           }
-          const { error: deletePlaylistError } = yield call(
+          const response = yield call(
             AudiusBackend.deletePlaylistTrack,
             confirmedPlaylistId,
             trackId,
             timestamp
           )
-          if (deletePlaylistError) throw deletePlaylistError
+          if (response.error) throw response.error
+
+          blockHash = response.blockHash
+          blockNumber = response.blockNumber
         }
 
-        return yield call(
-          pollPlaylist,
-          confirmedPlaylistId,
-          userId,
-          playlist =>
-            countTrackIds(playlist.playlist_contents, trackId) <= count
-        )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm remove playlist track for playlist id ${playlistId} and track id ${trackId}`
+          )
+        }
+
+        return (yield call(AudiusBackend.getPlaylists, userId, [
+          confirmedPlaylistId
+        ]))[0]
       },
       function* (confirmedPlaylist) {
         yield put(
@@ -677,7 +679,7 @@ function* confirmOrderPlaylist(userId, playlistId, trackIds) {
       function* (confirmedPlaylistId) {
         // NOTE: In an attempt to fix playlists in a corrupted state, only attempt the order playlist tracks once,
         // if it fails, check if the playlist is in a corrupted state and if so fix it before re-attempting to order playlist
-        const { error } = yield call(
+        let { blockHash, blockNumber, error } = yield call(
           AudiusBackend.orderPlaylist,
           confirmedPlaylistId,
           trackIds,
@@ -699,18 +701,27 @@ function* confirmOrderPlaylist(userId, playlistId, trackIds) {
             const invalidIds = new Set(invalidTrackIds)
             trackIds = trackIds.filter(id => !invalidIds.has(id))
           }
-          const { error: orderPlaylistError } = yield call(
+          const response = yield call(
             AudiusBackend.orderPlaylist,
             confirmedPlaylistId,
             trackIds
           )
-          if (orderPlaylistError) throw orderPlaylistError
+          if (response.error) throw response.error
+
+          blockHash = response.blockHash
+          blockNumber = response.blockNumber
         }
-        return yield call(pollPlaylist, confirmedPlaylistId, userId, playlist =>
-          playlist.playlist_contents.track_ids
-            .map(t => t.track)
-            .every((e, i) => e === trackIds[i])
-        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm order playlist for playlist id ${playlistId}`
+          )
+        }
+
+        return (yield call(AudiusBackend.getPlaylists, userId, [
+          confirmedPlaylistId
+        ]))[0]
       },
       function* (confirmedPlaylist) {
         yield put(
@@ -773,17 +784,21 @@ function* confirmPublishPlaylist(userId, playlistId) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, playlistId),
       function* (confirmedPlaylistId) {
-        const { error } = yield call(
+        const { blockHash, blockNumber, error } = yield call(
           AudiusBackend.publishPlaylist,
           confirmedPlaylistId
         )
         if (error) throw error
-        return yield call(
-          pollPlaylist,
-          confirmedPlaylistId,
-          userId,
-          playlist => !playlist.is_private
-        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm publish playlist for playlist id ${playlistId}`
+          )
+        }
+        return (yield call(AudiusBackend.getPlaylists, userId, [
+          confirmedPlaylistId
+        ]))[0]
       },
       function* (confirmedPlaylist) {
         confirmedPlaylist.is_private = false
@@ -908,37 +923,19 @@ function* confirmDeleteAlbum(playlistId, trackIds, userId) {
           )
         ])
 
-        const { error } = yield call(
+        const { blockHash, blockNumber, error } = yield call(
           AudiusBackend.deleteAlbum,
           playlistId,
           trackIds
         )
         if (error) throw error
-        const ids = trackIds.map(t => t.track)
-        const tracks = yield select(getTracks, { ids })
-        // We need to poll until both playlist and all tracks are deleted
-        console.debug(`Polling for album ${playlistId}`)
-        const handle = yield select(getUserHandle)
-        return yield all(
-          ids
-            .map(id =>
-              call(
-                pollTrack,
-                id,
-                formatUrlName(tracks[id].title),
-                handle,
-                t => t.is_delete
-              )
-            )
-            .concat(
-              call(
-                pollPlaylist,
-                playlistId,
-                userId,
-                playlist => playlist.is_delete
-              )
-            )
-        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(`Could not confirm delete album for id ${playlistId}`)
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {
         console.debug(`Successfully deleted album ${playlistId}`)
@@ -1010,17 +1007,22 @@ function* confirmDeletePlaylist(userId, playlistId) {
           )
         ])
 
-        const { error } = yield call(
+        const { blockHash, blockNumber, error } = yield call(
           AudiusBackend.deletePlaylist,
           confirmedPlaylistId
         )
         if (error) throw error
-        return yield call(
-          pollPlaylist,
-          confirmedPlaylistId,
-          userId,
-          playlist => playlist.is_delete
-        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm delete playlist track for playlist id ${playlistId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return (yield call(AudiusBackend.getPlaylists, userId, [
+          confirmedPlaylistId
+        ]))[0]
       },
       function* () {
         console.debug(`Successfully deleted playlist ${playlistId}`)

--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -934,8 +934,6 @@ function* confirmDeleteAlbum(playlistId, trackIds, userId) {
         if (!confirmed) {
           throw new Error(`Could not confirm delete album for id ${playlistId}`)
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {
         console.debug(`Successfully deleted album ${playlistId}`)
@@ -1019,10 +1017,6 @@ function* confirmDeletePlaylist(userId, playlistId) {
             `Could not confirm delete playlist track for playlist id ${playlistId}`
           )
         }
-        // todo do we really need to return anything here?
-        return (yield call(AudiusBackend.getPlaylists, userId, [
-          confirmedPlaylistId
-        ]))[0]
       },
       function* () {
         console.debug(`Successfully deleted playlist ${playlistId}`)

--- a/src/store/cache/tracks/sagas.js
+++ b/src/store/cache/tracks/sagas.js
@@ -218,7 +218,7 @@ function* confirmEditTrack(
         const userId = yield select(getUserId)
         const handle = yield select(getUserHandle)
 
-        return apiClient.getTrack(
+        return yield apiClient.getTrack(
           {
             id: trackId,
             currentUserId: userId,
@@ -328,7 +328,7 @@ function* confirmDeleteTrack(trackId) {
         const handle = yield select(getUserHandle)
         const userId = yield select(getUserId)
 
-        return apiClient.getTrack(
+        return yield apiClient.getTrack(
           {
             id: trackId,
             currentUserId: userId,

--- a/src/store/cache/tracks/sagas.js
+++ b/src/store/cache/tracks/sagas.js
@@ -7,7 +7,6 @@ import {
   takeEvery,
   takeLatest
 } from 'redux-saga/effects'
-import { pick, some } from 'lodash'
 import { Kind } from 'store/types'
 
 import AudiusBackend, { fetchCID } from 'services/AudiusBackend'
@@ -21,7 +20,6 @@ import {
   getUserHandle
 } from 'store/account/selectors'
 import { waitForBackendSetup } from 'store/backend/sagas'
-import { pollTrack } from 'store/confirmer/sagas'
 import { getCreatorNodeIPFSGateways } from 'utils/gatewayUtil'
 
 import * as cacheActions from 'store/cache/actions'
@@ -38,6 +36,8 @@ import { getTrack } from 'store/cache/tracks/selectors'
 import { waitForValue } from 'utils/sagaHelpers'
 import { makeKindId } from 'utils/uid'
 import { setColor } from 'store/application/ui/average-color/slice'
+import { confirmTransaction } from 'store/confirmer/sagas'
+import apiClient from 'services/audius-api-client/AudiusAPIClient'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
@@ -200,39 +200,34 @@ function* confirmEditTrack(
         if (!wasDownloadable && isNowDownloadable) {
           yield put(trackActions.checkIsDownloadable(trackId))
         }
-        yield call(AudiusBackend.updateTrack, trackId, { ...formFields })
-        const toConfirm = pick(formFields, [
-          'title',
-          'genre',
-          'isrc',
-          'iswc',
-          'license',
-          'mood',
-          'release_date',
-          'tags',
-          'download',
-          'description',
-          'is_unlisted',
-          'field_visibility'
-        ])
-        let check
-        // If the user is trying to upload a new album artwork, check for a new CID in confirmation.
-        if (formFields.artwork && formFields.artwork.file) {
-          check = track =>
-            some([track], toConfirm) &&
-            track.cover_art_sizes !== formFields.cover_art_sizes
-        } else {
-          check = track => some([track], toConfirm)
+
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.updateTrack,
+          trackId,
+          { ...formFields }
+        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm edit track for track id ${trackId}`
+          )
         }
 
         // Need to poll with the new track name in case it changed
+        const userId = yield select(getUserId)
         const handle = yield select(getUserHandle)
-        return yield call(
-          pollTrack,
-          trackId,
-          formatUrlName(formFields.title),
-          handle,
-          check
+
+        return apiClient.getTrack(
+          {
+            id: trackId,
+            currentUserId: userId,
+            unlistedArgs: {
+              urlTitle: formatUrlName(formFields.title),
+              handle
+            }
+          },
+          /* retry */ false
         )
       },
       function* (confirmedTrack) {
@@ -317,15 +312,32 @@ function* confirmDeleteTrack(trackId) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),
       function* () {
-        yield call(AudiusBackend.deleteTrack, trackId)
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.deleteTrack,
+          trackId
+        )
+
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm delete track for track id ${trackId}`
+          )
+        }
+
         const track = yield select(getTrack, { id: trackId })
         const handle = yield select(getUserHandle)
-        return yield call(
-          pollTrack,
-          trackId,
-          formatUrlName(track.title),
-          handle,
-          track => track.is_delete
+        const userId = yield select(getUserId)
+
+        return apiClient.getTrack(
+          {
+            id: trackId,
+            currentUserId: userId,
+            unlistedArgs: {
+              urlTitle: formatUrlName(track.title),
+              handle
+            }
+          },
+          /* retry */ false
         )
       },
       function* (deletedTrack) {

--- a/src/store/confirmer/sagas.js
+++ b/src/store/confirmer/sagas.js
@@ -1,7 +1,6 @@
 import { delay } from 'redux-saga'
 import { call, put, race, select, takeEvery } from 'redux-saga/effects'
 
-import AudiusBackend from 'services/AudiusBackend'
 import { waitForValue } from 'utils/sagaHelpers'
 import * as confirmerActions from 'store/confirmer/actions'
 import {
@@ -22,41 +21,6 @@ const BlockConfirmation = Object.freeze({
 const POLLING_FREQUENCY_MILLIS = 2000
 
 /* Exported  */
-
-/**
- * Polls a playlist in discprov and checks for existence as well as whether a custom check
- * on the playlist is fulfilled.
- * @param {number} playlistId
- * @param {?number} userId playlist owner id. Can be null ONLY if the playlist is PUBLIC.
- * @param {function} check single argument function that takes a playlist and returns a boolean.
- */
-export function* pollPlaylist(
-  playlistId,
-  userId,
-  check = playlist => playlist
-) {
-  let playlists = yield call(AudiusBackend.getPlaylists, userId, [playlistId])
-  while (playlists.length === 0 || !check(playlists[0])) {
-    yield delay(POLLING_FREQUENCY_MILLIS)
-    playlists = yield call(AudiusBackend.getPlaylists, userId, [playlistId])
-  }
-  return playlists[0]
-}
-
-/**
- * Polls a user in discprov and checks for existence as well as whether a custom check
- * on the user is fulfilled.
- * @param {number} userId
- * @param {function} check single argument function that takes a user and returns a boolean.
- */
-export function* pollUser(userId, check = user => user) {
-  let users = yield call(AudiusBackend.getCreators, [userId])
-  while (users.length === 0 || !check(users[0])) {
-    yield delay(POLLING_FREQUENCY_MILLIS)
-    users = yield call(AudiusBackend.getCreators, [userId])
-  }
-  return users[0]
-}
 
 export function* confirmTransaction(blockHash, blockNumber) {
   /**

--- a/src/store/confirmer/sagas.js
+++ b/src/store/confirmer/sagas.js
@@ -59,14 +59,17 @@ export function* pollUser(userId, check = user => user) {
 }
 
 export function* confirmTransaction(blockHash, blockNumber) {
-  console.log({ blockHash, blockNumber })
+  /**
+   * Assume confirmation when there is nothing to confirm
+   */
+  if (!blockHash || !blockNumber) return true
 
   function* confirmBlock() {
     const { block_found, block_passed } = yield apiClient.getBlockConfirmation(
       blockHash,
       blockNumber
     )
-    console.log({ block_found, block_passed })
+
     return block_found
       ? BlockConfirmation.CONFIRMED
       : block_passed

--- a/src/store/social/collections/sagas.ts
+++ b/src/store/social/collections/sagas.ts
@@ -102,8 +102,6 @@ export function* confirmRepostCollection(
             `Could not confirm repost collection for collection id ${collectionId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -199,8 +197,6 @@ export function* confirmUndoRepostCollection(
             `Could not confirm undo repost collection for collection id ${collectionId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -346,8 +342,6 @@ export function* confirmSaveCollection(ownerId: ID, collectionId: ID) {
             `Could not confirm save collection for collection id ${collectionId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -453,8 +447,6 @@ export function* confirmUnsaveCollection(ownerId: ID, collectionId: ID) {
             `Could not confirm unsave collection for collection id ${collectionId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed

--- a/src/store/social/collections/sagas.ts
+++ b/src/store/social/collections/sagas.ts
@@ -12,7 +12,7 @@ import {
   getCollection
 } from 'store/cache/collections/selectors'
 import { waitForBackendSetup } from 'store/backend/sagas'
-import { pollPlaylist } from 'store/confirmer/sagas'
+import { confirmTransaction } from 'store/confirmer/sagas'
 import AudiusBackend from 'services/AudiusBackend'
 import { makeUid, makeKindId } from 'utils/uid'
 import * as signOnActions from 'containers/sign-on/store/actions'
@@ -20,7 +20,6 @@ import { adjustUserField } from 'store/cache/users/sagas'
 import watchCollectionErrors from './errorSagas'
 import { ID } from 'models/common/Identifiers'
 import User from 'models/User'
-import Collection from 'models/Collection'
 import { albumPage, playlistPage } from 'utils/route'
 import { share } from 'utils/share'
 import { formatShareText } from 'utils/formatUtil'
@@ -93,13 +92,18 @@ export function* confirmRepostCollection(
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, collectionId),
       function* () {
-        yield call(AudiusBackend.repostCollection, collectionId)
-        return yield call(
-          pollPlaylist,
-          collectionId,
-          ownerId,
-          (playlist: Collection) => playlist.has_current_user_reposted
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.repostCollection,
+          collectionId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm repost collection for collection id ${collectionId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -185,13 +189,18 @@ export function* confirmUndoRepostCollection(
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, collectionId),
       function* () {
-        yield call(AudiusBackend.undoRepostCollection, collectionId)
-        return yield call(
-          pollPlaylist,
-          collectionId,
-          ownerId,
-          (playlist: Collection) => !playlist.has_current_user_reposted
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.undoRepostCollection,
+          collectionId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm undo repost collection for collection id ${collectionId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -327,13 +336,18 @@ export function* confirmSaveCollection(ownerId: ID, collectionId: ID) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, collectionId),
       function* () {
-        yield call(AudiusBackend.saveCollection, collectionId)
-        return yield call(
-          pollPlaylist,
-          collectionId,
-          ownerId,
-          (playlist: Collection) => playlist.has_current_user_saved
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.saveCollection,
+          collectionId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm save collection for collection id ${collectionId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -429,13 +443,18 @@ export function* confirmUnsaveCollection(ownerId: ID, collectionId: ID) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.COLLECTIONS, collectionId),
       function* () {
-        yield call(AudiusBackend.unsaveCollection, collectionId)
-        return yield call(
-          pollPlaylist,
-          collectionId,
-          ownerId,
-          (playlist: Collection) => !playlist.has_current_user_saved
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.unsaveCollection,
+          collectionId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm unsave collection for collection id ${collectionId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed

--- a/src/store/social/tracks/sagas.ts
+++ b/src/store/social/tracks/sagas.ts
@@ -147,8 +147,6 @@ export function* confirmRepostTrack(trackId: ID, user: User) {
             `Could not confirm repost track for track id ${trackId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -253,8 +251,6 @@ export function* confirmUndoRepostTrack(trackId: ID, user: User) {
             `Could not confirm undo repost track for track id ${trackId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -383,8 +379,6 @@ export function* confirmSaveTrack(trackId: ID) {
             `Could not confirm save track for track id ${trackId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -479,8 +473,6 @@ export function* confirmUnsaveTrack(trackId: ID) {
             `Could not confirm unsave track for track id ${trackId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed

--- a/src/store/social/tracks/sagas.ts
+++ b/src/store/social/tracks/sagas.ts
@@ -9,13 +9,13 @@ import { getUserId, getUserHandle } from 'store/account/selectors'
 import { getTrack, getTracks } from 'store/cache/tracks/selectors'
 import { getUser } from 'store/cache/users/selectors'
 import { waitForBackendSetup } from 'store/backend/sagas'
-import { pollTrack } from 'store/confirmer/sagas'
+import { confirmTransaction } from 'store/confirmer/sagas'
 import AudiusBackend from 'services/AudiusBackend'
 import TrackDownload from 'services/audius-backend/TrackDownload'
 import * as signOnActions from 'containers/sign-on/store/actions'
 import { adjustUserField } from 'store/cache/users/sagas'
 import { makeKindId } from 'utils/uid'
-import { formatUrlName, formatShareText } from 'utils/formatUtil'
+import { formatShareText } from 'utils/formatUtil'
 import watchTrackErrors from './errorSagas'
 import { ID } from 'models/common/Identifiers'
 import User from 'models/User'
@@ -137,17 +137,18 @@ export function* confirmRepostTrack(trackId: ID, user: User) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),
       function* () {
-        yield call(AudiusBackend.repostTrack, trackId)
-        const fetchedTrack = yield select(getTrack, { id: trackId })
-        const user = yield select(getUser, { id: fetchedTrack.owner_id })
-        const handle = user.handle
-        return yield call(
-          pollTrack,
-          trackId,
-          formatUrlName(fetchedTrack.title),
-          handle,
-          (track: Track) => track.has_current_user_reposted
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.repostTrack,
+          trackId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm repost track for track id ${trackId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -242,17 +243,18 @@ export function* confirmUndoRepostTrack(trackId: ID, user: User) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),
       function* () {
-        yield call(AudiusBackend.undoRepostTrack, trackId)
-        const fetchedTrack = yield select(getTrack, { id: trackId })
-        const user = yield select(getUser, { id: fetchedTrack.owner_id })
-        const handle = user.handle
-        return yield call(
-          pollTrack,
-          trackId,
-          formatUrlName(fetchedTrack.title),
-          handle,
-          (track: Track) => !track.has_current_user_reposted
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.undoRepostTrack,
+          trackId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm undo repost track for track id ${trackId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -371,17 +373,18 @@ export function* confirmSaveTrack(trackId: ID) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),
       function* () {
-        yield call(AudiusBackend.saveTrack, trackId)
-        const fetchedTrack = yield select(getTrack, { id: trackId })
-        const user = yield select(getUser, { id: fetchedTrack.owner_id })
-        const handle = user.handle
-        return yield call(
-          pollTrack,
-          trackId,
-          formatUrlName(fetchedTrack.title),
-          handle,
-          (track: Track) => track.has_current_user_saved
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.saveTrack,
+          trackId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm save track for track id ${trackId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -466,17 +469,18 @@ export function* confirmUnsaveTrack(trackId: ID) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.TRACKS, trackId),
       function* () {
-        yield call(AudiusBackend.unsaveTrack, trackId)
-        const fetchedTrack = yield select(getTrack, { id: trackId })
-        const user = yield select(getUser, { id: fetchedTrack.owner_id })
-        const handle = user.handle
-        return yield call(
-          pollTrack,
-          trackId,
-          formatUrlName(fetchedTrack.title),
-          handle,
-          (track: Track) => track.has_current_user_saved
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.unsaveTrack,
+          trackId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm unsave track for track id ${trackId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed

--- a/src/store/social/users/sagas.ts
+++ b/src/store/social/users/sagas.ts
@@ -6,7 +6,7 @@ import { Kind } from 'store/types'
 import * as confirmerActions from 'store/confirmer/actions'
 import { getUsers, getUser } from 'store/cache/users/selectors'
 import { waitForBackendSetup } from 'store/backend/sagas'
-import { pollUser } from 'store/confirmer/sagas'
+import { confirmTransaction } from 'store/confirmer/sagas'
 import AudiusBackend from 'services/AudiusBackend'
 import { getUserId } from 'store/account/selectors'
 import * as signOnActions from 'containers/sign-on/store/actions'
@@ -14,7 +14,6 @@ import { adjustUserField } from 'store/cache/users/sagas'
 import { makeKindId } from 'utils/uid'
 import errorSagas from './errorSagas'
 import { ID } from 'models/common/Identifiers'
-import User from 'models/User'
 import { profilePage } from 'utils/route'
 import { make } from 'store/analytics/actions'
 import { Name } from 'services/analytics'
@@ -75,12 +74,18 @@ export function* confirmFollowUser(userId: ID, accountId: ID) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.USERS, userId),
       function* () {
-        yield call(AudiusBackend.followUser, userId)
-        return yield call(
-          pollUser,
-          userId,
-          (user: User) => user.does_current_user_follow
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.followUser,
+          userId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm follow user for user id ${userId} and account id ${accountId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       // @ts-ignore: remove when confirmer is typed
       function* () {
@@ -174,12 +179,18 @@ export function* confirmUnfollowUser(userId: ID, accountId: ID) {
     confirmerActions.requestConfirmation(
       makeKindId(Kind.USERS, userId),
       function* () {
-        yield call(AudiusBackend.unfollowUser, userId)
-        return yield call(
-          pollUser,
-          userId,
-          (user: User) => !user.does_current_user_follow
+        const { blockHash, blockNumber } = yield call(
+          AudiusBackend.unfollowUser,
+          userId
         )
+        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm unfollow user for user id ${userId} and account id ${accountId}`
+          )
+        }
+        // todo do we really need to return anything here?
+        return confirmed
       },
       // @ts-ignore: remove when confirmer is typed
       function* () {

--- a/src/store/social/users/sagas.ts
+++ b/src/store/social/users/sagas.ts
@@ -84,8 +84,6 @@ export function* confirmFollowUser(userId: ID, accountId: ID) {
             `Could not confirm follow user for user id ${userId} and account id ${accountId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       // @ts-ignore: remove when confirmer is typed
       function* () {
@@ -189,8 +187,6 @@ export function* confirmUnfollowUser(userId: ID, accountId: ID) {
             `Could not confirm unfollow user for user id ${userId} and account id ${accountId}`
           )
         }
-        // todo do we really need to return anything here?
-        return confirmed
       },
       // @ts-ignore: remove when confirmer is typed
       function* () {


### PR DESCRIPTION
### Description
This will make the confirmation of different actions such as repost, save, upload, signup, follow, etc. to use the same confirmation paradigm. That is, by using the transaction receipt block hash and block number and verifying that they have been indexed.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
This touches many flows in the dapp and we want to make sure those still work as intended.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Spun up local libs with changes, and spun up local dapp and tested all the impacted flows.

