### PR TITLE
AUD-848 Fix explore tile kebab position

### DIFF
--- a/src/components/card/desktop/CollectionArtCard.tsx
+++ b/src/components/card/desktop/CollectionArtCard.tsx
@@ -13,7 +13,7 @@ import PerspectiveCard from 'components/perspective-card/PerspectiveCard'
 import RepostFavoritesStats, {
   Size
 } from 'components/repost-favorites-stats/RepostFavoritesStats'
-import Menu from 'containers/menu/Menu'
+import Menu, { MenuType } from 'containers/menu/Menu'
 import { useCollectionCoverArt } from 'hooks/useImageSize'
 import { ID } from 'models/common/Identifiers'
 import { SquareSizes } from 'models/common/ImageSizes'
@@ -124,7 +124,7 @@ const CollectionArtCard = g(
     if (image && setDidLoad) setDidLoad(index)
 
     const menu = {
-      type: is_album ? 'album' : 'playlist',
+      type: (is_album ? 'album' : 'playlist') as MenuType,
       handle,
       playlistId: playlist_id,
       playlistName: playlist_name,
@@ -150,12 +150,7 @@ const CollectionArtCard = g(
             wrapperClassName={styles.coverArt}
             image={isLoading ? '' : image}
           >
-            <Menu
-              // @ts-ignore
-              menu={menu}
-              onClose={() => setIsPerspectiveDisabled(false)}
-              className={styles.iconKebabHorizontalWrapper}
-            >
+            <Menu menu={menu} onClose={() => setIsPerspectiveDisabled(false)}>
               {(ref, triggerPopup) => (
                 <div
                   onClick={e => {
@@ -163,6 +158,7 @@ const CollectionArtCard = g(
                     setIsPerspectiveDisabled(true)
                     triggerPopup()
                   }}
+                  className={styles.iconKebabHorizontalWrapper}
                 >
                   <IconKebabHorizontal
                     className={styles.iconKebabHorizontal}

--- a/src/containers/menu/Menu.tsx
+++ b/src/containers/menu/Menu.tsx
@@ -22,6 +22,8 @@ export type MenuOptionType =
   | TrackMenuProps
   | NotificationMenuProps
 
+export type MenuType = MenuOptionType['type']
+
 export type MenuProps = {
   children: PopupMenuProps['renderTrigger']
   menu: Omit<MenuOptionType, 'children'>


### PR DESCRIPTION
### Description

The overflow menu kebab on the explore tile got shifted due to a classname being incorrectly applied. Typescript missed this because we had a `// @ts-ignore` 💀 

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
