### PR TITLE
Fix gif preview

### DIFF
--- a/src/containers/collectibles/ethCollectibleHelpers.ts
+++ b/src/containers/collectibles/ethCollectibleHelpers.ts
@@ -264,29 +264,6 @@ export const isNotFromNullAddress = (event: OpenSeaEvent) => {
 }
 
 export const getFrameFromGif = async (url: string, name: string) => {
-  const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1
-  const isSafariMobile =
-    navigator.userAgent.match(/iPad/i) || navigator.userAgent.match(/iPhone/i)
-  let preview
-  try {
-    // Firefox does not handle partial gif rendering well
-    if (isFirefox || isSafariMobile) {
-      throw new Error('partial gif not supported')
-    }
-    const req = await fetch(url, {
-      headers: {
-        // Extremely heuristic 200KB. This should contain the first frame
-        // and then some. Rendering this out into an <img tag won't allow
-        // animation to play. Some gifs may not load if we do this, so we
-        // can try-catch it.
-        Range: 'bytes=0-200000'
-      }
-    })
-    const ab = await req.arrayBuffer()
-    preview = new Blob([ab])
-  } catch (e) {
-    preview = await gifPreview(url)
-  }
-
+  const preview = await gifPreview(url)
   return URL.createObjectURL(preview)
 }


### PR DESCRIPTION
### Description

Display gif frame instead of autoplaying gif in collectibles page.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Locally against prod accounts with collectibles

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
