### PR TITLE
Fix optimizely bug

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -35,10 +35,6 @@ import {
 import { monitoringCallbacks } from './serviceMonitoring'
 import { isElectron } from 'utils/clientUtil'
 import { getCreatorNodeIPFSGateways } from 'utils/gatewayUtil'
-import {
-  FeatureFlagIdentifierType,
-  OPTIMIZELY_LOCAL_STORAGE_KEY
-} from './remote-config/FeatureFlags'
 
 export const IDENTITY_SERVICE = process.env.REACT_APP_IDENTITY_SERVICE
 export const USER_NODE = process.env.REACT_APP_USER_NODE
@@ -385,11 +381,6 @@ class AudiusBackend {
     }
 
     try {
-      // Set sessionId for feature flag bucketing
-      if (!window.localStorage.getItem(OPTIMIZELY_LOCAL_STORAGE_KEY)) {
-        window.localStorage.setItem(OPTIMIZELY_LOCAL_STORAGE_KEY, uuid())
-      }
-
       audiusLibs = new AudiusLibs({
         web3Config,
         ethWeb3Config,
@@ -418,12 +409,10 @@ class AudiusBackend {
           : { siteKey: RECAPTCHA_SITE_KEY },
         isServer: false,
         useTrackContentPolling: getFeatureEnabled(
-          FeatureFlags.USE_TRACK_CONTENT_POLLING,
-          FeatureFlagIdentifierType.SESSION_ID
+          FeatureFlags.USE_TRACK_CONTENT_POLLING
         ),
         useResumableTrackUpload: getFeatureEnabled(
-          FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD,
-          FeatureFlagIdentifierType.SESSION_ID
+          FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD
         )
       })
       await audiusLibs.init()

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -386,7 +386,9 @@ class AudiusBackend {
 
     try {
       // Set sessionId for feature flag bucketing
-      window.localStorage.setItem(OPTIMIZELY_LOCAL_STORAGE_KEY, uuid())
+      if (!window.localStorage.getItem(OPTIMIZELY_LOCAL_STORAGE_KEY)) {
+        window.localStorage.setItem(OPTIMIZELY_LOCAL_STORAGE_KEY, uuid())
+      }
 
       audiusLibs = new AudiusLibs({
         web3Config,
@@ -421,10 +423,6 @@ class AudiusBackend {
         ),
         useResumableTrackUpload: getFeatureEnabled(
           FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD,
-          FeatureFlagIdentifierType.SESSION_ID
-        ),
-        vickyTest: getFeatureEnabled(
-          FeatureFlags.USE_TRACK_CONTENT_POLLING,
           FeatureFlagIdentifierType.SESSION_ID
         )
       })

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -35,6 +35,10 @@ import {
 import { monitoringCallbacks } from './serviceMonitoring'
 import { isElectron } from 'utils/clientUtil'
 import { getCreatorNodeIPFSGateways } from 'utils/gatewayUtil'
+import {
+  FeatureFlagIdentifierType,
+  OPTIMIZELY_LOCAL_STORAGE_KEY
+} from './remote-config/FeatureFlags'
 
 export const IDENTITY_SERVICE = process.env.REACT_APP_IDENTITY_SERVICE
 export const USER_NODE = process.env.REACT_APP_USER_NODE
@@ -381,6 +385,9 @@ class AudiusBackend {
     }
 
     try {
+      // Set sessionId for feature flag bucketing
+      window.localStorage.setItem(OPTIMIZELY_LOCAL_STORAGE_KEY, uuid())
+
       audiusLibs = new AudiusLibs({
         web3Config,
         ethWeb3Config,
@@ -409,10 +416,16 @@ class AudiusBackend {
           : { siteKey: RECAPTCHA_SITE_KEY },
         isServer: false,
         useTrackContentPolling: getFeatureEnabled(
-          FeatureFlags.USE_TRACK_CONTENT_POLLING
+          FeatureFlags.USE_TRACK_CONTENT_POLLING,
+          FeatureFlagIdentifierType.SESSION_ID
         ),
         useResumableTrackUpload: getFeatureEnabled(
-          FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD
+          FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD,
+          FeatureFlagIdentifierType.SESSION_ID
+        ),
+        vickyTest: getFeatureEnabled(
+          FeatureFlags.USE_TRACK_CONTENT_POLLING,
+          FeatureFlagIdentifierType.SESSION_ID
         )
       })
       await audiusLibs.init()

--- a/src/services/remote-config/FeatureFlags.ts
+++ b/src/services/remote-config/FeatureFlags.ts
@@ -14,3 +14,10 @@ export const flagDefaults: { [key in FeatureFlags]: boolean } = {
   [FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD]: true,
   [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: false
 }
+
+export enum FeatureFlagIdentifierType {
+  USER_ID = 'user_id',
+  SESSION_ID = 'session_id'
+}
+
+export const OPTIMIZELY_LOCAL_STORAGE_KEY = 'optimizelyKey'

--- a/src/services/remote-config/FeatureFlags.ts
+++ b/src/services/remote-config/FeatureFlags.ts
@@ -15,9 +15,19 @@ export const flagDefaults: { [key in FeatureFlags]: boolean } = {
   [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: false
 }
 
-export enum FeatureFlagIdentifierType {
+export enum FeatureFlagBucketType {
   USER_ID = 'user_id',
   SESSION_ID = 'session_id'
+}
+
+export const flagBucketType: {
+  [key in FeatureFlags]: FeatureFlagBucketType
+} = {
+  [FeatureFlags.USE_TRACK_CONTENT_POLLING]: FeatureFlagBucketType.SESSION_ID,
+  [FeatureFlags.SOLANA_LISTEN_ENABLED]: FeatureFlagBucketType.SESSION_ID,
+  [FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD]: FeatureFlagBucketType.SESSION_ID,
+  [FeatureFlags.TRENDING_UNDERGROUND]: FeatureFlagBucketType.USER_ID,
+  [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: FeatureFlagBucketType.USER_ID
 }
 
 export const OPTIMIZELY_LOCAL_STORAGE_KEY = 'optimizelyKey'

--- a/src/services/remote-config/FeatureFlags.ts
+++ b/src/services/remote-config/FeatureFlags.ts
@@ -25,7 +25,7 @@ export enum FeatureFlagCohortType {
    */
   USER_ID = 'user_id',
   /**
-   * Segments feature experiments by a random uuid set in local storage defined by FEATURE_FLAG_SESSION_ID.
+   * Segments feature experiments by a random uuid set in local storage defined by FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY.
    * There should always be a value for sessionId. This is managed in Provider.ts
    */
   SESSION_ID = 'session_id'
@@ -41,4 +41,4 @@ export const flagCohortType: {
   [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: FeatureFlagCohortType.USER_ID
 }
 
-export const FEATURE_FLAG_SESSION_ID = 'featureFlagSessionId'
+export const FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY = 'featureFlagSessionId'

--- a/src/services/remote-config/FeatureFlags.ts
+++ b/src/services/remote-config/FeatureFlags.ts
@@ -7,27 +7,38 @@ export enum FeatureFlags {
   PLAYLIST_UPDATES_ENABLED = 'playlist_updates_enabled'
 }
 
+/**
+ * If optimizely errors, these default values are used.
+ */
 export const flagDefaults: { [key in FeatureFlags]: boolean } = {
   [FeatureFlags.TRENDING_UNDERGROUND]: false,
-  [FeatureFlags.USE_TRACK_CONTENT_POLLING]: true,
+  [FeatureFlags.USE_TRACK_CONTENT_POLLING]: false,
   [FeatureFlags.SOLANA_LISTEN_ENABLED]: false,
-  [FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD]: true,
+  [FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD]: false,
   [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: false
 }
 
-export enum FeatureFlagBucketType {
+export enum FeatureFlagCohortType {
+  /**
+   * Segments feature experiments by a user's id. If userId is not present,
+   * the feature is off.
+   */
   USER_ID = 'user_id',
+  /**
+   * Segments feature experiments by a random uuid set in local storage defined by FEATURE_FLAG_SESSION_ID.
+   * There should always be a value for sessionId. This is managed in Provider.ts
+   */
   SESSION_ID = 'session_id'
 }
 
-export const flagBucketType: {
-  [key in FeatureFlags]: FeatureFlagBucketType
+export const flagCohortType: {
+  [key in FeatureFlags]: FeatureFlagCohortType
 } = {
-  [FeatureFlags.USE_TRACK_CONTENT_POLLING]: FeatureFlagBucketType.SESSION_ID,
-  [FeatureFlags.SOLANA_LISTEN_ENABLED]: FeatureFlagBucketType.SESSION_ID,
-  [FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD]: FeatureFlagBucketType.SESSION_ID,
-  [FeatureFlags.TRENDING_UNDERGROUND]: FeatureFlagBucketType.USER_ID,
-  [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: FeatureFlagBucketType.USER_ID
+  [FeatureFlags.USE_TRACK_CONTENT_POLLING]: FeatureFlagCohortType.SESSION_ID,
+  [FeatureFlags.SOLANA_LISTEN_ENABLED]: FeatureFlagCohortType.SESSION_ID,
+  [FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD]: FeatureFlagCohortType.SESSION_ID,
+  [FeatureFlags.TRENDING_UNDERGROUND]: FeatureFlagCohortType.USER_ID,
+  [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: FeatureFlagCohortType.USER_ID
 }
 
-export const OPTIMIZELY_LOCAL_STORAGE_KEY = 'optimizelyKey'
+export const FEATURE_FLAG_SESSION_ID = 'featureFlagSessionId'

--- a/src/services/remote-config/Provider.ts
+++ b/src/services/remote-config/Provider.ts
@@ -11,7 +11,7 @@ import {
   flagDefaults,
   flagCohortType,
   FeatureFlagCohortType,
-  FEATURE_FLAG_SESSION_ID
+  FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY
 } from './FeatureFlags'
 import {
   remoteConfigIntDefaults,
@@ -30,7 +30,7 @@ const REMOTE_CONFIG_FEATURE_KEY = 'remote_config'
 type State = {
   didInitialize: boolean
   onDidInitializeFunc: (() => void) | undefined
-  userId: string | null
+  userId: Nullable<string>
   sessionId: string
 }
 
@@ -38,7 +38,7 @@ const state: State = {
   didInitialize: false,
   onDidInitializeFunc: undefined,
   userId: null,
-  sessionId: window.localStorage.getItem(FEATURE_FLAG_SESSION_ID) || uuid()
+  sessionId: window.localStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY) || uuid()
 }
 
 // Don't spam logs. Comment out this line for info logs.
@@ -195,8 +195,8 @@ const init = async () => {
   await waitForRemoteConfigDataFile()
 
   // Set sessionId for feature flag bucketing
-  if (!window.localStorage.getItem(FEATURE_FLAG_SESSION_ID)) {
-    window.localStorage.setItem(FEATURE_FLAG_SESSION_ID, state.sessionId)
+  if (!window.localStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY)) {
+    window.localStorage.setItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY, state.sessionId)
   }
 
   provider = optimizely.createInstance({

--- a/src/services/remote-config/Provider.ts
+++ b/src/services/remote-config/Provider.ts
@@ -38,7 +38,7 @@ const state: State = {
   didInitialize: false,
   onDidInitializeFunc: undefined,
   userId: null,
-  sessionId: 
+  sessionId:
     window.localStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY) ||
     uuid()
 }

--- a/src/services/remote-config/Provider.ts
+++ b/src/services/remote-config/Provider.ts
@@ -38,7 +38,9 @@ const state: State = {
   didInitialize: false,
   onDidInitializeFunc: undefined,
   userId: null,
-  sessionId: window.localStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY) || uuid()
+  sessionId: 
+    window.localStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY) ||
+    uuid()
 }
 
 // Don't spam logs. Comment out this line for info logs.
@@ -196,7 +198,10 @@ const init = async () => {
 
   // Set sessionId for feature flag bucketing
   if (!window.localStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY)) {
-    window.localStorage.setItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY, state.sessionId)
+    window.localStorage.setItem(
+      FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY,
+      state.sessionId
+    )
   }
 
   provider = optimizely.createInstance({

--- a/src/services/remote-config/Provider.ts
+++ b/src/services/remote-config/Provider.ts
@@ -20,6 +20,7 @@ import {
   remoteConfigBooleanDefaults
 } from './defaults'
 import { ID } from 'models/common/Identifiers'
+import { Nullable } from 'utils/typeUtils'
 import { uuid } from 'utils/uid'
 
 // Constants

--- a/src/services/remote-config/Provider.ts
+++ b/src/services/remote-config/Provider.ts
@@ -88,7 +88,7 @@ export function getRemoteVar(
   // If the provider is not ready yet, return early with `null`
   if (!provider) return null
 
-  // If userId is null, set to string default. May effectively capture all users
+  // If userId is null, set to string default. This will effectively capture all users as intended for remote config
   const id = state.userId || 'ANONYMOUS_USER'
 
   if (isIntKey(key)) {

--- a/src/services/remote-config/Provider.ts
+++ b/src/services/remote-config/Provider.ts
@@ -26,14 +26,13 @@ import { uuid } from 'utils/uid'
 // All optimizely feature keys are lowercase_snake
 const REMOTE_CONFIG_FEATURE_KEY = 'remote_config'
 const ANONYMOUS_USER_ID = 'ANONYMOUS_USER'
-const ANONYMOUS_SESSION_ID = 'ANONYMOUS_SESSION'
 
 // Internal State
 const state = {
   didInitialize: false,
   onDidInitializeFunc: undefined as (() => void) | undefined,
   userId: ANONYMOUS_USER_ID,
-  sessionId: ANONYMOUS_SESSION_ID
+  sessionId: window.localStorage.getItem(OPTIMIZELY_LOCAL_STORAGE_KEY) || uuid()
 }
 
 // Don't spam logs. Comment out this line for info logs.
@@ -64,10 +63,6 @@ export function onProviderReady(func: () => void) {
  */
 export function setUserId(userId: ID) {
   state.userId = userId.toString()
-}
-
-export function setSessionId(sessionId: string) {
-  state.sessionId = sessionId
 }
 
 /**
@@ -192,13 +187,9 @@ const init = async () => {
   await waitForRemoteConfigDataFile()
 
   // Set sessionId for feature flag bucketing
-  let sessionId = window.localStorage.getItem(OPTIMIZELY_LOCAL_STORAGE_KEY)
-  if (!sessionId) {
-    sessionId = uuid()
-    window.localStorage.setItem(OPTIMIZELY_LOCAL_STORAGE_KEY, sessionId)
+  if (!window.localStorage.getItem(OPTIMIZELY_LOCAL_STORAGE_KEY)) {
+    window.localStorage.setItem(OPTIMIZELY_LOCAL_STORAGE_KEY, state.sessionId)
   }
-
-  setSessionId(sessionId)
 
   provider = optimizely.createInstance({
     // @ts-ignore: injected in index.html

--- a/src/services/remote-config/Provider.ts
+++ b/src/services/remote-config/Provider.ts
@@ -137,7 +137,7 @@ export function getFeatureEnabled(
       window.localStorage.getItem(OPTIMIZELY_LOCAL_STORAGE_KEY) || state.userId
   }
 
-  if (!id || id === ANONYMOUS_USER_ID) return defaultVal
+  if (id === ANONYMOUS_USER_ID) return false
 
   try {
     const enabled = state.didInitialize


### PR DESCRIPTION
### Description

**Context:** As of right now, we use userIds to bucket users for certain features in Optimizely. Since users are initialized with userIds as `ANONYMOUS_USER`, if this id is deterministically bucketed by Optimizely to have a certain feature on, then effectively all users will have the feature on. 

**Problem:** This prevents proper feature rollout. 

**Solution:** 
1. Enable session based feature rollouts using a local storage Optimizely key as the unique identifier for users. 
2. Keep userId feature rollouts, but if `ANONYMOUS_USER`, disable

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

1. Set feature flag to 100% in development mode (ex: `USE_TRACK_CONTENT_POLLING`) and set it to use the sessionId
2. Check to see that the feature is turned on
```
in audiusLibs:
useTrackContentPolling: true
```

1. Set feature flag to 100% in development mode (ex: `USE_TRACK_CONTENT_POLLING`) and set it to use the userId
2. Check to see if a feature flag is used and
  - userId is still `ANONYMOUS_USER`  --> feature is disabled
  -  userId is set --> feature is enabled

```
let flagEnabled = getFeatureEnabled(
    FeatureFlags.VICKY_DUMMY_FEATURE
  )

  if (flagEnabled) {
    console.log('1 i am enabled cus theres an id') 
  } else {
    console.log('1 i am not enabled cus theres no userid') // gets logged in console
  }

  // Set account ID in remote-config provider
  setUserId(account.user_id)

  flagEnabled = getFeatureEnabled(
    FeatureFlags.VICKY_DUMMY_FEATURE
  )

  if (flagEnabled) {
    console.log('2 i am enabled cus theres an id') 
  } else {
    console.log('2 i am not enabled cus theres no userid') // gets logged in console
  }
```