### PR TITLE
Fix fork fetch collections

### DIFF
--- a/src/common/store/cache/sagas.js
+++ b/src/common/store/cache/sagas.js
@@ -312,7 +312,7 @@ export function* add(kind, entries, replace, persist) {
     // If something is confirming and in the cache, we probably don't
     // want to replace it (unless explicit) because we would lose client
     // state, e.g. "has_current_user_reposted"
-    if (!replace && makeKindId(kind, entry.id) in confirmCallsInCache) {
+    if (!replace && entry.id in confirmCallsInCache) {
       entriesToSubscribe.push({ uid: entry.uid, id: entry.id })
     } else {
       entriesToAdd.push(entry)

--- a/src/common/store/cache/sagas.js
+++ b/src/common/store/cache/sagas.js
@@ -1,3 +1,4 @@
+import { pick } from 'lodash'
 import { all, call, put, select, takeEvery, spawn } from 'redux-saga/effects'
 
 import Kind from 'common/models/Kind'
@@ -8,7 +9,7 @@ import { CACHE_PRUNE_MIN } from 'common/store/cache/config'
 import { getCache } from 'common/store/cache/selectors'
 import { getTracks } from 'common/store/cache/tracks/selectors'
 import { getUsers } from 'common/store/cache/users/selectors'
-import { makeUids, makeKindId } from 'common/utils/uid'
+import { makeUids, makeKindId, getIdFromKindId } from 'common/utils/uid'
 import { getConfirmCalls } from 'store/confirmer/selectors'
 import * as persistentCache from 'utils/persistentCache'
 
@@ -297,12 +298,21 @@ function* retrieveFromSourceThenCache({
 }
 
 export function* add(kind, entries, replace, persist) {
+  // Get cached things that are confirming
   const confirmCalls = yield select(getConfirmCalls)
+  const cache = yield select(getCache, { kind })
+  const confirmCallsInCache = pick(
+    cache.entries,
+    Object.keys(confirmCalls).map(kindId => getIdFromKindId(kindId))
+  )
 
   const entriesToAdd = []
   const entriesToSubscribe = []
   entries.forEach(entry => {
-    if (!replace && makeKindId(kind, entry.id) in confirmCalls) {
+    // If something is confirming and in the cache, we probably don't
+    // want to replace it (unless explicit) because we would lose client
+    // state, e.g. "has_current_user_reposted"
+    if (!replace && makeKindId(kind, entry.id) in confirmCallsInCache) {
       entriesToSubscribe.push({ uid: entry.uid, id: entry.id })
     } else {
       entriesToAdd.push(entry)

--- a/src/common/store/cache/store.test.js
+++ b/src/common/store/cache/store.test.js
@@ -74,7 +74,12 @@ describe('add', () => {
           confirmer: noopReducer()
         }),
         {
-          tracks: { ...initialCacheState },
+          tracks: {
+            ...initialCacheState,
+            entries: {
+              1: { metadata: { data: 10 } }
+            }
+          },
           confirmer: {
             ...initialConfirmerState,
             confirm: {
@@ -102,7 +107,8 @@ describe('add', () => {
       )
       .silentRun()
     expect(storeState.tracks.entries).toEqual({
-      ...initialCacheState.entries
+      ...initialCacheState.entries,
+      1: { metadata: { data: 10 } }
     })
     expect(storeState.tracks.uids).toEqual({
       '111': 1

--- a/src/containers/sign-on/store/sagas.js
+++ b/src/containers/sign-on/store/sagas.js
@@ -4,6 +4,7 @@ import { delay } from 'redux-saga'
 import {
   all,
   call,
+  fork,
   put,
   race,
   select,
@@ -66,8 +67,8 @@ if (IS_PRODUCTION) {
   // user id 51: official audius account
   defaultFollowUserIds = new Set([51])
 } else if (IS_STAGING) {
-  // user id 12372: official audius account
-  defaultFollowUserIds = new Set([12372])
+  // user id 1964: stage testing account
+  defaultFollowUserIds = new Set([1964])
 }
 
 export const fetchSuggestedFollowUserIds = async () => {
@@ -438,7 +439,9 @@ function* followArtists() {
   try {
     // Auto-follow Hot & New Playlist
     if (IS_PRODUCTION) {
-      yield call(followCollections, [4281], FavoriteSource.SIGN_UP)
+      yield fork(followCollections, [4281], FavoriteSource.SIGN_UP)
+    } else if (IS_STAGING) {
+      yield fork(followCollections, [555], FavoriteSource.SIGN_UP)
     }
 
     const signOn = yield select(getSignOn)


### PR DESCRIPTION
### Description
The change in #621, while functional, does not address the root cause of why the fork didn't work.
What actually was happening behind the scenes is that when the followed collection belongs to the auto followed user, we get into a situation where:
1. The user is not in the cache
2. The `follow user` action is being confirmed
3. The collection follow (save) fails because the user is not in the cache

The reason the user is not in the cache is because we have a check that disallows recaching of fetched assets while something is confirming. Generally this is really good because we don't overwrite client state around fields like `has_current_user_followed.` However, in this case, the user was never cached in the first place, so we were unable to complete the collection save.

This PR addresses such cases by cross referencing the cache against the confirmer and only blocking recaching if an entity is in *both* the confirmer and the cache*

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Updated follows for staging to mirror prod & registered an account against staging

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
