### PR TITLE
Update configureLocalEnv.js to use new name for discovery

### DIFF
--- a/scripts/configureLocalEnv.js
+++ b/scripts/configureLocalEnv.js
@@ -22,8 +22,7 @@ try {
   const solConfigFile = require(path.join(homeDir, AUDIUS_SOL_CONFIG))
 
   const REACT_APP_ENVIRONMENT = 'development'
-  const REACT_APP_EAGER_DISCOVERY_NODES =
-    'http://audius-disc-prov_web-server_1:5000'
+  const REACT_APP_EAGER_DISCOVERY_NODES = 'http://dn1_web-server_1:5000'
   const REACT_APP_IDENTITY_SERVICE = `http://${HOST}:7000`
   const REACT_APP_USER_NODE = 'http://cn-um_creator-node_1:4099'
 


### PR DESCRIPTION
### Description

`audius-disc-prov_web-server_1` isn't used anywhere now that we can have multiple disc provs.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
