### PR TITLE
Close transfer waudio modal after 2 sec

### DIFF
--- a/src/store/account/sagas.js
+++ b/src/store/account/sagas.js
@@ -34,6 +34,7 @@ import {
 import { identify } from 'store/analytics/actions'
 import {
   getModalIsOpen,
+  getModalVisibility,
   setVisibility
 } from 'store/application/ui/modals/slice'
 import { confirmTransferAudioToWAudio } from 'store/audio-manager/slice'
@@ -131,7 +132,12 @@ function* initAudioChecks() {
         })
       )
     }
-    yield put(setVisibility({ modal: 'ConfirmAudioToWAudio', visible: false }))
+    const isModalOpen = yield select(getModalVisibility, 'ConfirmAudioToWAudio')
+    if (isModalOpen) {
+      yield put(
+        setVisibility({ modal: 'ConfirmAudioToWAudio', visible: false })
+      )
+    }
   }
 }
 


### PR DESCRIPTION
### Description
Closes the transfer waudio to audio modal after 2 seconds if not already closed (ie. still waiting for transfer transaction to be completed and confirmed)

Also updated the analytics event to be correct

Closes AUD-807

### Dragons
none

### How Has This Been Tested?
Ran it manually with a timeout in place of the transfer audio to waudio 

### How will this change be monitored?
manually