### PR TITLE
AUD-840 Add zIndex to ImageSelectionPopup

### DIFF
--- a/src/components/image-selection/ImageSelectionPopup.js
+++ b/src/components/image-selection/ImageSelectionPopup.js
@@ -9,6 +9,7 @@ import TabSlider from 'components/data-entry/TabSlider'
 import Dropzone from 'components/upload/Dropzone'
 import InvalidFileType from 'components/upload/InvalidFileType'
 import RandomImage from 'services/RandomImage'
+import zIndex from 'utils/zIndex'
 
 import styles from './ImageSelectionPopup.module.css'
 import { ImageSelectionProps, ImageSelectionDefaults } from './PropTypes'
@@ -141,6 +142,7 @@ const ImageSelectionPopup = ({
       onAfterClose={onAfterClose}
       showHeader={true}
       title={messages.addImage}
+      zIndex={zIndex.IMAGE_SELECTION_POPUP}
     >
       <TabSlider
         className={styles.slider}

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -12,6 +12,7 @@ export enum zIndex {
   // NAVIGATOR = 14,
   NAVIGATOR_POPUP = 15,
   NAVIGATOR_POPUP_OVERFLOW_POPUP = 16,
+  IMAGE_SELECTION_POPUP = 17,
 
   // Set to 1000 to account for nested modals inside, which take a higher z-index
   EDIT_TRACK_MODAL = 1000,

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -12,11 +12,11 @@ export enum zIndex {
   // NAVIGATOR = 14,
   NAVIGATOR_POPUP = 15,
   NAVIGATOR_POPUP_OVERFLOW_POPUP = 16,
-  IMAGE_SELECTION_POPUP = 17,
 
   // Set to 1000 to account for nested modals inside, which take a higher z-index
   EDIT_TRACK_MODAL = 1000,
-  EDIT_PLAYLIST_MODAL = 1000
+  EDIT_PLAYLIST_MODAL = 1000,
+  IMAGE_SELECTION_POPUP = 1001
 }
 
 export default zIndex


### PR DESCRIPTION
### Description

The migration to `Popup` introduced a visual bug on the profile page when editing the profile photo or cover photo. This PR adds a zIndex to the `ImageSelectionPopup` to fix this bug

![image](https://user-images.githubusercontent.com/19916043/128103379-3833dd76-8ff7-4a2a-8e56-d7992b55473c.png)


### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
