### PR TITLE
Fix useTabs setOffset hook

### DIFF
--- a/src/hooks/useTabs/useTabs.tsx
+++ b/src/hooks/useTabs/useTabs.tsx
@@ -431,8 +431,8 @@ const GestureSupportingBodyContainer = memo(
     const snapbackInterval = containerWidth * SNAPBACK_RATIO
 
     // Throttle the callbacks to set the tab accent for performance.
-    const throttledSetTabBarOffset = useCallback(
-      (offset: number) => throttle(setTabBarFractionalOffset, 150)(offset),
+    const throttledSetTabBarOffset = useMemo(
+      () => throttle(setTabBarFractionalOffset, 150),
       [setTabBarFractionalOffset]
     )
 


### PR DESCRIPTION
### Description
The commit that fixed our terser issues involved upgrading react-scripts & therefore ts version, which complained about this hook: https://github.com/AudiusProject/audius-client/commit/55992434196d44a949a1d83c1dcf8a85c4ac7ae8#diff-8b5683265aeafe8204c7641fd7620982cba8605cb28e7e6bc47c50e5b89fdd57R434 (b/c the signature changed)

Solution from that change was not correct, see https://github.com/facebook/react/issues/19240#issuecomment-652945246

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

* ngrok to mobile device
