### PR TITLE
Import jimp without preload

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -187,7 +187,7 @@
     </script>
 
     <!-- TODO: Remove this when we compute average colors on the backend -->
-    <link rel="preload" href="/scripts/jimp.min.js" as="script" crossorigin>
+    <link href="/scripts/jimp.min.js" as="script">
   </head>
   <body ontouchstart="">
     <noscript>


### PR DESCRIPTION
### Description

AFAIK, jimp does not need to be preloaded (it's used for computing average artwork colors in a web worker, resizing images on upload). Also, I do not believe it needs to have CORS setup -- it'd always be coming from the same domain.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
