### PR TITLE
Fix Popup styling

### DIFF
--- a/src/components/actions-tab/ActionsTab.js
+++ b/src/components/actions-tab/ActionsTab.js
@@ -123,13 +123,13 @@ const ExpandedActionsTab = props => {
           </Toast>
         </div>
       </Tooltip>
-      <div className={styles.actionButton}>
+      <div className={cn(styles.actionButton, styles.menuKebabContainer)}>
         {isDisabled || isHidden ? (
           <div className={styles.iconKebabHorizontalWrapper}>
             <IconKebabHorizontal className={styles.iconKebabHorizontal} />
           </div>
         ) : (
-          <Menu {...overflowMenu} className={styles.menuKebabContainer}>
+          <Menu {...overflowMenu}>
             {(ref, triggerPopup) => (
               <div
                 className={styles.iconKebabHorizontalWrapper}

--- a/src/components/actions-tab/ActionsTab.module.css
+++ b/src/components/actions-tab/ActionsTab.module.css
@@ -82,13 +82,8 @@
   justify-content: center;
 }
 
-.menuKebabContainer {
-  width: 100%;
-  height: 100%;
-}
-
 .menuKebabContainer > div {
-  margin: 0px auto;
+  width: 100%;
 }
 
 .iconKebabHorizontalWrapper {

--- a/src/components/actions-tab/ActionsTab.module.css
+++ b/src/components/actions-tab/ActionsTab.module.css
@@ -93,7 +93,6 @@
   align-items: center;
   margin: 0 auto;
   text-align: center;
-  padding: 4px;
 }
 
 .actionButton svg,

--- a/src/components/create-playlist/CreatePlaylistModal.js
+++ b/src/components/create-playlist/CreatePlaylistModal.js
@@ -11,6 +11,7 @@ import { useCollectionCoverArt } from 'hooks/useImageSize'
 import { SquareSizes } from 'models/common/ImageSizes'
 import * as schemas from 'schemas'
 import { resizeImage } from 'utils/imageProcessingUtil'
+import zIndex from 'utils/zIndex'
 
 import styles from './CreatePlaylistModal.module.css'
 
@@ -204,7 +205,8 @@ CreatePlaylistModal.defaultProps = {
   visible: true,
   title: 'Create Playlist',
   isAlbum: false,
-  editMode: false
+  editMode: false,
+  zIndex: zIndex.CREATE_PLAYLIST_MODAL
 }
 
 export default memo(CreatePlaylistModal)

--- a/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/src/containers/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -87,7 +87,6 @@ const EditPlaylistModal = ({
         onDelete={onClickDelete}
         onSave={onSaveEdit}
         onCancel={onClose}
-        zIndex={zIndex.EDIT_PLAYLIST_MODAL}
       />
       <DeleteConfirmationModal
         title={`${messages.delete} ${

--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -57,7 +57,6 @@ import {
   playlistPage,
   EXPLORE_PAGE
 } from 'utils/route'
-import zIndex from 'utils/zIndex'
 
 import styles from './NavColumn.module.css'
 import NavHeader from './NavHeader'

--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -57,6 +57,7 @@ import {
   playlistPage,
   EXPLORE_PAGE
 } from 'utils/route'
+import zIndex from 'utils/zIndex'
 
 import styles from './NavColumn.module.css'
 import NavHeader from './NavHeader'
@@ -362,6 +363,7 @@ const NavColumn = ({
           visible={showCreatePlaylistModal}
           onSave={onCreatePlaylist}
           onCancel={closeCreatePlaylistModal}
+          zIndex={zIndex.CREATE_PLAYLIST_MODAL}
         />
       </div>
       <div className={styles.navAnchor}>

--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -363,7 +363,6 @@ const NavColumn = ({
           visible={showCreatePlaylistModal}
           onSave={onCreatePlaylist}
           onCancel={closeCreatePlaylistModal}
-          zIndex={zIndex.CREATE_PLAYLIST_MODAL}
         />
       </div>
       <div className={styles.navAnchor}>

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -16,6 +16,7 @@ export enum zIndex {
   // Set to 1000 to account for nested modals inside, which take a higher z-index
   EDIT_TRACK_MODAL = 1000,
   EDIT_PLAYLIST_MODAL = 1000,
+  CREATE_PLAYLIST_MODAL = 1000,
   IMAGE_SELECTION_POPUP = 1001
 }
 

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -15,7 +15,6 @@ export enum zIndex {
 
   // Set to 1000 to account for nested modals inside, which take a higher z-index
   EDIT_TRACK_MODAL = 1000,
-  EDIT_PLAYLIST_MODAL = 1000,
   CREATE_PLAYLIST_MODAL = 1000,
   IMAGE_SELECTION_POPUP = 1001
 }


### PR DESCRIPTION
### Description

Noticed a couple of styling issues:
1. The zIndex issue I thought I'd addressed still persisting on the CreatePlaylistModal. This is preventing creation of new playlists in prod on the web client
![image](https://user-images.githubusercontent.com/19916043/130097902-13adcca3-bd3f-4796-b3a7-bc1cdc2ca106.png)

2. Issue with the alignment of the kebab icon on the Card
![image](https://user-images.githubusercontent.com/19916043/130098142-f07e0723-9841-42a8-b82c-0cee10167902.png)

### Dragons

Probably need to deploy this to prod asap

### How Has This Been Tested?

Manually, confirmed the image popover has correct z-index in the following places:
* Create Playlist
* Edit Playlist
* Edit Track
* Change cover photo
* Change profile photo
* Upload Track

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
