### PR TITLE
hotfix: Add temporary fix for old-style route

### DIFF
--- a/scripts/workers-site/index.js
+++ b/scripts/workers-site/index.js
@@ -29,6 +29,19 @@ function checkIsBot(val) {
 }
 
 async function handleEvent(event) {
+  // One-off fix for old-style route shared on twitter
+  // We don't make old-style routes anymore but older mobile app versions generate bad links
+  // TODO: Remove this and make old style routes for a while longer until user sediment updates
+  if (
+    event.request.url.endsWith(
+      'hannibalburess/coach-wilson-produced-by-flux-pavilion-517598'
+    )
+  )
+    event.request.url = event.request.url.substring(
+      0,
+      event.request.url.length - '-517598'.length
+    )
+
   const url = new URL(event.request.url)
   const { pathname, search, hash } = url
   const userAgent = event.request.headers.get('User-Agent') || ''
@@ -52,7 +65,6 @@ async function handleEvent(event) {
     const newRequest = new Request(destinationURL, event.request)
     return await fetch(newRequest)
   }
-
 
   const options = {}
   // Always map requests to `/`


### PR DESCRIPTION
### Description

Adds a check for a specific route in the cloudflare worker in order to rewrite it to be a new-style route.

Old style routes are not generated on the DN anymore, but outdated mobile apps will still generate them. This hotfix fixes one specific Audius link but a fix should go out next release to continue making old-style links until user sediment moves to the latest app version.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

** This can never fail or all URLs will fail **

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested the new code on a dummy "request" JS object in the console.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

Once shipped, clicking the old style link should work, and then there should be a follow up change for the proper fix and removal of this code.
