### PR TITLE
Handle duplicates in playlist library

### DIFF
--- a/src/store/playlist-library/helpers.test.js
+++ b/src/store/playlist-library/helpers.test.js
@@ -3,6 +3,7 @@ import {
   findIndexInPlaylistLibrary,
   findInPlaylistLibrary,
   removeFromPlaylistLibrary,
+  removePlaylistLibraryDuplicates,
   reorderPlaylistLibrary
 } from './helpers'
 
@@ -169,6 +170,107 @@ describe('removeFromPlaylistLibrary', () => {
       ]
     })
     expect(removed).toEqual(null)
+  })
+})
+
+describe('removePlaylistLibraryDuplicates', () => {
+  it('can remove single dupes', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 1 }
+      ]
+    }
+    const ret = removePlaylistLibraryDuplicates(library)
+    expect(ret).toEqual({
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 }
+      ]
+    })
+  })
+
+  it('does not remove non duplicates', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 4 },
+        { type: 'playlist', playlist_id: 5 },
+        { type: 'playlist', playlist_id: 6 }
+      ]
+    }
+    const ret = removePlaylistLibraryDuplicates(library)
+    expect(ret).toEqual({
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 4 },
+        { type: 'playlist', playlist_id: 5 },
+        { type: 'playlist', playlist_id: 6 }
+      ]
+    })
+  })
+
+  it('can remove multiple dupes', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 3 }
+      ]
+    }
+    const ret = removePlaylistLibraryDuplicates(library)
+    expect(ret).toEqual({
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 }
+      ]
+    })
+  })
+
+  it('can remove nested dupes', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 },
+        {
+          type: 'folder',
+          name: 'favorites',
+          contents: [
+            { type: 'playlist', playlist_id: 2 },
+            { type: 'playlist', playlist_id: 3 },
+            { type: 'playlist', playlist_id: 5 }
+          ]
+        },
+        { type: 'playlist', playlist_id: 3 }
+      ]
+    }
+    const ret = removePlaylistLibraryDuplicates(library)
+    expect(ret).toEqual({
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'playlist', playlist_id: 3 },
+        {
+          type: 'folder',
+          name: 'favorites',
+          contents: [{ type: 'playlist', playlist_id: 5 }]
+        }
+      ]
+    })
   })
 })
 

--- a/src/store/playlist-library/helpers.ts
+++ b/src/store/playlist-library/helpers.ts
@@ -119,6 +119,46 @@ export const removeFromPlaylistLibrary = (
 }
 
 /**
+ * Removes duplicates in a playlist library
+ * @param library
+ * @param ids ids to keep track of as we recurse
+ */
+export const removePlaylistLibraryDuplicates = (
+  library: PlaylistLibrary | PlaylistLibraryFolder,
+  ids: Set<string> = new Set([])
+) => {
+  if (!library.contents) return library
+  const newContents: (PlaylistLibraryFolder | PlaylistLibraryIdentifier)[] = []
+
+  // Simple DFS (this likely is very small, so this is fine)
+  for (const item of library.contents) {
+    switch (item.type) {
+      case 'folder': {
+        const folder = removePlaylistLibraryDuplicates(
+          item,
+          ids
+        ) as PlaylistLibraryFolder
+        newContents.push(folder)
+        break
+      }
+      case 'playlist':
+      case 'explore_playlist':
+      case 'temp_playlist':
+        if (ids.has(`${item.playlist_id}`)) {
+          break
+        }
+        ids.add(`${item.playlist_id}`)
+        newContents.push(item)
+        break
+    }
+  }
+  return {
+    ...library,
+    contents: newContents
+  }
+}
+
+/**
  * Reorders a playlist library
  * TODO: Support folder reordering
  * @param library

--- a/src/store/playlist-library/sagas.ts
+++ b/src/store/playlist-library/sagas.ts
@@ -29,7 +29,10 @@ import { makeKindId } from 'utils/uid'
 import { Kind } from 'store/types'
 import { ID } from 'models/common/Identifiers'
 import * as cacheActions from 'store/cache/actions'
-import { containsTempPlaylist } from './helpers'
+import {
+  containsTempPlaylist,
+  removePlaylistLibraryDuplicates
+} from './helpers'
 
 const TEMP_PLAYLIST_UPDATE_HELPER = 'TEMP_PLAYLIST_UPDATE_HELPER'
 
@@ -68,7 +71,7 @@ function* watchUpdatePlaylistLibrary() {
     yield call(waitForBackendSetup)
 
     const account: User = yield select(getAccountUser)
-    account.playlist_library = playlistLibrary
+    account.playlist_library = removePlaylistLibraryDuplicates(playlistLibrary)
     yield put(
       cacheActions.update(Kind.USERS, [
         {
@@ -105,7 +108,7 @@ function* watchUpdatePlaylistLibraryWithTempPlaylist() {
   ) {
     const { playlistLibrary } = action.payload
     const account: User = yield select(getAccountUser)
-    account.playlist_library = playlistLibrary
+    account.playlist_library = removePlaylistLibraryDuplicates(playlistLibrary)
 
     // Map over playlist library contents and resolve each temp id playlist
     // to one with an actual id. Once we have the actual id, we can proceed


### PR DESCRIPTION
### Description
Currently on prod, I do not believe you could end up in a situation with duplicates, but I did for my account because I was playing around with it on release.audius.co before using audius.co where it tried to re-"migrate" me over to the new library from the identity stored library. Since there are not db constraints around how playlist library is handled, I think it's best to add this safeguard.

On every reorder, with this change, we will just remove duplicates if somehow they happen to exist.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
- Unit
- Locally against prod, repairing my duplicates
