### PR TITLE
Fix subtle bug in explore layout

### DIFF
--- a/src/containers/explore-page/ExplorePage.tsx
+++ b/src/containers/explore-page/ExplorePage.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 
+import { isRemoteConfigLoaded } from 'containers/remote-config/selectors'
 import { AppState } from 'store/types'
 import { isMobile } from 'utils/clientUtil'
 
@@ -14,6 +15,12 @@ type OwnProps = {}
 type ExplorePageContentProps = ReturnType<typeof mapStateToProps> & OwnProps
 const ExplorePage = ({ isMobile }: ExplorePageContentProps) => {
   const content = isMobile ? MobileExplorePage : DesktopExplorePage
+
+  // Do not render content until remote config is loaded so
+  // that tiling layout does not change.
+  // TODO: Remove this when Remixables feature flag is removed
+  const remoteConfigLoaded = useSelector(isRemoteConfigLoaded)
+  if (!remoteConfigLoaded) return null
 
   return <ExplorePageProvider>{content}</ExplorePageProvider>
 }

--- a/src/containers/explore-page/components/desktop/ExplorePage.tsx
+++ b/src/containers/explore-page/components/desktop/ExplorePage.tsx
@@ -23,6 +23,7 @@ import {
   INTIMATE_PLAYLISTS
 } from 'containers/explore-page/collections'
 import { ExploreCollectionsVariant } from 'containers/explore-page/store/types'
+import { useFlag } from 'containers/remote-config/hooks'
 import {
   HEAVY_ROTATION,
   BEST_NEW_RELEASES,
@@ -34,7 +35,7 @@ import {
 import { useOrderedLoad } from 'hooks/useOrderedLoad'
 import { UserCollection, Variant as CollectionVariant } from 'models/Collection'
 import User from 'models/User'
-import { FeatureFlags, getFeatureEnabled } from 'services/remote-config'
+import { FeatureFlags } from 'services/remote-config'
 import { Status } from 'store/types'
 import { BASE_URL, EXPLORE_PAGE, stripBaseUrl } from 'utils/route'
 
@@ -61,7 +62,7 @@ export const justForYou = [
   BEST_NEW_RELEASES,
   UNDER_THE_RADAR,
   TOP_ALBUMS,
-  ...(getFeatureEnabled(FeatureFlags.REMIXABLES) ? [REMIXABLES] : []),
+  REMIXABLES,
   MOST_LOVED,
   FEELING_LUCKY
 ]
@@ -114,6 +115,7 @@ const ExplorePage = ({
     },
     [goToRoute]
   )
+  const { isEnabled: remixablesEnabled } = useFlag(FeatureFlags.REMIXABLES)
 
   return (
     <Page
@@ -129,6 +131,13 @@ const ExplorePage = ({
         layout={Layout.TWO_COLUMN_DYNAMIC_WITH_DOUBLE_LEADING_ELEMENT}
       >
         {justForYou.map(i => {
+          if (
+            i.variant === CollectionVariant.SMART &&
+            i.playlist_name === REMIXABLES.playlist_name &&
+            !remixablesEnabled
+          ) {
+            return null
+          }
           const title =
             i.variant === CollectionVariant.SMART ? i.playlist_name : i.title
           const subtitle =

--- a/src/containers/explore-page/components/mobile/ExplorePage.tsx
+++ b/src/containers/explore-page/components/mobile/ExplorePage.tsx
@@ -36,6 +36,7 @@ import {
 import CardLineup from 'containers/lineup/CardLineup'
 import { useMainPageHeader } from 'containers/nav/store/context'
 import { useFlag } from 'containers/remote-config/hooks'
+import { REMIXABLES } from 'containers/smart-collection/smartCollections'
 import useTabs from 'hooks/useTabs/useTabs'
 import {
   UserCollection,
@@ -140,6 +141,13 @@ const ExplorePage = ({
 
   const justForYouTiles = justForYou.map(
     (t: SmartCollection | ExploreCollection) => {
+      if (
+        t.variant === CollectionVariant.SMART &&
+        t.playlist_name === REMIXABLES.playlist_name &&
+        !remixablesEnabled
+      ) {
+        return null
+      }
       const Icon = t.icon ? t.icon : React.Fragment
       if (t.variant === CollectionVariant.SMART) {
         return (

--- a/src/containers/remote-config/hooks.ts
+++ b/src/containers/remote-config/hooks.ts
@@ -15,8 +15,9 @@ import {
   flagCohortType
 } from 'services/remote-config/FeatureFlags'
 import { getAccountUser } from 'store/account/selectors'
-import { AppState } from 'store/types'
 import { useSelector } from 'utils/reducer'
+
+import { isRemoteConfigLoaded } from './selectors'
 
 /**
  * Hooks into updates for a given feature flag.
@@ -24,9 +25,7 @@ import { useSelector } from 'utils/reducer'
  * @param flag
  */
 export const useFlag = (flag: FeatureFlags) => {
-  const configLoaded = useSelector(
-    (state: AppState) => state.remoteConfig.remoteConfigLoaded
-  )
+  const configLoaded = useSelector(isRemoteConfigLoaded)
   const userIdFlag = flagCohortType[flag] === FeatureFlagCohortType.USER_ID
   const hasAccount = useSelector(getAccountUser)
   const shouldRecompute = userIdFlag ? hasAccount : true
@@ -45,9 +44,7 @@ export function useRemoteVar(key: BooleanKeys): boolean
 export function useRemoteVar(
   key: AllRemoteConfigKeys
 ): boolean | string | number | null {
-  const configLoaded = useSelector(
-    (state: AppState) => state.remoteConfig.remoteConfigLoaded
-  )
+  const configLoaded = useSelector(isRemoteConfigLoaded)
   // eslint complains about configLoaded as part of the deps array
   // eslint-disable-next-line
   const remoteVar = useMemo(() => getRemoteVar(key), [key, configLoaded])

--- a/src/containers/remote-config/selectors.ts
+++ b/src/containers/remote-config/selectors.ts
@@ -1,0 +1,4 @@
+import { AppState } from 'store/types'
+
+export const isRemoteConfigLoaded = (state: AppState) =>
+  state.remoteConfig.remoteConfigLoaded


### PR DESCRIPTION
### Description

Because the layout for the explore page is now controlled by a feature flag, the first few renders happen when the feature flag is off and then renders happen when it's on. This causes two issues:
1. The layout jumps when the Remixables tile shows up
2. It's possible that the array of explore tiles gets instantiated before the feature flag loads at all, making remixables never show

Both of these issues are fixed by
1. Moving the decision to render the remixables tab into the conmponent lifecycle rather than as a global
2. Wait to render explore until remote config loads in

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

1. Feature flag on
2. Feature flag off

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
