### PR TITLE
[AUD-1071] Improve Avenir font load to avoid FOUT

### DIFF
--- a/public/fonts.css
+++ b/public/fonts.css
@@ -5,7 +5,6 @@
 
 /**
  * Avenir font
- * The main DApp font, prefetched in css bundles before rendering
  */
 @font-face {
   font-family: 'Avenir Next LT Pro';

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,14 @@
   <head>
     <meta charset="utf-8">
 
+    <!-- Avenir Font -->
+    <link rel="preload" as="style" href="/fonts.css" />
+    <link rel="stylesheet" href="/fonts.css" media="print" onload="this.media='all'" />
+    <noscript>
+      <link rel="stylesheet"
+            href="/fonts.css" />
+    </noscript>
+
     <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicons/favicon-16x16.png">

--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -1,4 +1,3 @@
-@import '~assets/styles/fonts.css';
 @import '~assets/styles/colors.css';
 @import '~assets/styles/sizing.css';
 @import '~assets/styles/type.css';

--- a/src/components/collection/mobile/CollectionHeader.module.css
+++ b/src/components/collection/mobile/CollectionHeader.module.css
@@ -156,7 +156,6 @@
   height: 14px;
   width: 76px;
   color: var(--neutral-light-5);
-  font-family: "Avenir Next LT Pro";
   font-size: 14px;
   font-weight: bold;
   letter-spacing: 0.35px;

--- a/src/containers/artist-dashboard-page/components/TotalPlaysChart.js
+++ b/src/containers/artist-dashboard-page/components/TotalPlaysChart.js
@@ -76,7 +76,6 @@ const getLineGraphOptions = transformXValue => ({
         ticks: {
           padding: 13,
           fontColor: 'rgba(133,129,153, 0.5)',
-          fontFamily: 'Avenir Next LT Pro',
           fontSize: 10,
           fontStyle: 'bold'
         }
@@ -91,7 +90,6 @@ const getLineGraphOptions = transformXValue => ({
           beginAtZero: true,
           width: 1000,
           fontColor: 'rgba(133,129,153, 0.5)',
-          fontFamily: 'Avenir Next LT Pro',
           fontSize: 10,
           fontStyle: 'bold',
           callback: (value, index, values) => {
@@ -112,13 +110,11 @@ const getLineGraphOptions = transformXValue => ({
   },
   tooltips: {
     enabled: false,
-    titleFontFamily: 'Avenir Next LT Pro',
     titleFontSize: 10,
     titleFontStyle: 500,
     titleFontColor: '#FFFFFF',
     titleSpacing: 0,
     titleMarginBottom: 7,
-    bodyFontFamily: 'Avenir Next LT Pro',
     bodyFontSize: 16,
     bodyFontStyle: 'bold',
     bodyFontColor: '#FFFFFF',

--- a/src/containers/landing-page/components/FeaturedContent.module.css
+++ b/src/containers/landing-page/components/FeaturedContent.module.css
@@ -109,7 +109,6 @@
 .track .trackTitle {
   opacity: 0;
   color: #FFFFFF;
-  font-family: "Avenir Next LT Pro";
   font-size: 18px;
   font-weight: 700;
   line-height: 23px;
@@ -121,7 +120,6 @@
 .track .trackArtist {
   opacity: 0;
   color: rgba(255,255,255, 1);
-  font-family: "Avenir Next LT Pro";
   font-size: 18px;
   font-weight: 500;
   line-height: 23px;
@@ -222,7 +220,6 @@
 .mobileContainer .trackTitle {
   position: relative;
   color: #858199;
-  font-family: "Avenir Next LT Pro";
   font-size: 14px;
   font-weight: 500;
   line-height: 18px;
@@ -243,7 +240,6 @@
 
 .mobileContainer .trackArtist {
   color: #858199;
-  font-family: "Avenir Next LT Pro";
   font-size: 14px;
   font-weight: 500;
   line-height: 18px;

--- a/src/containers/nav/desktop/NavHeader.module.css
+++ b/src/containers/nav/desktop/NavHeader.module.css
@@ -114,7 +114,6 @@ svg.logo.matrixLogo path {
   border-radius: 8px;
   background-color: #D0021B;
   color: #FFFFFF;
-  font-family: "Avenir Next LT Pro";
   font-size: 11px;
   font-weight: bold;
   letter-spacing: 0.07px;

--- a/src/containers/profile-page/components/mobile/ProfileHeader.module.css
+++ b/src/containers/profile-page/components/mobile/ProfileHeader.module.css
@@ -216,7 +216,6 @@
   margin-top: 8px;
   text-align: left;
   color: var(--primary);
-  font-family: 'Avenir Next LT Pro';
   font-size: 14px;
   font-weight: 500;
 }

--- a/src/containers/sign-on/components/desktop/EmailPage.module.css
+++ b/src/containers/sign-on/components/desktop/EmailPage.module.css
@@ -239,7 +239,6 @@
   padding: 4px 0px;
   margin: 12px 0px 6px;
   color: var(--secondary);
-  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   user-select: none;

--- a/src/containers/sign-on/components/desktop/MetaMaskOption.module.css
+++ b/src/containers/sign-on/components/desktop/MetaMaskOption.module.css
@@ -1,7 +1,6 @@
 /* Metamask Button */
 .metaMaskSignupButton {
   color: var(--neutral);
-  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-bold);
   text-align: center;

--- a/src/containers/sign-on/components/desktop/SignInPage.module.css
+++ b/src/containers/sign-on/components/desktop/SignInPage.module.css
@@ -82,7 +82,6 @@
   margin-top: 31px;
   margin-bottom: 17px;
   color: var(--neutral);
-  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   user-select: none;
@@ -175,7 +174,6 @@
   margin-top: 32px;
   margin-bottom: 17px;
   color: var(--secondary);
-  font-family: 'Avenir Next LT Pro';
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   user-select: none;

--- a/src/containers/sign-on/components/mobile/FollowPage.module.css
+++ b/src/containers/sign-on/components/mobile/FollowPage.module.css
@@ -98,7 +98,6 @@
   margin-bottom: 16px;
 
   color: var(--neutral);
-  font-family: "Avenir Next LT Pro";
   font-size: var(--font-s);
   font-weight: var(--font-medium);
   letter-spacing: 0.13px;

--- a/src/containers/sign-on/components/mobile/LoadingPage.module.css
+++ b/src/containers/sign-on/components/mobile/LoadingPage.module.css
@@ -11,8 +11,7 @@
 }
 
 .title {
-  color: #7E1BCC;
-  font-family: "Avenir Next LT Pro";
+  color: var(--secondary);
   font-size: 28px;
   font-weight: bold;
   text-align: center;
@@ -22,8 +21,7 @@
 }
 
 .subtitle {
-  color: #9849D6;
-  font-family: "Avenir Next LT Pro";
+  color: var(--secondary-light-2);
   font-size: 16px;
   font-weight: bold;
   line-height: 25px;
@@ -38,5 +36,5 @@
 }
 
 .animationContainer svg path {
-  fill: #7E1BCC;
+  fill: var(--secondary);
 }

--- a/src/containers/sign-on/components/mobile/NotificationPermissionsPage.module.css
+++ b/src/containers/sign-on/components/mobile/NotificationPermissionsPage.module.css
@@ -13,7 +13,6 @@
 
 .title {
   color: #7E1BCC;
-  font-family: "Avenir Next LT Pro";
   font-size: 18px;
   font-weight: bold;
   line-height: 26px;
@@ -23,7 +22,6 @@
 
 .bodyText {
   color: #858199;
-  font-family: "Avenir Next LT Pro";
   font-size: 14px;
   line-height: 21px;
   text-align: center;
@@ -40,7 +38,6 @@
 .skipText {
   margin-top: 20px;
   color: #7E1BCC;
-  font-family: "Avenir Next LT Pro";
   font-size: 14px;
   font-weight: 500;
   line-height: 22px;

--- a/src/containers/upload-page/components/TracksPreview.module.css
+++ b/src/containers/upload-page/components/TracksPreview.module.css
@@ -23,7 +23,6 @@
 .header {
   text-transform: uppercase;
   color: var(--neutral-light-2);
-  font-family: "Avenir Next LT Pro";
   font-size: 15px;
   font-weight: bold;
   letter-spacing: 0.5px;


### PR DESCRIPTION
### Description

On prod nowadays b/c our main css bundle is pretty heavy, we have a decent amount of FOUT (flash of unstyled text).
I think there are two camps around the base64 encoding of fonts like we do (I generally like it, primarily b/c it's self-contained), but regardless, we should be pulling the font in far earlier than we do in the main css bundle.

Some best practices stolen from 
https://css-tricks.com/how-to-load-fonts-in-a-way-that-fights-fout-and-makes-lighthouse-happy/

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

ray.audius.co

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
