### PR TITLE
AUD-651 Update styles for UserListModal to allow seeing the bottom of the list

### DIFF
--- a/src/containers/user-list-modal/components/UserListModal.module.css
+++ b/src/containers/user-list-modal/components/UserListModal.module.css
@@ -1,6 +1,8 @@
 .modalBody {
   max-width: 360px;
   width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .modalHeader {
@@ -23,6 +25,7 @@
 }
 
 .scrollable {
+  display: flex;
   margin: 16px;
   min-height: 0;
   max-height: 690px;


### PR DESCRIPTION
### Description

There was an error with styling where the bottom of the UserList in the UserListModal would not be visible. This updates the styles of the UserListModal to use flexbox to force the content to the the correct size within the modal. 

Should fix AUD-651

### Dragons

I think this will only affect these two modals (Reposts and Favorites), but there may be other modals that are affected

### How Has This Been Tested?

I opened the modal and it looked good. :chef-kiss:

