### PR TITLE
Set volume when initialVolume is 0

### DIFF
--- a/src/containers/play-bar/desktop/PlayBar.js
+++ b/src/containers/play-bar/desktop/PlayBar.js
@@ -111,7 +111,7 @@ class PlayBar extends Component {
 
     // If there was an intent to set initial volume and audio is defined
     // set the initial volume
-    if (this.state.initialVolume && audio) {
+    if (this.state.initialVolume !== null && audio) {
       audio.setVolume(this.state.initialVolume)
       this.setState({
         initialVolume: null


### PR DESCRIPTION
### Description

In `PlayBar.js`, the audio volume is being conditionally set when `initialVolume` has a truthy value. This breaks when the volume in local storage is 0. The volume doesn't get set, but the volume bar still displays the volume at 0.

Solution is to explicitly check for `null`. `initialVolume` is either `null` or the numeric value from local storage.

### Dragons

None introduced by this PR, the only dragon being JS's amazing truthy/falsy values

### How Has This Been Tested?

Tested locally against staging. Did not write a test case because `Playbar.js` doesn't have any tests yet and it seemed overkill to add a test file for this small bug fix

https://linear.app/audius/issue/AUD-323/volume-slider-doesnt-take-effect-until-interacted-with

