### PR TITLE
Fix playlist library bug when explore playlist is not found

### DIFF
--- a/src/containers/nav/desktop/PlaylistLibrary.tsx
+++ b/src/containers/nav/desktop/PlaylistLibrary.tsx
@@ -223,6 +223,7 @@ const PlaylistLibrary = ({
           switch (identifier.type) {
             case 'explore_playlist': {
               const playlist = SMART_COLLECTION_MAP[identifier.playlist_id]
+              if (!playlist) return null
               return renderExplorePlaylist(playlist)
             }
             case 'playlist': {


### PR DESCRIPTION
### Description
For some reason, while dog-fooding the playlist library feature, I ended up with an explore playlist "Under the Radar" which is not the canonical string. "Under The Radar" is. I looked at identity and I'm the only user with this (i must have been playing with this in prod before we launched explore).

https://discoveryprovider.audius.co/v1/full/users/7eP5n?user_id=7eP5n

I'm going to manually issue the write to chain to clear this from my subscribed playlists, but in general, I think this safety check would be good on the off chance that the playlist literally cannot be found given the id reference

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
Local against prod
