### PR TITLE
Add support for referrer and is_mobile_user events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,9 +72,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.11.tgz",
-      "integrity": "sha512-wooNsruZSy2cvI26asNlPqPwvx5wXYQH6KXWg5YjI+sLK8QQ6X12cAZ5sjGDaKWL5XBntR9L9nbDKNPd8s1hmw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.12.tgz",
+      "integrity": "sha512-SvWLlkrjCky7SsDEh//Ankei69dfN6OD8NMfi7ZO+U+AZguDSXoxkNlBhIxv2+2RWDkGOc8UgcTkCBWwR8YhNQ==",
       "requires": {
         "@audius/hedgehog": "1.0.8",
         "@ethersproject/solidity": "5.0.5",
@@ -6753,9 +6753,9 @@
       "dev": true
     },
     "@types/connect": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
-      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -6787,9 +6787,9 @@
       "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg=="
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.22",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.22.tgz",
-      "integrity": "sha512-WdqmrUsRS4ootGha6tVwk/IVHM1iorU8tGehftQD2NWiPniw/sm7xdJOIlXLwqdInL9wBw/p7oO8vaYEF3NDmA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -6980,14 +6980,14 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
       "version": "16.9.34",
@@ -7806,7 +7806,7 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
           "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
           "requires": {
-            "bignumber.js": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2": "*",
@@ -10422,8 +10422,8 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
-      "version": "git+ssh://git@github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
-      "from": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+      "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+      "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -10926,9 +10926,9 @@
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "buffer-layout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.1.tgz",
-      "integrity": "sha512-RUTGEYG1vX0Zp1dStQFl8yeU/LEBPXVtHwzzDbPWkE5zq+Prt9fkFLKNiwmaeHg6BBiRMcQAgj4cynazO6eekw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
+      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA=="
     },
     "buffer-to-arraybuffer": {
       "version": "0.0.5",
@@ -19137,14 +19137,14 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.170",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
-          "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q=="
+          "version": "4.14.171",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
+          "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg=="
         },
         "@types/node": {
-          "version": "12.20.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-          "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg=="
+          "version": "12.20.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
+          "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
         }
       }
     },
@@ -36357,9 +36357,9 @@
       }
     },
     "ws": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
-      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow=="
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.22",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.11",
+    "@audius/libs": "1.2.12",
     "@audius/stems": "0.3.11",
     "@optimizely/optimizely-sdk": "^4.0.0",
     "@reduxjs/toolkit": "^1.3.2",

--- a/src/containers/sign-on/SignOnProvider.tsx
+++ b/src/containers/sign-on/SignOnProvider.tsx
@@ -121,7 +121,13 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
       }
     })
 
