### PR TITLE
Ms download tracks mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,14 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "proper-url-join": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/proper-url-join/-/proper-url-join-1.2.0.tgz",
+          "integrity": "sha512-diW+mPxH2TRtX4bNGczzyryvlk42BmzDdlq8qn5JDSktP0w/mZZG1SwexlbkATdikgN68CSUkYVzmDiw00nL3Q==",
+          "requires": {
+            "query-string": "^5.0.1"
+          }
         }
       }
     },
@@ -2077,15 +2085,33 @@
       }
     },
     "@ethersproject/web": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
+      "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
       "requires": {
-        "@ethersproject/base64": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
+        "@ethersproject/base64": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
+      },
+      "dependencies": {
+        "@ethersproject/base64": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
+          "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
+          "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        }
       }
     },
     "@ethersproject/wordlists": {
@@ -12566,6 +12592,18 @@
             "@ethersproject/logger": "^5.4.0"
           }
         },
+        "@ethersproject/web": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+          "requires": {
+            "@ethersproject/base64": "^5.4.0",
+            "@ethersproject/bytes": "^5.4.0",
+            "@ethersproject/logger": "^5.4.0",
+            "@ethersproject/properties": "^5.4.0",
+            "@ethersproject/strings": "^5.4.0"
+          }
+        },
         "js-sha3": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
@@ -14814,6 +14852,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -23914,11 +23957,29 @@
       }
     },
     "proper-url-join": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/proper-url-join/-/proper-url-join-1.2.0.tgz",
-      "integrity": "sha512-diW+mPxH2TRtX4bNGczzyryvlk42BmzDdlq8qn5JDSktP0w/mZZG1SwexlbkATdikgN68CSUkYVzmDiw00nL3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/proper-url-join/-/proper-url-join-2.1.1.tgz",
+      "integrity": "sha512-40x6taKMwsDn4TrWx4YvnVxv5mO1O9KUrbK/jx8N0oDYf38ZFUK/OHNSAwTvu7Aj+cQcjBuf5aDh5R328YrrXg==",
       "requires": {
-        "query-string": "^5.0.1"
+        "query-string": "^6.3.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "6.14.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+          "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "filter-obj": "^1.1.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+        }
       }
     },
     "proto-list": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14853,11 +14853,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
-    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -23953,32 +23948,6 @@
           "version": "0.10.1",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
           "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
-        }
-      }
-    },
-    "proper-url-join": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/proper-url-join/-/proper-url-join-2.1.1.tgz",
-      "integrity": "sha512-40x6taKMwsDn4TrWx4YvnVxv5mO1O9KUrbK/jx8N0oDYf38ZFUK/OHNSAwTvu7Aj+cQcjBuf5aDh5R328YrrXg==",
-      "requires": {
-        "query-string": "^6.3.0"
-      },
-      "dependencies": {
-        "query-string": {
-          "version": "6.14.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-          "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "filter-obj": "^1.1.0",
-            "split-on-first": "^1.0.0",
-            "strict-uri-encode": "^2.0.0"
-          }
-        },
-        "strict-uri-encode": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "pixi.js": "4.8.9",
     "promise.allsettled": "1.0.4",
     "prop-types": "15.7.2",
-    "proper-url-join": "^2.1.1",
     "raw-loader": "0.5.1",
     "react": "16.13.1",
     "react-beautiful-dnd": "10.0.4",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "pixi.js": "4.8.9",
     "promise.allsettled": "1.0.4",
     "prop-types": "15.7.2",
+    "proper-url-join": "^2.1.1",
     "raw-loader": "0.5.1",
     "react": "16.13.1",
     "react-beautiful-dnd": "10.0.4",

