### PR TITLE
[AUD-613] Optimistically load the feed on signup rather than waiting for confirmations

### DIFF
--- a/src/containers/sign-on/components/desktop/SignOnPage.tsx
+++ b/src/containers/sign-on/components/desktop/SignOnPage.tsx
@@ -22,11 +22,15 @@ import PasswordPage from 'containers/sign-on/components/desktop/PasswordPage'
 import ProfilePage from 'containers/sign-on/components/desktop/ProfilePage'
 import SignInPage from 'containers/sign-on/components/desktop/SignInPage'
 import StartPlatformPage from 'containers/sign-on/components/desktop/StartPlatformPage'
+import { getStatus } from 'containers/sign-on/store/selectors'
 import { Pages, FollowArtistsCategory } from 'containers/sign-on/store/types'
 import User from 'models/User'
 import { ID } from 'models/common/Identifiers'
 import { InstagramProfile } from 'store/account/reducer'
+import { getAccountStatus } from 'store/account/selectors'
+import { Status } from 'store/types'
 import lazyWithPreload from 'utils/lazyWithPreload'
+import { useSelector } from 'utils/reducer'
 import { BASE_URL, SIGN_UP_PAGE } from 'utils/route'
 
 import AppCTA from './AppCTA'
@@ -174,14 +178,20 @@ const SignOnProvider = ({
     verified,
     profileImage,
     status,
-    accountReady,
     followArtists: { selectedCategory, selectedUserIds }
   } = fields
+
+  const accountStatus = useSelector(getAccountStatus)
+  const signOnStatus = useSelector(getStatus)
   useEffect(() => {
-    if (accountReady && page === Pages.LOADING) {
+    if (
+      accountStatus === Status.SUCCESS &&
+      signOnStatus === 'success' &&
+      page === Pages.LOADING
+    ) {
       onNextPage()
     }
-  }, [accountReady, onNextPage, page])
+  }, [accountStatus, signOnStatus, onNextPage, page])
 
   let backgroundImage = null
   let backgroundOverlayGradient = null

--- a/src/containers/sign-on/store/reducer.js
+++ b/src/containers/sign-on/store/reducer.js
@@ -34,7 +34,8 @@ import {
   UPDATE_ROUTE_ON_EXIT,
   ADD_FOLLOW_ARTISTS,
   REMOVE_FOLLOW_ARTISTS,
-  SET_REFERRER
+  SET_REFERRER,
+  FOLLOW_ARTISTS
 } from './actions'
 import { Pages, FollowArtistsCategory } from './types'
 
@@ -57,7 +58,7 @@ const initialState = {
   accountAlreadyExisted: false,
   verified: false,
   useMetaMask: false,
-  accountReady: false,
+  accountReady: null,
   twitterId: '',
   twitterScreenName: '',
   instagramId: '',
@@ -389,6 +390,12 @@ const actionsMap = {
           id => !removeUserIds.has(id)
         )
       }
+    }
+  },
+  [FOLLOW_ARTISTS](state, action) {
+    return {
+      ...state,
+      accountReady: false
     }
   },
   [UPDATE_ROUTE_ON_EXIT](state, action) {


### PR DESCRIPTION
### Description

Instead of waiting for confirmer to confirm the follows the user selected during signup, generate a feed optimistically with the artists they selected using the new DP parameters.

TODOS:
- [ ] Finish wiring up the new API call (update libs, etc)
- [ ] Rework the `accountReady` flag to be less of a hack

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
