### PR TITLE
Fix linked module import order lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,14 @@ module.exports = {
   },
   plugins: ['react', 'react-hooks', '@typescript-eslint', 'jest', 'import'],
   settings: {
+    // Only modules resolved from these folders will be considered "external".
+    // If you are `npm link`ing from a directory not listed here you may run
+    // into linting issues
+    'import/external-module-folders': [
+      'node_modules',
+      'stems',
+      'audius-protocol'
+    ],
     'import/resolver': {
       // NOTE: sk - These aliases are required for the import/order rule.
       // We are using the typescript baseUrl to do absolute import paths


### PR DESCRIPTION
### Description

Adding the `import/order` eslint rule caused an issue when a local module was `npm link`ed. The module was no longer considered "external" and therefore the rule required it to be in a different import group. This PR fixes that by specifying the directories from which modules should be considered "external"

### Dragons

Are there any other modules we commonly link?

If we were to add a `stems` or `audius-protocol` directory in the client, this would consider files imported from those directories external. But I don't think there would ever be a reason to have directories of those names in the client

### How Has This Been Tested?

Manually, by linking/unlinking and running the linter

