### PR TITLE
[AUD-1068] Migrate history call to use new discovery API endpoint

### DIFF
--- a/src/containers/history-page/store/lineups/tracks/sagas.js
+++ b/src/containers/history-page/store/lineups/tracks/sagas.js
@@ -34,7 +34,7 @@ function* getHistoryTracks() {
       if (trackMetadata) {
         lineupTracks.push({
           ...trackMetadata,
-          dateListened: activity.track.listenDate
+          dateListened: activity.timestamp
         })
       }
     })

--- a/src/containers/history-page/store/lineups/tracks/sagas.js
+++ b/src/containers/history-page/store/lineups/tracks/sagas.js
@@ -1,37 +1,40 @@
 import { keyBy } from 'lodash'
-import { call } from 'redux-saga/effects'
+import { call, select } from 'redux-saga/effects'
 
 import Kind from 'common/models/Kind'
+import { getUserId } from 'common/store/account/selectors'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import {
   PREFIX,
   tracksActions
 } from 'containers/history-page/store/lineups/tracks/actions'
 import AudiusBackend from 'services/AudiusBackend'
+import apiClient from 'services/audius-api-client/AudiusAPIClient'
 import { LineupSagas } from 'store/lineup/sagas'
 
 function* getHistoryTracks() {
   try {
-    const listenHistory = yield call(AudiusBackend.getListenHistoryTracks)
-    const uniqueTrackIds = [
-      ...new Set(listenHistory.tracks.map(t => t.trackId))
-    ]
-    const tracks = yield call(AudiusBackend.getAllTracks, {
-      offset: 0,
-      limit: uniqueTrackIds.length,
-      idsArray: uniqueTrackIds
+    const currentUserId = yield select(getUserId)
+    const activity = yield apiClient.getUserTrackHistory({
+      currentUserId,
+      userId: currentUserId,
+      limit: 100
     })
-    const processedTracks = yield call(processAndCacheTracks, tracks)
+
+    const processedTracks = yield call(
+      processAndCacheTracks,
+      activity.map(a => a.track)
+    )
     const processedTracksMap = keyBy(processedTracks, 'track_id')
 
     const lineupTracks = []
-    listenHistory.tracks.forEach((track, i) => {
-      const trackMetadata = processedTracksMap[track.trackId]
+    activity.forEach((activity, i) => {
+      const trackMetadata = processedTracksMap[activity.track.track_id]
       // Prevent history for invalid tracks from getting into the lineup.
       if (trackMetadata) {
         lineupTracks.push({
           ...trackMetadata,
-          dateListened: track.listenDate
+          dateListened: activity.track.listenDate
         })
       }
     })

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -880,20 +880,6 @@ class AudiusBackend {
     }
   }
 
-  static async getListenHistoryTracks(limit = 100, offset = 0) {
-    await waitForLibsInit()
-    try {
-      const trackListens = await audiusLibs.Track.getListenHistoryTracks(
-        limit,
-        offset
-      )
-
-      return trackListens
-    } catch (err) {
-      console.error(err.message)
-    }
-  }
-
   static async repostTrack(trackId) {
     try {
       return audiusLibs.Track.addTrackRepost(trackId)


### PR DESCRIPTION
### Description

Proper history endpoint support was added in 
https://github.com/AudiusProject/audius-protocol/pull/2045

Migrate AudiusBackend history API to APIClient, add support for history & update the lineup

Note: the new endpoint supports up to limit =500, but this PR keeps parity at limit =100 for the history page. In the future, we will make the table paginate, but will probably not store indefinite history

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Client locally vs. prod & verified history results are consistent.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
