### PR TITLE
[AUD-1037] Send filename instead of title

### DIFF
--- a/src/services/audius-backend/TrackDownload.js
+++ b/src/services/audius-backend/TrackDownload.js
@@ -22,8 +22,8 @@ class TrackDownload {
     )
 
     const message = new DownloadTrackMessage({
-      title: filename.split('.').slice(0, -1).join(''),
-      urls: urls
+      filename,
+      urls
     })
     message.send()
   }

--- a/src/services/native-mobile-interface/downloadTrack.ts
+++ b/src/services/native-mobile-interface/downloadTrack.ts
@@ -2,7 +2,7 @@ import { NativeMobileMessage } from './helpers'
 import { MessageType } from './types'
 
 export class DownloadTrackMessage extends NativeMobileMessage {
-  constructor(downloadProps: { title: string; urls: string }) {
+  constructor(downloadProps: { filename: string; urls: string }) {
     super(MessageType.DOWNLOAD_TRACK, { ...downloadProps, saveToFiles: true })
   }
 }


### PR DESCRIPTION
### Description
QOL fix, send filename instead of title to the mobile-client so the mobile-client doesn't have to generate it.

### Dragons

### How Has This Been Tested?
Ran on iOS simulator and iOS device to ensure download tracks still works

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
