### PR TITLE
Add wait between validating email

### DIFF
--- a/src/containers/sign-on/store/actions.js
+++ b/src/containers/sign-on/store/actions.js
@@ -3,6 +3,7 @@ export const SET_VALUE_FIELD = 'SIGN_ON/SET_VALUE_FIELD'
 export const RESET_SIGN_ON = 'SIGN_ON/RESET_SIGN_ON'
 
 export const VALIDATE_EMAIL = 'SIGN_ON/VALIDATE_EMAIL'
+export const VALIDATE_EMAIL_IN_USE = 'SIGN_ON/VALIDATE_EMAIL_IN_USE'
 export const VALIDATE_EMAIL_SUCCEEDED = 'SIGN_ON/VALIDATE_EMAIL_SUCCEEDED'
 export const VALIDATE_EMAIL_FAILED = 'SIGN_ON/VALIDATE_EMAIL_FAILED'
 
@@ -86,6 +87,10 @@ export function resetSignOn() {
  */
 export function validateEmail(email) {
   return { type: VALIDATE_EMAIL, email }
+}
+
+export function validateEmailInUse(email) {
+  return { type: VALIDATE_EMAIL_IN_USE, email }
 }
 
 export function validateEmailSucceeded(available) {


### PR DESCRIPTION
### Description
Creates a new action/saga for validating email, throttling the email check to 2 seconds
The throttle method was used in place of a delay in the existing saga so that it does not have to wait on the very first pass.

Closes AUD-930

### Dragons
none

### How Has This Been Tested?
Running locally

### How will this change be monitored?
manually