### PR TITLE
Fix user id

### DIFF
--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1220,7 +1220,7 @@ class AudiusAPIClient {
     this._assertInitialized()
     const headers = current_user_id
       ? {
-          'X-User-Id': current_user_id.toString()
+          'X-User-ID': current_user_id.toString()
         }
       : undefined
     const response: Nullable<APIResponse<


### PR DESCRIPTION
### Description

X-User-ID is added in two places and this one was -Id versus -ID. Previously makeRequest never copied headers, now it does, and this leads to `X-User-ID = (val, val)` instead of `X-User-ID = val` if two cases are sent through.

=> API client

{ 'X-User-ID' : 1 }

=> makeRequest

{ 'X-User-ID' : 1, 'X-User-Id': 1 }

=> axios

{ 'x-user-id' : (1, 1) }

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
