### PR TITLE
Fix duplicate data/refetch suggestions bug

### DIFF
--- a/src/containers/artist-recommendations/store/sagas.ts
+++ b/src/containers/artist-recommendations/store/sagas.ts
@@ -1,4 +1,5 @@
 import { Action } from '@reduxjs/toolkit'
+import { shuffle } from 'lodash'
 import { call, put, select, takeEvery } from 'redux-saga/effects'
 
 import User from 'models/User'
@@ -55,11 +56,7 @@ function* fetchTopArtists() {
   )
   if (filteredArtists.length > 0) {
     // Pick 5 at random
-    const selectedArtists = []
-    for (let i = 0; i < 5; i++) {
-      const index = Math.floor(Math.random() * filteredArtists.length)
-      selectedArtists.push(filteredArtists[index])
-    }
+    const selectedArtists = shuffle(filteredArtists).slice(0, 5)
     return selectedArtists
   }
   return []

--- a/src/containers/artist-recommendations/store/slice.ts
+++ b/src/containers/artist-recommendations/store/slice.ts
@@ -10,21 +10,17 @@ const slice = createSlice({
   initialState,
   reducers: {
     fetchRelatedArtists: (state, action: PayloadAction<{ userId: ID }>) => {
-      return {
-        ...state,
-        [action.payload.userId]: {
-          ...state[action.payload.userId],
-          status: Status.LOADING
-        }
+      state[action.payload.userId] = {
+        ...state[action.payload.userId],
+        status: Status.LOADING
       }
     },
     fetchRelatedArtistsSucceeded: (
       state,
       action: PayloadAction<{ userId: ID; relatedArtistIds: ID[] }>
     ) => {
-      return {
-        ...state,
-        [action.payload.userId]: {
+      if (!state[action.payload.userId].relatedArtistIds) {
+        state[action.payload.userId] = {
           relatedArtistIds: action.payload.relatedArtistIds,
           status: Status.SUCCESS
         }


### PR DESCRIPTION
### Description

Fix bugs in fetching suggested follows
1. If filteredArtists.length < 5, we will definitely re-pick the same ones. Even if >5 it could still repick. Use shuffle/slice instead
2. Update reducer to only update recommendations if not already set

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally vs. prod with my account

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
