### PR TITLE
Fix sign up flow race condition

### DIFF
--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -438,7 +438,7 @@ function* followArtists() {
   try {
     // Auto-follow Hot & New Playlist
     if (IS_PRODUCTION) {
-      yield fork(followCollections, [4281], FavoriteSource.SIGN_UP)
+      yield call(followCollections, [4281], FavoriteSource.SIGN_UP)
     }
 
     const signOn = yield select(getSignOn)


### PR DESCRIPTION
### Description

Race condition when using fork to have the auto follow Hot & New flow run in parallel. Switched it back to call

