### PR TITLE
Update "accept" field on image uploads to allowable images

### DIFF
--- a/src/components/image-selection/ImageSelectionButton.js
+++ b/src/components/image-selection/ImageSelectionButton.js
@@ -77,7 +77,7 @@ const ImageSelectionButton = ({
           <ReactDropzone
             onDrop={onSelect}
             className={styles.dropzone}
-            accept='image/*'
+            accept='image/png, image/jpeg'
           >
             <Button
               className={cn(styles.button, styles.noPopup, {

--- a/src/components/image-selection/ImageSelectionButton.js
+++ b/src/components/image-selection/ImageSelectionButton.js
@@ -9,6 +9,7 @@ import ImageSelectionPopup from './ImageSelectionPopup'
 
 import { ImageSelectionProps, ImageSelectionDefaults } from './PropTypes'
 import styles from './ImageSelectionButton.module.css'
+import { ALLOWED_IMAGE_FILE_TYPES } from 'utils/imageProcessingUtil'
 
 const messages = {
   add: 'Add',
@@ -77,7 +78,7 @@ const ImageSelectionButton = ({
           <ReactDropzone
             onDrop={onSelect}
             className={styles.dropzone}
-            accept='image/png, image/jpeg'
+            accept={ALLOWED_IMAGE_FILE_TYPES.join(', ')}
           >
             <Button
               className={cn(styles.button, styles.noPopup, {

--- a/src/components/upload/Dropzone.js
+++ b/src/components/upload/Dropzone.js
@@ -86,8 +86,7 @@ Dropzone.propTypes = {
   subtitle: PropTypes.string,
   allowMultiple: PropTypes.bool,
   onDrop: PropTypes.func,
-  disabled: PropTypes.bool,
-  accept: PropTypes.string
+  disabled: PropTypes.bool
 }
 
 Dropzone.defaultProps = {

--- a/src/components/upload/Dropzone.js
+++ b/src/components/upload/Dropzone.js
@@ -56,6 +56,7 @@ const Dropzone = ({
       className={cn(styles.dropzone, className)}
       disabled={disabled}
       disableClick={disabled || disableClick}
+      accept={type === 'image' ? 'image/jpeg, image/png' : 'audio/*'}
     >
       <div className={styles.hoverBoundingBox}>
         <span className={styles.contentWrapper}>
@@ -85,7 +86,8 @@ Dropzone.propTypes = {
   subtitle: PropTypes.string,
   allowMultiple: PropTypes.bool,
   onDrop: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  accept: PropTypes.string
 }
 
 Dropzone.defaultProps = {

--- a/src/components/upload/Dropzone.js
+++ b/src/components/upload/Dropzone.js
@@ -5,6 +5,7 @@ import cn from 'classnames'
 
 import styles from './Dropzone.module.css'
 import { ReactComponent as IconUpload } from 'assets/img/iconUpload.svg'
+import { ALLOWED_IMAGE_FILE_TYPES } from 'utils/imageProcessingUtil'
 
 const messages = {
   track: 'Drag-and-drop a track here, or ',
@@ -56,7 +57,9 @@ const Dropzone = ({
       className={cn(styles.dropzone, className)}
       disabled={disabled}
       disableClick={disabled || disableClick}
-      accept={type === 'image' ? 'image/jpeg, image/png' : 'audio/*'}
+      accept={
+        type === 'image' ? ALLOWED_IMAGE_FILE_TYPES.join(', ') : 'audio/*'
+      }
     >
       <div className={styles.hoverBoundingBox}>
         <span className={styles.contentWrapper}>

--- a/src/utils/imageProcessingUtil.js
+++ b/src/utils/imageProcessingUtil.js
@@ -6,7 +6,7 @@ import gifPreviewWorkerFile from 'workers/gifPreview.worker.js'
 const averageRgbWorker = new WebWorker(averageRgbWorkerFile, false)
 const gifPreviewWorker = new WebWorker(gifPreviewWorkerFile, false)
 
-const ALLOWED_IMAGE_FILE_TYPES = [
+export const ALLOWED_IMAGE_FILE_TYPES = [
   'image/jpeg',
   'image/png',
   'image/bmp',


### PR DESCRIPTION
### Description

Certain image formats are not supported by the back end, so we should filter them out on the client.

Adds an explicit `accept` prop to React Dropzone (docs: https://react-dropzone.js.org/#!/Accepting%20specific%20file%20types ) so that invalid types aren't mistakenly uploaded.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

- Higher coupling with the utils file (the cost of a single source of truth for file support)
- Defaulted the `accept` prop to `audio/*` when `type` is not `'image'` as the only types for the `ImageSelectionPopup` are `'track'`, `'stem'`, and `'image'` (and both track and image should be audio files). Previously, no such filter existed.


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested manually locally by uploading an individual track.