### PR TITLE
[AUD-1026] Fix rewards modal popping up on escape

### DIFF
--- a/src/containers/audio-rewards-page/components/modals/HCaptchaModal.tsx
+++ b/src/containers/audio-rewards-page/components/modals/HCaptchaModal.tsx
@@ -27,9 +27,11 @@ export const HCaptchaModal = () => {
   const [, setRewardModalOpen] = useModalState('ChallengeRewardsExplainer')
 
   const handleClose = useCallback(() => {
-    setRewardModalOpen(true)
-    setOpen(false)
-  }, [setRewardModalOpen, setOpen])
+    if (isOpen) {
+      setRewardModalOpen(true)
+      setOpen(false)
+    }
+  }, [setRewardModalOpen, isOpen, setOpen])
 
   const onVerify = useCallback(
     async (token: string) => {


### PR DESCRIPTION
### Description

Fixed two ways:
- This PR makes it so "closing" the hcaptcha modal (even if not open) doesn't trigger opening of the rewards modal
- This PR: https://github.com/AudiusProject/stems/pull/63 makes it so that pressing escape does nothing to a closed modal

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally against stage w/ linked Stems

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
