### PR TITLE
AUD-857 disable tiktok sharing for unlisted tracks

### DIFF
--- a/src/components/track/GiantTrackTile.js
+++ b/src/components/track/GiantTrackTile.js
@@ -409,6 +409,7 @@ class GiantTrackTile extends PureComponent {
         includeEmbed: !isUnlisted,
         includeArtistPick: !isUnlisted,
         includeAddToPlaylist: !isUnlisted,
+        includeShareToTikTok: !isUnlisted,
         extraMenuItems: overflowMenuExtraItems
       }
     }

--- a/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -95,6 +95,7 @@ const ConnectedTrackTile = memo(
   }: ConnectedTrackTileProps) => {
     const {
       is_delete,
+      is_unlisted,
       track_id: trackId,
       title,
       permalink,
@@ -162,6 +163,7 @@ const ConnectedTrackTile = memo(
         includeFavorite: false,
         includeRepost: false,
         includeShare: false,
+        includeShareToTikTok: !is_unlisted,
         includeTrackPage: true,
         isArtistPick: isArtistPick,
         isDeleted: is_delete,

--- a/src/components/track/desktop/TrackListItem.tsx
+++ b/src/components/track/desktop/TrackListItem.tsx
@@ -100,6 +100,7 @@ const TrackListItem = ({
     includeFavorite: true,
     includeRepost: true,
     includeShare: true,
+    includeShareToTikTok: track.is_unlisted,
     includeTrackPage: true,
     isArtistPick: track.user._artist_pick === track.track_id,
     isDeleted: deleted,

--- a/src/components/track/desktop/TrackListItem.tsx
+++ b/src/components/track/desktop/TrackListItem.tsx
@@ -100,7 +100,7 @@ const TrackListItem = ({
     includeFavorite: true,
     includeRepost: true,
     includeShare: true,
-    includeShareToTikTok: track.is_unlisted,
+    includeShareToTikTok: !track.is_unlisted,
     includeTrackPage: true,
     isArtistPick: track.user._artist_pick === track.track_id,
     isDeleted: deleted,

--- a/src/components/track/helpers.ts
+++ b/src/components/track/helpers.ts
@@ -17,6 +17,7 @@ export const getTrackWithFallback = (track: Track | null) => {
       has_current_user_saved: false,
       play_count: 0,
       is_delete: false,
+      is_unlisted: false,
       activity_timestamp: '',
       _co_sign: undefined,
       _cover_art_sizes: {

--- a/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -82,6 +82,7 @@ const ConnectedTrackTile = memo(
 
     const {
       is_delete,
+      is_unlisted,
       track_id,
       title,
       permalink,
@@ -167,7 +168,7 @@ const ConnectedTrackTile = memo(
             : OverflowAction.FAVORITE
           : null,
         OverflowAction.SHARE,
-        isShareSoundToTikTokEnabled && isOwner
+        isShareSoundToTikTokEnabled && isOwner && !is_unlisted
           ? OverflowAction.SHARE_TO_TIKTOK
           : null,
         OverflowAction.ADD_TO_PLAYLIST,

--- a/src/components/tracks-table/TableOptionsButton.js
+++ b/src/components/tracks-table/TableOptionsButton.js
@@ -23,7 +23,8 @@ class TableOptionsButton extends Component {
       onRemove,
       removeText,
       hiddenUntilHover,
-      trackPermalink
+      trackPermalink,
+      isUnlisted
     } = this.props
 
     const removeMenuItem = {
@@ -36,6 +37,7 @@ class TableOptionsButton extends Component {
         type: 'track',
         mount: 'page',
         includeShare: true,
+        includeShareToTikTok: !isUnlisted,
         isOwner,
         isArtistPick,
         ...this.props,

--- a/src/containers/artist-dashboard-page/ArtistDashboardPage.tsx
+++ b/src/containers/artist-dashboard-page/ArtistDashboardPage.tsx
@@ -139,6 +139,7 @@ const makeColumns = (account: User, isUnlisted: boolean) => {
             isFavorited={val.has_current_user_saved}
             isOwner
             isArtistPick={account._artist_pick === val.track_id}
+            isUnlisted={record.is_unlisted}
             index={index}
             trackTitle={val.name}
             hiddenUntilHover={false}

--- a/src/containers/menu/TrackMenu.tsx
+++ b/src/containers/menu/TrackMenu.tsx
@@ -66,6 +66,7 @@ export type OwnProps = {
   includeFavorite: boolean
   includeRepost: boolean
   includeShare: boolean
+  includeShareToTikTok: boolean
   includeTrackPage: boolean
   isArtistPick: boolean
   isDeleted: boolean
@@ -97,6 +98,7 @@ const TrackMenu = (props: TrackMenuProps) => {
       includeFavorite,
       includeRepost,
       includeShare,
+      includeShareToTikTok,
       includeTrackPage,
       isArtistPick,
       isDeleted,
@@ -229,6 +231,7 @@ const TrackMenu = (props: TrackMenuProps) => {
       menu.items.push(embedMenuItem)
     }
     if (
+      includeShareToTikTok &&
       getFeatureEnabled(FeatureFlags.SHARE_SOUND_TO_TIKTOK) &&
       trackId &&
       isOwner &&

--- a/src/containers/now-playing/NowPlaying.tsx
+++ b/src/containers/now-playing/NowPlaying.tsx
@@ -14,6 +14,7 @@ import PreviousButtonProvider from 'components/play-bar/previous-button/Previous
 import RepeatButtonProvider from 'components/play-bar/repeat-button/RepeatButtonProvider'
 import ShuffleButtonProvider from 'components/play-bar/shuffle-button/ShuffleButtonProvider'
 import { PlayButtonStatus } from 'components/play-bar/types'
+import { useFlag } from 'containers/remote-config/hooks'
 import { getCastMethod } from 'containers/settings-page/store/selectors'
 import UserBadges from 'containers/user-badges/UserBadges'
 import { useTrackCoverArt } from 'hooks/useImageSize'
@@ -27,6 +28,7 @@ import {
   ShareSource
 } from 'services/analytics'
 import { HapticFeedbackMessage } from 'services/native-mobile-interface/haptics'
+import { FeatureFlags } from 'services/remote-config'
 import { getUserId } from 'store/account/selectors'
 import { useRecord, make } from 'store/analytics/actions'
 import { getAverageColorByTrack } from 'store/application/ui/average-color/slice'
@@ -254,8 +256,13 @@ const NowPlaying = g(
       goToRoute(profilePage(handle))
     }
 
+    const { isEnabled: isShareSoundToTikTokEnabled } = useFlag(
+      FeatureFlags.SHARE_SOUND_TO_TIKTOK
+    )
+
     const onClickOverflow = useCallback(() => {
       const isOwner = currentUserId === owner_id
+      const isUnlisted = track.is_unlisted
 
       const overflowActions = [
         !isOwner
@@ -269,6 +276,9 @@ const NowPlaying = g(
             : OverflowAction.FAVORITE
           : null,
         OverflowAction.SHARE,
+        isShareSoundToTikTokEnabled && isOwner && !isUnlisted
+          ? OverflowAction.SHARE_TO_TIKTOK
+          : null,
         OverflowAction.ADD_TO_PLAYLIST,
         OverflowAction.VIEW_TRACK_PAGE,
         OverflowAction.VIEW_ARTIST_PAGE
@@ -283,6 +293,8 @@ const NowPlaying = g(
       track_id,
       owner_id,
       clickOverflow,
+      track,
+      isShareSoundToTikTokEnabled,
       has_current_user_saved,
       has_current_user_reposted,
       onClose

--- a/src/containers/share-sound-to-tiktok-modal/store/sagas.ts
+++ b/src/containers/share-sound-to-tiktok-modal/store/sagas.ts
@@ -73,7 +73,7 @@ function* handleShare() {
     }
   } catch (e) {
     console.log(e)
-    yield put(make(Name.TIKTOK_SHARE_SOUND_ERROR, { error: e }))
+    yield put(make(Name.TIKTOK_SHARE_SOUND_ERROR, { error: e.message }))
     yield put(setStatus({ status: Status.SHARE_ERROR }))
   }
 }
@@ -115,7 +115,7 @@ function* handleUpload(action: ReturnType<typeof upload>) {
     yield put(showConfetti())
   } catch (e) {
     console.log(e)
-    yield put(make(Name.TIKTOK_SHARE_SOUND_ERROR, { error: e }))
+    yield put(make(Name.TIKTOK_SHARE_SOUND_ERROR, { error: e.message }))
     yield put(setStatus({ status: Status.SHARE_ERROR }))
   } finally {
     trackBlob = null

--- a/src/containers/track-page/components/mobile/TrackHeader.tsx
+++ b/src/containers/track-page/components/mobile/TrackHeader.tsx
@@ -191,7 +191,7 @@ const TrackHeader = ({
         ? OverflowAction.UNFAVORITE
         : OverflowAction.FAVORITE,
       isUnlisted && !fieldVisibility.share ? null : OverflowAction.SHARE,
-      isShareSoundToTikTokEnabled && isOwner
+      isShareSoundToTikTokEnabled && isOwner && !isUnlisted
         ? OverflowAction.SHARE_TO_TIKTOK
         : null,
       OverflowAction.ADD_TO_PLAYLIST,

--- a/src/containers/upload-page/components/ShareBanner.tsx
+++ b/src/containers/upload-page/components/ShareBanner.tsx
@@ -181,6 +181,14 @@ const ShareBanner = ({ isHidden, type, upload, user }: ShareBannerProps) => {
     )
   }, [type, user, upload, record])
 
+  const shouldShowShareToTikTok = () => {
+    return (
+      type === 'Track' &&
+      isShareSoundToTikTokEnabled &&
+      !upload.tracks[0]?.metadata.is_unlisted
+    )
+  }
+
   const continuePage = getContinuePage(type)
 
   return (
@@ -201,7 +209,7 @@ const ShareBanner = ({ isHidden, type, upload, user }: ShareBannerProps) => {
           text={messages.share}
           leftIcon={<IconTwitterBird />}
         />
-        {type === 'Track' && isShareSoundToTikTokEnabled && (
+        {shouldShowShareToTikTok() && (
           <Button
             onClick={onClickTikTok}
             className={cn(styles.button, styles.buttonTikTok)}


### PR DESCRIPTION
### Description

This PR:
* Hides the "Share to TikTok" option for unlisted tracks
  * In the overflow menu
  * In the upload flow
* Tweaks one of the error analytics calls to only include the error message, not the entire error

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
