### PR TITLE
Fix playlist library staleness bug

### DIFF
--- a/src/containers/profile-page/store/actions.js
+++ b/src/containers/profile-page/store/actions.js
@@ -78,7 +78,7 @@ export function updateCurrentUserFollows(follow = false) {
   return { type: UPDATE_CURRENT_USER_FOLLOWS, follow }
 }
 
-export function fetchFollowUsers(followerGroup, limit = 22, offset = 0) {
+export function fetchFollowUsers(followerGroup, limit = 15, offset = 0) {
   return { type: FETCH_FOLLOW_USERS, followerGroup, offset, limit }
 }
 

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -305,12 +305,12 @@ function* fetchFolloweeFollows(action) {
   )
 }
 
-function* cacheUsers(followers) {
+function* cacheUsers(users) {
   const currentUserId = yield select(getUserId)
-  const toCache = followers.filter(
-    followee => followee.user_id !== currentUserId
+  // Filter out the current user from the list to cache
+  yield processAndCacheUsers(
+    users.filter(user => user.user_id !== currentUserId)
   )
-  const users = yield processAndCacheUsers(toCache)
   return users.map(f => ({ id: f.user_id }))
 }
 

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -2198,32 +2198,6 @@ class AudiusBackend {
     }
   }
 
-  /**
-   * Gets an ordered string-like list of playlists that the
-   * current account has favorited.
-   * @DEPRECATED
-   * TODO: Remove this method after a ~month or so from launch of playlist
-   * library.
-   */
-  static async getAccountPlaylistFavorites() {
-    await waitForLibsInit()
-    const account = audiusLibs.Account.getCurrentUser()
-    if (!account) return
-    try {
-      const { data, signature } = await AudiusBackend.signData()
-      const res = await fetch(`${IDENTITY_SERVICE}/user_playlist_favorites`, {
-        headers: {
-          [AuthHeaders.Message]: data,
-          [AuthHeaders.Signature]: signature
-        }
-      }).then(res => res.json())
-      return res.userPlaylistFavorites
-    } catch (e) {
-      console.error(e)
-      return []
-    }
-  }
-
   static async sendWelcomeEmail({ name }) {
     await waitForLibsInit()
     const account = audiusLibs.Account.getCurrentUser()

--- a/src/store/account/sagas.js
+++ b/src/store/account/sagas.js
@@ -148,27 +148,6 @@ export function* fetchAccountAsync(action) {
   // Set account ID in remote-config provider
   setUserId(account.user_id)
 
-  // @@@@@ Migration @@@@@
-  // Migrate users with old playlist orderings
-  // TODO: After a sufficient time post release (~month), we should remove this
-  // migration in favor of users being on the proper playlist library.
-  const accountPlaylistFavorites = yield call(
-    AudiusBackend.getAccountPlaylistFavorites
-  )
-  const orderedPlaylists = accountPlaylistFavorites
-    ? accountPlaylistFavorites.favorites
-    : []
-
-  if (orderedPlaylists.length > 0 && !account.playlist_library) {
-    const contents = orderedPlaylists.map(id => ({
-      type: 'explore_playlist',
-      playlist_id: id
-    }))
-    const playlistLibrary = { contents }
-    yield put(updatePlaylistLibrary({ playlistLibrary }))
-  }
-  // @@@@@ End migration @@@@@
-
   // Cache the account and fire the onFetch callback. We're done.
   yield call(cacheAccount, account)
   yield call(onFetchAccount, account)


### PR DESCRIPTION
### Description
It's possible while fetching another profile to refetch your own account as part of the followers/followees/mutual followers and these endpoints don't respect (or support) the ?user_id route param fo the current user.
In those cases, we don't really need to refetch the current user, so filter it out.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Repro was from my account => profile /emilyhou and verified the bug no longer shows up with this change

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
