### PR TITLE
Up resource class and pin node version for probers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,8 @@ jobs:
   test-staging:
     working_directory: ~/
     docker:
-      - image: circleci/node:latest-browsers
+      - image: circleci/node:14.18-browsers
+    resource_class: large
     steps:
       - run:
           name: download probers


### PR DESCRIPTION
### Description

Following along w/ changes in:
https://github.com/AudiusProject/probers/commit/269c32effb4b932b7e60fe57837af3b405bc80ef
This PR ups the resource class to run the web driver test and fixes the node version to 14 for consistency.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

only ci

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Ran probers

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