-    this.props.fetchReferrer(this.props.location)
+    const referrerHandle = new URLSearchParams(this.props.location.search).get(
+      'ref'
+    )
+    if (referrerHandle) {
+      this.props.fetchReferrer(referrerHandle)
+    }
+
     const closeModalHotkey = setupHotkeys({
       27 /* Escape */: () => {
         if (
@@ -476,8 +482,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     onSignIn: (email: string, password: string) =>
       dispatch(signOnAction.signIn(email, password)),
     fetchFollowArtists: () => dispatch(signOnAction.fetchAllFollowArtists()),
-    fetchReferrer: (location: Location) =>
-      dispatch(signOnAction.fetchReferrer(location)),
+    fetchReferrer: (handle: string) =>
+      dispatch(signOnAction.fetchReferrer(handle)),
     signUp: (email: string, password: string, handle: string) =>
       dispatch(signOnAction.signUp(email, password, handle)),
     setTwitterProfile: (

--- a/src/containers/sign-on/SignOnProvider.tsx
+++ b/src/containers/sign-on/SignOnProvider.tsx
@@ -5,7 +5,7 @@ import {
   replace as replaceRoute,
   goBack
 } from 'connected-react-router'
-import { UnregisterCallback } from 'history'
+import { Location, UnregisterCallback } from 'history'
 import { sampleSize } from 'lodash'
 import { connect } from 'react-redux'
 import { withRouter, RouteComponentProps } from 'react-router-dom'
@@ -121,6 +121,7 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
       }
     })
 
+    this.props.fetchReferrer(this.props.location)
     const closeModalHotkey = setupHotkeys({
       27 /* Escape */: () => {
         if (
@@ -475,6 +476,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     onSignIn: (email: string, password: string) =>
       dispatch(signOnAction.signIn(email, password)),
     fetchFollowArtists: () => dispatch(signOnAction.fetchAllFollowArtists()),
+    fetchReferrer: (location: Location) =>
+      dispatch(signOnAction.fetchReferrer(location)),
     signUp: (email: string, password: string, handle: string) =>
       dispatch(signOnAction.signUp(email, password, handle)),
     setTwitterProfile: (

--- a/src/containers/sign-on/store/actions.js
+++ b/src/containers/sign-on/store/actions.js
@@ -317,13 +317,13 @@ export const sendWelcomeEmail = name => ({
 })
 
 /**
- * Fetches the referrer from the sign on URL
- * @param {Location<History.PoorMansUnknown>} location
- *  the history location which captures the ?ref=<handle> param
+ * Fetches the referring user given their handle
+ * @param {string} handle
+ *  the handle captured by the ?ref=<handle> search param
  */
-export const fetchReferrer = location => ({
+export const fetchReferrer = handle => ({
   type: FETCH_REFERRER,
-  location
+  handle
 })
 
 /**

--- a/src/containers/sign-on/store/actions.js
+++ b/src/containers/sign-on/store/actions.js
@@ -50,6 +50,9 @@ export const REMOVE_FOLLOW_ARTISTS = 'SIGN_ON/REMOVE_FOLLOW_ARTISTS'
 
 export const SEND_WELCOME_EMAIL = 'SIGN_ON/SEND_WELCOME_EMAIL'
 
+export const FETCH_REFERRER = 'SIGN_ON/FETCH_REFERRER'
+export const SET_REFERRER = 'SIGN_ON/SET_REFERRER'
+
 /**
  * Sets athe value for a field in the sign on state
  * @param {string} field the field to be set
@@ -311,4 +314,23 @@ export const updateRouteOnExit = route => ({
 export const sendWelcomeEmail = name => ({
   type: SEND_WELCOME_EMAIL,
   name
+})
+
+/**
+ * Fetches the referrer from the sign on URL
+ * @param {Location<History.PoorMansUnknown>} location
+ *  the history location which captures the ?ref=<handle> param
+ */
+export const fetchReferrer = location => ({
+  type: FETCH_REFERRER,
+  location
+})
+
+/**
+ * Sets the user id of the referrer who invited this user signing up
+ * @param {ID} userId
+ */
+export const setReferrer = userId => ({
+  type: SET_REFERRER,
+  userId
 })

--- a/src/containers/sign-on/store/reducer.js
+++ b/src/containers/sign-on/store/reducer.js
@@ -33,7 +33,8 @@ import {
   UPDATE_ROUTE_ON_COMPLETION,
   UPDATE_ROUTE_ON_EXIT,
   ADD_FOLLOW_ARTISTS,
-  REMOVE_FOLLOW_ARTISTS
+  REMOVE_FOLLOW_ARTISTS,
+  SET_REFERRER
 } from './actions'
 import { Pages, FollowArtistsCategory } from './types'
 
@@ -71,7 +72,8 @@ const initialState = {
     selectedCategory: FollowArtistsCategory.FEATURED,
     categories: {},
     selectedUserIds: []
-  }
+  },
+  referrer: null
 }
 
 const actionsMap = {
@@ -393,6 +395,12 @@ const actionsMap = {
     return {
       ...state,
       routeOnExit: action.route
+    }
+  },
+  [SET_REFERRER](state, action) {
+    return {
+      ...state,
+      referrer: action.userId
     }
   }
 }

--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -115,8 +115,7 @@ function* fetchFollowArtistGenre(followArtistCategory) {
 }
 
 function* fetchReferrer(action) {
-  const { location } = action
-  const handle = new URLSearchParams(location.search).get('ref')
+  const { handle } = action
   if (handle) {
     try {
       const user = yield call(fetchUserByHandle, handle)

--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -117,12 +117,14 @@ function* fetchFollowArtistGenre(followArtistCategory) {
 function* fetchReferrer(action) {
   const { location } = action
   const handle = new URLSearchParams(location.search).get('ref')
-  try {
-    const user = yield call(fetchUserByHandle, handle)
-    if (!user) return
-    yield put(signOnActions.setReferrer(user.user_id))
-  } catch (e) {
-    console.error(e)
+  if (handle) {
+    try {
+      const user = yield call(fetchUserByHandle, handle)
+      if (!user) return
+      yield put(signOnActions.setReferrer(user.user_id))
+    } catch (e) {
+      console.error(e)
+    }
   }
 }
 

--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -310,9 +310,6 @@ function* signUp(action) {
       },
       function* () {
         yield put(signOnActions.signUpSucceeded())
-        yield fork(AudiusBackend.updateUserEvent, {
-          hasSignedInNativeMobile: !!NATIVE_MOBILE
-        })
         yield call(fetchAccountAsync)
       },
       function* ({ timeout }) {

--- a/src/containers/sign-on/store/selectors.js
+++ b/src/containers/sign-on/store/selectors.js
@@ -16,6 +16,7 @@ export const getRouteOnExit = state => state.signOn.routeOnExit
 export const getAccountReady = state => state.signOn.accountReady
 export const getStartedSignOnProcess = state =>
   state.signOn.startedSignOnProcess
+export const getReferrer = state => state.signOn.referrer
 
 export const getFollowIds = state => state.signOn.followArtists.selectedUserIds
 export const getSuggestedFollowIds = state => {

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -109,7 +109,8 @@ const userMetadataSchema = {
   updated_at: null,
   associated_wallets: null,
   collectibles: null,
-  playlist_library: null
+  playlist_library: null,
+  events: null
 }
 
 export const newUserMetadata = (fields, validate = false) => {

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1,9 +1,9 @@
-/* global web3, localStorage, fetch, Image */
+/* globals web3, localStorage, fetch, Image */
+
+import moment from 'moment-timezone'
 
 import * as DiscoveryAPI from '@audius/libs/src/services/discoveryProvider/requests'
 import * as IdentityAPI from '@audius/libs/src/services/identity/requests'
-import moment from 'moment-timezone'
-
 import placeholderCoverArt from 'assets/img/imageBlank2x.png'
 import imageCoverPhotoBlank from 'assets/img/imageCoverPhotoBlank.jpg'
 import placeholderProfilePicture from 'assets/img/imageProfilePicEmpty2X.png'
@@ -1589,7 +1589,7 @@ class AudiusBackend {
    * @param {string} password
    * @param {Object} formFields {name, handle, profilePicture, coverPhoto, isVerified, location}
    * @param {boolean?} hasWallet the user already has a wallet but didn't complete sign up
-   * @param {ID} referrer the user_id of the account that referred this one
+   * @param {ID?} referrer the user_id of the account that referred this one
    */
   static async signUp({
     email,
@@ -1613,6 +1613,7 @@ class AudiusBackend {
     if (formFields.location) {
       metadata.location = formFields.location
     }
+
     const hasEvents = referrer || NATIVE_MOBILE
     if (hasEvents) {
       metadata.events = {}

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1,9 +1,9 @@
 /* globals web3, localStorage, fetch, Image */
 
-import moment from 'moment-timezone'
-
 import * as DiscoveryAPI from '@audius/libs/src/services/discoveryProvider/requests'
 import * as IdentityAPI from '@audius/libs/src/services/identity/requests'
+import moment from 'moment-timezone'
+
 import placeholderCoverArt from 'assets/img/imageBlank2x.png'
 import imageCoverPhotoBlank from 'assets/img/imageCoverPhotoBlank.jpg'
 import placeholderProfilePicture from 'assets/img/imageProfilePicEmpty2X.png'

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1,9 +1,9 @@
 /* global web3, localStorage, fetch, Image */
 
-import moment from 'moment-timezone'
-
 import * as DiscoveryAPI from '@audius/libs/src/services/discoveryProvider/requests'
 import * as IdentityAPI from '@audius/libs/src/services/identity/requests'
+import moment from 'moment-timezone'
+
 import placeholderCoverArt from 'assets/img/imageBlank2x.png'
 import imageCoverPhotoBlank from 'assets/img/imageCoverPhotoBlank.jpg'
 import placeholderProfilePicture from 'assets/img/imageProfilePicEmpty2X.png'
@@ -18,6 +18,7 @@ import {
   BooleanKeys,
   FeatureFlags
 } from 'services/remote-config'
+import { IS_MOBILE_USER_KEY } from 'store/account/mobileSagas'
 import { track } from 'store/analytics/providers/segment'
 import CIDCache from 'store/cache/CIDCache'
 import { isElectron } from 'utils/clientUtil'
@@ -1612,8 +1613,16 @@ class AudiusBackend {
     if (formFields.location) {
       metadata.location = formFields.location
     }
+    const hasEvents = referrer || NATIVE_MOBILE
+    if (hasEvents) {
+      metadata.events = {}
+    }
     if (referrer) {
-      metadata.events = { referrer }
+      metadata.events.referrer = referrer
+    }
+    if (NATIVE_MOBILE) {
+      metadata.events.is_mobile_user = true
+      window.localStorage.setItem(IS_MOBILE_USER_KEY, 'true')
     }
 
     // Returns { userId, error, phase }

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1,9 +1,9 @@
 /* global web3, localStorage, fetch, Image */
 
-import * as DiscoveryAPI from '@audius/libs/src/services/discoveryProvider/requests'
-import * as IdentityAPI from '@audius/libs/src/services/identity/requests'
 import moment from 'moment-timezone'
 
+import * as DiscoveryAPI from '@audius/libs/src/services/discoveryProvider/requests'
+import * as IdentityAPI from '@audius/libs/src/services/identity/requests'
 import placeholderCoverArt from 'assets/img/imageBlank2x.png'
 import imageCoverPhotoBlank from 'assets/img/imageCoverPhotoBlank.jpg'
 import placeholderProfilePicture from 'assets/img/imageProfilePicEmpty2X.png'
@@ -1588,8 +1588,15 @@ class AudiusBackend {
    * @param {string} password
    * @param {Object} formFields {name, handle, profilePicture, coverPhoto, isVerified, location}
    * @param {boolean?} hasWallet the user already has a wallet but didn't complete sign up
+   * @param {ID} referrer the user_id of the account that referred this one
    */
-  static async signUp(email, password, formFields, hasWallet = false) {
+  static async signUp({
+    email,
+    password,
+    formFields,
+    hasWallet = false,
+    referrer = null
+  }) {
     await waitForLibsInit()
     const metadata = schemas.newUserMetadata()
     metadata.is_creator = false
@@ -1604,6 +1611,9 @@ class AudiusBackend {
     }
     if (formFields.location) {
       metadata.location = formFields.location
+    }
+    if (referrer) {
+      metadata.events = { referrer }
     }
 
     // Returns { userId, error, phase }

--- a/src/store/account/mobileSagas.ts
+++ b/src/store/account/mobileSagas.ts
@@ -1,6 +1,9 @@
 import { push as pushRoute } from 'connected-react-router'
-import { takeEvery, put } from 'redux-saga/effects'
+import { takeEvery, put, call } from 'redux-saga/effects'
 
+import { updateProfileAsync } from 'containers/profile-page/store/sagas'
+import User from 'models/User'
+import AudiusBackend from 'services/AudiusBackend'
 import { ReloadMessage } from 'services/native-mobile-interface/linking'
 import { MessageType } from 'services/native-mobile-interface/types'
 import * as accountActions from 'store/account/reducer'
@@ -10,6 +13,7 @@ import { setNeedsAccountRecovery } from './reducer'
 
 export const RESET_REQUIRED_KEY = 'password-reset-required'
 export const ENTROPY_KEY = 'hedgehog-entropy-key'
+export const IS_MOBILE_USER_KEY = 'is-mobile-user'
 
 function* watchFetchAccountFailed() {
   yield takeEvery(accountActions.fetchAccountFailed.type, function* () {
@@ -50,6 +54,29 @@ function* watchAccountRecovery() {
       yield put(setNeedsAccountRecovery())
     }
   })
+}
+
+export function* setHasSignedInOnMobile(account: User) {
+  const isMobileUser = window.localStorage.getItem(IS_MOBILE_USER_KEY)
+  if (!isMobileUser || isMobileUser !== 'true') {
+    try {
+      // Legacy method to update whether a user has signed in on
+      // native mobile. Used in identity service for notification indexing
+      yield call(AudiusBackend.updateUserEvent, {
+        hasSignedInNativeMobile: true
+      })
+      // Updates the user metadata with an event `is_mobile_user` set to true
+      // if the account is being fetched from a mobile context
+      yield call(updateProfileAsync, {
+        metadata: { ...account, events: { is_mobile_user: true } }
+      })
+
+      window.localStorage.setItem(IS_MOBILE_USER_KEY, 'true')
+    } catch (e) {
+      console.error(e)
+      // Do nothing. A retry on the next session will suffice.
+    }
+  }
 }
 
 const sagas = () => {

--- a/src/store/account/sagas.js
+++ b/src/store/account/sagas.js
@@ -53,7 +53,7 @@ import {
 import { isMobile, isElectron } from 'utils/clientUtil'
 import { waitForValue } from 'utils/sagaHelpers'
 
-import mobileSagas from './mobileSagas'
+import mobileSagas, { setHasSignedInOnMobile } from './mobileSagas'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
@@ -77,17 +77,9 @@ function* onFetchAccount(account) {
 
   yield fork(AudiusBackend.updateUserLocationTimezone)
   if (NATIVE_MOBILE) {
-    yield fork(AudiusBackend.updateUserEvent, {
-      hasSignedInNativeMobile: true
-    })
-    yield fork(
-      AudiusBackend.updateCreator,
-      { events: { is_mobile_user: true } },
-      account.user_id
-    )
+    yield fork(setHasSignedInOnMobile, account)
     new SignedIn(account).send()
   }
-
   // Add playlists that might not have made it into the user's library.
   // This could happen if the user creates a new playlist and then leaves their session.
   yield fork(addPlaylistsNotInLibrary)

--- a/src/store/account/sagas.js
+++ b/src/store/account/sagas.js
@@ -76,10 +76,15 @@ function* onFetchAccount(account) {
   }
 
   yield fork(AudiusBackend.updateUserLocationTimezone)
-  yield fork(AudiusBackend.updateUserEvent, {
-    hasSignedInNativeMobile: !!NATIVE_MOBILE
-  })
   if (NATIVE_MOBILE) {
+    yield fork(AudiusBackend.updateUserEvent, {
+      hasSignedInNativeMobile: true
+    })
+    yield fork(
+      AudiusBackend.updateCreator,
+      { events: { is_mobile_user: true } },
+      account.user_id
+    )
     new SignedIn(account).send()
   }
 

--- a/src/utils/signOut.js
+++ b/src/utils/signOut.js
@@ -6,6 +6,7 @@ import {
   clearAudiusAccountUser
 } from 'services/LocalStorage'
 import { ReloadMessage } from 'services/native-mobile-interface/linking'
+import { IS_MOBILE_USER_KEY } from 'store/account/mobileSagas'
 import { removeHasRequestedBrowserPermission } from 'utils/browserNotifications'
 
 import { clearTheme } from './theme/theme'
@@ -15,7 +16,12 @@ const AUDIUS_EVENTS = 'events'
 const AUDIUS_USE_METAMASK = 'useMetaMask'
 
 const removeLocalStorageItems = () => {
-  const items = [AUDIUS_EVENTS, AUDIUS_USE_METAMASK, BADGE_LOCAL_STORAGE_KEY]
+  const items = [
+    AUDIUS_EVENTS,
+    AUDIUS_USE_METAMASK,
+    BADGE_LOCAL_STORAGE_KEY,
+    IS_MOBILE_USER_KEY
+  ]
   items.map(k => localStorage.removeItem(k))
 }
 


### PR DESCRIPTION
### Description

Add referrer and is_mobile_user events tracking

_referrer_ gets added on sign up and parsed off of the URL, e.g. audius.co/signup?ref=ray
_is_mobile_user_ gets added along w/ the existing flow that writes hasUserSignedInOnMobile to the identity service for notification email processing

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

Nope other than there should be a point of notification refactor where we remove the identity field and use the user metadata one. That would also include a discovery database migration for backward compat.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Ran against local backend services & tested setting `referrer` and `is_mobile_user`

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
