### PR TITLE
AUD-991 Fix Profile Page Reposts Lineup Infinite Scrolling

### DIFF
--- a/src/containers/profile-page/store/lineups/feed/reducer.js
+++ b/src/containers/profile-page/store/lineups/feed/reducer.js
@@ -4,8 +4,7 @@ import { initialLineupState } from 'store/lineup/reducer'
 
 const initialState = {
   ...initialLineupState,
-  prefix: PREFIX,
-  containsDeleted: false
+  prefix: PREFIX
 }
 
 const actionsMap = {

--- a/src/store/lineup/reducer.js
+++ b/src/store/lineup/reducer.js
@@ -29,7 +29,9 @@ export const initialLineupState = {
   inView: false,
   // Boolean if the lineup should remove duplicate content in entries
   dedupe: false,
-  // Boolean if the lineup fetch call returns deleted tracks/collections
+  // Boolean if the lineup fetch call pagination includes deleted tracks/collections
+  // e.g. This should be true if we request 10 tracks but only get 9 back because
+  // one is deleted
   // - Used to know if the lineup should stop fetching more content
   containsDeleted: true,
   // Whether the lineup is limited to a certain length


### PR DESCRIPTION
### Description

This PR fixes the infinite scroll on the reposts tab on the profile page.

The issue was due to the feed lineup having `containsDeleted: true` and there being a deleted track in the lineup. When a page request was made for 19 reposts and only 18 came back, the lineup was incorrectly marked as `hasMore: false`.

I think confusion was caused by the `containsDeleted` flag, so I updated the comment to be a bit more descriptive.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
