### PR TITLE
Save shuffle and repeat states to local storage

### DIFF
--- a/src/components/play-bar/repeat-button/RepeatButton.js
+++ b/src/components/play-bar/repeat-button/RepeatButton.js
@@ -14,11 +14,23 @@ const RepeatStates = Object.freeze({
   ANIMATE_SINGLE_OFF: 5
 })
 
+const REPEAT_STATE_LS_KEY = 'repeatState'
+const getRepeatState = defaultState => {
+  const localStorageRepeatState = window.localStorage.getItem(
+    REPEAT_STATE_LS_KEY
+  )
+  if (localStorageRepeatState === null) {
+    window.localStorage.setItem(REPEAT_STATE_LS_KEY, defaultState)
+    return defaultState
+  } else {
+    return parseInt(localStorageRepeatState)
+  }
+}
 class RepeatButton extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      repeatState: RepeatStates.OFF,
+      repeatState: getRepeatState(RepeatStates.OFF),
       isPaused: true,
       icon: props.animations ? props.animations.pbIconRepeatAll : null
     }
@@ -71,6 +83,7 @@ class RepeatButton extends Component {
         icon = pbIconRepeatAll
         isPaused = true
     }
+    window.localStorage.setItem(REPEAT_STATE_LS_KEY, repeatState)
     this.setState({
       icon,
       isPaused,

--- a/src/components/play-bar/shuffle-button/ShuffleButton.js
+++ b/src/components/play-bar/shuffle-button/ShuffleButton.js
@@ -12,11 +12,24 @@ const ShuffleStates = Object.freeze({
   ANIMATE_ON_OFF: 3
 })
 
+const SHUFFLE_STATE_LS_KEY = 'shuffleState'
+const getShuffleState = defaultState => {
+  const localStorageShuffleState = window.localStorage.getItem(
+    SHUFFLE_STATE_LS_KEY
+  )
+  if (localStorageShuffleState === null) {
+    window.localStorage.setItem(SHUFFLE_STATE_LS_KEY, defaultState)
+    return defaultState
+  } else {
+    return parseInt(localStorageShuffleState)
+  }
+}
+
 class ShuffleButton extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      shuffleState: ShuffleStates.OFF,
+      shuffleState: getShuffleState(ShuffleStates.OFF),
       isPaused: true,
       icon: props.animations ? props.animations.pbIconShuffleOn : null
     }
@@ -56,6 +69,7 @@ class ShuffleButton extends Component {
         icon = pbIconShuffleOn
         isPaused = true
     }
+    window.localStorage.setItem(SHUFFLE_STATE_LS_KEY, shuffleState)
     this.setState({
       icon,
       isPaused,


### PR DESCRIPTION
### Description

Save the user's shuffle/repeat states to local storage to persist it on page reload.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Manually tested on Microsoft Edge Desktop:
1) Toggle Shuffle/Repeat settings
2) Refresh page
3) Observe settings persist

1) Open local storage in devtools
2) Set relevant keys to 1 (for the "ANIMATE_OFF_ALL" etc keys)
3) Observe the settings change to 2
