### PR TITLE
TikTok share sound fixes

### DIFF
--- a/src/containers/share-sound-to-tiktok-modal/ShareSoundToTikTokModal.tsx
+++ b/src/containers/share-sound-to-tiktok-modal/ShareSoundToTikTokModal.tsx
@@ -42,7 +42,7 @@ const fileRequirementErrorMessages = {
 }
 
 const ShareSoundToTikTokModal = () => {
-  const [isOpen, setIsOpen] = useModalState('ShareSoundToTikTokModal')
+  const [isOpen, setIsOpen] = useModalState('ShareSoundToTikTok')
   const dispatch = useDispatch()
 
   const track = useSelector(getTrack)

--- a/src/containers/share-sound-to-tiktok-modal/ShareSoundToTikTokModal.tsx
+++ b/src/containers/share-sound-to-tiktok-modal/ShareSoundToTikTokModal.tsx
@@ -10,12 +10,13 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+import { useModalState } from 'hooks/useModalState'
 import { useTikTokAuth } from 'hooks/useTikTokAuth'
 import { Nullable } from 'utils/typeUtils'
 
 import styles from './ShareSoundToTikTokModal.module.css'
-import { getStatus, getIsOpen, getTrack } from './store/selectors'
-import { authenticated, close, setStatus, share } from './store/slice'
+import { getStatus, getTrack } from './store/selectors'
+import { authenticated, setStatus, share } from './store/slice'
 import { Status } from './store/types'
 
 enum FileRequirementError {
@@ -41,9 +42,9 @@ const fileRequirementErrorMessages = {
 }
 
 const ShareSoundToTikTokModal = () => {
+  const [isOpen, setIsOpen] = useModalState('ShareSoundToTikTokModal')
   const dispatch = useDispatch()
 
-  const isOpen = useSelector(getIsOpen)
   const track = useSelector(getTrack)
   const status = useSelector(getStatus)
 
@@ -101,7 +102,7 @@ const ShareSoundToTikTokModal = () => {
       return (
         <Button
           className={styles.button}
-          onClick={() => dispatch(close())}
+          onClick={() => setIsOpen(false)}
           text={messages.completeButton}
         />
       )
@@ -136,7 +137,7 @@ const ShareSoundToTikTokModal = () => {
           <div>{messages.title}</div>
         </div>
       }
-      onClose={() => dispatch(close())}
+      onClose={() => setIsOpen(false)}
       allowScroll={false}
       bodyClassName={styles.modalBody}
       headerContainerClassName={styles.modalHeader}

--- a/src/containers/share-sound-to-tiktok-modal/store/sagas.ts
+++ b/src/containers/share-sound-to-tiktok-modal/store/sagas.ts
@@ -3,6 +3,7 @@ import { takeEvery, put, call, select } from 'redux-saga/effects'
 import { show as showConfetti } from 'containers/music-confetti/store/slice'
 import User from 'models/User'
 import { getAccountUser } from 'store/account/selectors'
+import { getCreatorNodeIPFSGateways } from 'utils/gatewayUtil'
 
 import { getIsAuthenticated } from './selectors'
 import {
@@ -31,7 +32,7 @@ function* handleShare(action: ReturnType<typeof share>) {
     const { data } = yield call(
       window.audiusLibs.File.fetchCID,
       action.payload.cid,
-      [`${creator_node_endpoint}/ipfs/`],
+      getCreatorNodeIPFSGateways(creator_node_endpoint),
       () => {}
     )
     track = data

--- a/src/containers/share-sound-to-tiktok-modal/store/selectors.ts
+++ b/src/containers/share-sound-to-tiktok-modal/store/selectors.ts
@@ -5,10 +5,6 @@ import { AppState } from 'store/types'
 const shareSoundToTikTokModalState = (state: AppState) =>
   state.application.ui.shareSoundToTikTokModal
 
-export const getIsOpen = createSelector(
-  shareSoundToTikTokModalState,
-  state => state.isOpen
-)
 export const getTrack = createSelector(
   shareSoundToTikTokModalState,
   state => state.track

--- a/src/containers/share-sound-to-tiktok-modal/store/slice.ts
+++ b/src/containers/share-sound-to-tiktok-modal/store/slice.ts
@@ -10,7 +10,6 @@ import {
 
 const initialState: ShareSoundToTikTokModalState = {
   isAuthenticated: false,
-  isOpen: false,
   status: Status.SHARE_UNINITIALIZED
 }
 
@@ -21,13 +20,9 @@ const slice = createSlice({
   initialState,
   reducers: {
     authenticated: () => {},
-    close: state => {
-      state.isOpen = false
-    },
     open: (state, action: PayloadAction<OpenPayload>) => {
       const { track } = action.payload
       state.isAuthenticated = false
-      state.isOpen = true
       state.track = track
       state.status = Status.SHARE_UNINITIALIZED
     },
@@ -37,7 +32,6 @@ const slice = createSlice({
     setStatus: (state, action: PayloadAction<SetStatusPayload>) => {
       const { status } = action.payload
       state.status = status
-      state.isOpen = true
     },
     share: (state, action: PayloadAction<SharePayload>) => {},
     upload: () => {}
@@ -46,7 +40,6 @@ const slice = createSlice({
 
 export const {
   authenticated,
-  close,
   open,
   setIsAuthenticated,
   setStatus,

--- a/src/containers/share-sound-to-tiktok-modal/store/slice.ts
+++ b/src/containers/share-sound-to-tiktok-modal/store/slice.ts
@@ -37,6 +37,7 @@ const slice = createSlice({
     setStatus: (state, action: PayloadAction<SetStatusPayload>) => {
       const { status } = action.payload
       state.status = status
+      state.isOpen = true
     },
     share: (state, action: PayloadAction<SharePayload>) => {},
     upload: () => {}

--- a/src/containers/share-sound-to-tiktok-modal/store/types.ts
+++ b/src/containers/share-sound-to-tiktok-modal/store/types.ts
@@ -16,7 +16,6 @@ export type Track = {
 
 export type ShareSoundToTikTokModalState = {
   isAuthenticated: boolean
-  isOpen: boolean
   track?: Track
   status: Status
 }

--- a/src/containers/upload-page/components/ShareBanner.tsx
+++ b/src/containers/upload-page/components/ShareBanner.tsx
@@ -10,6 +10,7 @@ import Toast from 'components/toast/Toast'
 import { MountPlacement, ComponentPlacement } from 'components/types'
 import { useFlag } from 'containers/remote-config/hooks'
 import { open as openTikTokModal } from 'containers/share-sound-to-tiktok-modal/store/slice'
+import { useModalState } from 'hooks/useModalState'
 import User from 'models/User'
 import AudiusBackend from 'services/AudiusBackend'
 import { Name } from 'services/analytics'
@@ -138,6 +139,7 @@ const TOAST_DELAY = 3000
 const ShareBanner = ({ isHidden, type, upload, user }: ShareBannerProps) => {
   const dispatch = useDispatch()
   const record = useRecord()
+  const [_, setIsTikTokModalOpen] = useModalState('ShareSoundToTikTokModal')
   const { isEnabled: isShareSoundToTikTokEnabled } = useFlag(
     FeatureFlags.SHARE_SOUND_TO_TIKTOK
   )
@@ -167,9 +169,10 @@ const ShareBanner = ({ isHidden, type, upload, user }: ShareBannerProps) => {
           }
         })
       )
+      setIsTikTokModalOpen(true)
     }
     record(make(Name.TRACK_UPLOAD_SHARE_SOUND_TO_TIKTOK, {}))
-  }, [upload, record, dispatch])
+  }, [upload, record, dispatch, setIsTikTokModalOpen])
 
   const onCopy = useCallback(async () => {
     const { url } = await getShareTextUrl(type, user, upload, false)

--- a/src/containers/upload-page/components/ShareBanner.tsx
+++ b/src/containers/upload-page/components/ShareBanner.tsx
@@ -139,7 +139,7 @@ const TOAST_DELAY = 3000
 const ShareBanner = ({ isHidden, type, upload, user }: ShareBannerProps) => {
   const dispatch = useDispatch()
   const record = useRecord()
-  const [_, setIsTikTokModalOpen] = useModalState('ShareSoundToTikTokModal')
+  const [_, setIsTikTokModalOpen] = useModalState('ShareSoundToTikTok')
   const { isEnabled: isShareSoundToTikTokEnabled } = useFlag(
     FeatureFlags.SHARE_SOUND_TO_TIKTOK
   )

--- a/src/services/remote-config/FeatureFlags.ts
+++ b/src/services/remote-config/FeatureFlags.ts
@@ -20,7 +20,7 @@ export const flagDefaults: { [key in FeatureFlags]: boolean } = {
   [FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD]: false,
   [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: false,
   [FeatureFlags.CREATE_WAUDIO_USER_BANK_ON_SIGN_UP]: false,
-  [FeatureFlags.SHARE_SOUND_TO_TIKTOK]: true,
+  [FeatureFlags.SHARE_SOUND_TO_TIKTOK]: false,
   [FeatureFlags.REMIXABLES]: false
 }
 

--- a/src/store/application/ui/modals/slice.ts
+++ b/src/store/application/ui/modals/slice.ts
@@ -9,7 +9,6 @@ export type Modals =
   | 'APIRewardsExplainer'
   | 'TransferAudioMobileWarning'
   | 'MobileConnectWalletsDrawer'
-  | 'ShareSoundToTikTok'
 
 type InitialModalsState = { [modal in Modals]: boolean }
 
@@ -19,8 +18,7 @@ const initialState: InitialModalsState = {
   LinkSocialRewardsExplainer: false,
   APIRewardsExplainer: false,
   TransferAudioMobileWarning: false,
-  MobileConnectWalletsDrawer: false,
-  ShareSoundToTikTok: false
+  MobileConnectWalletsDrawer: false
 }
 
 const slice = createSlice({

--- a/src/store/application/ui/modals/slice.ts
+++ b/src/store/application/ui/modals/slice.ts
@@ -9,6 +9,7 @@ export type Modals =
   | 'APIRewardsExplainer'
   | 'TransferAudioMobileWarning'
   | 'MobileConnectWalletsDrawer'
+  | 'ShareSoundToTikTokModal'
 
 type InitialModalsState = { [modal in Modals]: boolean }
 
@@ -18,7 +19,8 @@ const initialState: InitialModalsState = {
   LinkSocialRewardsExplainer: false,
   APIRewardsExplainer: false,
   TransferAudioMobileWarning: false,
-  MobileConnectWalletsDrawer: false
+  MobileConnectWalletsDrawer: false,
+  ShareSoundToTikTokModal: false
 }
 
 const slice = createSlice({

--- a/src/store/application/ui/modals/slice.ts
+++ b/src/store/application/ui/modals/slice.ts
@@ -9,7 +9,7 @@ export type Modals =
   | 'APIRewardsExplainer'
   | 'TransferAudioMobileWarning'
   | 'MobileConnectWalletsDrawer'
-  | 'ShareSoundToTikTokModal'
+  | 'ShareSoundToTikTok'
 
 type InitialModalsState = { [modal in Modals]: boolean }
 
@@ -20,7 +20,7 @@ const initialState: InitialModalsState = {
   APIRewardsExplainer: false,
   TransferAudioMobileWarning: false,
   MobileConnectWalletsDrawer: false,
-  ShareSoundToTikTokModal: false
+  ShareSoundToTikTok: false
 }
 
 const slice = createSlice({


### PR DESCRIPTION
### Description

This PR:

* Fixes a bug where the `creator_node_endpoint` was being used incorrectly, causing the request to the users CN to fail and always falling back to the public ipfs gateways
* Sets the default value for the TikTok sharing feature flag  to `false`
* Adopts the pattern of using the `modal` slice to handle open/close state while using a custom slice for the business logic

### Dragons

No

### How Has This Been Tested?

Manually

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
