### PR TITLE
Close artist recommendations when navigating away from the profile

### DIFF
--- a/src/containers/profile-page/ProfilePageProvider.tsx
+++ b/src/containers/profile-page/ProfilePageProvider.tsx
@@ -201,12 +201,11 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       }
     }
 
-    // If editing profile and route to another user profile, exit edit mode
-    if (
-      prevProps.profile?.profile?.handle !== profile?.profile?.handle &&
-      editMode
-    ) {
-      this.setState({ editMode: false })
+    if (prevProps.profile?.profile?.handle !== profile?.profile?.handle) {
+      // If editing profile and route to another user profile, exit edit mode
+      if (editMode) this.setState({ editMode: false })
+      // Close artist recommendations when the profile changes
+      this.setState({ areArtistRecommendationsVisible: false })
     }
   }
 


### PR DESCRIPTION
### Description

Closes the artist recommendations if the profile changes from one user to another.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Manually: Open an artist profile with > 200 followers, click follow (unfollow first if necessary), then hover over an artist profile in the recommendations. Click on one of their names/handles, and observe the artist recommendations popup will be closed.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
