### PR TITLE
AUD-756 Add tik tok handle to profile page

### DIFF
--- a/src/containers/profile-page/ProfilePageProvider.tsx
+++ b/src/containers/profile-page/ProfilePageProvider.tsx
@@ -62,6 +62,7 @@ const INITIAL_UPDATE_FIELDS = {
   updatedLocation: null,
   updatedTwitterHandle: null,
   updatedInstagramHandle: null,
+  updatedTikTokHandle: null,
   updatedWebsite: null,
   updatedDonation: null
 }
@@ -89,6 +90,7 @@ type ProfilePageState = {
   updatedLocation: string | null
   updatedTwitterHandle: string | null
   updatedInstagramHandle: string | null
+  updatedTikTokHandle: string | null
   updatedWebsite: string | null
   updatedDonation: string | null
   tracksLineupOrder: TracksSortMode
@@ -349,6 +351,12 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     })
   }
 
+  updateTikTokHandle = (handle: string) => {
+    this.setState({
+      updatedTikTokHandle: handle
+    })
+  }
+
   updateWebsite = (website: string) => {
     this.setState({
       updatedWebsite: website
@@ -404,6 +412,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       updatedLocation: null,
       updatedTwitterHandle: null,
       updatedInstagramHandle: null,
+      updatedTikTokHandle: null,
       updatedWebsite: null,
       updatedDonation: null
     })
@@ -423,6 +432,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       updatedLocation,
       updatedTwitterHandle,
       updatedInstagramHandle,
+      updatedTikTokHandle,
       updatedWebsite,
       updatedDonation
     } = this.state
@@ -450,6 +460,9 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     }
     if (updatedInstagramHandle !== null) {
       updatedMetadata.instagram_handle = updatedInstagramHandle
+    }
+    if (updatedTikTokHandle !== null) {
+      updatedMetadata.tiktok_handle = updatedTikTokHandle
     }
     if (updatedWebsite !== null) {
       updatedMetadata.website = updatedWebsite
@@ -717,6 +730,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       updatedProfilePicture,
       updatedTwitterHandle,
       updatedInstagramHandle,
+      updatedTikTokHandle,
       updatedWebsite,
       updatedDonation
     } = this.state
@@ -764,6 +778,11 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
         : profile.instagramVerified
         ? profile.handle
         : profile.instagram_handle || ''
+      : ''
+    const tikTokHandle = profile
+      ? updatedTikTokHandle !== null
+        ? updatedTikTokHandle
+        : profile.tiktok_handle || ''
       : ''
     const website = profile
       ? updatedWebsite !== null
@@ -819,6 +838,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       location,
       twitterHandle,
       instagramHandle,
+      tikTokHandle,
       website,
       donation,
       coverPhotoSizes,
@@ -869,6 +889,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       updateLocation: this.updateLocation,
       updateTwitterHandle: this.updateTwitterHandle,
       updateInstagramHandle: this.updateInstagramHandle,
+      updateTikTokHandle: this.updateTikTokHandle,
       updateWebsite: this.updateWebsite,
       updateDonation: this.updateDonation,
       updateCoverPhoto: this.updateCoverPhoto,
@@ -885,6 +906,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
         updatedLocation !== null ||
         updatedTwitterHandle !== null ||
         updatedInstagramHandle !== null ||
+        updatedTikTokHandle !== null ||
         updatedWebsite !== null ||
         updatedDonation !== null ||
         updatedCoverPhoto !== null ||

--- a/src/containers/profile-page/components/SocialLink.tsx
+++ b/src/containers/profile-page/components/SocialLink.tsx
@@ -1,10 +1,11 @@
-import React, { ReactNode, useCallback } from 'react'
+import React, { ReactNode, useCallback, useMemo } from 'react'
 
 import {
   IconTwitterBird,
   IconInstagram,
   IconDonate,
-  IconLink
+  IconLink,
+  IconTikTokInverted
 } from '@audius/stems'
 import cn from 'classnames'
 import Linkify from 'linkifyjs/react'
