### PR TITLE
Fix collectible deep link

### DIFF
--- a/src/containers/collectibles/components/CollectibleDetails.tsx
+++ b/src/containers/collectibles/components/CollectibleDetails.tsx
@@ -22,7 +22,8 @@ import styles from './CollectiblesPage.module.css'
 
 const CollectibleDetails: React.FC<{
   collectible: Collectible
-}> = ({ collectible }) => {
+  onClick: () => void
+}> = ({ collectible, onClick }) => {
   const dispatch = useDispatch()
   const match = useRouteMatch()
   const navigate = useNavigateToPage()
@@ -74,7 +75,8 @@ const CollectibleDetails: React.FC<{
     window.history.pushState('', '', url)
     dispatch(setCollectible({ collectible }))
     setIsModalOpen(true)
-  }, [collectible, match.params, dispatch, setIsModalOpen])
+    onClick()
+  }, [collectible, match.params, dispatch, setIsModalOpen, onClick])
 
   return (
     <div className={styles.detailsContainer}>

--- a/src/containers/collectibles/components/CollectibleDetails.tsx
+++ b/src/containers/collectibles/components/CollectibleDetails.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import cn from 'classnames'
+import { useDispatch } from 'react-redux'
 import { useRouteMatch } from 'react-router'
 
 import { ReactComponent as IconPlay } from 'assets/img/pbIconPlay.svg'
+import { useModalState } from 'common/hooks/useModalState'
 import { Collectible, CollectibleMediaType } from 'common/models/Collectible'
+import { setCollectible } from 'common/store/ui/collectible-details/slice'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import PerspectiveCard from 'components/perspective-card/PerspectiveCard'
 import PreloadImage from 'components/preload-image/PreloadImage'
@@ -20,6 +23,7 @@ import styles from './CollectiblesPage.module.css'
 const CollectibleDetails: React.FC<{
   collectible: Collectible
 }> = ({ collectible }) => {
+  const dispatch = useDispatch()
   const match = useRouteMatch()
   const navigate = useNavigateToPage()
   const { mediaType, frameUrl, videoUrl, gifUrl, name } = collectible
@@ -27,6 +31,7 @@ const CollectibleDetails: React.FC<{
   const [isLoading, setIsLoading] = useState(true)
   const [frame, setFrame] = useState(frameUrl)
   const [showSpinner, setShowSpinner] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useModalState('CollectibleDetails')
 
   // Debounce showing the spinner for a second
   useEffect(() => {
@@ -62,8 +67,14 @@ const CollectibleDetails: React.FC<{
   const handleItemClick = useCallback(() => {
     // Ignore needed bc typescript doesn't think that match.params has handle property
     // @ts-ignore
-    navigate(`/${match.params.handle}/collectibles/${getHash(collectible.id)}`)
-  }, [collectible.id, match.params, navigate])
+    const url = `/${match.params.handle}/collectibles/${getHash(
+      collectible.id
+    )}`
+    // Push window state as to not trigger router change & component remount
+    window.history.pushState('', '', url)
+    dispatch(setCollectible({ collectible }))
+    setIsModalOpen(true)
+  }, [collectible, match.params, dispatch, setIsModalOpen])
 
   return (
     <div className={styles.detailsContainer}>

--- a/src/containers/collectibles/components/CollectibleDetails.tsx
+++ b/src/containers/collectibles/components/CollectibleDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import cn from 'classnames'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useRouteMatch } from 'react-router'
 
 import { ReactComponent as IconPlay } from 'assets/img/pbIconPlay.svg'
@@ -11,6 +11,7 @@ import { setCollectible } from 'common/store/ui/collectible-details/slice'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import PerspectiveCard from 'components/perspective-card/PerspectiveCard'
 import PreloadImage from 'components/preload-image/PreloadImage'
+import { getProfileUserHandle } from 'containers/profile-page/store/selectors'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
 import { preload } from 'utils/image'
 
@@ -25,8 +26,6 @@ const CollectibleDetails: React.FC<{
   onClick: () => void
 }> = ({ collectible, onClick }) => {
   const dispatch = useDispatch()
-  const match = useRouteMatch()
-  const navigate = useNavigateToPage()
   const { mediaType, frameUrl, videoUrl, gifUrl, name } = collectible
 
   const [isLoading, setIsLoading] = useState(true)
@@ -65,18 +64,17 @@ const CollectibleDetails: React.FC<{
     load()
   }, [mediaType, frameUrl, gifUrl, name, setFrame, setIsLoading])
 
+  const handle = useSelector(getProfileUserHandle)
   const handleItemClick = useCallback(() => {
     // Ignore needed bc typescript doesn't think that match.params has handle property
     // @ts-ignore
-    const url = `/${match.params.handle}/collectibles/${getHash(
-      collectible.id
-    )}`
+    const url = `/${handle}/collectibles/${getHash(collectible.id)}`
     // Push window state as to not trigger router change & component remount
     window.history.pushState('', '', url)
     dispatch(setCollectible({ collectible }))
     setIsModalOpen(true)
     onClick()
-  }, [collectible, match.params, dispatch, setIsModalOpen, onClick])
+  }, [collectible, handle, dispatch, setIsModalOpen, onClick])
 
   return (
     <div className={styles.detailsContainer}>

--- a/src/containers/collectibles/components/CollectibleDetailsModal.tsx
+++ b/src/containers/collectibles/components/CollectibleDetailsModal.tsx
@@ -12,7 +12,7 @@ import {
   Modal
 } from '@audius/stems'
 import cn from 'classnames'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useRouteMatch } from 'react-router'
 
 import { ReactComponent as IconEmbed } from 'assets/img/iconEmbed.svg'
@@ -23,6 +23,7 @@ import { Chain } from 'common/models/Chain'
 import { Collectible, CollectibleMediaType } from 'common/models/Collectible'
 import { getAccountUser } from 'common/store/account/selectors'
 import { getCollectible } from 'common/store/ui/collectible-details/selectors'
+import { setCollectible } from 'common/store/ui/collectible-details/slice'
 import { formatDateWithTimezoneOffset } from 'common/utils/timeUtil'
 import Drawer from 'components/drawer/Drawer'
 import Toast from 'components/toast/Toast'
@@ -165,7 +166,7 @@ const CollectibleDetailsModal = ({
   setIsEmbedModalOpen: (val: boolean) => void
 }) => {
   const match = useRouteMatch()
-  const navigate = useNavigateToPage()
+  const dispatch = useDispatch()
   const [isModalOpen, setIsModalOpen] = useModalState('CollectibleDetails')
   const [isMuted, setIsMuted] = useState<boolean>(true)
   const collectible = useSelector(getCollectible)
@@ -186,10 +187,14 @@ const CollectibleDetailsModal = ({
     tierNumber >= badgeTiers.findIndex(t => t.tier === MIN_COLLECTIBLES_TIER)
 
   const handleClose = useCallback(() => {
+    dispatch(setCollectible({ collectible: null }))
+    setIsModalOpen(false)
     // Ignore needed bc typescript doesn't think that match.params has handle property
     // @ts-ignore
-    navigate(`/${match.params.handle}/collectibles`)
-  }, [match.params, navigate])
+    const url = `/${match.params.handle}/collectibles`
+    // Push window state as to not trigger router change & component remount
+    window.history.pushState('', '', url)
+  }, [match.params, dispatch, setIsModalOpen])
 
   const toggleMute = useCallback(() => {
     setIsMuted(!isMuted)

--- a/src/containers/collectibles/components/CollectibleDetailsModal.tsx
+++ b/src/containers/collectibles/components/CollectibleDetailsModal.tsx
@@ -153,7 +153,8 @@ const CollectibleDetailsModal = ({
   updateProfilePicture,
   isUserOnTheirProfile,
   shareUrl,
-  setIsEmbedModalOpen
+  setIsEmbedModalOpen,
+  onClose
 }: {
   isMobile: boolean
   onSave?: () => void
@@ -164,6 +165,7 @@ const CollectibleDetailsModal = ({
   isUserOnTheirProfile: boolean
   shareUrl: string
   setIsEmbedModalOpen: (val: boolean) => void
+  onClose: () => void
 }) => {
   const match = useRouteMatch()
   const dispatch = useDispatch()
@@ -194,7 +196,8 @@ const CollectibleDetailsModal = ({
     const url = `/${match.params.handle}/collectibles`
     // Push window state as to not trigger router change & component remount
     window.history.pushState('', '', url)
-  }, [match.params, dispatch, setIsModalOpen])
+    onClose()
+  }, [match.params, dispatch, setIsModalOpen, onClose])
 
   const toggleMute = useCallback(() => {
     setIsMuted(!isMuted)

--- a/src/containers/collectibles/components/CollectiblesPage.tsx
+++ b/src/containers/collectibles/components/CollectiblesPage.tsx
@@ -25,13 +25,14 @@ import {
   Droppable,
   DropResult
 } from 'react-beautiful-dnd'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useRouteMatch } from 'react-router'
 
 import { ReactComponent as IconGradientCollectibles } from 'assets/img/iconGradientCollectibles.svg'
 import useInstanceVar from 'common/hooks/useInstanceVar'
 import { useModalState } from 'common/hooks/useModalState'
 import { Collectible, CollectiblesMetadata } from 'common/models/Collectible'
+import { getCollectible } from 'common/store/ui/collectible-details/selectors'
 import { setCollectible } from 'common/store/ui/collectible-details/slice'
 import Drawer from 'components/drawer/Drawer'
 import Toast from 'components/toast/Toast'
@@ -443,23 +444,26 @@ const CollectiblesPage: React.FC<{
     return []
   }, [getVisibleCollectibles, collectibleList])
 
+  const collectible = useSelector(getCollectible)
   // Handle rendering details modal based on route
   useEffect(() => {
     // @ts-ignore
     const collectibleId = match.params.collectibleId ?? null
-    let collectible = null
 
-    if (collectibleId) {
-      collectible =
+    // If the URL matches a collectible ID and we haven't set a collectible in the
+    // store yet, open up the modal
+    if (collectibleId && !collectible) {
+      const collectibleFromUrl =
         getVisibleCollectibles().find(c => getHash(c.id) === collectibleId) ??
         null
+      if (collectibleFromUrl) {
+        dispatch(setCollectible({ collectible: collectibleFromUrl }))
+        setIsDetailsModalOpen(true)
+        setEmbedCollectibleHash(collectibleId)
+      }
     }
-
-    // Set state based on route
-    dispatch(setCollectible({ collectible }))
-    setIsDetailsModalOpen(collectible !== null)
-    setEmbedCollectibleHash(collectibleId)
   }, [
+    collectible,
     dispatch,
     getVisibleCollectibles,
     match,

--- a/src/containers/collectibles/components/CollectiblesPage.tsx
+++ b/src/containers/collectibles/components/CollectiblesPage.tsx
@@ -444,7 +444,14 @@ const CollectiblesPage: React.FC<{
     return []
   }, [getVisibleCollectibles, collectibleList])
 
+  // On first mount, if the route matches a collectible id route,
+  // trigger the modal to open.
+  // Afterwards, allow the user to trigger opening the modal only.
   const collectible = useSelector(getCollectible)
+  const [
+    hasSetDeepLinkedCollectible,
+    setHasSetDeepLinkedCollectible
+  ] = useState(false)
   // Handle rendering details modal based on route
   useEffect(() => {
     // @ts-ignore
@@ -452,7 +459,7 @@ const CollectiblesPage: React.FC<{
 
     // If the URL matches a collectible ID and we haven't set a collectible in the
     // store yet, open up the modal
-    if (collectibleId && !collectible) {
+    if (collectibleId && !collectible && !hasSetDeepLinkedCollectible) {
       const collectibleFromUrl =
         getVisibleCollectibles().find(c => getHash(c.id) === collectibleId) ??
         null
@@ -460,9 +467,12 @@ const CollectiblesPage: React.FC<{
         dispatch(setCollectible({ collectible: collectibleFromUrl }))
         setIsDetailsModalOpen(true)
         setEmbedCollectibleHash(collectibleId)
+        setHasSetDeepLinkedCollectible(true)
       }
     }
   }, [
+    hasSetDeepLinkedCollectible,
+    setHasSetDeepLinkedCollectible,
     collectible,
     dispatch,
     getVisibleCollectibles,
@@ -545,6 +555,9 @@ const CollectiblesPage: React.FC<{
                 <CollectibleDetails
                   key={collectible.id}
                   collectible={collectible}
+                  onClick={() =>
+                    setEmbedCollectibleHash(getHash(collectible.id))
+                  }
                 />
               ))}
             </div>
@@ -559,6 +572,7 @@ const CollectiblesPage: React.FC<{
         onSave={onSave}
         shareUrl={shareUrl}
         setIsEmbedModalOpen={setIsEmbedModalOpen}
+        onClose={() => setEmbedCollectibleHash(null)}
       />
 
       <Modal


### PR DESCRIPTION
### Description

Use pushState instead of navigate (pushRoute) to change the URL, so it doesn't trigger a full page remount.
I think there is probably an overhaul due in the land of how we handle rendering pages based on routes, but in the near-term, this is a reasonable solution. Opening the modal triggers a history state change, but not a re-route to a new page. I think ~reasonable because we don't actually change "pages."

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Click on collectible (no rerender)
- Click out of details modal (no rerender)
- Navigate directly to collectibles page
- Navigate directly to collectible id page 

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
