### PR TITLE
Wait for follow artists before sending account available to mobile

### DIFF
--- a/src/containers/sign-on/store/mobileSagas.ts
+++ b/src/containers/sign-on/store/mobileSagas.ts
@@ -184,7 +184,8 @@ function* watchAccountAvailable(): any {
   while (
     yield all([
       take(signOnActions.SIGN_UP_SUCCEEDED),
-      take(accountActions.fetchAccountSucceeded.type)
+      take(accountActions.fetchAccountSucceeded.type),
+      take(signOnActions.FOLLOW_ARTISTS)
     ])
   ) {
     yield put(pushRoute(FEED_PAGE, { noAnimation: true }))


### PR DESCRIPTION
### Description

Currently, if user on a mobile client spends a long time on the follow artists screen during sign up and then clicks continue, the feed is empty because the account would've already been available/ready before the followees had a chance to be triggered. This fix waits for the follows trigger to set the account available flag.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
