### PR TITLE
Fix permalink selector to lowercase

### DIFF
--- a/src/store/cache/tracks/selectors.ts
+++ b/src/store/cache/tracks/selectors.ts
@@ -19,11 +19,6 @@ export const getTrack = (
   })
 }
 
-export const getTrackByPermalink = (
-  state: AppState,
-  props: { permalink: string }
-) => state.tracks.permalinks[props.permalink.toLowerCase()] || null
-
 export const getStatus = (state: AppState, props: { id?: ID | null }) =>
   (props.id && state.tracks.statuses[props.id]) || null
 
@@ -56,11 +51,8 @@ export const getTracks = (
   } else if (props && props.permalinks) {
     const tracks: { [permalink: string]: Track } = {}
     props.permalinks.forEach(permalink => {
-      const { id } = getTrackByPermalink(state, { permalink }) || {}
-      if (id) {
-        const track = getTrack(state, { id })
-        if (track) tracks[permalink] = track
-      }
+      const track = getTrack(state, { permalink })
+      if (track) tracks[permalink] = track
     })
     return tracks
   }

--- a/src/store/cache/tracks/selectors.ts
+++ b/src/store/cache/tracks/selectors.ts
@@ -18,10 +18,12 @@ export const getTrack = (
     kind: Kind.TRACKS
   })
 }
+
 export const getTrackByPermalink = (
   state: AppState,
   props: { permalink: string }
-) => state.tracks.permalinks[props.permalink] || null
+) => state.tracks.permalinks[props.permalink.toLowerCase()] || null
+
 export const getStatus = (state: AppState, props: { id?: ID | null }) =>
   (props.id && state.tracks.statuses[props.id]) || null
 


### PR DESCRIPTION
### Description

We lowercase all permalinks in storage:
https://github.com/AudiusProject/audius-client/blob/daf20f01b3737d8ca9a975b71f7f662eaa2c9aeb/src/store/cache/tracks/selectors.ts#L14

The selector does not lowercase though, so tracks w/ capitalization are not fetched properly by the selector

^^^^^^^
After this first change, realizing that there's already a permalink selector that does the .toLowerCase and some of the logic can be consolidated. I believe this second fix is safe as well.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

Touches track retrieval

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally against prod (mobile + web)

http://localhost:3002/Galazy_Music
-> click on first track
-> 404
(prior to change)

No 404 after


* Uploaded track
* Navigated between tracks
* Linked directly to track

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
