### PR TITLE
Fallback to parsing the ID from URL on 404

### DIFF
--- a/scripts/workers-site/index.js
+++ b/scripts/workers-site/index.js
@@ -29,21 +29,6 @@ function checkIsBot(val) {
 }
 
 async function handleEvent(event) {
-  // One-off fix for old-style route shared on twitter
-  // We don't make old-style routes anymore but older mobile app versions generate bad links
-  // TODO: Remove this and make old style routes for a while longer until user sediment updates
-  if (
-    event.request.url.endsWith(
-      'hannibalburess/coach-wilson-produced-by-flux-pavilion-517598'
-    )
-  ) {
-    const newUrl = event.request.url.substring(
-      0,
-      event.request.url.length - '-517598'.length
-    )
-    return Response.redirect(newUrl, 301)
-  }
-
   const url = new URL(event.request.url)
   const { pathname, search, hash } = url
   const userAgent = event.request.headers.get('User-Agent') || ''

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -712,7 +712,18 @@ class AudiusAPIClient {
       args,
       true
     )
-    if (!trackResponse) return null
+    // Try the old route method, ensuring that the track once found has the same owner handle
+    if (!trackResponse) {
+      const matches = args.slug.match(/[0-9]{6,}$/)
+      if (!matches) return null
+      const oldTrackResponse = await this.getTrack({
+        id: parseInt(matches[0])
+      })
+      if (!oldTrackResponse || oldTrackResponse.user.handle !== args.handle) {
+        return null
+      }
+      return oldTrackResponse
+    }
     return adapter.makeTrack(trackResponse.data)
   }
 

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -713,8 +713,9 @@ class AudiusAPIClient {
       true
     )
     // Try the old route method, ensuring that the track once found has the same owner handle
+    // Ensure at least 5 digits (anything lower has old route in the DB)
     if (!trackResponse) {
-      const matches = args.slug.match(/[0-9]{6,}$/)
+      const matches = args.slug.match(/[0-9]{5,}$/)
       if (!matches) return null
       const oldTrackResponse = await this.getTrack({
         id: parseInt(matches[0])


### PR DESCRIPTION
### Description

Updates the `getTrackByHandleAndSlug` method to fallback to trying to parse the ID from the route if the initial request 404s. This fixes the links sent out by mobile users using outdated app versions.

Also removes one-off since that link should now also work.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested manually on -instrumental-prod.-by-mattrickbeats-530271 and -instrumental-prod.-by-mattrickbeats-100000 and -instrumental-prod.-by-mattrickbeats-1 to ensure the proper logic. (First one redirects to the proper track, second 404s, third 404s)

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

Tempted to add some logs here so that we can see more clearly when we can remove the logic. Thoughts @raymondjacobson ?