@@ -16,16 +17,20 @@ import styles from './SocialLink.module.css'
 export enum Type {
   TWITTER,
   INSTAGRAM,
+  TIKTOK,
   WEBSITE,
   DONATION
 }
 
 const SITE_URL_MAP = {
   [Type.TWITTER]: 'https://twitter.com/',
-  [Type.INSTAGRAM]: 'https://instagram.com/'
+  [Type.INSTAGRAM]: 'https://instagram.com/',
+  [Type.TIKTOK]: 'https://tiktok.com/@'
 }
 
-const goToHandle = (type: Type.TWITTER | Type.INSTAGRAM, handle: string) => {
+type HandleType = keyof typeof SITE_URL_MAP
+
+const goToHandle = (type: HandleType, handle: string) => {
   if (SITE_URL_MAP[type] && handle) {
     const win = window.open(`${SITE_URL_MAP[type]}${handle}`, '_blank')
     if (win) win.focus()
@@ -40,6 +45,14 @@ const goToLink = (link: string) => {
   if (win) win.focus()
 }
 
+export const handleTypes = [Type.TWITTER, Type.INSTAGRAM, Type.TIKTOK]
+const singleLinkTypes = [
+  Type.TWITTER,
+  Type.INSTAGRAM,
+  Type.TIKTOK,
+  Type.WEBSITE
+]
+
 type SocialLinkProps = {
   type: Type
   link: string
@@ -47,14 +60,17 @@ type SocialLinkProps = {
 }
 
 const SocialLink = ({ type, link, onClick }: SocialLinkProps) => {
+  const isHandle = useMemo(() => handleTypes.includes(type), [type])
+  const isSingleLink = useMemo(() => singleLinkTypes.includes(type), [type])
+
   const onIconClick = useCallback(() => {
-    if (type === Type.TWITTER || type === Type.INSTAGRAM) {
-      goToHandle(type, link)
+    if (isHandle) {
+      goToHandle(type as HandleType, link)
     } else {
       goToLink(link)
     }
     if (onClick) onClick()
-  }, [type, link, onClick])
+  }, [isHandle, type, link, onClick])
 
   let icon: ReactNode
   switch (type) {
@@ -63,6 +79,9 @@ const SocialLink = ({ type, link, onClick }: SocialLinkProps) => {
       break
     case Type.INSTAGRAM:
       icon = <IconInstagram className={styles.icon} />
+      break
+    case Type.TIKTOK:
+      icon = <IconTikTokInverted className={styles.icon} />
       break
     case Type.WEBSITE:
       icon = <IconLink className={styles.icon} />
@@ -77,7 +96,7 @@ const SocialLink = ({ type, link, onClick }: SocialLinkProps) => {
   }
 
   let text: ReactNode
-  if (type === Type.TWITTER || type === Type.INSTAGRAM) {
+  if (isHandle) {
     text = `@${link}`
   } else {
     text = link.replace(/((?:https?):\/\/)|www./g, '')
@@ -93,15 +112,13 @@ const SocialLink = ({ type, link, onClick }: SocialLinkProps) => {
       )
     }
   }
-  const singleLink =
-    type === Type.TWITTER || type === Type.INSTAGRAM || type === Type.WEBSITE
 
   return (
     <div className={styles.socialLink}>
       <div
-        onClick={singleLink ? onIconClick : () => {}}
+        onClick={isSingleLink ? onIconClick : () => {}}
         className={cn(styles.wrapper, {
-          [styles.singleLink]: singleLink
+          [styles.singleLink]: isSingleLink
         })}
       >
         {icon}

--- a/src/containers/profile-page/components/SocialLinkInput.tsx
+++ b/src/containers/profile-page/components/SocialLinkInput.tsx
@@ -28,7 +28,7 @@ const sanitizeHandle = (handle: string) => {
         return split.split('/')[0]
       }
     }
-    if (handle.includes('instagram')) {
+    if (handle.includes('tiktok')) {
       const split = handle.split('tiktok.com/')[1]
       if (split) {
         return split.split('/')[0]

--- a/src/containers/profile-page/components/SocialLinkInput.tsx
+++ b/src/containers/profile-page/components/SocialLinkInput.tsx
@@ -1,16 +1,17 @@
-import React, { useState, useRef, ReactNode } from 'react'
+import React, { useState, useRef, ReactNode, useMemo } from 'react'
 
 import {
   IconTwitterBird,
   IconInstagram,
   IconDonate,
-  IconLink
+  IconLink,
+  IconTikTok
 } from '@audius/stems'
 import cn from 'classnames'
 
 import Input from 'components/data-entry/Input'
 
-import { Type } from './SocialLink'
+import { Type, handleTypes } from './SocialLink'
 import styles from './SocialLinkInput.module.css'
 
 const sanitizeHandle = (handle: string) => {
@@ -23,6 +24,12 @@ const sanitizeHandle = (handle: string) => {
     }
     if (handle.includes('instagram')) {
       const split = handle.split('instagram.com/')[1]
+      if (split) {
+        return split.split('/')[0]
+      }
+    }
+    if (handle.includes('instagram')) {
+      const split = handle.split('tiktok.com/')[1]
       if (split) {
         return split.split('/')[0]
       }
@@ -54,6 +61,8 @@ const SocialLinkInput = ({
 
   const inputRef = useRef()
 
+  const isHandle = useMemo(() => handleTypes.includes(type), [type])
+
   const handleOnChange = (text: string) => {
     if (textLimitMinusLinks) {
       const textWithoutLinks = text.replace(/(?:https?):\/\/[\n\S]+/g, '')
@@ -61,7 +70,7 @@ const SocialLinkInput = ({
     }
 
     let sanitized: string
-    if (type === Type.TWITTER || type === Type.INSTAGRAM) {
+    if (isHandle) {
       clearTimeout(timeoutRef.current)
       timeoutRef.current = setTimeout(() => {
         if (text.startsWith('@')) {
@@ -100,6 +109,9 @@ const SocialLinkInput = ({
     case Type.INSTAGRAM:
       icon = <IconInstagram className={styles.icon} />
       break
+    case Type.TIKTOK:
+      icon = <IconTikTok className={styles.icon} />
+      break
     case Type.WEBSITE:
       icon = <IconLink className={styles.icon} />
       break
@@ -108,13 +120,16 @@ const SocialLinkInput = ({
       break
   }
 
-  let placeholder: string
+  let placeholder = ''
   switch (type) {
     case Type.TWITTER:
       placeholder = 'Twitter Handle'
       break
     case Type.INSTAGRAM:
       placeholder = 'Instagram Handle'
+      break
+    case Type.TIKTOK:
+      placeholder = 'TikTok Handle'
       break
     case Type.WEBSITE:
       placeholder = 'Website'
@@ -132,12 +147,10 @@ const SocialLinkInput = ({
       })}
     >
       <div className={styles.icon}>{icon}</div>
-      {(type === Type.TWITTER || type === Type.INSTAGRAM) && (
-        <span className={styles.at}>{'@'}</span>
-      )}
+      {isHandle && <span className={styles.at}>{'@'}</span>}
       <Input
         className={cn(styles.input, className, {
-          [styles.handle]: type === Type.TWITTER || type === Type.INSTAGRAM
+          [styles.handle]: isHandle
         })}
         characterLimit={200}
         size='small'

--- a/src/containers/profile-page/components/desktop/ProfilePage.tsx
+++ b/src/containers/profile-page/components/desktop/ProfilePage.tsx
@@ -64,6 +64,7 @@ export type ProfilePageProps = {
   location: string
   twitterHandle: string
   instagramHandle: string
+  tikTokHandle: string
   twitterVerified?: boolean
   instagramVerified?: boolean
   website: string
@@ -108,6 +109,7 @@ export type ProfilePageProps = {
   updateLocation: (location: string) => void
   updateTwitterHandle: (handle: string) => void
   updateInstagramHandle: (handle: string) => void
+  updateTikTokHandle: (handle: string) => void
   updateWebsite: (website: string) => void
   updateDonation: (donation: string) => void
   changeTab: (tab: Tabs) => void
@@ -172,6 +174,7 @@ const ProfilePage = ({
   updateLocation,
   updateTwitterHandle,
   updateInstagramHandle,
+  updateTikTokHandle,
   updateWebsite,
   updateDonation,
   updateProfilePicture,
@@ -204,6 +207,7 @@ const ProfilePage = ({
   location,
   twitterHandle,
   instagramHandle,
+  tikTokHandle,
   twitterVerified,
   instagramVerified,
   website,
@@ -647,6 +651,7 @@ const ProfilePage = ({
           location={location}
           twitterHandle={twitterHandle}
           instagramHandle={instagramHandle}
+          tikTokHandle={tikTokHandle}
           twitterVerified={twitterVerified}
           instagramVerified={instagramVerified}
           website={website}
@@ -659,6 +664,7 @@ const ProfilePage = ({
           onUpdateLocation={updateLocation}
           onUpdateTwitterHandle={updateTwitterHandle}
           onUpdateInstagramHandle={updateInstagramHandle}
+          onUpdateTikTokHandle={updateTikTokHandle}
           onUpdateWebsite={updateWebsite}
           onUpdateDonation={updateDonation}
           goToRoute={goToRoute}

--- a/src/containers/profile-page/components/desktop/ProfileWrapping.js
+++ b/src/containers/profile-page/components/desktop/ProfileWrapping.js
@@ -84,7 +84,14 @@ const ProfileWrapping = props => {
     false
   )
   const record = useRecord()
-  const { handle, goToRoute, twitterHandle, instagramHandle, website } = props
+  const {
+    handle,
+    goToRoute,
+    twitterHandle,
+    instagramHandle,
+    tikTokHandle,
+    website
+  } = props
   const onClickTwitter = useCallback(() => {
     record(
       make(Name.PROFILE_PAGE_CLICK_TWITTER, {
@@ -101,6 +108,14 @@ const ProfileWrapping = props => {
       })
     )
   }, [record, handle, instagramHandle])
+  const onClickTikTok = useCallback(() => {
+    record(
+      make(Name.PROFILE_PAGE_CLICK_TIKTOK, {
+        handle: handle.replace('@', ''),
+        tikTokHandle
+      })
+    )
+  }, [record, handle, tikTokHandle])
   const onClickWebsite = useCallback(() => {
     record(
       make(Name.PROFILE_PAGE_CLICK_WEBSITE, {
@@ -184,6 +199,14 @@ const ProfileWrapping = props => {
             onChange={props.onUpdateInstagramHandle}
           />
         </div>
+        <div className={styles.editField}>
+          <SocialLinkInput
+            defaultValue={props.tikTokHandle}
+            className={styles.tikTokInput}
+            type={Type.TIKTOK}
+            onChange={props.onUpdateTikTokHandle}
+          />
+        </div>
         <div className={cn(styles.editLabel, styles.section)}>Website</div>
         <div className={styles.editField}>
           <SocialLinkInput
@@ -227,6 +250,13 @@ const ProfileWrapping = props => {
               type={Type.INSTAGRAM}
               link={props.instagramHandle}
               onClick={onClickInstagram}
+            />
+          )}
+          {props.tikTokHandle && (
+            <SocialLink
+              type={Type.TIKTOK}
+              link={props.tikTokHandle}
+              onClick={onClickTikTok}
             />
           )}
           {props.website && (

--- a/src/containers/profile-page/components/mobile/EditProfile.tsx
+++ b/src/containers/profile-page/components/mobile/EditProfile.tsx
@@ -4,7 +4,8 @@ import {
   IconTwitterBird,
   IconInstagram,
   IconDonate,
-  IconLink
+  IconLink,
+  IconTikTok
 } from '@audius/stems'
 
 import EditableRow, { Format } from 'components/groupable-list/EditableRow'
@@ -20,6 +21,7 @@ type EditProfileProps = {
   isVerified: boolean
   twitterHandle: string
   instagramHandle: string
+  tikTokHandle: string
   twitterVerified?: boolean
   instagramVerified?: boolean
   website: string
@@ -30,6 +32,7 @@ type EditProfileProps = {
   onUpdateLocation: (location: string) => void
   onUpdateTwitterHandle: (handle: string) => void
   onUpdateInstagramHandle: (handle: string) => void
+  onUpdateTikTokHandle: (handle: string) => void
   onUpdateWebsite: (website: string) => void
   onUpdateDonation: (donation: string) => void
 }
@@ -41,6 +44,7 @@ const EditProfile = ({
   isVerified,
   twitterHandle,
   instagramHandle,
+  tikTokHandle,
   twitterVerified,
   instagramVerified,
   website,
@@ -50,6 +54,7 @@ const EditProfile = ({
   onUpdateLocation,
   onUpdateTwitterHandle,
   onUpdateInstagramHandle,
+  onUpdateTikTokHandle,
   onUpdateWebsite,
   onUpdateDonation
 }: EditProfileProps) => {
@@ -95,6 +100,14 @@ const EditProfile = ({
             maxLength={200}
             inputPrefix='@'
             isDisabled={!!instagramVerified}
+          />
+          <EditableRow
+            label={<IconTikTok className={styles.icon} />}
+            format={Format.INPUT}
+            initialValue={tikTokHandle}
+            onChange={onUpdateTikTokHandle}
+            maxLength={200}
+            inputPrefix='@'
           />
           <EditableRow
             label={<IconLink className={styles.icon} />}

--- a/src/containers/profile-page/components/mobile/ProfileHeader.tsx
+++ b/src/containers/profile-page/components/mobile/ProfileHeader.tsx
@@ -7,7 +7,8 @@ import {
   IconTwitterBird,
   IconInstagram,
   IconDonate,
-  IconLink
+  IconLink,
+  IconTikTok
 } from '@audius/stems'
 import Skeleton from 'antd/lib/skeleton'
 import cn from 'classnames'
@@ -99,6 +100,7 @@ type ProfileHeaderProps = {
   setFollowingUserId: (id: ID) => void
   twitterHandle: string
   instagramHandle: string
+  tikTokHandle: string
   website: string
   donation: string
   followers: any
@@ -135,6 +137,7 @@ const ProfileHeader = ({
   followingCount,
   twitterHandle,
   instagramHandle,
+  tikTokHandle,
   website,
   donation,
   setFollowersUserId,
@@ -228,6 +231,17 @@ const ProfileHeader = ({
     const win = window.open(`https://twitter.com/${twitterHandle}`, '_blank')
     if (win) win.focus()
   }, [record, twitterHandle, handle])
+
+  const onGoToTikTok = useCallback(() => {
+    record(
+      make(Name.PROFILE_PAGE_CLICK_TIKTOK, {
+        handle: handle.replace('@', ''),
+        tikTokHandle
+      })
+    )
+    const win = window.open(`https://tiktok.com/@${tikTokHandle}`, '_blank')
+    if (win) win.focus()
+  }, [record, tikTokHandle, handle])
 
   const onExternalLinkClick = useCallback(
     event => {
@@ -405,6 +419,12 @@ const ProfileHeader = ({
               <IconInstagram
                 className={cn(styles.socialIcon)}
                 onClick={onGoToInstagram}
+              />
+            )}
+            {tikTokHandle && (
+              <IconTikTok
+                className={cn(styles.socialIcon)}
+                onClick={onGoToTikTok}
               />
             )}
           </div>

--- a/src/containers/profile-page/components/mobile/ProfilePage.tsx
+++ b/src/containers/profile-page/components/mobile/ProfilePage.tsx
@@ -59,6 +59,7 @@ export type ProfilePageProps = {
   location: string
   twitterHandle: string
   instagramHandle: string
+  tikTokHandle: string
   twitterVerified?: boolean
   instagramVerified?: boolean
   website: string
@@ -119,6 +120,7 @@ export type ProfilePageProps = {
   updateLocation: (location: string) => void
   updateTwitterHandle: (handle: string) => void
   updateInstagramHandle: (handle: string) => void
+  updateTikTokHandle: (handle: string) => void
   updateWebsite: (website: string) => void
   updateDonation: (donation: string) => void
   updateProfilePicture: (
@@ -189,6 +191,7 @@ const ProfilePage = g(
     followers,
     twitterHandle,
     instagramHandle,
+    tikTokHandle,
     twitterVerified,
     instagramVerified,
     website,
@@ -226,6 +229,7 @@ const ProfilePage = g(
     updateLocation,
     updateTwitterHandle,
     updateInstagramHandle,
+    updateTikTokHandle,
     updateWebsite,
     updateDonation,
     updateProfilePicture,
@@ -341,6 +345,7 @@ const ProfilePage = g(
           isVerified={verified}
           twitterHandle={twitterHandle}
           instagramHandle={instagramHandle}
+          tikTokHandle={tikTokHandle}
           twitterVerified={twitterVerified}
           instagramVerified={instagramVerified}
           website={website}
@@ -350,6 +355,7 @@ const ProfilePage = g(
           onUpdateLocation={updateLocation}
           onUpdateTwitterHandle={updateTwitterHandle}
           onUpdateInstagramHandle={updateInstagramHandle}
+          onUpdateTikTokHandle={updateTikTokHandle}
           onUpdateWebsite={updateWebsite}
           onUpdateDonation={updateDonation}
         />
@@ -642,6 +648,7 @@ const ProfilePage = g(
                 setFollowersUserId={setFollowersUserId}
                 twitterHandle={twitterHandle}
                 instagramHandle={instagramHandle}
+                tikTokHandle={tikTokHandle}
                 website={website}
                 donation={donation}
                 followers={followers}

--- a/src/containers/profile-page/store/sagas.js
+++ b/src/containers/profile-page/store/sagas.js
@@ -185,6 +185,7 @@ function* fetchUserSocials(handle) {
         metadata: {
           twitter_handle: socials.twitterHandle || null,
           instagram_handle: socials.instagramHandle || null,
+          tiktok_handle: socials.tikTokHandle || null,
           website: socials.website || null,
           donation: socials.donation || null,
           _artist_pick: socials.pinnedTrackId || null

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -42,6 +42,7 @@ export type UserMetadata = {
   user_id: number
   twitter_handle?: string
   instagram_handle?: string
+  tiktok_handle?: string
   website?: string
   wallet?: string
   donation?: string

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -596,6 +596,7 @@ class AudiusBackend {
         const body = await AudiusBackend.getCreatorSocialHandle(account.handle)
         account.twitter_handle = body.twitterHandle || null
         account.instagram_handle = body.instagramHandle || null
+        account.tiktok_handle = body.tikTokHandle || null
         account.website = body.website || null
         account.donation = body.donation || null
         account._artist_pick = body.pinnedTrackId || null
@@ -1099,6 +1100,7 @@ class AudiusBackend {
       if (
         newMetadata.twitter_handle ||
         newMetadata.instagram_handle ||
+        newMetadata.tiktok_handle ||
         newMetadata.website ||
         newMetadata.donation
       ) {
@@ -1113,6 +1115,7 @@ class AudiusBackend {
           body: JSON.stringify({
             twitterHandle: newMetadata.twitter_handle,
             instagramHandle: newMetadata.instagram_handle,
+            tikTokHandle: newMetadata.tiktok_handle,
             website: newMetadata.website,
             donation: newMetadata.donation
           })

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -110,6 +110,7 @@ export enum Name {
   PROFILE_PAGE_SORT = 'Profile Page: Sort',
   PROFILE_PAGE_CLICK_INSTAGRAM = 'Profile Page: Go To Instagram',
   PROFILE_PAGE_CLICK_TWITTER = 'Profile Page: Go To Twitter',
+  PROFILE_PAGE_CLICK_TIKTOK = 'Profile Page: Go To TikTok',
   PROFILE_PAGE_CLICK_WEBSITE = 'ProfilePage: Go To Website',
   PROFILE_PAGE_CLICK_DONATION = 'ProfilePage: Go To Donation',
 
@@ -575,6 +576,11 @@ type ProfilePageClickTwitter = {
   handle: string
   twitterHandle: string
 }
+type ProfilePageClickTikTok = {
+  eventName: Name.PROFILE_PAGE_CLICK_TIKTOK
+  handle: string
+  tikTokHandle: string
+}
 type ProfilePageClickWebsite = {
   eventName: Name.PROFILE_PAGE_CLICK_WEBSITE
   handle: string
@@ -887,6 +893,7 @@ export type AllTrackingEvents =
   | ProfilePageSort
   | ProfilePageClickInstagram
   | ProfilePageClickTwitter
+  | ProfilePageClickTikTok
   | ProfilePageClickWebsite
   | ProfilePageClickDonation
   | TrackPageDownload


### PR DESCRIPTION
### Description

This PR:
* Adds and input for the tiktok handle to the profile page
![image](https://user-images.githubusercontent.com/19916043/129419205-07478c8f-8fcf-4c30-9aff-07e2ede2d96a.png)

This does not pull from the tiktok user when they have been authed, mainly because they aren't setting their account up with tiktok and it would be weird to populate this field based on their auth for sharing a sound IMO

Also, crazy how many changes were required to do this. I feel like this could be structured differently to improve maintainability, but due to time constraints I followed the existing pattern (classic)

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
