### PR TITLE
Retrigger useFlag when userId gets set

### DIFF
--- a/src/containers/remote-config/hooks.ts
+++ b/src/containers/remote-config/hooks.ts
@@ -29,8 +29,8 @@ export const useFlag = (flag: FeatureFlags) => {
   const userIdFlag = flagCohortType[flag] === FeatureFlagCohortType.USER_ID
   const hasAccount = useSelector(getAccountUser)
   const shouldRecompute = userIdFlag ? hasAccount : true
-  // eslint complains about configLoaded as part of the deps array
   const isEnabled = useMemo(
+    // We want configLoaded and shouldRecompute to trigger refreshes of the memo
     // eslint-disable-next-line
     () => getFeatureEnabled(flag), [flag, configLoaded, shouldRecompute]
   )

--- a/src/containers/remote-config/hooks.ts
+++ b/src/containers/remote-config/hooks.ts
@@ -11,6 +11,11 @@ import {
   StringKeys
 } from 'services/remote-config'
 import { useSelector } from 'utils/reducer'
+import { getAccountUser } from 'store/account/selectors'
+import {
+  FeatureFlagCohortType,
+  flagCohortType
+} from 'services/remote-config/FeatureFlags'
 
 /**
  * Hooks into updates for a given feature flag.
@@ -21,9 +26,14 @@ export const useFlag = (flag: FeatureFlags) => {
   const configLoaded = useSelector(
     (state: AppState) => state.remoteConfig.remoteConfigLoaded
   )
+  const userIdFlag = flagCohortType[flag] === FeatureFlagCohortType.USER_ID
+  const hasAccount = useSelector(getAccountUser)
+  const shouldRecompute = userIdFlag ? hasAccount : true
   // eslint complains about configLoaded as part of the deps array
-  // eslint-disable-next-line
-  const isEnabled = useMemo(() => getFeatureEnabled(flag), [flag, configLoaded])
+  const isEnabled = useMemo(
+    // eslint-disable-next-line
+    () => getFeatureEnabled(flag), [flag, configLoaded, shouldRecompute]
+  )
   return { isLoaded: configLoaded, isEnabled }
 }
 


### PR DESCRIPTION
### Description
userId gets set after the useFlag hook may be called. The useMemo prevents recomputation, so add the account selector in to the mix for USER_ID experiments

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Locally against prod: verified user id experiment triggers (playlist library update dots). Verified mobile still works as well.
- Locally against stage: verified that track polling session id exp is working as intended
