### PR TITLE
Add current discovery node to preview

### DIFF
--- a/src/containers/confirmer-preview/ConfirmerPreview.module.css
+++ b/src/containers/confirmer-preview/ConfirmerPreview.module.css
@@ -10,6 +10,7 @@
   display: flex;
   flex-direction: column;
   padding: 8px;
+  border: 1px solid var(--neutral-light-6);
 }
 
 .title {

--- a/src/containers/discovery-node-selection/DiscoveryNodeSelection.module.css
+++ b/src/containers/discovery-node-selection/DiscoveryNodeSelection.module.css
@@ -11,11 +11,17 @@
   flex-direction: column;
   padding: 8px;
   text-align: center;
+  border: 1px solid var(--neutral-light-6);
+}
+
+.current {
+  margin-bottom: 16px;
+  font-weight: var(--font-medium);
 }
 
 .title {
-  font-size: 20;
-  font-weight: bold;
+  font-size: var(--font-large);
+  font-weight: var(--font-bold);
   width: 100%;
   margin: 10px 0;
 }

--- a/src/containers/discovery-node-selection/DiscoveryNodeSelection.tsx
+++ b/src/containers/discovery-node-selection/DiscoveryNodeSelection.tsx
@@ -2,9 +2,12 @@ import React, { ChangeEvent, useState } from 'react'
 
 import { Button, ButtonType } from '@audius/stems'
 
+import Input from 'components/data-entry/Input'
 import { useDevModeHotkey } from 'hooks/useHotkey'
 
 import styles from './DiscoveryNodeSelection.module.css'
+
+const localStorageKey = '@audius/libs:discovery-node-timestamp'
 
 const DiscoveryNodeSelection = () => {
   const isEnabled = useDevModeHotkey(68 /* d */)
@@ -21,10 +24,7 @@ const DiscoveryNodeSelection = () => {
         endpoint: url,
         timestamp: Date.now()
       }
-      window.localStorage.setItem(
-        '@audius/libs:discovery-node-timestamp',
-        JSON.stringify(item)
-      )
+      window.localStorage.setItem(localStorageKey, JSON.stringify(item))
       setEndpoint('')
       setSuccess(true)
       setError(false)
@@ -34,17 +34,27 @@ const DiscoveryNodeSelection = () => {
     }
   }
 
+  const getDiscoveryNode = () => {
+    const storedItem = window.localStorage.getItem(localStorageKey)
+    const { endpoint } = JSON.parse(storedItem || '{}') as {
+      endpoint: string
+      timestamp: string
+    }
+    return endpoint
+  }
+
   return isEnabled ? (
     <div className={styles.container}>
       <div className={styles.title}>Discovery Node Selection Preview</div>
       <div className={styles.inputContainer}>
-        <input
+        <div className={styles.current}>
+          {`Current discovery node is: ${getDiscoveryNode()}`}
+        </div>
+        <Input
           // not using messages variable because this is not intended for end user
-          placeholder='Please enter a valid discovery node'
+          placeholder='Enter a valid discovery node to change'
           value={endpoint}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setEndpoint(e.target.value.trim())
-          }
+          onChange={(value: string) => setEndpoint(value.trim())}
         />
 
         <Button


### PR DESCRIPTION
### Description

Add current to discovery preview
<img width="479" alt="Screen Shot 2021-12-20 at 2 53 24 PM" src="https://user-images.githubusercontent.com/2731362/146843309-9cad09a9-dcd7-49d0-9af0-a4c93e53dc7f.png">

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Locally vs. stage

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
