### PR TITLE
[AUD-753] Update xcode version for macOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -572,7 +572,7 @@ jobs:
   dist-mac-staging:
     working_directory: ~/audius-client
     macos: # Run on osx so dmg can be created and signed.
-      xcode: "10.2.1"
+      xcode: "12.2.0"
     steps:
       - checkout
       - attach_workspace:
@@ -611,7 +611,7 @@ jobs:
   dist-mac-production:
     working_directory: ~/audius-client
     macos: # Run on osx so dmg can be created and signed.
-      xcode: "10.2.1"
+      xcode: "12.2.0"
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
### Description

Per https://circleci.com/docs/2.0/xcode-policy/ the version of xcode we are using for macOS builds has been sunset. Time to upgrade!

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

Nope

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Manual staging run: https://app.circleci.com/pipelines/github/AudiusProject/audius-client/2182/workflows/12f47af0-490c-4f7d-8437-1d9e75d549ac

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

🧑‍🍳 
