### PR TITLE
Use libs 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.1.tgz",
-      "integrity": "sha512-KpY7FivedgP08bkVWjnaGDN5k2NtPTsG0P0hfux1fNrWCgrLQU2NkIAWOt3RxCewtxkmBmDrJVNTlCh+SnZzrA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.2.tgz",
+      "integrity": "sha512-B5njk7NGCEy4epZL+1HAnBt1Dqfa0GalqmeL0pq8iMBfBwxGn+6wVAOTR6IYnRaqf1vmIcihQJCSLJP2jx6zyw==",
       "requires": {
         "@audius/hedgehog": "1.0.8",
         "@ethersproject/solidity": "5.0.5",
@@ -2936,64 +2936,53 @@
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
-      "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.3.0.tgz",
+      "integrity": "sha512-5xguJ+Q1/zRMgHgDCaqAexx/8DwDVLRemw2i6uR8KyGjwGdXI8f32QZZ1cKGucBN6ekJvpUpHy6XAuQnTv0mPA==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "bn.js": "^4.4.0"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "bn.js": "^4.11.9"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-      "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.3.0.tgz",
+      "integrity": "sha512-rqLJjdVqCcn7glPer7Fxh87PRqlnRScVAoxcIP3PmOUNApMWJ6yRdOFfo2KvPAdO7Le3yEI1o0YW+Yvr7XCYvw==",
       "requires": {
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-      "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.3.0.tgz",
+      "integrity": "sha512-4y1feNOwEpgjAfiCFWOHznvv6qUF/H6uI0UKp8xdhftb+H+FbKflXg1pOgH5qs4Sr7EYBL+zPyPb+YD5g1aEyw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0"
+        "@ethersproject/bignumber": "^5.3.0"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
-      "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.3.0.tgz",
+      "integrity": "sha512-Gv2YqgIUmRbYVNIibafT0qGaeGYLIA/EdWHJ7JcVxVSs2vyxafGxOJ5VpSBHWeOIsE6OOaCelYowhuuTicgdFQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/bytes": "^5.3.0",
         "js-sha3": "0.5.7"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-      "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.3.0.tgz",
+      "integrity": "sha512-8bwJ2gxJGkZZnpQSq5uSiZSJjyVTWmlGft4oH8vxHdvO1Asy4TwVepAhPgxIQIMxXZFUNMych1YjIV4oQ4I7dA=="
     },
     "@ethersproject/sha2": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.1.0.tgz",
-      "integrity": "sha512-+fNSeZRstOpdRJpdGUkRONFCaiAqWkc91zXgg76Nlp5ndBQE25Kk5yK8gCPG1aGnCrbariiPr5j9DmrYH78JCA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.3.0.tgz",
+      "integrity": "sha512-r5ftlwKcocYEuFz2JbeKOT5SAsCV4m1RJDsTOEfQ5L67ZC7NFDK5i7maPdn1bx4nPhylF9VAwxSrQ1esmwzylg==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "hash.js": "1.1.3"
-      },
-      "dependencies": {
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        }
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0",
+        "hash.js": "1.1.7"
       }
     },
     "@ethersproject/solidity": {
@@ -3009,13 +2998,13 @@
       }
     },
     "@ethersproject/strings": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
-      "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.3.0.tgz",
+      "integrity": "sha512-j/AzIGZ503cvhuF2ldRSjB0BrKzpsBMtCieDtn4TYMMZMQ9zScJn9wLzTQl/bRNvJbBE6TOspK0r8/Ngae/f2Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/bytes": "^5.3.0",
+        "@ethersproject/constants": "^5.3.0",
+        "@ethersproject/logger": "^5.3.0"
       }
     },
     "@hapi/address": {
@@ -17637,9 +17626,9 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA=="
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -21336,6 +21325,14 @@
       "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -32187,14 +32184,6 @@
             "timed-out": "^4.0.0",
             "url-parse-lax": "^1.0.0",
             "url-to-options": "^1.0.1"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "requires": {
-            "graceful-fs": "^4.1.6"
           }
         },
         "p-cancelable": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.17",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.1",
+    "@audius/libs": "1.2.2",
     "@audius/stems": "0.3.7",
     "@optimizely/optimizely-sdk": "^4.0.0",
     "@reduxjs/toolkit": "^1.3.2",


### PR DESCRIPTION
### Description

This libs bump is inclusive of the protocol hashes
`27576f58c4cdfa8e18e3f90f2c427d1e4a7eb51c` to `d2a7b99e5b098c3eff761c543936f9773e707457`

most importantly, this libs bump includes fixing the `creator_node_endpoint` bug where some users on signup were not getting assigned a `creator_node_endpoint`. now, there will be a sanity check that assigns a replica set & on file upload, will also assign a replica set if necessary

NOTE: 1.2.1 in libs was not merged into `audius-protocol`, but was published to npm. 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?



### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

