### PR TITLE
Fix reposts tab content ordering/pagination

### DIFF
--- a/src/utils/uid.js
+++ b/src/utils/uid.js
@@ -86,6 +86,18 @@ export function makeUid(kind, id, source) {
  */
 export const makeKindId = (kind, id) => `${kind}-${id}`
 
+/**
+ * Gets the id from a kind id
+ * @param {String} kindId
+ */
+export const getIdFromKindId = kindId => kindId.split('-')[1]
+
+/**
+ * Gets the kind from a kind id
+ * @param {String} kindId
+ */
+export const getKindFromKindId = kindId => kindId.split('-')[0]
+
 export const uuid = () => {
   // https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript/873856#873856
   const s = []


### PR DESCRIPTION
### Description
There were a couple issues with the chunk of code in the reposts tab that added "unconfirmed" reposted content in (https://github.com/AudiusProject/audius-client/commit/368abbc67453083e245fbd42b09c592bcf2d65e4).

1. The logic checks anything that's in the cache and only dedupes against what is currently coming back in the lineup pagination. If you visited some track pages/trending/etc. where you had tracks that were reposted, the existing code basically ends up shoving all of that content into your reposts tab (even if you had reposted it months ago)
2. The logic runs on every pagination so you'd get the same content repeated many times at the end of each page
3. The logic only accounted for tracks, not collections

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Loaded my prod reposts tab in a clean state (no confirming actions) and paginated through. Made a lot more sense.
- Ran against staging and made sure that having unconfirmed track & collection reposts do indeed show up in the tab