--- a/src/components/track/GiantTrackTile.js
+++ b/src/components/track/GiantTrackTile.js
@@ -346,7 +346,7 @@ class GiantTrackTile extends PureComponent {
   renderDownloadButtons = () => {
     return (
       <DownloadButtons
-        className={styles.downloadButtons}
+        className={styles.downloadButtonsContainer}
         trackId={this.props.trackId}
         isOwner={this.props.isOwner}
         following={this.props.following}

--- a/src/components/track/GiantTrackTile.module.css
+++ b/src/components/track/GiantTrackTile.module.css
@@ -223,8 +223,11 @@
   margin-bottom: 8px;
 }
 
-.downloadButtons {
-  margin-top: 6px !important;
+.downloadButtonsContainer {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    margin-top: 6px;
 }
 
 .verified {

--- a/src/containers/download-buttons/DownloadButtons.module.css
+++ b/src/containers/download-buttons/DownloadButtons.module.css
@@ -60,14 +60,6 @@
   cursor: auto;
 }
 
-
-.downloadButtonsContainer {
-  width: 100%;
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: 14px;
-}
-
 .downloadButtonsContainer.isHidden {
   display: none;
 }

--- a/src/containers/download-buttons/DownloadButtons.tsx
+++ b/src/containers/download-buttons/DownloadButtons.tsx
@@ -139,7 +139,7 @@ const DownloadButtons = ({
 
   return (
     <div
-      className={cn(styles.downloadButtonsContainer, {
+      className={cn({
         [className!]: !!className,
         [styles.isHidden]: isHidden
       })}

--- a/src/containers/track-page/components/mobile/TrackHeader.module.css
+++ b/src/containers/track-page/components/mobile/TrackHeader.module.css
@@ -222,6 +222,15 @@
   margin: -4px 0px 0px 4px;
 }
 
+/* Download Buttons Container */
+.downloadButtonsContainer {
+  border-top: 1px solid var(--neutral-light-7);
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 16px 0px;
+}
+
 /* Tags */
 .tags {
   border-top: 1px solid var(--neutral-light-7);
@@ -229,7 +238,7 @@
   display: inline-flex;
   justify-content: center;
   flex-wrap: wrap;
-  padding: 24px 0px 24px;
+  padding: 16px 0px;
 }
 
 .tag {

--- a/src/containers/track-page/components/mobile/TrackHeader.tsx
+++ b/src/containers/track-page/components/mobile/TrackHeader.tsx
@@ -232,9 +232,10 @@ const TrackHeader = ({
     )
   }
 
-  const renderHiddenDownloadButtons = () => {
+  const renderDownloadButtons = () => {
     return (
       <DownloadButtons
+        className={styles.downloadButtonsContainer}
         trackId={trackId}
         isOwner={isOwner}
         following={isFollowing}
@@ -358,8 +359,8 @@ const TrackHeader = ({
       >
         {renderTrackLabels()}
       </div>
+      {renderDownloadButtons()}
       {renderTags()}
-      {renderHiddenDownloadButtons()}
     </div>
   )
 }

--- a/src/containers/track-page/components/mobile/TrackHeader.tsx
+++ b/src/containers/track-page/components/mobile/TrackHeader.tsx
@@ -6,7 +6,7 @@ import Linkify from 'linkifyjs/react'
 
 import placeholderArt from 'assets/img/imageBlank2x.png'
 import { Name } from 'common/models/Analytics'
-import { ID } from 'common/models/Identifiers'
+import { CID, ID } from 'common/models/Identifiers'
 import { SquareSizes, CoverArtSizes } from 'common/models/ImageSizes'
 import { FieldVisibility, Remix } from 'common/models/Track'
 import { OverflowAction } from 'common/store/ui/mobile-overflow-menu/types'
@@ -99,6 +99,12 @@ type TrackHeaderProps = {
   onShare: () => void
   onSave: () => void
   onRepost: () => void
+  onDownload: (
+    trackId: ID,
+    cid: CID,
+    category?: string,
+    parentTrackId?: ID
+  ) => void
   goToFavoritesPage: (trackId: ID) => void
   goToRepostsPage: (trackId: ID) => void
 }
@@ -136,6 +142,7 @@ const TrackHeader = ({
   onShare,
   onSave,
   onRepost,
+  onDownload,
   onClickMobileOverflow,
   goToFavoritesPage,
   goToRepostsPage
@@ -228,12 +235,10 @@ const TrackHeader = ({
   const renderHiddenDownloadButtons = () => {
     return (
       <DownloadButtons
-        isHidden
         trackId={trackId}
         isOwner={isOwner}
         following={isFollowing}
-        // Downloads not supported on mobile, do nothing
-        onDownload={() => {}}
+        onDownload={onDownload}
       />
     )
   }

--- a/src/containers/track-page/components/mobile/TrackPage.tsx
+++ b/src/containers/track-page/components/mobile/TrackPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext } from 'react'
 
-import { ID } from 'common/models/Identifiers'
+import { CID, ID } from 'common/models/Identifiers'
 import { Track } from 'common/models/Track'
 import { User } from 'common/models/User'
 import { OverflowAction } from 'common/store/ui/mobile-overflow-menu/types'
@@ -53,6 +53,13 @@ export type OwnProps = {
   ) => void
 
   onSaveTrack: (isSaved: boolean, trackId: ID) => void
+  onDownloadTrack: (
+    trackId: ID,
+    cid: CID,
+    creatorNodeEndpoints: string,
+    category?: string,
+    parentTrackId?: ID
+  ) => void
   // Tracks Lineup Props
   tracks: LineupState<{ id: ID }>
   currentQueueItem: QueueItem
@@ -81,6 +88,7 @@ const TrackPage = ({
   goToAllRemixesPage,
   goToParentRemixesPage,
   onSaveTrack,
+  onDownloadTrack,
   onHeroRepost,
   onClickMobileOverflow,
 
@@ -134,6 +142,24 @@ const TrackPage = ({
     <div className={styles.lineupHeader}>{messages.originalTrack}</div>
   )
 
+  const onDownload = (
+    trackId: ID,
+    cid: CID,
+    category?: string,
+    parentTrackId?: ID
+  ) => {
+    if (!user) return
+    const { creator_node_endpoint } = user
+    if (!creator_node_endpoint) return
+    onDownloadTrack(
+      trackId,
+      cid,
+      creator_node_endpoint,
+      category,
+      parentTrackId
+    )
+  }
+
   const renderMoreByTitle = () =>
     (defaults.remixParentTrackId && entries.length > 2) ||
     (!defaults.remixParentTrackId && entries.length > 1) ? (
@@ -182,6 +208,7 @@ const TrackPage = ({
             onSave={onSave}
             onShare={onShare}
             onRepost={onRepost}
+            onDownload={onDownload}
             isUnlisted={defaults.isUnlisted}
             isRemix={!!defaults.remixParentTrackId}
             fieldVisibility={defaults.fieldVisibility}

--- a/src/services/audius-backend/TrackDownload.js
+++ b/src/services/audius-backend/TrackDownload.js
@@ -1,4 +1,7 @@
+import urlJoin from 'proper-url-join'
+
 import * as schemas from 'schemas'
+import { DownloadTrackMessage } from 'services/native-mobile-interface/downloadTrack'
 
 import { waitForLibsInit } from './eagerLoadUtils'
 
@@ -13,6 +16,21 @@ class TrackDownload {
       creatorNodeEndpoints,
       filename
     )
+  }
+
+  static async downloadTrackMobile(cid, creatorNodeGateways, filename, title) {
+    if (urlJoin && urlJoin.default) {
+      urlJoin = urlJoin.default
+    }
+    const urls = creatorNodeGateways.map(gateway =>
+      urlJoin(gateway, cid, { query: { filename } })
+    )
+
+    const message = new DownloadTrackMessage({
+      title: title,
+      urls: urls
+    })
+    message.send()
   }
 
   /**

--- a/src/services/audius-backend/TrackDownload.js
+++ b/src/services/audius-backend/TrackDownload.js
@@ -1,5 +1,3 @@
-import urlJoin from 'proper-url-join'
-
 import * as schemas from 'schemas'
 import { DownloadTrackMessage } from 'services/native-mobile-interface/downloadTrack'
 
@@ -19,11 +17,8 @@ class TrackDownload {
   }
 
   static async downloadTrackMobile(cid, creatorNodeGateways, filename, title) {
-    if (urlJoin && urlJoin.default) {
-      urlJoin = urlJoin.default
-    }
-    const urls = creatorNodeGateways.map(gateway =>
-      urlJoin(gateway, cid, { query: { filename } })
+    const urls = creatorNodeGateways.map(
+      gateway => new URL(`${gateway}${cid}?filename=${filename}`)
     )
 
     const message = new DownloadTrackMessage({

--- a/src/services/native-mobile-interface/downloadTrack.ts
+++ b/src/services/native-mobile-interface/downloadTrack.ts
@@ -1,0 +1,8 @@
+import { NativeMobileMessage } from './helpers'
+import { MessageType } from './types'
+
+export class DownloadTrackMessage extends NativeMobileMessage {
+  constructor(downloadProps: { title: string; urls: string }) {
+    super(MessageType.DOWNLOAD_TRACK, { ...downloadProps, saveToFiles: true })
+  }
+}

--- a/src/services/native-mobile-interface/types.ts
+++ b/src/services/native-mobile-interface/types.ts
@@ -105,6 +105,9 @@ export enum MessageType {
   // Share
   SHARE_MESSAGE = 'share',
 
+  // Download
+  DOWNLOAD_TRACK = 'download-track',
+
   // Navigation
   ON_FIRST_PAGE = 'nav-on-first-page',
   NOT_ON_FIRST_PAGE = 'nav-not-on-first-page',

--- a/src/store/social/tracks/sagas.ts
+++ b/src/store/social/tracks/sagas.ts
@@ -598,7 +598,18 @@ function* watchDownloadTrack() {
     const endpoints = action.creatorNodeEndpoints
       .split(',')
       .map(endpoint => `${endpoint}/ipfs/`)
-    yield call(TrackDownload.downloadTrack, action.cid, endpoints, filename)
+
+    if (NATIVE_MOBILE) {
+      yield call(
+        TrackDownload.downloadTrackMobile,
+        action.cid,
+        endpoints,
+        filename,
+        track.title
+      )
+    } else {
+      yield call(TrackDownload.downloadTrack, action.cid, endpoints, filename)
+    }
   })
 }
 


### PR DESCRIPTION
### Description
Trigger a mobile download onto audius-mobile-client when clicking the "download" button on the track page. 
- Create new type of message: DownloadTrackMessage
- When download button is clicked -> send that message to audius-mobile-client which will handle the rest. 

Designs
https://www.figma.com/file/ii6uNAdGGoQ7X7p7cENGhf/Mobile-Download-Buttons?node-id=101%3A141

### Dragons
- Easier to review by commit
- Drawer functionality was fully moved to the audius-mobile-client

### How Has This Been Tested?
Running through the download track flow from both web and mobile. See [MobilePR](https://github.com/AudiusProject/audius-mobile-client/pull/180) for more testing.  

Making sure the UI for the buttons looks good. 
| | Web | Mobile |
|-- | -- | -- |
| One button |![Screen Shot 2021-12-04 at 3 46 38 PM](https://user-images.githubusercontent.com/12490332/145494417-4b4eb6f7-53f2-45ea-8f47-d3fc954be602.png)|![img1](https://user-images.githubusercontent.com/12490332/145494399-ec0b4f3a-f5ae-4c99-aa4a-4b4bdf9de12e.png)
| Two buttons |![Img3](https://user-images.githubusercontent.com/12490332/145494312-5a38e2e8-1c93-4c01-8e44-9f5301fe6069.png)|![img4](https://user-images.githubusercontent.com/12490332/145494280-75fff7fa-faf8-4003-9e88-89fb0c7629dd.png)| 

### How will this change be monitored?


For features that are critical or could fail silently please describe the monitoring/alerting being added.
