### PR TITLE
[AUD-900] Add main content context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,9 +118,9 @@
       }
     },
     "@audius/stems": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.17.tgz",
-      "integrity": "sha512-PU+AbT9FKrFhPUA9lMkrr+MkkiBw8jrs74t8WbwYeyxzz+F3QISksBXLJ3dTqyci++ViyXSfX893XwwC5+ZTXA==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.18.tgz",
+      "integrity": "sha512-QUpCWikpgLj9DYfyRZ/DIQwGkmSfYHV72SEf9HcSvclfoskBU+Zuw4OdcMh8Xp2h97kEKB0kuYxGOhSvM6WO9w==",
       "requires": {
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,9 +118,9 @@
       }
     },
     "@audius/stems": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.16.tgz",
-      "integrity": "sha512-hXoGmGdY0cUJiRPjv2HWOAMTjp5OeDEsfuQSfYCTMawmWTDfdWT0V6qxNvzzmQhQ4myZzOcBlTWc+RXFacFeWQ==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.17.tgz",
+      "integrity": "sha512-PU+AbT9FKrFhPUA9lMkrr+MkkiBw8jrs74t8WbwYeyxzz+F3QISksBXLJ3dTqyci++ViyXSfX893XwwC5+ZTXA==",
       "requires": {
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@audius/libs": "1.2.27",
-    "@audius/stems": "0.3.17",
+    "@audius/stems": "0.3.18",
     "@hcaptcha/react-hcaptcha": "0.3.6",
     "@optimizely/optimizely-sdk": "4.0.0",
     "@project-serum/sol-wallet-adapter": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@audius/libs": "1.2.27",
-    "@audius/stems": "0.3.16",
+    "@audius/stems": "0.3.17",
     "@hcaptcha/react-hcaptcha": "0.3.6",
     "@optimizely/optimizely-sdk": "4.0.0",
     "@project-serum/sol-wallet-adapter": "0.2.5",

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { HeaderContextProvider } from 'components/general/header/mobile/HeaderContextProvider'
 import { ToastContextProvider } from 'components/toast/ToastContext'
+import { MainContentContextProvider } from 'containers/MainContentContext'
 import { RouterContextProvider } from 'containers/animated-switch/RouterContextProvider'
 import { NavProvider } from 'containers/nav/store/context'
 import { ScrollProvider } from 'containers/scroll-provider/ScrollProvider'
@@ -15,9 +16,11 @@ const AppContext = ({ children }: AppContextProps) => {
     <NavProvider>
       <ScrollProvider>
         <RouterContextProvider>
-          <HeaderContextProvider>
-            <ToastContextProvider>{children}</ToastContextProvider>
-          </HeaderContextProvider>
+          <MainContentContextProvider>
+            <HeaderContextProvider>
+              <ToastContextProvider>{children}</ToastContextProvider>
+            </HeaderContextProvider>
+          </MainContentContextProvider>
         </RouterContextProvider>
       </ScrollProvider>
     </NavProvider>

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import '@audius/stems/dist/stems.css'
 import { ConnectedRouter } from 'connected-react-router'
 import { Provider } from 'react-redux'
 
+import { MainContentContext } from 'containers/MainContentContext'
 import logger from 'utils/logger'
 
 import AppContext from './AppContext'
@@ -41,16 +42,21 @@ const AudiusApp = ({
     <Provider store={store}>
       <ConnectedRouter history={history}>
         <AppContext>
-          <App
-            // TS has some issue with withRouter when
-            // interacting between TS + JS components.
-            // This goes away when we port `App` to TS
-            // @ts-ignore
-            setReady={setReady}
-            isReady={isReady}
-            setConnectivityFailure={setConnectivityFailure}
-            shouldShowPopover={shouldShowPopover}
-          />
+          <MainContentContext.Consumer>
+            {({ mainContentRef }) => (
+              <App
+                // TS has some issue with withRouter when
+                // interacting between TS + JS components.
+                // This goes away when we port `App` to TS
+                // @ts-ignore
+                setReady={setReady}
+                isReady={isReady}
+                mainContentRef={mainContentRef}
+                setConnectivityFailure={setConnectivityFailure}
+                shouldShowPopover={shouldShowPopover}
+              />
+            )}
+          </MainContentContext.Consumer>
         </AppContext>
       </ConnectedRouter>
     </Provider>

--- a/src/components/image-selection/ImageSelectionPopup.js
+++ b/src/components/image-selection/ImageSelectionPopup.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react'
+import React, { useState, useCallback, useRef, useContext } from 'react'
 
 import { Button, ButtonType, Popup } from '@audius/stems'
 import cn from 'classnames'
@@ -10,6 +10,7 @@ import { getAccountUser } from 'common/store/account/selectors'
 import TabSlider from 'components/data-entry/TabSlider'
 import Dropzone from 'components/upload/Dropzone'
 import InvalidFileType from 'components/upload/InvalidFileType'
+import { MainContentContext } from 'containers/MainContentContext'
 import { MIN_COLLECTIBLES_TIER } from 'containers/profile-page/ProfilePageProvider'
 import { useFlag } from 'containers/remote-config/hooks'
 import { useSelectTierInfo } from 'containers/user-badges/hooks'
@@ -223,6 +224,7 @@ const ImageSelectionPopup = ({
   onSelect,
   source
 }) => {
+  const { mainContentRef } = useContext(MainContentContext)
   const [page, setPage] = useState(messages.uploadYourOwn)
   const {
     collectibles,
@@ -292,6 +294,7 @@ const ImageSelectionPopup = ({
       showHeader={true}
       title={messages.popupTitle}
       zIndex={zIndex.IMAGE_SELECTION_POPUP}
+      containerRef={mainContentRef}
     >
       <TabSlider
         className={styles.slider}

--- a/src/components/tracks-table/TracksTable.module.css
+++ b/src/components/tracks-table/TracksTable.module.css
@@ -172,7 +172,7 @@
 .optionsButtonFormatting {
   position: absolute;
   left: -6px;
-  top: 9px;
+  top: 12px;
 }
 
 :global(.colOptionsButton) {

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -210,9 +210,9 @@ class App extends Component {
   headerGutterRef = React.createRef()
 
   scrollToTop = () => {
-    this.state.mainContent &&
-      this.state.mainContent.scrollTo &&
-      this.state.mainContent.scrollTo({ top: 0 })
+    this.props.mainContentRef.current &&
+      this.props.mainContentRef.current.scrollTo &&
+      this.props.mainContentRef.current.scrollTo({ top: 0 })
   }
 
   componentDidMount() {
@@ -391,10 +391,6 @@ class App extends Component {
     }
   }
 
-  setContainerRef = r => {
-    this.setState({ mainContent: r })
-  }
-
   dismissCTABanner = () => {
     this.setState({ showCTABanner: false })
     window.localStorage.setItem(MOBILE_BANNER_LOCAL_STORAGE_KEY, 'true')
@@ -519,7 +515,7 @@ class App extends Component {
         />
         <div className={styles.draggableArea} />
         <div
-          ref={this.setContainerRef}
+          ref={this.props.mainContentRef}
           id={MAIN_CONTENT_ID}
           className={cn(styles.mainContentWrapper, {
             [styles.bannerMargin]: showBanner,
@@ -549,7 +545,7 @@ class App extends Component {
                 path={FEED_PAGE}
                 isMobile={isMobileClient}
                 render={() => (
-                  <FeedPage containerRef={this.state.mainContent} />
+                  <FeedPage containerRef={this.props.mainContentRef.current} />
                 )}
               />
               <Route
@@ -580,7 +576,9 @@ class App extends Component {
                 exact
                 path={TRENDING_PAGE}
                 render={() => (
-                  <TrendingPage containerRef={this.state.mainContent} />
+                  <TrendingPage
+                    containerRef={this.props.mainContentRef.current}
+                  />
                 )}
               />
               <Redirect
@@ -592,7 +590,7 @@ class App extends Component {
                 path={TRENDING_PLAYLISTS_PAGE}
                 render={() => (
                   <TrendingPlaylistsPage
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />
@@ -601,7 +599,7 @@ class App extends Component {
                 path={TRENDING_UNDERGROUND_PAGE}
                 render={() => (
                   <TrendingUndergroundPage
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />
@@ -694,7 +692,7 @@ class App extends Component {
                   <SearchPage
                     {...props}
                     scrollToTop={this.scrollToTop}
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />
@@ -704,7 +702,7 @@ class App extends Component {
                   <SearchPage
                     {...props}
                     scrollToTop={this.scrollToTop}
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />
@@ -800,7 +798,7 @@ class App extends Component {
                 render={props => (
                   <ProfilePage
                     {...props}
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />
@@ -824,7 +822,7 @@ class App extends Component {
                 render={props => (
                   <ProfilePage
                     {...props}
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />
@@ -837,7 +835,7 @@ class App extends Component {
                 render={props => (
                   <RemixesPage
                     {...props}
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />
@@ -878,7 +876,7 @@ class App extends Component {
                 render={props => (
                   <ProfilePage
                     {...props}
-                    containerRef={this.state.mainContent}
+                    containerRef={this.props.mainContentRef.current}
                   />
                 )}
               />

--- a/src/containers/MainContentContext.tsx
+++ b/src/containers/MainContentContext.tsx
@@ -1,12 +1,12 @@
 import React, { createContext, memo, useRef, MutableRefObject } from 'react'
 
 export const MainContentContext = createContext({
-  mainContentRef: { current: null } as MutableRefObject<HTMLDivElement | null>
+  mainContentRef: {} as MutableRefObject<HTMLDivElement | undefined>
 })
 
 export const MainContentContextProvider = memo(
   (props: { children: JSX.Element }) => {
-    const mainContentRef = useRef<HTMLDivElement>(null)
+    const mainContentRef = useRef<HTMLDivElement>()
     return (
       <MainContentContext.Provider
         value={{

--- a/src/containers/MainContentContext.tsx
+++ b/src/containers/MainContentContext.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, memo, useRef, MutableRefObject } from 'react'
+
+export const MainContentContext = createContext({
+  mainContentRef: { current: null } as MutableRefObject<HTMLDivElement | null>
+})
+
+export const MainContentContextProvider = memo(
+  (props: { children: JSX.Element }) => {
+    const mainContentRef = useRef<HTMLDivElement>(null)
+    return (
+      <MainContentContext.Provider
+        value={{
+          mainContentRef
+        }}
+      >
+        {props.children}
+      </MainContentContext.Provider>
+    )
+  }
+)

--- a/src/containers/artist-recommendations/ArtistRecommendationsPopup.tsx
+++ b/src/containers/artist-recommendations/ArtistRecommendationsPopup.tsx
@@ -1,4 +1,10 @@
-import React, { MutableRefObject, useCallback, useEffect, useMemo } from 'react'
+import React, {
+  MutableRefObject,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo
+} from 'react'
 
 import { Popup, PopupPosition } from '@audius/stems'
 import { useSelector } from 'react-redux'
@@ -6,6 +12,7 @@ import { useSelector } from 'react-redux'
 import { ID } from 'common/models/Identifiers'
 import User from 'common/models/User'
 import { getUser } from 'common/store/cache/users/selectors'
+import { MainContentContext } from 'containers/MainContentContext'
 import { useFlag } from 'containers/remote-config/hooks'
 import { FeatureFlags } from 'services/remote-config'
 import { AppState } from 'store/types'
@@ -30,6 +37,7 @@ export const ArtistRecommendationsPopup = ({
   isVisible,
   onClose
 }: ArtistRecommendationsPopupProps) => {
+  const { mainContentRef } = useContext(MainContentContext)
   const { isEnabled, isLoaded } = useFlag(
     FeatureFlags.ARTIST_RECOMMENDATIONS_ENABLED
   )
@@ -51,6 +59,7 @@ export const ArtistRecommendationsPopup = ({
       zIndex={zIndex.FOLLOW_RECOMMENDATIONS_POPUP}
       onClose={onClose}
       className={styles.popup}
+      containerRef={mainContentRef}
     >
       <ArtistRecommendations
         itemClassName={styles.popupItem}

--- a/src/containers/menu/Menu.tsx
+++ b/src/containers/menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useContext } from 'react'
 
 import {
   PopupMenu,
@@ -6,6 +6,8 @@ import {
   PopupMenuProps,
   PopupPosition
 } from '@audius/stems'
+
+import { MainContentContext } from 'containers/MainContentContext'
 
 import CollectionMenu, {
   OwnProps as CollectionMenuProps
@@ -34,6 +36,8 @@ export type MenuProps = {
 const Menu = forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
   const { menu, onClose, zIndex } = props
 
+  const { mainContentRef } = useContext(MainContentContext)
+
   const renderMenu = (items: PopupMenuItem[]) => (
     <PopupMenu
       items={items}
@@ -42,6 +46,7 @@ const Menu = forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
       ref={ref}
       renderTrigger={props.children}
       zIndex={zIndex}
+      containerRef={mainContentRef}
     />
   )
 


### PR DESCRIPTION
### Description

Create a "global" MainContentRef context that allows components to grab a ref for the "main content" (everything inside the left nav and bottom bar).

Use that main context ref instead of mucking with state everywhere in App.js (perf win? 🤞)

This change should be paired with https://github.com/AudiusProject/stems/pull/64 to fix the actual bug at hand

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally vs. stage
* ImageSelectionPopup
* Menu popup
* Artist recommendations popup

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
