### PR TITLE
Handle twitter & insta oauth profiles better

### DIFF
--- a/src/components/general/TwitterAuth.js
+++ b/src/components/general/TwitterAuth.js
@@ -12,6 +12,8 @@ class TwitterLogin extends Component {
     super(props)
 
     this.onButtonClick = this.onButtonClick.bind(this)
+    this.getOauthToken = this.getOauthToken.bind(this)
+    window.getOauthToken = this.getOauthToken
   }
 
   onButtonClick(e) {
@@ -174,6 +176,8 @@ class TwitterLogin extends Component {
     )
   }
 }
+
+window.TwitterLogin = TwitterLogin
 
 TwitterLogin.propTypes = {
   tag: PropTypes.string,

--- a/src/components/general/TwitterAuth.js
+++ b/src/components/general/TwitterAuth.js
@@ -12,8 +12,6 @@ class TwitterLogin extends Component {
     super(props)
 
     this.onButtonClick = this.onButtonClick.bind(this)
-    this.getOauthToken = this.getOauthToken.bind(this)
-    window.getOauthToken = this.getOauthToken
   }
 
   onButtonClick(e) {
@@ -176,8 +174,6 @@ class TwitterLogin extends Component {
     )
   }
 }
-
-window.TwitterLogin = TwitterLogin
 
 TwitterLogin.propTypes = {
   tag: PropTypes.string,

--- a/src/containers/sign-on/SignOnProvider.tsx
+++ b/src/containers/sign-on/SignOnProvider.tsx
@@ -190,6 +190,7 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
         recordCompleteProfile,
         fields: { email, password, handle }
       } = this.props
+
       // Dispatch event to create account
       signUp(email.value, password.value, handle.value)
       recordCompleteProfile(email.value, handle.value)
