### PR TITLE
Adjust AudioContext type

### DIFF
--- a/src/audio/AudioStream.ts
+++ b/src/audio/AudioStream.ts
@@ -9,7 +9,7 @@ import { decodeHashId } from 'utils/route/hashIds'
 declare global {
   interface Window {
     audio: HTMLAudioElement
-    webkitAudioContext: AudioContext
+    webkitAudioContext: typeof AudioContext
   }
 }
 


### PR DESCRIPTION
### Description

This PR:
* Adjusts the `webkitAudioContext` declaration to the class `AudioContext` instead of the interface `AudioContext` (Thanks typescript)

This is needed to properly typecheck `audius-mobile-client`. The mobile client is necessarily using a newer version of typescript and gets upset when we try to construct an `AudioContext` below in this file

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
