### PR TITLE
Fix copyright year where hardcoded to 2019

### DIFF
--- a/src/containers/settings-page/components/desktop/SettingsPage.tsx
+++ b/src/containers/settings-page/components/desktop/SettingsPage.tsx
@@ -28,6 +28,7 @@ import Theme from 'models/Theme'
 import AudiusBackend from 'services/AudiusBackend'
 import DownloadApp from 'services/download-app/DownloadApp'
 import { isMobile, isElectron, getOS } from 'utils/clientUtil'
+import { COPYRIGHT_TEXT } from 'utils/copyright'
 import { signOut } from 'utils/signOut'
 
 import { version } from '../../../../../package.json'
@@ -48,11 +49,10 @@ const SIGN_OUT_MODAL_TEXT = `
 `
 
 const EMAIL_TOAST_TIMEOUT = 2000
-const currentYear = new Date().getFullYear().toString()
 
 const messages = {
   version: 'Audius Version',
-  copyright: `Copyright © ${currentYear} Audius`,
+  copyright: COPYRIGHT_TEXT,
   emailSent: 'Email Sent!',
   emailNotSent: 'Something broke! Please try again!',
   darkModeOn: 'On',

--- a/src/containers/settings-page/components/mobile/AboutSettingsPage.tsx
+++ b/src/containers/settings-page/components/mobile/AboutSettingsPage.tsx
@@ -11,6 +11,7 @@ import GroupableList from 'components/groupable-list/GroupableList'
 import Grouping from 'components/groupable-list/Grouping'
 import Row from 'components/groupable-list/Row'
 import { GetVersion } from 'services/native-mobile-interface/version'
+import { COPYRIGHT_TEXT } from 'utils/copyright'
 
 import { version } from '../../../../../package.json'
 
@@ -19,7 +20,6 @@ import { SettingsPageProps } from './SettingsPage'
 import settingsPageStyles from './SettingsPage.module.css'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
-const currentYear = new Date().getFullYear().toString()
 
 const links = {
   discord: 'https://discordapp.com/invite/yNUg2e2',
@@ -42,7 +42,7 @@ const messages = {
 
   title: 'Audius Music',
   version: 'Audius Version',
-  copyright: `Copyright © ${currentYear} Audius`
+  copyright: COPYRIGHT_TEXT
 }
 
 /** Gets the latest app or dapp version */

--- a/src/utils/copyright.ts
+++ b/src/utils/copyright.ts
@@ -1,0 +1,2 @@
+const currentYear = new Date().getFullYear().toString()
+export const COPYRIGHT_TEXT = `Copyright © ${currentYear} Audius`


### PR DESCRIPTION
### Description

See https://github.com/AudiusProject/audius-protocol/pull/1995 - I noticed while troubleshooting the weird logout issue on my personal computer tonight that we had hardcoded 2019 in our copyright. It's time to be PRESENT ✨ 