### PR TITLE
Remove unnecessary route comparison on ProfilePage mount

### DIFF
--- a/src/containers/profile-page/ProfilePageProvider.tsx
+++ b/src/containers/profile-page/ProfilePageProvider.tsx
@@ -127,11 +127,11 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
 
     // Switching from profile page => profile page
     this.unlisten = this.props.history.listen((location, action) => {
-      // If changing profiles or "POP" on router (with goBack, the pathnames are equal)
-      const profileHandle1 = getPathname(this.props.location).split('/')[1]
-      const profileHandle2 = getPathname(location).split('/')[1]
-
-      if (profileHandle1 !== profileHandle2 || action === 'POP') {
+      // If changing pages or "POP" on router (with goBack, the pathnames are equal)
+      if (
+        getPathname(this.props.location) !== getPathname(location) ||
+        action === 'POP'
+      ) {
         this.props.resetProfile()
         this.props.resetArtistTracks()
         this.props.resetUserFeedTracks()


### PR DESCRIPTION
### Description
Remove unnecessary profile handle check on profile page mount to fix tracks not loading when hitting the back button

### How Has This Been Tested?

Manually tested. tracks load
