### PR TITLE
Add release-candidate flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,23 +393,31 @@ jobs:
               -H "Content-Type: application/json" \
               --data '{"type":"TXT","name":"'"$DNS_NAME"'","content":"\"dnslink=/ipfs/'"$CID"'\"","ttl":1,"proxied":false}'
 
-  deploy-release:
+  deploy-release-candidate:
     working_directory: ~/audius-client
     docker:
-      - image: circleci/python:2.7-jessie
+      - image: circleci/node:10.13
     steps:
       - checkout
-      - run:
-          name: install-awscli
-          command: sudo pip install awscli
       - attach_workspace:
           at: ./
       - run:
-          name: Deploy to S3
+          name: update-npm
+          command: 'sudo npm install -g npm@latest'
+      - run:
+          name: install wrangler
+          command: 'npm install @cloudflare/wrangler'
+      - run:
+          name: Deploy to Cloudflare
           command: |
-            aws s3 sync --exclude "*.map" --exclude ./resources/apple-app-site-association --exclude robots.txt --exclude "sitemaps/*" build-production s3://release.audius.co --delete --cache-control max-age=604800
-            aws s3 cp s3://release.audius.co/index.html s3://release.audius.co/index.html --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --metadata-directive REPLACE --acl public-read
-            aws s3 cp ./resources/apple-app-site-association s3://release.audius.co --cache-control max-age=0 --content-type 'application/json' --metadata-directive REPLACE
+            cd scripts/workers-site
+            npm i
+            cd ../../
+            mv build-production build
+            cp ./resources/apple-app-site-association build
+            cp ./robots.txt build
+            echo ${GA_ACCESS_TOKEN} | npx wrangler secret put GA_ACCESS_TOKEN --env release
+            npx wrangler publish --env release
 
   deploy-production-s3:
     working_directory: ~/audius-client
@@ -707,15 +715,14 @@ workflows:
             branches:
               only: /^master$/
 
-      - deploy-release:
+      - deploy-release-candidate:
           context: Audius Client
           requires:
             - init
-            - test-staging
             - build-production
           filters:
             branches:
-              only: /(^master)|(^hotfix.*)|(^release.*)$/
+              only: /(^hotfix.*)|(^release.*)$/
 
       # Allow hotfix to go to staging on command
       - hold-staging:

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,6 +10,10 @@ entry-point = "./scripts/workers-site"
 name = "audius-staging"
 vars = { ENVIRONMENT = "staging", GA = "https://general-admission.staging.audius.co", SITEMAP = "http://staging.audius.co.s3-website-us-west-1.amazonaws.com" }
 
+[env.release]
+name = "audius-release-candidate"
+vars = { ENVIRONMENT = "production", GA = "https://general-admission.audius.co", SITEMAP = "http://audius.co.s3-website-us-west-1.amazonaws.com" }
+
 [env.production]
 name = "audius"
 vars = { ENVIRONMENT = "production", GA = "https://general-admission.audius.co", SITEMAP = "http://audius.co.s3-website-us-west-1.amazonaws.com" }


### PR DESCRIPTION
### Description

Sets up release-candidate flow to be on cloudflare (rather than s3)

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Job on CircleCI
https://app.circleci.com/pipelines/github/AudiusProject/audius-client/1709/workflows/2c819698-367c-42c2-b6ed-89703a8877b3

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
