### PR TITLE
Increase description field limit to 1000 characters

### DIFF
--- a/src/components/data-entry/FormTile.js
+++ b/src/components/data-entry/FormTile.js
@@ -151,6 +151,7 @@ const BasicForm = props => {
               placeholder='Description'
               defaultValue={props.defaultFields.description || ''}
               onChange={value => props.onChangeField('description', value)}
+              characterLimit={1000}
             />
           </div>
         </div>


### PR DESCRIPTION
### Description

Changes the character limit of the Description field on tracks to 1000 characters (was the default 256 characters).

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

Might be worth investigating a "see more" link if there's more than a few lines of description on a track.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested that DN accepts that many characters and that they display fine by uploading a track with that description length as well as editing an existing track (against stage, no backend changes necessary)

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
