### PR TITLE
Fix init track event

### DIFF
--- a/src/store/analytics/providers/amplitude.ts
+++ b/src/store/analytics/providers/amplitude.ts
@@ -28,7 +28,7 @@ export const init = async () => {
         .init(AMP_API_KEY, undefined, { apiEndpoint: AMPLITUDE_PROXY })
       amp = amplitude
       const source = getSource()
-      amp.track(Name.SESSION_START, { source })
+      amp.getInstance().logEvent(Name.SESSION_START, { source })
     }
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
### Description
Bug in the amplitude tracking
The init event was not called correctly - bug from #665 
NOTE: we did not turn on the amplitude feature flag yet, so this code path is not executed

### Dragons
none

### How Has This Been Tested?
ran locally against prod and manually forced amplitude instead of using the feature flag

### How will this change be monitored?
By looking for the amplitude events for init