### PR TITLE
Remove mobile confirm keydown

### DIFF
--- a/src/containers/sign-on/components/mobile/PasswordPage.tsx
+++ b/src/containers/sign-on/components/mobile/PasswordPage.tsx
@@ -197,15 +197,6 @@ const PasswordPage = ({
     }
   }, [password, onValidatePasswordChange, onNextPage, fulfillsRequirements])
 
-  const onConfirmKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.keyCode === 13 /** enter */) {
-        onClickContinue()
-      }
-    },
-    [onClickContinue]
-  )
-
   onTermsOfServiceClick = () => {
     if (NATIVE_MOBILE) {
       new OpenLinkMessage(`${BASE_URL}${TERMS_OF_SERVICE}`).send()
@@ -273,7 +264,6 @@ const PasswordPage = ({
           value={passwordConfirm}
           variant={'normal'}
           onChange={onPasswordConfirmChange}
-          onKeyDown={onConfirmKeyDown}
           className={cn(styles.passwordInput, {
             [styles.placeholder]: passwordConfirm === '',
             [styles.inputError]: inputStatus === CheckState.ERROR,


### PR DESCRIPTION
### Description
Remove mobile onConfirmKeyDown on password pg of signup as it causes the user to double submit the onClickContinue btn and skip the profile page of signup on mobile only

### Dragons

### How Has This Been Tested?
* manually in mobile view on desktop
* mobile web

### How will this change be monitored?
