### PR TITLE
Return result from confirmation calls

### DIFF
--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -272,7 +272,6 @@ function* signUp(action) {
         if (!confirmed) {
           throw new Error(`Could not confirm sign up for user id ${userId}`)
         }
-        // todo do we actually need the next line
         return yield call(AudiusBackend.getCreators, [userId])[0]
       },
       function* () {

--- a/src/store/cache/collections/sagas.js
+++ b/src/store/cache/collections/sagas.js
@@ -932,6 +932,7 @@ function* confirmDeleteAlbum(playlistId, trackIds, userId) {
         if (!confirmed) {
           throw new Error(`Could not confirm delete album for id ${playlistId}`)
         }
+        return playlistId
       },
       function* () {
         console.debug(`Successfully deleted album ${playlistId}`)
@@ -1015,6 +1016,7 @@ function* confirmDeletePlaylist(userId, playlistId) {
             `Could not confirm delete playlist track for playlist id ${playlistId}`
           )
         }
+        return confirmedPlaylistId
       },
       function* () {
         console.debug(`Successfully deleted playlist ${playlistId}`)

--- a/src/store/social/collections/sagas.ts
+++ b/src/store/social/collections/sagas.ts
@@ -103,6 +103,7 @@ export function* confirmRepostCollection(
             `Could not confirm repost collection for collection id ${collectionId}`
           )
         }
+        return collectionId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -198,6 +199,7 @@ export function* confirmUndoRepostCollection(
             `Could not confirm undo repost collection for collection id ${collectionId}`
           )
         }
+        return collectionId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -349,6 +351,7 @@ export function* confirmSaveCollection(ownerId: ID, collectionId: ID) {
             `Could not confirm save collection for collection id ${collectionId}`
           )
         }
+        return collectionId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -454,6 +457,7 @@ export function* confirmUnsaveCollection(ownerId: ID, collectionId: ID) {
             `Could not confirm unsave collection for collection id ${collectionId}`
           )
         }
+        return collectionId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed

--- a/src/store/social/tracks/sagas.ts
+++ b/src/store/social/tracks/sagas.ts
@@ -147,6 +147,7 @@ export function* confirmRepostTrack(trackId: ID, user: User) {
             `Could not confirm repost track for track id ${trackId}`
           )
         }
+        return trackId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -251,6 +252,7 @@ export function* confirmUndoRepostTrack(trackId: ID, user: User) {
             `Could not confirm undo repost track for track id ${trackId}`
           )
         }
+        return trackId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -379,6 +381,7 @@ export function* confirmSaveTrack(trackId: ID) {
             `Could not confirm save track for track id ${trackId}`
           )
         }
+        return trackId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed
@@ -473,6 +476,7 @@ export function* confirmUnsaveTrack(trackId: ID) {
             `Could not confirm unsave track for track id ${trackId}`
           )
         }
+        return trackId
       },
       function* () {},
       // @ts-ignore: remove when confirmer is typed

--- a/src/store/social/users/sagas.ts
+++ b/src/store/social/users/sagas.ts
@@ -84,6 +84,7 @@ export function* confirmFollowUser(userId: ID, accountId: ID) {
             `Could not confirm follow user for user id ${userId} and account id ${accountId}`
           )
         }
+        return accountId
       },
       // @ts-ignore: remove when confirmer is typed
       function* () {
@@ -187,6 +188,7 @@ export function* confirmUnfollowUser(userId: ID, accountId: ID) {
             `Could not confirm unfollow user for user id ${userId} and account id ${accountId}`
           )
         }
+        return accountId
       },
       // @ts-ignore: remove when confirmer is typed
       function* () {

--- a/src/store/token-dashboard/sagas.ts
+++ b/src/store/token-dashboard/sagas.ts
@@ -379,6 +379,7 @@ function* removeWallet(action: ConfirmRemoveWalletAction) {
               `Could not confirm remove wallet for account user id ${accountUserId}`
             )
           }
+          return accountUserId
         },
         // @ts-ignore: remove when confirmer is typed
         function* () {


### PR DESCRIPTION
Return result from confirmation calls so subsequent confirmations do not get blocked

### Description

### Dragons

### How Has This Been Tested?
Tested locally

