### PR TITLE
Fix 3d object nft frame in case of gif

### DIFF
--- a/src/containers/collectibles/components/CollectibleDetails.tsx
+++ b/src/containers/collectibles/components/CollectibleDetails.tsx
@@ -151,7 +151,12 @@ const CollectibleDetails: React.FC<{
   useEffect(() => {
     const load = async () => {
       let f = frameUrl
-      if (!f && mediaType === CollectibleMediaType.GIF) {
+      if (
+        !f &&
+        [CollectibleMediaType.GIF, CollectibleMediaType.THREE_D].includes(
+          mediaType
+        )
+      ) {
         f = await getFrameFromGif(gifUrl!, name || '')
       } else if (!f && mediaType === CollectibleMediaType.VIDEO) {
         setIsLoading(false)

--- a/src/containers/collectibles/ethCollectibleHelpers.ts
+++ b/src/containers/collectibles/ethCollectibleHelpers.ts
@@ -146,12 +146,23 @@ export const assetToCollectible = async (
       gifUrl = imageUrls.find(url => url?.endsWith('.gif'))!
     } else if (isAssetThreeDAndIncludesImage(asset)) {
       mediaType = CollectibleMediaType.THREE_D
-      frameUrl = imageUrls.find(
-        url => url && NON_IMAGE_EXTENSIONS.every(ext => !url.endsWith(ext))
-      )!
       threeDUrl = [animation_url, animation_original_url, ...imageUrls].find(
         url => url && SUPPORTED_3D_EXTENSIONS.some(ext => url.endsWith(ext))
       )!
+      frameUrl = imageUrls.find(
+        url => url && NON_IMAGE_EXTENSIONS.every(ext => !url.endsWith(ext))
+      )!
+      // image urls may not end in known extensions
+      // just because the don't end with the NON_IMAGE_EXTENSIONS above does not mean they are images
+      // they may be gifs
+      // example: https://lh3.googleusercontent.com/rOopRU-wH9mqMurfvJ2INLIGBKTtF8BN_XC7KZxTh8PPHt5STSNJ-i8EQit8ZTwE3Mi8LK4on_4YazdC3Cl-HdaxbnKJ23P8kocvJHQ
+      const res = await fetch(frameUrl, { method: 'HEAD' })
+      const hasGifFrame = res.headers.get('Content-Type')?.includes('gif')
+      if (hasGifFrame) {
+        gifUrl = frameUrl
+        // frame url for the gif is computed later in the collectibles page
+        frameUrl = null
+      }
     } else if (isAssetVideo(asset)) {
       mediaType = CollectibleMediaType.VIDEO
       frameUrl =

--- a/src/services/WebWorker.js
+++ b/src/services/WebWorker.js
@@ -41,9 +41,7 @@ export default class WebWorker {
         if (event.data.key) {
           if (event.data.key === key) {
             resolve(event.data.result)
-          } else {
           }
-          // todo: what is the above else here for?
         } else {
           resolve(event.data)
         }

--- a/src/services/WebWorker.js
+++ b/src/services/WebWorker.js
@@ -43,6 +43,7 @@ export default class WebWorker {
             resolve(event.data.result)
           } else {
           }
+          // todo: what is the above else here for?
         } else {
           resolve(event.data)
         }


### PR DESCRIPTION
### Description

3D nfts on opensea with a gif frame were display the gif instead of a still image on the collectibles page. This PR makes an image out of the gif so the card shows a still image.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Spun app locally and tested account with 3d nft that had a gif as a frame. The frame now shows a still image instead of a gif.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
