### PR TITLE
Fix remixes with non-ascii characters

### DIFF
--- a/src/components/remix-settings-modal/RemixSettingsModal.tsx
+++ b/src/components/remix-settings-modal/RemixSettingsModal.tsx
@@ -99,8 +99,12 @@ const RemixSettingsModal = ({
 
   const onChange = useCallback(
     (url: string) => {
-      setUrl(url)
-      debounce(() => onEditUrl(url), INPUT_DEBOUNCE_MS, {
+      // Need to decode the URL
+      // here to properly show pasted
+      // URLS with non-ascii chars
+      const decoded = decodeURI(url)
+      setUrl(decoded)
+      debounce(() => onEditUrl(decoded), INPUT_DEBOUNCE_MS, {
         leading: true,
         trailing: false
       })()

--- a/src/containers/remix-settings-modal/store/sagas.ts
+++ b/src/containers/remix-settings-modal/store/sagas.ts
@@ -13,8 +13,9 @@ const getHandleAndSlug = (url: string) => {
   // Get just the pathname part from the url
   try {
     const trackUrl = new URL(url)
-    const pathname = trackUrl.pathname
-
+    // Decode the extracted pathname so we don't end up
+    // double encoding it later on
+    const pathname = decodeURIComponent(trackUrl.pathname)
     if (
       trackUrl.hostname !== process.env.REACT_APP_PUBLIC_HOSTNAME &&
       trackUrl.hostname !== window.location.hostname
@@ -33,6 +34,7 @@ function* watchFetchTrack() {
   ) {
     const { url } = action.payload
     const params = getHandleAndSlug(url)
+    console.log({ params })
     if (params) {
       const { handle, slug, trackId } = params
       let track: TrackMetadata | null = null

--- a/src/containers/remix-settings-modal/store/sagas.ts
+++ b/src/containers/remix-settings-modal/store/sagas.ts
@@ -34,7 +34,6 @@ function* watchFetchTrack() {
   ) {
     const { url } = action.payload
     const params = getHandleAndSlug(url)
-    console.log({ params })
     if (params) {
       const { handle, slug, trackId } = params
       let track: TrackMetadata | null = null


### PR DESCRIPTION
### Description

- Setting remix parents would fail for tracks with non-ascii characters, because the slug was double encoded
- We would also show the encoded version of the title in the remix box, which is annoying

### Dragons

None

### How Has This Been Tested?

Locally against stage

### How will this change be monitored?

n/a
