### PR TITLE
Don't show deactivated user tracks in Explore Remixables

### DIFF
--- a/src/containers/smart-collection/store/sagas.ts
+++ b/src/containers/smart-collection/store/sagas.ts
@@ -3,10 +3,9 @@ import { takeEvery, put, call, select } from 'redux-saga/effects'
 import { ID } from 'common/models/Identifiers'
 import { SmartCollectionVariant } from 'common/models/SmartCollectionVariant'
 import Status from 'common/models/Status'
-import { Track, TrackMetadata, UserTrack } from 'common/models/Track'
+import { Track, UserTrack, UserTrackMetadata } from 'common/models/Track'
 import { getAccountStatus, getUserId } from 'common/store/account/selectors'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
-import { fetchUsers } from 'common/store/cache/users/sagas'
 import { setSmartCollection } from 'containers/collection-page/store/actions'
 import Explore from 'services/audius-backend/Explore'
 import { waitForBackendSetup } from 'store/backend/sagas'
@@ -125,7 +124,7 @@ function* fetchFeelingLucky() {
 
 function* fetchRemixables() {
   const currentUserId: ID = yield select(getUserId)
-  const tracks: TrackMetadata[] = yield call(
+  const tracks: UserTrackMetadata[] = yield call(
     Explore.getRemixables,
     currentUserId,
     75 // limit
@@ -136,8 +135,13 @@ function* fetchRemixables() {
   const artistCount: Record<number, number> = {}
 
   const filteredTracks = tracks.filter(trackMetadata => {
+    if (!trackMetadata.user || trackMetadata.user.is_deactivated) {
+      return false
+    }
     const id = trackMetadata.owner_id
-    if (!artistCount[id]) artistCount[id] = 0
+    if (!artistCount[id]) {
+      artistCount[id] = 0
+    }
     artistCount[id]++
     return artistCount[id] <= artistLimit
   })
@@ -151,11 +155,6 @@ function* fetchRemixables() {
     time: track.created_at,
     track: track.track_id
   }))
-
-  // Fetch the users for the tracks
-  // TODO: Remove when remixables query is updated
-  const userIds = processedTracks.map((track: Track) => track.owner_id)
-  yield call(fetchUsers, userIds)
 
   return {
     ...REMIXABLES,

--- a/src/containers/smart-collection/store/sagas.ts
+++ b/src/containers/smart-collection/store/sagas.ts
@@ -135,7 +135,7 @@ function* fetchRemixables() {
   const artistCount: Record<number, number> = {}
 
   const filteredTracks = tracks.filter(trackMetadata => {
-    if (!trackMetadata.user || trackMetadata.user.is_deactivated) {
+    if (trackMetadata.user?.is_deactivated) {
       return false
     }
     const id = trackMetadata.owner_id

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -491,8 +491,8 @@ class AudiusAPIClient {
     const encodedCurrentUserId = encodeHashId(currentUserId)
     const params = {
       limit,
-      user_id: encodedCurrentUserId || undefined
-      // with_users: true
+      user_id: encodedCurrentUserId || undefined,
+      with_users: true
     }
     const remixablesResponse: Nullable<APIResponse<
       APITrack[]
@@ -501,7 +501,7 @@ class AudiusAPIClient {
     if (!remixablesResponse) return []
 
     const adapted = remixablesResponse.data
-      .map(adapter.makeUserlessTrack)
+      .map(adapter.makeTrack)
       .filter(removeNullable)
 
     return adapted


### PR DESCRIPTION
### Description

- Updates `getRemixables` to call with `with_users` set to true, and filters tracks that are from deactivated users on the client

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested manually locally against staging on `mjp-tombstones`

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
