### PR TITLE
Make sure a user id is present before allowing reorders

### DIFF
--- a/src/containers/collection-page/components/desktop/CollectionPage.tsx
+++ b/src/containers/collection-page/components/desktop/CollectionPage.tsx
@@ -242,7 +242,10 @@ const CollectionPage = ({
                 playingIndex={playingIndex}
                 dataSource={dataSource}
                 allowReordering={
-                  userId === playlistOwnerId && allowReordering && !isAlbum
+                  userId !== null &&
+                  userId === playlistOwnerId &&
+                  allowReordering &&
+                  !isAlbum
                 }
                 onClickRow={onClickRow}
                 onClickFavorite={onClickSave}


### PR DESCRIPTION
### Description
Fixes a tiny bug on explore page collections where if no user is signed in, it's possible for null === null (since explore collections have no "owner") and reordering to be allowed.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Explore collection signed out
- Normal playlist signed out
- Normal playlist signed in (can reorder if owner)

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