@@ -337,19 +338,22 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
   setTwitterProfile = (
     twitterId: string,
     profile: { screen_name?: string; verified?: boolean },
-    profileImage: any,
-    coverPhoto: any
+    profileImg?: { url: string; file: any },
+    coverBannerImg?: { url: string; file: any },
+    skipEdit?: boolean
   ) => {
     const {
       fields: { email, handle }
     } = this.props
-    if (profile.screen_name) this.props.validateHandle(profile.screen_name)
-    this.props.setTwitterProfile(twitterId, profile, profileImage, coverPhoto)
+    this.props.setTwitterProfile(twitterId, profile, profileImg, coverBannerImg)
     this.props.recordTwitterComplete(
       !!profile.verified,
       email.value,
       handle.value
     )
+    if (skipEdit) {
+      this.onNextPage()
+    }
   }
 
   onRecordTwitterStart = () => {
@@ -360,10 +364,14 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
   setInstagramProfile = (
     instagramId: string,
     profile: { username?: string; is_verified?: boolean },
-    profileImage?: any
+    profileImg?: { url: string; file: any },
+    skipEdit?: boolean
   ) => {
     if (profile.username) this.props.validateHandle(profile.username)
-    this.props.setInstagramProfile(instagramId, profile, profileImage)
+    this.props.setInstagramProfile(instagramId, profile, profileImg)
+    if (skipEdit) {
+      this.onNextPage()
+    }
   }
 
   onMetaMaskSignIn = () => {
@@ -427,6 +435,7 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
       onViewSignUp: this.onViewSignUp,
       setTwitterProfile: this.setTwitterProfile,
       setInstagramProfile: this.setInstagramProfile,
+      validateHandle: this.props.validateHandle,
       onMetaMaskSignIn: this.onMetaMaskSignIn,
       recordTwitterStart: this.onRecordTwitterStart,
       recordTwitterComplete: this.props.recordTwitterComplete
@@ -468,8 +477,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     setTwitterProfile: (
       twitterId: string,
       profile: object,
-      profileImage: object,
-      coverPhoto: string
+      profileImage?: { url: string; file: any },
+      coverPhoto?: { url: string; file: any }
     ) =>
       dispatch(
         signOnAction.setTwitterProfile(
@@ -491,8 +500,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(signOnAction.sendWelcomeEmail(name)),
     validateEmail: (email: string) =>
       dispatch(signOnAction.validateEmail(email)),
-    validateHandle: (handle: string) =>
-      dispatch(signOnAction.validateHandle(handle)),
+    validateHandle: (handle: string, onValidate?: (error: boolean) => void) =>
+      dispatch(signOnAction.validateHandle(handle, onValidate)),
     setValueField: (field: string, value: any) =>
       dispatch(signOnAction.setValueField(field, value)),
     setField: (field: string, value: any) =>

--- a/src/containers/sign-on/components/ProfileForm.js
+++ b/src/containers/sign-on/components/ProfileForm.js
@@ -19,6 +19,7 @@ const messages = {
   manual: 'I’d rather fill out my profile manually',
   uploadProfilePicture: 'Upload a profile picture',
   errors: {
+    tooLong: 'Sorry, handle not supported',
     characters: 'Only use A-Z, 0-9, and underscores',
     inUse: 'That handle has already been taken',
     twitterReserved: 'This verified Twitter handle is reserved.',

--- a/src/containers/sign-on/components/desktop/SignOnPage.tsx
+++ b/src/containers/sign-on/components/desktop/SignOnPage.tsx
@@ -69,15 +69,21 @@ export type SignOnProps = {
   onNameChange: (name: string) => void
   onSetProfileImage: (img: any) => void
   setTwitterProfile: (
-    twitterId: string,
-    profile: { screen_name?: string },
-    profileImage: any,
-    coverPhoto: any
+    uuid: string,
+    profile: any,
+    profileImg?: { url: string; file: any },
+    coverBannerImg?: { url: string; file: any },
+    skipEdit?: boolean
   ) => void
   setInstagramProfile: (
-    instagramId: string,
+    uuid: string,
     profile: InstagramProfile,
-    profileImage?: any
+    profileImg?: { url: string; file: any },
+    skipEdit?: boolean
+  ) => void
+  validateHandle: (
+    handle: string,
+    onValidate?: (error: boolean) => void
   ) => void
   onAddFollows: (followIds: ID[]) => void
   onRemoveFollows: (followIds: ID[]) => void
@@ -142,6 +148,7 @@ const SignOnProvider = ({
   onSetProfileImage,
   setTwitterProfile,
   setInstagramProfile,
+  validateHandle,
   onAddFollows,
   onRemoveFollows,
   onAutoSelect,
@@ -256,6 +263,7 @@ const SignOnProvider = ({
           setProfileImage={onSetProfileImage}
           setTwitterProfile={setTwitterProfile}
           setInstagramProfile={setInstagramProfile}
+          validateHandle={validateHandle}
           recordTwitterStart={recordTwitterStart}
           onNextPage={onNextPage}
         />

--- a/src/containers/sign-on/components/mobile/ProfilePage.tsx
+++ b/src/containers/sign-on/components/mobile/ProfilePage.tsx
@@ -112,7 +112,6 @@ const ProfilePage = (props: ProfilePageProps) => {
         requiresUserReview
       } = await formatTwitterProfile(twitterProfile)
 
-      // call validate here with callback
       validateHandle(profile.screen_name, (error: boolean) => {
         setTwitterProfile(
           uuid,

--- a/src/containers/sign-on/components/mobile/ProfilePage.tsx
+++ b/src/containers/sign-on/components/mobile/ProfilePage.tsx
@@ -3,13 +3,14 @@ import React, { useState, useCallback, useEffect } from 'react'
 import cn from 'classnames'
 
 import styles from './ProfilePage.module.css'
-import { resizeImage } from 'utils/imageProcessingUtil'
 import TwitterOverlay from 'containers/sign-on/components/mobile/TwitterOverlay'
 import ProfileForm from 'containers/sign-on/components/ProfileForm'
-import { InstagramProfile } from 'store/account/reducer'
+import { InstagramProfile, TwitterProfile } from 'store/account/reducer'
 import { MAIN_CONTENT_ID } from 'containers/App'
-
-const GENERAL_ADMISSION = process.env.REACT_APP_GENERAL_ADMISSION
+import {
+  formatInstagramProfile,
+  formatTwitterProfile
+} from 'containers/sign-on/utils/formatSocialProfile'
 
 const messages = {
   header: 'Tell Us About Yourself So Others Can Find You'
@@ -26,19 +27,23 @@ type ProfilePageProps = {
     uuid: string,
     profile: any,
     profileImg?: { url: string; file: any },
-    coverBannerImg?: { url: string; file: any }
+    coverBannerImg?: { url: string; file: any },
+    skipEdit?: boolean
   ) => void
   setInstagramProfile: (
     uuid: string,
     profile: InstagramProfile,
-    profileImg?: { url: string; file: any }
+    profileImg?: { url: string; file: any },
+    skipEdit?: boolean
   ) => void
   onHandleChange: (handle: string) => void
   onNameChange: (name: string) => void
   setProfileImage: (img: { url: string; file: any }) => void
+  validateHandle: (
+    handle: string,
+    onValidate?: (error: boolean) => void
+  ) => void
 }
-
-type TwitterProfile = any
 
 const ProfilePage = (props: ProfilePageProps) => {
   // If the handle field is disabled, don't let the user twitter auth
@@ -77,7 +82,8 @@ const ProfilePage = (props: ProfilePageProps) => {
     onNextPage,
     twitterId,
     setTwitterProfile,
-    setInstagramProfile
+    setInstagramProfile,
+    validateHandle
   } = props
 
   const onToggleTwitterOverlay = useCallback(() => {
@@ -96,72 +102,55 @@ const ProfilePage = (props: ProfilePageProps) => {
     if (getProfileValid()) onNextPage()
   }, [getProfileValid, onNextPage])
 
-  const onTwitterLogin = async (twitterProfile: TwitterProfile) => {
+  const onTwitterLogin = async (twitterProfileRes: Body) => {
+    const { uuid, profile: twitterProfile } = await twitterProfileRes.json()
     try {
-      const { uuid, profile } = await twitterProfile.json()
-      const profileUrl = profile.profile_image_url_https.replace(
-        /_(normal|bigger|mini)/g,
-        ''
-      )
-      const imageBlob = await fetch(profileUrl).then(r => r.blob())
-      const artworkFile = new File([imageBlob], 'Artwork', {
-        type: 'image/jpeg'
-      })
-      const file = await resizeImage(artworkFile)
-      const url = URL.createObjectURL(file)
+      const {
+        profile,
+        profileImage,
+        profileBanner,
+        requiresUserReview
+      } = await formatTwitterProfile(twitterProfile)
 
-      if (profile.profile_banner_url) {
-        const bannerImageBlob = await fetch(
-          profile.profile_banner_url
-        ).then(r => r.blob())
-        const bannerArtworkFile = new File([bannerImageBlob], 'Artwork', {
-          type: 'image/webp'
-        })
-        const bannerFile = await resizeImage(
-          bannerArtworkFile,
-          2000,
-          /* square= */ false
-        )
-        const bannerUrl = URL.createObjectURL(bannerFile)
+      // call validate here with callback
+      validateHandle(profile.screen_name, (error: boolean) => {
         setTwitterProfile(
           uuid,
           profile,
-          { url, file },
-          { url: bannerUrl, file: bannerFile }
+          profileImage,
+          profileBanner,
+          !error && !requiresUserReview
         )
-      } else {
-        setTwitterProfile(uuid, profile, { url, file })
-      }
+        setShowTwitterOverlay(false)
+        setIsInitial(false)
+        setIsLoading(false)
+      })
     } catch (err) {
-      // TODO: Log error
-    } finally {
+      console.error(err)
       setShowTwitterOverlay(false)
       setIsInitial(false)
       setIsLoading(false)
     }
   }
 
-  const onInstagramLogin = async (uuid: string, profile: InstagramProfile) => {
+  const onInstagramLogin = async (
+    uuid: string,
+    instagramProfile: InstagramProfile
+  ) => {
     try {
-      if (profile.profile_pic_url_hd) {
-        try {
-          const profileUrl = `${GENERAL_ADMISSION}/proxy/simple?url=${encodeURIComponent(
-            profile.profile_pic_url_hd
-          )}`
-          const imageBlob = await fetch(profileUrl).then(r => r.blob())
-          const artworkFile = new File([imageBlob], 'Artwork', {
-            type: 'image/jpeg'
-          })
-          const file = await resizeImage(artworkFile)
-          const url = URL.createObjectURL(file)
-          setInstagramProfile(uuid, profile, { url, file })
-        } catch (e) {
-          console.error('Failed to fetch profile_pic_url_hd', e)
-          setInstagramProfile(uuid, profile)
-        }
-      } else {
-        setInstagramProfile(uuid, profile)
-      }
+      const {
+        profile,
+        profileImage,
+        requiresUserReview
+      } = await formatInstagramProfile(instagramProfile)
+      validateHandle(profile.username, (error: boolean) => {
+        setInstagramProfile(
+          uuid,
+          profile,
+          profileImage,
+          !error && !requiresUserReview
+        )
+      })
     } catch (err) {
       // Continue if error
     } finally {

--- a/src/containers/sign-on/components/mobile/SignOnPage.tsx
+++ b/src/containers/sign-on/components/mobile/SignOnPage.tsx
@@ -49,15 +49,21 @@ export type SignOnProps = {
   onNameChange: (name: string) => void
   onSetProfileImage: (img: any) => void
   setTwitterProfile: (
-    twitterId: string,
-    profile: { screen_name?: string },
-    profileImage: any,
-    coverPhoto: any
+    uuid: string,
+    profile: any,
+    profileImg?: { url: string; file: any },
+    coverBannerImg?: { url: string; file: any },
+    skipEdit?: boolean
   ) => void
   setInstagramProfile: (
-    instagramId: string,
+    uuid: string,
     profile: InstagramProfile,
-    profileImage?: any
+    profileImg?: { url: string; file: any },
+    skipEdit?: boolean
+  ) => void
+  validateHandle: (
+    handle: string,
+    onValidate?: (error: boolean) => void
   ) => void
   onAddFollows: (followIds: ID[]) => void
   onRemoveFollows: (followIds: ID[]) => void
@@ -98,6 +104,7 @@ const SignOnPage = ({
   onSetProfileImage,
   setTwitterProfile,
   setInstagramProfile,
+  validateHandle,
   onAddFollows,
   onRemoveFollows,
   onAutoSelect,
@@ -221,6 +228,7 @@ const SignOnPage = ({
           setProfileImage={onSetProfileImage}
           setTwitterProfile={setTwitterProfile}
           setInstagramProfile={setInstagramProfile}
+          validateHandle={validateHandle}
           onNextPage={onNextPage}
         />
       </animated.div>

--- a/src/containers/sign-on/store/actions.js
+++ b/src/containers/sign-on/store/actions.js
@@ -100,13 +100,15 @@ export function validateEmailFailed(error) {
 /**
  * Requests the backend to check if handle is valid
  * @param {string} handle the handle to check
+ * @param {((error: boolean) => void) | undefined} onValidate
+ *  callback to fire on successful validation
  */
-export function validateHandle(handle) {
-  return { type: VALIDATE_HANDLE, handle }
+export function validateHandle(handle, onValidate) {
+  return { type: VALIDATE_HANDLE, handle, onValidate }
 }
 
-export function validateHandleSucceeded(available, error = 'inUse') {
-  return { type: VALIDATE_HANDLE_SUCCEEDED, available, error }
+export function validateHandleSucceeded() {
+  return { type: VALIDATE_HANDLE_SUCCEEDED }
 }
 
 /**

--- a/src/containers/sign-on/store/reducer.js
+++ b/src/containers/sign-on/store/reducer.js
@@ -276,8 +276,8 @@ const actionsMap = {
       ...state,
       handle: {
         ...state.handle,
-        status: action.available ? 'success' : 'failure',
-        error: action.available ? '' : action.error
+        status: 'success',
+        error: ''
       }
     }
   },

--- a/src/containers/sign-on/utils/formatSocialProfile.ts
+++ b/src/containers/sign-on/utils/formatSocialProfile.ts
@@ -1,0 +1,92 @@
+import { InstagramProfile, TwitterProfile } from 'store/account/reducer'
+import { resizeImage } from 'utils/imageProcessingUtil'
+
+const GENERAL_ADMISSION = process.env.REACT_APP_GENERAL_ADMISSION
+
+export const MAX_HANDLE_LENGTH = 16
+
+export const formatTwitterProfile = async (twitterProfile: TwitterProfile) => {
+  const profileUrl = twitterProfile.profile_image_url_https.replace(
+    /_(normal|bigger|mini)/g,
+    ''
+  )
+  const imageBlob = await fetch(profileUrl).then(r => r.blob())
+  const artworkFile = new File([imageBlob], 'Artwork', {
+    type: 'image/jpeg'
+  })
+  const file = await resizeImage(artworkFile)
+  const url = URL.createObjectURL(file)
+
+  let bannerUrl, bannerFile
+  if (twitterProfile.profile_banner_url) {
+    const bannerImageBlob = await fetch(
+      twitterProfile.profile_banner_url
+    ).then(r => r.blob())
+    const bannerArtworkFile = new File([bannerImageBlob], 'Artwork', {
+      type: 'image/webp'
+    })
+    bannerFile = await resizeImage(bannerArtworkFile, 2000, /* square= */ false)
+    bannerUrl = URL.createObjectURL(bannerFile)
+  }
+  // Truncate to MAX_HANDLE_LENGTH characters because we don't support longer handles.
+  // If the user is verifed, they won't be able to claim the status if
+  // the handle doesn't match, so just pass through.
+  let requiresUserReview = false
+  if (twitterProfile.screen_name.length > MAX_HANDLE_LENGTH) {
+    requiresUserReview = true
+    if (!twitterProfile.verified) {
+      twitterProfile.screen_name = twitterProfile.screen_name.slice(
+        0,
+        MAX_HANDLE_LENGTH
+      )
+    }
+  }
+
+  return {
+    profile: twitterProfile,
+    profileImage: { url, file },
+    profileBanner: bannerUrl ? { url: bannerUrl, file: bannerFile } : undefined,
+    requiresUserReview
+  }
+}
+
+export const formatInstagramProfile = async (
+  instagramProfile: InstagramProfile
+) => {
+  let profileImage
+  if (instagramProfile.profile_pic_url_hd) {
+    try {
+      const profileUrl = `${GENERAL_ADMISSION}/proxy/simple?url=${encodeURIComponent(
+        instagramProfile.profile_pic_url_hd
+      )}`
+      const imageBlob = await fetch(profileUrl).then(r => r.blob())
+      const artworkFile = new File([imageBlob], 'Artwork', {
+        type: 'image/jpeg'
+      })
+      const file = await resizeImage(artworkFile)
+      const url = URL.createObjectURL(file)
+      profileImage = { url, file }
+    } catch (e) {
+      console.error('Failed to fetch profile_pic_url_hd', e)
+    }
+  }
+  // Truncate to MAX_HANDLE_LENGTH characters because we don't support longer handles.
+  // If the user is verifed, they won't be able to claim the status if
+  // the handle doesn't match, so just pass through.
+  let requiresUserReview = false
+  if (instagramProfile.username.length > MAX_HANDLE_LENGTH) {
+    requiresUserReview = true
+    if (!instagramProfile.is_verified) {
+      instagramProfile.username = instagramProfile.username.slice(
+        0,
+        MAX_HANDLE_LENGTH
+      )
+    }
+  }
+
+  return {
+    profile: instagramProfile,
+    profileImage,
+    requiresUserReview
+  }
+}

--- a/src/store/account/reducer.ts
+++ b/src/store/account/reducer.ts
@@ -39,8 +39,8 @@ export type InstagramProfile = {
   username: string
   biography?: string
   business_email?: string
-  edge_follow: { count: number }
-  edge_followed_by: { count: number }
+  edge_follow?: { count: number }
+  edge_followed_by?: { count: number }
   external_url?: string
   full_name?: string
   is_business_account?: boolean
@@ -51,9 +51,11 @@ export type InstagramProfile = {
 }
 
 export type TwitterProfile = {
-  verified: boolean
-  name: string
   screen_name: string
+  name: string
+  verified: boolean
+  profile_image_url_https: string
+  profile_banner_url?: string
 }
 
 const slice = createSlice({


### PR DESCRIPTION
### Description
Handles oauth profiles from twitter and instagram a bit better. Does a little bit of work to typescriptify + condense the code around processing profiles.

The changes are best understood by the test cases

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

For both twitter & instagram (i mocked data since that doesn't work against local):

1. Create an account and oauth with a valid handle that's unclaimed on audius => skips the "edit profile page" of sign up
2. Create an account and oauth with a valid  handle that's claimed on audius => shows the "edit profile page" with handle in use message
3. Create an account and oauth with a handle that's > 16 chars and not verified => truncates => shows the "edit profile page"
4. Create an account and oauth with a handle that's > 16 chars and verified => shows the "edit profile page" with an error text Sorry handle not supported, prompting the user to either leave or change it