### PR TITLE
Fix bug to make download buttons show up in vertical alignment

### DIFF
--- a/src/common/store/cache/users/sagas.js
+++ b/src/common/store/cache/users/sagas.js
@@ -280,7 +280,6 @@ function* watchFetchProfilePicture() {
           yield put(
             cacheActions.update(Kind.USERS, [{ id: userId, metadata: user }])
           )
-          
         }
       }
     } catch (e) {

--- a/src/containers/download-buttons/DownloadButtons.tsx
+++ b/src/containers/download-buttons/DownloadButtons.tsx
@@ -132,16 +132,18 @@ const DownloadButtons = ({
   isOwner,
   following,
   onDownload,
-  isHidden,
   className
 }: DownloadButtonsProps) => {
   const buttons = useButtons(trackId, onDownload, isOwner, following)
+  const shouldHide = buttons.length === 0
+  if (shouldHide) {
+    return null
+  }
 
   return (
     <div
       className={cn({
-        [className!]: !!className,
-        [styles.isHidden]: isHidden
+        [className!]: !!className
       })}
     >
       {buttons.map(({ label, state, type, onClick }) => (

--- a/src/containers/track-page/components/mobile/TrackHeader.module.css
+++ b/src/containers/track-page/components/mobile/TrackHeader.module.css
@@ -227,7 +227,8 @@
   border-top: 1px solid var(--neutral-light-7);
   width: 100%;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   padding: 16px 0px;
 }
 


### PR DESCRIPTION
### Description
Fix two bugs
1. Don't show download buttons container when no download button
2. Horizontally stack download buttons when there are multiple

### Dragons

### How Has This Been Tested?
|--|Mobile|Desktop|
|--|--|--|
|No Download Track|![1](https://user-images.githubusercontent.com/12490332/146433471-e0e4bc93-132c-4e4d-ab09-07d8ed7219c3.png)|![Screen Shot 2021-12-16 at 11 00 35 AM](https://user-images.githubusercontent.com/12490332/146433558-9c92c470-eaf2-4bb1-9d49-bf8eb1ceed48.png)|
|Multiple Download Tracks|![Screen Shot 2021-12-16 at 10 59 14 AM](https://user-images.githubusercontent.com/12490332/146433510-046a50cd-c9a5-475a-a782-90803dbe0b5a.png)|![Screen Shot 2021-12-16 at 11 00 41 AM](https://user-images.githubusercontent.com/12490332/146433639-e55e2515-6b38-4ada-8789-226ae060459b.png)|

### How will this change be monitored?
