### PR TITLE
Stem files don't have a track.title, use filename instead

### DIFF
--- a/src/services/audius-backend/TrackDownload.js
+++ b/src/services/audius-backend/TrackDownload.js
@@ -16,13 +16,13 @@ class TrackDownload {
     )
   }
 
-  static async downloadTrackMobile(cid, creatorNodeGateways, filename, title) {
+  static async downloadTrackMobile(cid, creatorNodeGateways, filename) {
     const urls = creatorNodeGateways.map(
       gateway => new URL(`${gateway}${cid}?filename=${filename}`)
     )
 
     const message = new DownloadTrackMessage({
-      title: title,
+      title: filename.split('.').slice(0, -1).join(''),
       urls: urls
     })
     message.send()

--- a/src/store/social/tracks/sagas.ts
+++ b/src/store/social/tracks/sagas.ts
@@ -604,8 +604,7 @@ function* watchDownloadTrack() {
         TrackDownload.downloadTrackMobile,
         action.cid,
         endpoints,
-        filename,
-        track.title
+        filename
       )
     } else {
       yield call(TrackDownload.downloadTrack, action.cid, endpoints, filename)


### PR DESCRIPTION
### Description
Previously: No filename would show up when downloading stem version of a file on mobile
After this change: Filename shows up and track is saved to the user-specified directory

This was happening because stem files don't have a track name associated with them, they inherit the track name from the parent track file. This has already been incorporated into the "filename" within src/store/social/tracks/sagas.ts 

### Dragons

### How Has This Been Tested?
Tested downloading instrumental version & normal version on mobile. Filename now shows up. 

### How will this change be monitored?

