### PR TITLE
[AUD-1069] Fix missing repost on initial load

### DIFF
--- a/src/common/store/cache/tracks/utils/retrieveTracks.ts
+++ b/src/common/store/cache/tracks/utils/retrieveTracks.ts
@@ -58,11 +58,16 @@ export function* retrieveTrackByHandleAndSlug({
         return track
       },
       retrieveFromSource: function* (permalinks: string[]) {
+        const userId = yield select(getUserId)
         const track: UserTrackMetadata = yield call(args => {
           const split = args[0].split('/')
           const handle = split[1]
           const slug = split.slice(2).join('')
-          return apiClient.getTrackByHandleAndSlug({ handle, slug })
+          return apiClient.getTrackByHandleAndSlug({
+            handle,
+            slug,
+            currentUserId: userId
+          })
         }, permalinks)
         return track
       },


### PR DESCRIPTION
### Description

Fix bug where a track does not appear to be reposted immediately after reposting and reloading. The source of this issue (and the reason probers have been flaky most of the time) is because the current user id (if applicable) is not passed to the handle/slug endpoint, so `has_current_user_reposted` does not return as true.

My suspicion for why this has gone unnoticed for so long is that likely the track is being fetched by another endpoint the majority of the time on production and that is overwriting the `has_current_user_x` field

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

* Locally vs. staging as a logged in account
* Locally vs. staging logged out

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
