### PR TITLE
[AUD-1035] Fix bug with skeletons not loading on trending

### DIFF
--- a/src/containers/lineup/LineupProvider.tsx
+++ b/src/containers/lineup/LineupProvider.tsx
@@ -562,7 +562,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
     if (
       isMetadataLoading &&
       lineup.hasMore &&
-      tiles.length < (count !== undefined ? count : lineupCount) &&
+      tiles.length < (count !== undefined ? count : MAX_TILES_COUNT) &&
       (!limit || tiles.length !== limit)
     ) {
       // Calculate the number of loading tiles to display: total # requested - # rendered - # deleted

--- a/src/containers/profile-page/store/lineups/tracks/reducer.js
+++ b/src/containers/profile-page/store/lineups/tracks/reducer.js
@@ -4,7 +4,8 @@ import { initialLineupState } from 'store/lineup/reducer'
 
 const initialState = {
   ...initialLineupState,
-  prefix: PREFIX
+  prefix: PREFIX,
+  containsDeleted: false
 }
 
 const actionsMap = {


### PR DESCRIPTION
### Description
Skeletons were not loading due to change from MAX_TILES_COUNT to lineupCount in the lineup provider. 
Problem was found to be with lineup.hasMore as a result of having containsDeleted = true. This PR fixes that

### Dragons
Skeleton loading throughout the app

### How Has This Been Tested?
Tested by running through trending, feed pages and noticing skeletons show up. 
Tested by going to Artist profile page and see all tracks (hidden + public showing up)

### How will this change be monitored?
