### PR TITLE
[AUD-839] Fix remix settings modal to only fetch the most recent url

### DIFF
--- a/src/containers/remix-settings-modal/store/sagas.ts
+++ b/src/containers/remix-settings-modal/store/sagas.ts
@@ -1,4 +1,4 @@
-import { takeEvery, call, put } from 'redux-saga/effects'
+import { takeLatest, call, put } from 'redux-saga/effects'
 
 import { TrackMetadata } from 'common/models/Track'
 import {
@@ -28,7 +28,7 @@ const getHandleAndSlug = (url: string) => {
 }
 
 function* watchFetchTrack() {
-  yield takeEvery(fetchTrack.type, function* (
+  yield takeLatest(fetchTrack.type, function* (
     action: ReturnType<typeof fetchTrack>
   ) {
     const { url } = action.payload


### PR DESCRIPTION
### Description

Taking every fetch event meant that the "not found" case completed after the "success" case (since it takes longer to fail), even if the successful entry was the most recently typed.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Manually

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
