### PR TITLE
Adds null check on playbar

### DIFF
--- a/src/containers/play-bar/desktop/PlayBar.js
+++ b/src/containers/play-bar/desktop/PlayBar.js
@@ -232,7 +232,7 @@ class PlayBar extends Component {
       reset,
       currentQueueItem: { track }
     } = this.props
-    if (track.genre === Genre.PODCASTS) {
+    if (track?.genre === Genre.PODCASTS) {
       const position = audio.getPosition()
       const newPosition = position - SKIP_DURATION_SEC
       seek(Math.max(0, newPosition))
@@ -257,7 +257,7 @@ class PlayBar extends Component {
       next,
       currentQueueItem: { track }
     } = this.props
-    if (track.genre === Genre.PODCASTS) {
+    if (track?.genre === Genre.PODCASTS) {
       const duration = audio.getDuration()
       const position = audio.getPosition()
       const newPosition = position + SKIP_DURATION_SEC


### PR DESCRIPTION
### Description
If there is no currently playing track, the next and previous btn trigger an error because we try to get the field `genre` on an undefined track obj.
Sentry Error: `genre title:"TypeError: Cannot read property 'genre' of null" project:audius-client ` 

**Fix**: Add optional chaining to check if the track object is defined.

Closes AUD-816

### Dragons
none

### How Has This Been Tested?
Ran the client against staging and it didn't error

### How will this change be monitored?
Check if sentry errors go away. 