### PR TITLE
Add is_deactivated to default metadata fields

### DIFF
--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -111,7 +111,8 @@ const userMetadataSchema = {
   associated_sol_wallets: null,
   collectibles: null,
   playlist_library: null,
-  events: null
+  events: null,
+  is_deactivated: false
 }
 
 export const newUserMetadata = (fields, validate = false) => {


### PR DESCRIPTION
### Description

Updates newUserMetadata to include `is_deactivated` with default value of false.

Without this change, running the client with the latest libs fails signup as the user replica set validates the metadata and sees `is_deactivated` is missing.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Tested signup manually against latest libs.

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
