### PR TITLE
[AUD-1053] Avoid resetting genre & trending on componentWillUnmount

### DIFF
--- a/src/containers/trending-page/TrendingPageProvider.js
+++ b/src/containers/trending-page/TrendingPageProvider.js
@@ -110,8 +110,6 @@ class TrendingPageProvider extends PureComponent {
       this.props.makeResetTrending(TimeRange.WEEK)()
       this.props.makeResetTrending(TimeRange.MONTH)()
       this.props.makeResetTrending(TimeRange.YEAR)()
-      this.props.setTrendingGenre(null)
-      this.props.setTrendingTimeRange(TimeRange.WEEK)
     }
   }
 


### PR DESCRIPTION
### Description

Resetting the genre & timerange will cause the behavior noted in linear where:
1. Trending reducer sets initial genres and time ranges based on URL
2. User navigates away from trending and on unmount, resets genre & timerange in the reducer to null/week
3. User navigates back to trending and the lineup componentDidMount fires before the page's componentDidMount making it so the URL genres are never captured.

I think this is the most sane fix. We could try and pipe the trending actions to set store state down into the lineup's componentDidMount itself, but realistically, I think we can just avoid clearing this on unmount. Because we are still calling the makeReset, we will still get fresh data on every load.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally vs prod. Fixes the reproducible error 

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
