### PR TITLE
AUD-947 Truncate display names on signup if necessary

### DIFF
--- a/src/containers/sign-on/components/ProfileForm.js
+++ b/src/containers/sign-on/components/ProfileForm.js
@@ -14,6 +14,11 @@ import StatusMessage from 'components/general/StatusMessage'
 import { IDENTITY_SERVICE } from 'services/AudiusBackend'
 import { resizeImage } from 'utils/imageProcessingUtil'
 
+import {
+  MAX_DISPLAY_NAME_LENGTH,
+  MAX_HANDLE_LENGTH
+} from '../utils/formatSocialProfile'
+
 import styles from './ProfileForm.module.css'
 
 const messages = {
@@ -85,9 +90,9 @@ const ProfileForm = props => {
           size='medium'
           variant={props.isMobile ? 'normal' : 'elevatedPlaceholder'}
           value={name.value}
-          characterLimit={32}
-          showCharacterLimit={name.value.length === 32}
-          warning={name.value.length === 32}
+          characterLimit={MAX_DISPLAY_NAME_LENGTH}
+          showCharacterLimit={name.value.length === MAX_DISPLAY_NAME_LENGTH}
+          warning={name.value.length === MAX_DISPLAY_NAME_LENGTH}
           onChange={props.onNameChange}
           className={cn(styles.profileInput, styles.nameInput, {
             [styles.placeholder]: props.name.value === ''
@@ -102,9 +107,9 @@ const ProfileForm = props => {
             value={handle.value}
             disabled={!props.canUpdateHandle || handle.status === 'disabled'}
             onChange={props.onHandleChange}
-            characterLimit={16}
-            showCharacterLimit={handle.value.length === 16}
-            warning={handle.value.length === 16}
+            characterLimit={MAX_HANDLE_LENGTH}
+            showCharacterLimit={handle.value.length === MAX_HANDLE_LENGTH}
+            warning={handle.value.length === MAX_HANDLE_LENGTH}
             onKeyDown={props.onHandleKeyDown}
             variant={props.isMobile ? 'normal' : 'elevatedPlaceholder'}
             onFocus={() => {

--- a/src/containers/sign-on/components/desktop/ProfilePage.js
+++ b/src/containers/sign-on/components/desktop/ProfilePage.js
@@ -104,7 +104,7 @@ export class ProfilePage extends Component {
         profile,
         profileImage,
         requiresUserReview
-      } = await formatInstagramProfile(uuid, profile)
+      } = await formatInstagramProfile(instagramProfile)
       this.props.validateHandle(
         profile.username,
         profile.is_verified,

--- a/src/containers/sign-on/utils/formatSocialProfile.ts
+++ b/src/containers/sign-on/utils/formatSocialProfile.ts
@@ -4,6 +4,7 @@ import { resizeImage } from 'utils/imageProcessingUtil'
 const GENERAL_ADMISSION = process.env.REACT_APP_GENERAL_ADMISSION
 
 export const MAX_HANDLE_LENGTH = 16
+export const MAX_DISPLAY_NAME_LENGTH = 32
 
 export const formatTwitterProfile = async (twitterProfile: TwitterProfile) => {
   const profileUrl = twitterProfile.profile_image_url_https.replace(
@@ -40,6 +41,10 @@ export const formatTwitterProfile = async (twitterProfile: TwitterProfile) => {
         MAX_HANDLE_LENGTH
       )
     }
+  }
+  if (twitterProfile.name.length > MAX_DISPLAY_NAME_LENGTH) {
+    requiresUserReview = true
+    twitterProfile.name = twitterProfile.name.slice(0, MAX_DISPLAY_NAME_LENGTH)
   }
 
   return {
@@ -82,6 +87,13 @@ export const formatInstagramProfile = async (
         MAX_HANDLE_LENGTH
       )
     }
+  }
+  if ((instagramProfile.full_name?.length || 0) > MAX_DISPLAY_NAME_LENGTH) {
+    requiresUserReview = true
+    instagramProfile.full_name = instagramProfile.full_name!.slice(
+      0,
+      MAX_DISPLAY_NAME_LENGTH
+    )
   }
 
   return {

--- a/src/containers/sign-on/utils/formatSocialProfile.ts
+++ b/src/containers/sign-on/utils/formatSocialProfile.ts
@@ -88,7 +88,10 @@ export const formatInstagramProfile = async (
       )
     }
   }
-  if ((instagramProfile.full_name?.length || 0) > MAX_DISPLAY_NAME_LENGTH) {
+  if (
+    !instagramProfile.full_name ||
+    instagramProfile.full_name.length > MAX_DISPLAY_NAME_LENGTH
+  ) {
     requiresUserReview = true
     instagramProfile.full_name = instagramProfile.full_name!.slice(
       0,


### PR DESCRIPTION
### Description

- Fixes bug causing Instagram signup flow to not autofill for all desktop users
- Fixes bug when Twitter/Instagram names are longer than 32 characters, asks user to verify the truncated names.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Tested locally by placing breakpoints in `TwitterOverlay`'s `onClickInstagram` function, and then in the console running one of the following to fake a login from instagram or twitter respectively: 
```js
setTimeout( () => props.onInstagramLogin('', { username: 'foo', full_name:'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz', verified: false, id: 'idk'}), 5000)
```
```js
setTimeout( () => props.onTwitterLogin(new Response(JSON.stringify({uuid: '', profile: { screen_name: 'foo', name:'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz', verified: false, profile_image_url_https: 'https://pbs.twimg.com/app_img/1112838394780868609/A7KVqmDi?format=png&name=73x73'}}))), 5000)
```


### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

- None.