### PR TITLE
AUD-671 Sign Up/Sign In Redesign

### DIFF
--- a/src/containers/nav/desktop/NavColumn.js
+++ b/src/containers/nav/desktop/NavColumn.js
@@ -85,6 +85,7 @@ const NavColumn = ({
   resetUploadState,
   goToRoute,
   goToSignUp: routeToSignup,
+  goToSignIn,
   goToUpload,
   averageRGBColor
 }) => {
@@ -97,8 +98,8 @@ const NavColumn = ({
     [record, routeToSignup]
   )
 
-  const onClickNavProfile = useCallback(() => goToSignUp('nav profile'), [
-    goToSignUp
+  const onClickNavProfile = useCallback(() => goToSignIn('nav profile'), [
+    goToSignIn
   ])
   const onClickNavButton = useCallback(() => goToSignUp('nav button'), [
     goToSignUp
@@ -251,9 +252,9 @@ const NavColumn = ({
                 onClick={onClickNavProfile}
               />
               <div className={styles.userInfoWrapper}>
-                <div className={styles.haveAccount}>Want to Join?</div>
+                <div className={styles.haveAccount}>Have an Account?</div>
                 <div className={styles.logIn} onClick={onClickNavProfile}>
-                  Sign Up
+                  Sign In
                 </div>
               </div>
             </div>

--- a/src/containers/nav/desktop/NavColumn.module.css
+++ b/src/containers/nav/desktop/NavColumn.module.css
@@ -74,7 +74,7 @@ svg.logo path {
   flex-direction: row;
   align-items: center;
   flex-shrink: 0;
-  transition: all ease-in-out .18s;
+  transition: all ease-in-out 0.18s;
 
   color: var(--neutral);
 }
@@ -92,7 +92,7 @@ svg.logo path {
   height: 48px;
   border-radius: 30px;
   border: 1px solid var(--white);
-  box-shadow: 0 0 1px 0 rgba(133,129,153,0.5);
+  box-shadow: 0 0 1px 0 rgba(133, 129, 153, 0.5);
 
   text-align: center;
   background-size: cover;
@@ -110,7 +110,7 @@ svg.logo path {
   height: 48px;
   border-radius: 30px;
   border: 1px solid var(--white);
-  box-shadow: 0 0 1px 0 rgba(133,129,153,0.5);
+  box-shadow: 0 0 1px 0 rgba(133, 129, 153, 0.5);
 
   text-align: center;
   background-size: cover;
@@ -151,7 +151,6 @@ svg.logo path {
   text-decoration-color: var(--primary-light-2);
 }
 
-
 .navColumn .accountWrapper .userInfoWrapper .handleContainer {
   display: inline-flex;
   overflow: hidden;
@@ -164,7 +163,7 @@ svg.logo path {
   font-size: var(--font-xs);
   color: var(--neutral);
   font-weight: var(--font-medium);
-  transition: all .07s ease-in-out;
+  transition: all 0.07s ease-in-out;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -192,7 +191,7 @@ svg.logo path {
 }
 
 .navColumn .accountWrapper .userInfoWrapper .logIn {
-  color: var(--neutral);
+  color: var(--secondary);
   font-size: var(--font-xs);
   line-height: 14px;
   cursor: pointer;
@@ -309,7 +308,7 @@ svg.logo path {
 }
 
 .droppable {
-  background-color: rgba(0,0,0,0);
+  background-color: rgba(0, 0, 0, 0);
   transition: background 0.07s ease-in-out;
   border-radius: 6px;
   width: 100%;
@@ -327,11 +326,11 @@ svg.logo path {
 }
 
 .droppableHover {
-  background-color: rgba(152,73,214,0.15);
+  background-color: rgba(152, 73, 214, 0.15);
 }
 
 .droppableGroupHover {
-  background-color: rgba(152,73,214,0.15);
+  background-color: rgba(152, 73, 214, 0.15);
 }
 
 .links .link:hover:before {
@@ -343,8 +342,9 @@ svg.logo path {
 .links .link:global(.active):before {
   border-right: 4px solid var(--primary);
 }
-.links .link:hover:before, .links .link:global(.active):before {
-  content: "";
+.links .link:hover:before,
+.links .link:global(.active):before {
+  content: '';
   display: block;
   width: 20px;
   height: 20px;

--- a/src/containers/sign-on/SignOnProvider.tsx
+++ b/src/containers/sign-on/SignOnProvider.tsx
@@ -194,6 +194,13 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
 
   onNextPage = () => {
     const { page, isMobile } = this.props
+    if (page === Pages.PASSWORD) {
+      const {
+        fields: { email },
+        recordCompletePassword
+      } = this.props
+      recordCompletePassword(email.value)
+    }
     if (page === Pages.PROFILE) {
       const {
         signUp,
@@ -231,20 +238,6 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
     }
     this.addRouteHash(page)
     this.props.nextPage(isMobile)
-  }
-
-  handleOnContinue = (page: Pages) => {
-    return () => {
-      const { email } = this.props.fields
-      if (page === Pages.PASSWORD) {
-        this.props.onEmailSubmitted(email.value)
-        return
-      } else if (page === Pages.PROFILE) {
-        this.props.recordCompletePassword(email.value)
-      }
-      this.addRouteHash(page)
-      this.props.goToPage(page)
-    }
   }
 
   onPrevPage = () => {
@@ -427,10 +420,10 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
       onClickReadMetaMaskConfig: this.onClickReadMetaMaskConfig,
       closeModal: this.closeModal,
       onNextPage: this.onNextPage,
-      handleOnContinue: this.handleOnContinue,
       onPrevPage: this.onPrevPage,
       onConfigureWithMetaMask: this.onConfigureWithMetaMask,
       onEmailChange: this.onEmailChange,
+      onEmailSubmitted: this.props.onEmailSubmitted,
       onPasswordChange: this.onPasswordChange,
       onNameChange: this.onNameChange,
       onAddFollows: this.props.addFollows,

--- a/src/containers/sign-on/SignOnProvider.tsx
+++ b/src/containers/sign-on/SignOnProvider.tsx
@@ -237,7 +237,8 @@ export class SignOnProvider extends Component<SignOnProps, SignOnState> {
     return () => {
       const { email } = this.props.fields
       if (page === Pages.PASSWORD) {
-        this.props.recordCompleteEmail(email.value)
+        this.props.onEmailSubmitted(email.value)
+        return
       } else if (page === Pages.PROFILE) {
         this.props.recordCompletePassword(email.value)
       }
@@ -479,6 +480,8 @@ function makeMapStateToProps(state: AppState) {
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
     goToRoute: (route: string) => dispatch(pushRoute(route)),
+    onEmailSubmitted: (email: string) =>
+      dispatch(signOnAction.checkEmail(email)),
     onSignIn: (email: string, password: string) =>
       dispatch(signOnAction.signIn(email, password)),
     fetchFollowArtists: () => dispatch(signOnAction.fetchAllFollowArtists()),

--- a/src/containers/sign-on/components/desktop/EmailPage.module.css
+++ b/src/containers/sign-on/components/desktop/EmailPage.module.css
@@ -118,7 +118,7 @@
   padding: 4px 0px;
   margin-top: 45px;
   color: var(--neutral);
-  font-family: "Avenir Next LT Pro";
+  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   user-select: none;
@@ -145,7 +145,6 @@
   text-decoration: underline !important;
   color: var(--secondary);
 }
-
 
 /* Mobile Version */
 .isMobile.container {
@@ -201,7 +200,7 @@
   width: 100% !important;
   max-width: 354px !important;
 }
-.isMobile .signInInput > input[type=email] {   
+.isMobile .signInInput > input[type='email'] {
   /* Remove First */
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -211,14 +210,14 @@
   height: 100% !important;
   width: 100% !important;
   font-size: var(--font-m) !important;
-  border: 1px solid #F2F2F4 !important;
-  border-top: 1px solid #F2F2F4 !important;
+  border: 1px solid #f2f2f4 !important;
+  border-top: 1px solid #f2f2f4 !important;
   /* border-top: none !important; */
   box-shadow: none !important;
 }
 
-.isMobile input::-webkit-input-placeholder { 
-  line-height: normal !important; 
+.isMobile input::-webkit-input-placeholder {
+  line-height: normal !important;
 }
 
 .isMobile .signInInput.placeholder > input {
@@ -245,7 +244,7 @@
   padding: 4px 0px;
   margin: 12px 0px 6px;
   color: var(--secondary);
-  font-family: "Avenir Next LT Pro";
+  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   user-select: none;
@@ -268,3 +267,17 @@
   color: var(--secondary);
 }
 
+.spinner {
+  display: block;
+  height: 16px;
+  width: 16px;
+}
+
+.spinner :global(.ant-spin-dot) {
+  height: 16px;
+  width: 16px;
+}
+
+.spinner :global(.ant-spin-dot i) {
+  background-color: var(--static-white);
+}

--- a/src/containers/sign-on/components/desktop/EmailPage.module.css
+++ b/src/containers/sign-on/components/desktop/EmailPage.module.css
@@ -268,11 +268,6 @@
   width: 16px;
 }
 
-.spinner :global(.ant-spin-dot) {
-  height: 16px;
-  width: 16px;
-}
-
-.spinner :global(.ant-spin-dot i) {
-  background-color: var(--static-white);
+.spinner g path {
+  stroke: var(--white) !important;
 }

--- a/src/containers/sign-on/components/desktop/EmailPage.module.css
+++ b/src/containers/sign-on/components/desktop/EmailPage.module.css
@@ -13,11 +13,7 @@
   max-width: 159px;
   height: 100%;
   width: 100%;
-  margin: 40px auto 52px;
-}
-
-.metaMask .logo {
-  margin-bottom: 44px;
+  margin: 32px auto;
 }
 
 /* Title */
@@ -55,7 +51,7 @@
 }
 
 .signInInput {
-  margin-top: 50px;
+  margin-top: 32px;
   margin-bottom: 39px;
   text-align: center;
   height: 66px;
@@ -103,26 +99,32 @@
 }
 
 /* Sign In Button */
+.buttonsContainer {
+  width: 230px;
+  display: flex;
+  flex-wrap: wrap;
+  flex: 1;
+  justify-content: center;
+}
+
+.metaMask .buttonsContainer {
+  width: 250px;
+}
+
+.signInButton {
+  width: 100%;
+}
+
 .signInButton .signInButtonText {
   font-size: var(--font-l);
   font-weight: var(--font-bold);
 }
 
-/* Bottom Text */
-.metaMask .hasAccount {
-  margin-top: 18px;
-  margin-bottom: 17px;
-}
-
 .hasAccount {
+  width: 100%;
   padding: 4px 0px;
-  margin-top: 45px;
-  color: var(--neutral);
-  font-family: 'Avenir Next LT Pro';
-  font-size: var(--font-s);
-  font-weight: var(--font-medium);
-  user-select: none;
-  cursor: default;
+  margin-bottom: 24px;
+  align-self: flex-end;
 }
 
 .metaMask .hasAccountErrMetaMask {

--- a/src/containers/sign-on/components/desktop/EmailPage.module.css
+++ b/src/containers/sign-on/components/desktop/EmailPage.module.css
@@ -46,8 +46,7 @@
 /* Sign In Input */
 
 .metaMask .signInInput {
-  margin-top: 37px;
-  margin-bottom: 23px;
+  margin-bottom: 24px;
 }
 
 .signInInput {
@@ -98,19 +97,13 @@
   margin-bottom: 13px;
 }
 
-/* Sign In Button */
 .buttonsContainer {
-  width: 230px;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   flex: 1;
-  justify-content: center;
 }
 
-.metaMask .buttonsContainer {
-  width: 250px;
-}
-
+/* Sign In Button */
 .signInButton {
   width: 100%;
 }
@@ -121,10 +114,10 @@
 }
 
 .hasAccount {
-  width: 100%;
-  padding: 4px 0px;
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
   margin-bottom: 24px;
-  align-self: flex-end;
 }
 
 .metaMask .hasAccountErrMetaMask {

--- a/src/containers/sign-on/components/desktop/EmailPage.tsx
+++ b/src/containers/sign-on/components/desktop/EmailPage.tsx
@@ -1,13 +1,13 @@
 import React, { Component } from 'react'
 
 import { Button, ButtonSize, ButtonType, IconArrow } from '@audius/stems'
-import Spin from 'antd/lib/spin'
 import cn from 'classnames'
 import { Spring } from 'react-spring/renderprops'
 
 import audiusLogoColored from 'assets/img/audiusLogoColored.png'
 import Input from 'components/data-entry/Input'
 import StatusMessage from 'components/general/StatusMessage'
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import PreloadImage from 'components/preload-image/PreloadImage'
 
 import styles from './EmailPage.module.css'
@@ -161,7 +161,7 @@ export class EmailPage extends Component<EmailPageProps, EmailPageState> {
             name='continue'
             rightIcon={
               shouldDisableInputs ? (
-                <Spin className={styles.spinner} />
+                <LoadingSpinner className={styles.spinner} />
               ) : (
                 <IconArrow />
               )

--- a/src/containers/sign-on/components/desktop/EmailPage.tsx
+++ b/src/containers/sign-on/components/desktop/EmailPage.tsx
@@ -38,7 +38,7 @@ type EmailPageProps = {
     status: string
     error: 'inUse' | 'characters'
   }
-  onNextPage: () => void
+  onSubmit: (email: string) => void
   onEmailChange: (email: string) => void
   onToggleMetaMaskModal: () => void
   onSignIn: () => void
@@ -73,11 +73,10 @@ export class EmailPage extends Component<EmailPageProps, EmailPageState> {
   }
 
   onSubmit = () => {
-    const { onNextPage } = this.props
+    const { onSubmit, email } = this.props
     this.setState({ showValidation: true, isSubmitting: true })
-    if (!this.props.email.value)
-      this.props.onEmailChange(this.props.email.value)
-    onNextPage()
+    if (!email.value) this.props.onEmailChange(email.value)
+    onSubmit(email.value)
   }
 
   onToggleMetaMaskModal = () => {

--- a/src/containers/sign-on/components/desktop/EmailPage.tsx
+++ b/src/containers/sign-on/components/desktop/EmailPage.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import { Button, ButtonType, IconArrow } from '@audius/stems'
+import { Button, ButtonSize, ButtonType, IconArrow } from '@audius/stems'
 import Spin from 'antd/lib/spin'
 import cn from 'classnames'
 import { Spring } from 'react-spring/renderprops'
@@ -155,40 +155,42 @@ export class EmailPage extends Component<EmailPageProps, EmailPageState> {
             )}
           </Spring>
         ) : null}
-        <Button
-          text='Continue'
-          name='continue'
-          rightIcon={
-            shouldDisableInputs ? (
-              <Spin className={styles.spinner} />
-            ) : (
-              <IconArrow />
-            )
-          }
-          type={ButtonType.PRIMARY_ALT}
-          onClick={this.onSubmit}
-          textClassName={styles.signInButtonText}
-          className={styles.signInButton}
-          isDisabled={shouldDisableInputs}
-        />
-        <div
-          className={cn(styles.hasAccount, {
-            [styles.hasAccountErrMetaMask]: hasMetaMask && showError,
-            [styles.hasAccountErr]: !hasMetaMask && showError
-          })}
-        >
-          Already have an account?{' '}
-          <span className={styles.signInText} onClick={this.props.onSignIn}>
-            Sign In
-          </span>
-        </div>
-        {hasMetaMask ? (
-          <MetaMaskOption
-            text='Sign Up With'
-            subText='not recommended'
-            onClick={this.onToggleMetaMaskModal}
+        <div className={styles.buttonsContainer}>
+          <Button
+            size={ButtonSize.MEDIUM}
+            text='Continue'
+            name='continue'
+            rightIcon={
+              shouldDisableInputs ? (
+                <Spin className={styles.spinner} />
+              ) : (
+                <IconArrow />
+              )
+            }
+            type={ButtonType.PRIMARY_ALT}
+            onClick={this.onSubmit}
+            textClassName={styles.signInButtonText}
+            className={styles.signInButton}
+            isDisabled={shouldDisableInputs}
           />
-        ) : null}
+          {hasMetaMask ? (
+            <MetaMaskOption
+              text='Sign Up With'
+              subText='not recommended'
+              onClick={this.onToggleMetaMaskModal}
+            />
+          ) : null}
+          <Button
+            className={cn(styles.hasAccount, {
+              [styles.hasAccountErrMetaMask]: hasMetaMask && showError,
+              [styles.hasAccountErr]: !hasMetaMask && showError
+            })}
+            size={ButtonSize.MEDIUM}
+            type={ButtonType.COMMON_ALT}
+            text={'Have an account? Sign In'}
+            onClick={this.props.onSignIn}
+          />
+        </div>
       </div>
     )
   }

--- a/src/containers/sign-on/components/desktop/EmailPage.tsx
+++ b/src/containers/sign-on/components/desktop/EmailPage.tsx
@@ -179,16 +179,17 @@ export class EmailPage extends Component<EmailPageProps, EmailPageState> {
               onClick={this.onToggleMetaMaskModal}
             />
           ) : null}
-          <Button
-            className={cn(styles.hasAccount, {
-              [styles.hasAccountErrMetaMask]: hasMetaMask && showError,
-              [styles.hasAccountErr]: !hasMetaMask && showError
-            })}
-            size={ButtonSize.MEDIUM}
-            type={ButtonType.COMMON_ALT}
-            text={'Have an account? Sign In'}
-            onClick={this.props.onSignIn}
-          />
+          <div className={styles.hasAccount}>
+            <Button
+              className={cn(styles.hasAccountButton, {
+                [styles.hasAccountErrMetaMask]: hasMetaMask && showError,
+                [styles.hasAccountErr]: !hasMetaMask && showError
+              })}
+              type={ButtonType.COMMON_ALT}
+              text={'Have an Account? Sign In'}
+              onClick={this.props.onSignIn}
+            />
+          </div>
         </div>
       </div>
     )

--- a/src/containers/sign-on/components/desktop/MetaMaskOption.js
+++ b/src/containers/sign-on/components/desktop/MetaMaskOption.js
@@ -19,11 +19,6 @@ export class MetaMaskOption extends Component {
   render() {
     return (
       <>
-        <div className={styles.orMetaMask}>
-          <div className={styles.border} />
-          <div className={styles.text}>or</div>
-          <div className={styles.border} />
-        </div>
         <Button
           text={<MetaMaskSignupText text={this.props.text} />}
           onClick={this.props.onClick}

--- a/src/containers/sign-on/components/desktop/MetaMaskOption.module.css
+++ b/src/containers/sign-on/components/desktop/MetaMaskOption.module.css
@@ -1,9 +1,7 @@
-
 /* Metamask Button */
 .metaMaskSignupButton {
-  width: 100%;
   color: var(--neutral);
-  font-family: "Avenir Next LT Pro";
+  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-bold);
   text-align: center;
@@ -16,9 +14,9 @@
 .metaMaskSignupButton input {
   height: 52px;
   width: 246px;
-  border: 1px solid #DAD9E0;
+  border: 1px solid #dad9e0;
   border-radius: 4px;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 .metaMaskSignupText {
@@ -28,7 +26,7 @@
   align-items: center;
   color: var(--neutral);
   font-size: var(--font-s);
-  font-weight: var(--font-bold)
+  font-weight: var(--font-bold);
 }
 
 .metaMaskLogo {

--- a/src/containers/sign-on/components/desktop/MetaMaskOption.module.css
+++ b/src/containers/sign-on/components/desktop/MetaMaskOption.module.css
@@ -1,32 +1,13 @@
 
-/* MetaMask Option */
-.orMetaMask {
-  display: inline-flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 354px;
-  margin-bottom: 19px;
-}
-
-.orMetaMask .border {
-  width: 144px;
-  border-top: 1px solid var(--neutral-light-8);
-}
-
-.orMetaMask .text {
-  color: var(--neutral-light-4);
-  font-size: var(--font-s);
-  font-weight: var(--font-medium);
-  text-align: center;
-}
-
 /* Metamask Button */
 .metaMaskSignupButton {
+  width: 100%;
   color: var(--neutral);
   font-family: "Avenir Next LT Pro";
   font-size: var(--font-s);
   font-weight: var(--font-bold);
   text-align: center;
+  margin-top: 24px;
   margin-bottom: 10px;
   height: 52px !important;
   padding-left: 16px !important;
@@ -57,6 +38,7 @@
 
 /* Not recommended */
 .subText {
+  margin-bottom: 24px;
   color: var(--neutral);
   font-size: var(--font-s);
   font-weight: var(--font-medium);

--- a/src/containers/sign-on/components/desktop/SignInPage.js
+++ b/src/containers/sign-on/components/desktop/SignInPage.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react'
 
 import { Button, ButtonType, IconArrow } from '@audius/stems'
-import Spin from 'antd/lib/spin'
 import cn from 'classnames'
 import PropTypes from 'prop-types'
 import { Spring } from 'react-spring/renderprops'
@@ -9,6 +8,7 @@ import { Spring } from 'react-spring/renderprops'
 import audiusLogoColored from 'assets/img/audiusLogoColored.png'
 import Input from 'components/data-entry/Input'
 import StatusMessage from 'components/general/StatusMessage'
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import PreloadImage from 'components/preload-image/PreloadImage'
 
 import { MetaMaskOption } from './MetaMaskOption'
@@ -137,7 +137,11 @@ export class SignIn extends PureComponent {
             name='sign-in'
             text='Continue'
             rightIcon={
-              loading ? <Spin className={styles.spinner} /> : <IconArrow />
+              loading ? (
+                <LoadingSpinner className={styles.spinner} />
+              ) : (
+                <IconArrow />
+              )
             }
             type={ButtonType.PRIMARY_ALT}
             onClick={onSignIn}

--- a/src/containers/sign-on/components/desktop/SignInPage.js
+++ b/src/containers/sign-on/components/desktop/SignInPage.js
@@ -152,7 +152,7 @@ export class SignIn extends PureComponent {
           ) : null}
           <div className={styles.createAccount}>
             <Button
-              text={'New to Audius? Create an account'}
+              text={'New to Audius? Create an Account'}
               type={ButtonType.COMMON_ALT}
               onClick={onSignUp}
             />

--- a/src/containers/sign-on/components/desktop/SignInPage.js
+++ b/src/containers/sign-on/components/desktop/SignInPage.js
@@ -50,6 +50,12 @@ export class SignIn extends PureComponent {
     }
   }
 
+  componentDidMount() {
+    if (this.props.email && this.props.email.value) {
+      this.passwordInput.current.focus()
+    }
+  }
+
   render() {
     const {
       isMobile,

--- a/src/containers/sign-on/components/desktop/SignInPage.js
+++ b/src/containers/sign-on/components/desktop/SignInPage.js
@@ -132,29 +132,32 @@ export class SignIn extends PureComponent {
             )}
           </Spring>
         )}
-        <Button
-          name='sign-in'
-          text='Sign In'
-          rightIcon={
-            loading ? <Spin className={styles.spinner} /> : <IconArrow />
-          }
-          type={ButtonType.PRIMARY_ALT}
-          onClick={onSignIn}
-          textClassName={styles.signInButtonText}
-          className={styles.signInButton}
-        />
-        <div className={styles.newUserText}>
-          New to Audius?{' '}
-          <span className={styles.createAccountText} onClick={onSignUp}>
-            Create an Account
-          </span>
-        </div>
-        {hasMetaMask ? (
-          <MetaMaskOption
-            text='Sign In With'
-            onClick={this.onSignInWithMetaMask}
+        <div className={styles.buttonsContainer}>
+          <Button
+            name='sign-in'
+            text='Continue'
+            rightIcon={
+              loading ? <Spin className={styles.spinner} /> : <IconArrow />
+            }
+            type={ButtonType.PRIMARY_ALT}
+            onClick={onSignIn}
+            textClassName={styles.signInButtonText}
+            className={styles.signInButton}
           />
-        ) : null}
+          {hasMetaMask ? (
+            <MetaMaskOption
+              text='Sign In With'
+              onClick={this.onSignInWithMetaMask}
+            />
+          ) : null}
+          <div className={styles.createAccount}>
+            <Button
+              text={'New to Audius? Create an account'}
+              type={ButtonType.COMMON_ALT}
+              onClick={onSignUp}
+            />
+          </div>
+        </div>
       </div>
     )
   }

--- a/src/containers/sign-on/components/desktop/SignInPage.module.css
+++ b/src/containers/sign-on/components/desktop/SignInPage.module.css
@@ -9,12 +9,11 @@
 
 /*  */
 .logo {
-  max-height: 204px;
-  max-width: 180px;
+  max-height: 180px;
+  max-width: 159px;
   height: 100%;
   width: 100%;
-  margin-top: 40px;
-  margin-bottom: 31px;
+  margin: 32px auto;
 }
 
 .metaMask .logo {
@@ -31,13 +30,13 @@
   font-size: var(--font-l);
   height: 26px;
   font-weight: var(--font-demi-bold);
-  margin-bottom: 3px;
+  margin-bottom: 32px;
   user-select: none;
 }
 
 /* Sign In Button */
 .signInInput {
-  margin-top: 30px;
+  margin-bottom: 16px;
   text-align: center;
   height: 66px !important;
   width: 354px !important;
@@ -47,7 +46,7 @@
   width: 100% !important;
   font-size: 20px !important;
   color: var(--neutral);
-  border: 1px solid #F2F2F4;
+  border: 1px solid #f2f2f4;
   border-radius: 4px;
 }
 .signInInput.hasMetaMask {
@@ -66,9 +65,14 @@
   transform: translate(0px, -12px) !important;
 }
 
+.buttonsContainer {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
 /* Sign In Button */
 .signInButton {
-  margin-top: 31px;
   transition: none;
 }
 
@@ -86,7 +90,7 @@
   margin-top: 31px;
   margin-bottom: 17px;
   color: var(--neutral);
-  font-family: "Avenir Next LT Pro";
+  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   user-select: none;
@@ -112,7 +116,6 @@
 .hidden {
   display: none;
 }
-
 
 .errorContainer {
   display: inline-flex;
@@ -157,8 +160,8 @@
   font-size: 16px !important;
 }
 
-.isMobile input::-webkit-input-placeholder { 
-  line-height: normal !important; 
+.isMobile input::-webkit-input-placeholder {
+  line-height: normal !important;
 }
 
 /* Sign In Button */
@@ -180,7 +183,7 @@
   margin-top: 32px;
   margin-bottom: 17px;
   color: var(--secondary);
-  font-family: "Avenir Next LT Pro";
+  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   user-select: none;
@@ -190,17 +193,6 @@
 .isMobile.signInError .newUserText {
   transition: none;
   margin-top: 23px;
-}
-
-.isMobile .createAccountText {
-  text-decoration: none;
-  color: var(--secondary-light-2);
-  cursor: pointer;
-}
-.isMobile .createAccountText:hover,
-.isMobile .createAccountText:active {
-  text-decoration: underline !important;
-  color: var(--secondary);
 }
 
 .isMobile .hidden {
@@ -227,4 +219,11 @@
 
 .spinner :global(.ant-spin-dot i) {
   background-color: var(--static-white);
+}
+
+.createAccount {
+  flex: 1;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: flex-end;
 }

--- a/src/containers/sign-on/components/desktop/SignInPage.module.css
+++ b/src/containers/sign-on/components/desktop/SignInPage.module.css
@@ -204,13 +204,8 @@
   width: 16px;
 }
 
-.spinner :global(.ant-spin-dot) {
-  height: 16px;
-  width: 16px;
-}
-
-.spinner :global(.ant-spin-dot i) {
-  background-color: var(--static-white);
+.spinner g path {
+  stroke: var(--white) !important;
 }
 
 .createAccount {

--- a/src/containers/sign-on/components/desktop/SignInPage.module.css
+++ b/src/containers/sign-on/components/desktop/SignInPage.module.css
@@ -16,14 +16,6 @@
   margin: 32px auto;
 }
 
-.metaMask .logo {
-  max-height: 180px;
-  max-width: 159px;
-  height: 100%;
-  width: 100%;
-  margin: 40px auto 20px;
-}
-
 /* Title */
 .title {
   color: var(--secondary);

--- a/src/containers/sign-on/components/desktop/SignOnPage.tsx
+++ b/src/containers/sign-on/components/desktop/SignOnPage.tsx
@@ -63,7 +63,6 @@ export type SignOnProps = {
   onViewSignIn: () => void
   onEmailChange: (email: string, validate?: boolean) => void
   onPasswordChange: (password: string) => void
-  handleOnContinue: (page: Pages) => () => void
   onHandleChange: (handle: string) => void
   onNameChange: (name: string) => void
   onSetProfileImage: (img: any) => void
@@ -97,6 +96,7 @@ export type SignOnProps = {
   recordTwitterStart: () => void
   suggestedFollows: User[]
   onSelectArtistCategory: (category: FollowArtistsCategory) => void
+  onEmailSubmitted: (email: string) => void
 }
 
 const pagesAfterFollow = new Set([
@@ -141,7 +141,6 @@ const SignOnProvider = ({
   onViewSignIn,
   onEmailChange,
   onPasswordChange,
-  handleOnContinue,
   onHandleChange,
   onNameChange,
   onSetProfileImage,
@@ -160,7 +159,8 @@ const SignOnProvider = ({
   onConfigureWithMetaMask,
   suggestedFollows: suggestedFollowEntries,
   recordTwitterStart,
-  onSelectArtistCategory
+  onSelectArtistCategory,
+  onEmailSubmitted
 }: SignOnProps) => {
   const {
     email,
@@ -224,7 +224,7 @@ const SignOnProvider = ({
           onSignIn={onViewSignIn}
           onToggleMetaMaskModal={onToggleMetaMaskModal}
           onEmailChange={onEmailChange}
-          onNextPage={handleOnContinue(Pages.PASSWORD)}
+          onSubmit={onEmailSubmitted}
         />
       </animated.div>
     ),
@@ -239,7 +239,7 @@ const SignOnProvider = ({
         <PasswordPage
           email={email}
           onPasswordChange={onPasswordChange}
-          onNextPage={handleOnContinue(Pages.PROFILE)}
+          onNextPage={onNextPage}
         />
       </animated.div>
     ),

--- a/src/containers/sign-on/components/mobile/InitialPage.module.css
+++ b/src/containers/sign-on/components/mobile/InitialPage.module.css
@@ -14,7 +14,7 @@
   width: 100%;
   border-radius: 0 0 40px 40px;
   background-color: var(--white);
-  box-shadow: 0 2px 25px -5px rgba(17,17,34,0.5);
+  box-shadow: 0 2px 25px -5px rgba(17, 17, 34, 0.5);
 }
 
 .native .topSection {
@@ -239,7 +239,7 @@
 }
 
 .signInDescription {
-  color: #7E1BCC;
+  color: #7e1bcc;
   font-size: 18px;
   font-weight: bold;
   line-height: 16px;
@@ -253,11 +253,6 @@
   width: 16px;
 }
 
-.spinner :global(.ant-spin-dot) {
-  height: 16px;
-  width: 16px;
-}
-
-.spinner :global(.ant-spin-dot i) {
-  background-color: var(--static-white);
+.spinner g path {
+  stroke: var(--white) !important;
 }

--- a/src/containers/sign-on/components/mobile/InitialPage.tsx
+++ b/src/containers/sign-on/components/mobile/InitialPage.tsx
@@ -16,6 +16,7 @@ import audiusLogoHorizontal from 'assets/img/Horizontal-Logo-Full-Color.png'
 import signupCtaImage from 'assets/img/signUpCTA.png'
 import Input from 'components/data-entry/Input'
 import StatusMessage from 'components/general/StatusMessage'
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import PreloadImage from 'components/preload-image/PreloadImage'
 import { RouterContext } from 'containers/animated-switch/RouterContextProvider'
 
@@ -178,7 +179,11 @@ const SignUpEmail = ({
         text={messages.signUp}
         name='continue'
         rightIcon={
-          isSubmitting ? <Spin className={styles.spinner} /> : <IconArrow />
+          isSubmitting ? (
+            <LoadingSpinner className={styles.spinner} />
+          ) : (
+            <IconArrow />
+          )
         }
         type={ButtonType.PRIMARY_ALT}
         onClick={onSubmitEmail}
@@ -272,7 +277,7 @@ const SignIn = ({
         text='Sign In'
         rightIcon={
           isLoading || (didSucceed && !hasAccount) ? (
-            <Spin className={styles.spinner} />
+            <LoadingSpinner className={styles.spinner} />
           ) : (
             <IconArrow />
           )

--- a/src/containers/sign-on/components/mobile/InitialPage.tsx
+++ b/src/containers/sign-on/components/mobile/InitialPage.tsx
@@ -52,7 +52,7 @@ type SignUpEmailProps = {
   }
   onEmailChange: (email: string) => void
   onViewSignIn: () => void
-  onNextPage: () => void
+  onEmailSubmitted: (email: string) => void
 }
 
 type SignInProps = {
@@ -87,12 +87,13 @@ type InitialPageProps = SignUpEmailProps &
 const SignUpEmail = ({
   email,
   onEmailChange,
-  onNextPage,
+  onEmailSubmitted,
   onViewSignIn
 }: SignUpEmailProps) => {
   const { value: emailValue, status: emailStatus, error } = email
 
   const [attempted, setAttempted] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const onBlur = useCallback(() => {
     setAttempted(true)
@@ -100,11 +101,10 @@ const SignUpEmail = ({
 
   const onSubmitEmail = useCallback(() => {
     setAttempted(true)
+    setIsSubmitting(true)
     if (!emailValue) onEmailChange(emailValue)
-    if (emailStatus === 'success') {
-      onNextPage()
-    }
-  }, [emailValue, emailStatus, setAttempted, onNextPage, onEmailChange])
+    onEmailSubmitted(emailValue)
+  }, [emailValue, setAttempted, onEmailSubmitted, onEmailChange])
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -115,10 +115,16 @@ const SignUpEmail = ({
     [onSubmitEmail]
   )
 
+  useEffect(() => {
+    const { status } = email
+    if (isSubmitting && (status === 'success' || status === 'failure')) {
+      setIsSubmitting(false)
+    }
+  }, [email, isSubmitting, setIsSubmitting])
+
   const inputError = email.status === 'failure'
   const validInput = email.status === 'success'
-  const showError =
-    (inputError && error === 'inUse') || (inputError && attempted)
+  const showError = inputError && attempted
 
   return (
     <div className={styles.topContainer}>
@@ -148,6 +154,7 @@ const SignUpEmail = ({
         })}
         error={showError}
         onBlur={onBlur}
+        disabled={isSubmitting}
       />
       {showError ? (
         <Spring
@@ -170,11 +177,14 @@ const SignUpEmail = ({
       <Button
         text={messages.signUp}
         name='continue'
-        rightIcon={<IconArrow />}
+        rightIcon={
+          isSubmitting ? <Spin className={styles.spinner} /> : <IconArrow />
+        }
         type={ButtonType.PRIMARY_ALT}
         onClick={onSubmitEmail}
         className={styles.signUpButton}
         textClassName={styles.signUpButtonText}
+        isDisabled={isSubmitting}
       />
     </div>
   )
@@ -287,7 +297,7 @@ export const InitialPage = ({
   onViewSignIn,
   onSubmitSignIn,
   onViewSignUp,
-  onNextPage,
+  onEmailSubmitted,
   onAllowNotifications,
   hasAccount
 }: InitialPageProps) => {
@@ -329,7 +339,7 @@ export const InitialPage = ({
               email={email}
               onEmailChange={onEmailChange}
               onViewSignIn={onViewSignIn}
-              onNextPage={onNextPage}
+              onEmailSubmitted={onEmailSubmitted}
             />
           )}
         </div>

--- a/src/containers/sign-on/components/mobile/SignOnPage.tsx
+++ b/src/containers/sign-on/components/mobile/SignOnPage.tsx
@@ -45,8 +45,8 @@ export type SignOnProps = {
   onViewSignUp: () => void
   onViewSignIn: () => void
   onEmailChange: (email: string, validate?: boolean) => void
+  onEmailSubmitted: (email: string) => void
   onPasswordChange: (password: string) => void
-  handleOnContinue: (page: Pages) => () => void
   onHandleChange: (handle: string) => void
   onNameChange: (name: string) => void
   onSetProfileImage: (img: any) => void
@@ -99,8 +99,8 @@ const SignOnPage = ({
   onViewSignUp,
   onViewSignIn,
   onEmailChange,
+  onEmailSubmitted,
   onPasswordChange,
-  handleOnContinue,
   onHandleChange,
   onNameChange,
   onSetProfileImage,
@@ -180,7 +180,7 @@ const SignOnPage = ({
           onPasswordChange={onPasswordChange}
           onEmailChange={onEmailChange}
           onAllowNotifications={onAllowNotifications}
-          onNextPage={handleOnContinue(Pages.PASSWORD)}
+          onEmailSubmitted={onEmailSubmitted}
         />
       </animated.div>
     ),
@@ -201,7 +201,7 @@ const SignOnPage = ({
           password={password}
           inputStatus={''}
           onPasswordChange={onPasswordChange}
-          onNextPage={handleOnContinue(Pages.PROFILE)}
+          onNextPage={onNextPage}
           onTermsOfServiceClick={() => {}}
           onPrivacyPolicyClick={() => {}}
         />

--- a/src/containers/sign-on/store/actions.js
+++ b/src/containers/sign-on/store/actions.js
@@ -14,6 +14,8 @@ export const VALIDATE_HANDLE_FAILED = 'SIGN_ON/VALIDATE_HANDLE_FAILED'
 export const FOLLOW_ARTISTS = 'SIGN_ON/FOLLOW_ARTISTS'
 export const SET_ACCOUNT_READY = 'SIGN_ON/SET_ACCOUNT_READY'
 
+export const CHECK_EMAIL = 'SIGN_ON/CHECK_EMAIL'
+
 export const SIGN_IN = 'SIGN_ON/SIGN_IN'
 export const SIGN_IN_SUCCEEDED = 'SIGN_ON/SIGN_IN_SUCCEEDED'
 export const SIGN_IN_FAILED = 'SIGN_ON/SIGN_IN_FAILED'
@@ -79,6 +81,10 @@ export function setField(field, value) {
  */
 export function resetSignOn() {
   return { type: RESET_SIGN_ON }
+}
+
+export function checkEmail(email) {
+  return { type: CHECK_EMAIL, email }
 }
 
 /**

--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -234,28 +234,8 @@ function* checkEmail(action) {
 }
 
 function* validateEmail(action) {
-  try {
-    if (!isValidEmailString(action.email)) {
-      yield put(signOnActions.validateEmailFailed('characters'))
-      return
-    }
-    // Delay before validating the email via API. If another action comes in,
-    // this should cancel before we send the request since we use takeLatest.
-    // Effectively a debounce()
-    yield delay(DEBOUNCE_VALIDATE_EMAIL_MS)
-    yield validateEmailInUse(action)
-  } catch (err) {
-    yield put(signOnActions.validateEmailFailed(err.message))
-  }
-}
-
-function* validateEmailInUse(action) {
-  yield call(waitForBackendSetup)
-  try {
-    const inUse = yield call(AudiusBackend.emailInUse, action.email)
-    yield put(signOnActions.validateEmailSucceeded(!inUse))
-  } catch (err) {
-    yield put(signOnActions.validateEmailFailed(err.message))
+  if (!isValidEmailString(action.email)) {
+    yield put(signOnActions.validateEmailFailed('characters'))
   }
 }
 

--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -52,8 +52,8 @@ const SUGGESTED_FOLLOW_USER_HANDLE_URL =
   'https://download.audius.co/static-resources/signup-follows.json'
 const SIGN_UP_TIMEOUT_MILLIS = 20 /* min */ * 60 * 1000
 
-// Wait 2 seconds between validating an email
-const THROTTLE_VALIDATE_EMAIL_MS = 2 * 1000
+// Wait 500 milliseconds between validating an email
+const DEBOUNCE_VALIDATE_EMAIL_MS = 500
 
 const messages = {
   incompleteAccount:
@@ -239,7 +239,10 @@ function* validateEmail(action) {
       yield put(signOnActions.validateEmailFailed('characters'))
       return
     }
-    yield delay(2000)
+    // Delay before validating the email via API. If another action comes in,
+    // this should cancel before we send the request since we use takeLatest.
+    // Effectively a debounce()
+    yield delay(DEBOUNCE_VALIDATE_EMAIL_MS)
     yield validateEmailInUse(action)
   } catch (err) {
     yield put(signOnActions.validateEmailFailed(err.message))

--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -52,9 +52,6 @@ const SUGGESTED_FOLLOW_USER_HANDLE_URL =
   'https://download.audius.co/static-resources/signup-follows.json'
 const SIGN_UP_TIMEOUT_MILLIS = 20 /* min */ * 60 * 1000
 
-// Wait 500 milliseconds between validating an email
-const DEBOUNCE_VALIDATE_EMAIL_MS = 500
-
 const messages = {
   incompleteAccount:
     'Oops, it looks like your account was never fully completed!'


### PR DESCRIPTION
### Description
AUD-671
- Make the sidebar have a "Sign In" link instead of "Sign Up" when not logged in.
- Submitting an email that already exists in the "Sign Up" flow no longer errors but sends you to the "Sign In" page with the email pre-filled and the password field focused.
- Adjusted the "Sign Up" page to include a button instead of a link for "Have an account? Sign In"

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
- ~I dislike the way I handled the issues with the Saga for the `EmailPage`, would love to brainstorm other ideas here.~ Updated: Feedback still welcome but looks better now.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Manually/locally.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

- None.
