### PR TITLE
Add /ipfs to UM cid fetch

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -215,8 +215,7 @@ const fetchImageCID = async (cid, creatorNodeGateways = [], cache = true) => {
     return CIDCache.get(cid)
   }
 
-  creatorNodeGateways.push(USER_NODE)
-
+  creatorNodeGateways.push(`${USER_NODE}/ipfs`)
   const primary = creatorNodeGateways[0]
   if (primary) {
     // Attempt to fetch/load the image using the first creator node gateway


### PR DESCRIPTION
### Description

Fetching image cid was incorrect
![image](https://user-images.githubusercontent.com/60366641/146252950-e38bab93-007d-474a-8e79-21e594613a91.png)

This PR is to add the ipfs gateway in front of UM.

fetching ipfs gateways on client console.log results:

old:
(4)['https://creatornode10.staging.audius.co/ipfs/', 'https://creatornode5.staging.audius.co/ipfs/', 'https://creatornode7.staging.audius.co/ipfs/', **'https://usermetadata.staging.audius.co'**]


new:
(4)['https://creatornode10.staging.audius.co/ipfs/', 'https://creatornode5.staging.audius.co/ipfs/', 'https://creatornode7.staging.audius.co/ipfs/', **'https://usermetadata.staging.audius.co/ipfs**']

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?
Probably not. this potential bug has been in place for a year now

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

ran local dapp against stage

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

monitoring logs