### PR TITLE
[AUD-1088] Fix CardLineup layout when only 1-2 cards present

### DIFF
--- a/src/components/card/mobile/Card.module.css
+++ b/src/components/card/mobile/Card.module.css
@@ -1,4 +1,11 @@
+.cardContainerBase {
+  width: 100%;
+  min-width: 172px;
+  max-width: 190px;
+}
+
 .cardContainer {
+  composes: cardContainerBase;
   cursor: pointer;
   position: relative;
   border: 1px solid var(--neutral-light-8);
@@ -13,9 +20,6 @@
   box-shadow: 0 0 1px 0 var(--tile-shadow-1), 0 1px 0 0 var(--tile-shadow-2), 0 2px 5px -2px var(--tile-shadow-3);
   flex: 1;
   min-height: 216px;
-  width: 100%;
-  min-width: 172px;
-  max-width: 190px;
 }
 
 .cardContainer:hover {
@@ -26,6 +30,10 @@
 .cardContainer:active {
   background-color: var(--neutral-light-10);
   box-shadow: 0 0 1px 0 var(--tile-shadow-1), 0 2px 3px -2px var(--tile-shadow-3);
+}
+
+.emptyCardContainer {
+  composes: cardContainerBase;
 }
 
 .tileCoverArtContainer {

--- a/src/components/card/mobile/Card.tsx
+++ b/src/components/card/mobile/Card.tsx
@@ -49,6 +49,8 @@ const CollectionImage = (props: { id: ID; imageSize: CoverArtSizes }) => {
   return <DynamicImage wrapperClassName={styles.coverArt} image={image} />
 }
 
+export const EmptyCard = () => <div className={styles.emptyCardContainer} />
+
 type CardProps = {
   className?: string
   id: ID

--- a/src/containers/lineup/CardLineup.module.css
+++ b/src/containers/lineup/CardLineup.module.css
@@ -18,6 +18,8 @@
   margin-bottom: 5px;
 }
 
-.emptyMobileContainer {
-  width: 174px;
+.emptyMobileCard {
+  width: 100%;
+  min-width: 174px;
+  max-width: 190px;
 }

--- a/src/containers/lineup/CardLineup.tsx
+++ b/src/containers/lineup/CardLineup.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 
 import cn from 'classnames'
 import { connect } from 'react-redux'
@@ -51,8 +51,27 @@ const DesktopCardContainer = ({
   )
 }
 
+const EmptyMobileCard = () => (
+  <div className={styles.mobileCardContainer}>
+    <div className={styles.emptyMobileCard} />
+  </div>
+)
+
 const MobileCardContainer = ({ cards, containerClassName }: OwnProps) => {
-  const emptyMobileCard = cards.length % 2 === 1
+  let emptyCards: ReactElement | null = null
+  if (cards.length === 1) {
+    emptyCards = (
+      <>
+        <EmptyMobileCard />
+        <EmptyMobileCard />
+      </>
+    )
+  } else if (cards.length === 2) {
+    emptyCards = <EmptyMobileCard />
+  } else if (cards.length % 2 === 1) {
+    emptyCards = <EmptyMobileCard />
+  }
+
   return (
     <div className={cn(styles.mobileContainer, containerClassName)}>
       {cards.map((card, index) => (
@@ -60,14 +79,7 @@ const MobileCardContainer = ({ cards, containerClassName }: OwnProps) => {
           {card}
         </div>
       ))}
-      {emptyMobileCard ? (
-        <div
-          className={cn(
-            styles.mobileCardContainer,
-            styles.emptyMobileContainer
-          )}
-        ></div>
-      ) : null}
+      {emptyCards}
     </div>
   )
 }

--- a/src/containers/lineup/CardLineup.tsx
+++ b/src/containers/lineup/CardLineup.tsx
@@ -57,21 +57,25 @@ const EmptyMobileCard = () => (
   </div>
 )
 
-const MobileCardContainer = ({ cards, containerClassName }: OwnProps) => {
-  let emptyCards: ReactElement | null = null
-  if (cards.length === 1) {
-    emptyCards = (
+const renderEmptyCards = (cardsLength: number) => {
+  if (cardsLength === 1) {
+    return (
       <>
         <EmptyMobileCard />
         <EmptyMobileCard />
       </>
     )
-  } else if (cards.length === 2) {
-    emptyCards = <EmptyMobileCard />
-  } else if (cards.length % 2 === 1) {
-    emptyCards = <EmptyMobileCard />
   }
+  if (cardsLength === 2) {
+    return <EmptyMobileCard />
+  }
+  if (cardsLength % 2 === 1) {
+    ;<EmptyMobileCard />
+  }
+  return null
+}
 
+const MobileCardContainer = ({ cards, containerClassName }: OwnProps) => {
   return (
     <div className={cn(styles.mobileContainer, containerClassName)}>
       {cards.map((card, index) => (
@@ -79,7 +83,7 @@ const MobileCardContainer = ({ cards, containerClassName }: OwnProps) => {
           {card}
         </div>
       ))}
-      {emptyCards}
+      {renderEmptyCards(cards.length)}
     </div>
   )
 }

--- a/src/containers/lineup/CardLineup.tsx
+++ b/src/containers/lineup/CardLineup.tsx
@@ -71,7 +71,7 @@ const renderEmptyCards = (cardsLength: number) => {
     return <EmptyMobileCard />
   }
   if (cardsLength % 2 === 1) {
-    ;<EmptyMobileCard />
+    return <EmptyMobileCard />
   }
   return null
 }

--- a/src/containers/lineup/CardLineup.tsx
+++ b/src/containers/lineup/CardLineup.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react'
 import cn from 'classnames'
 import { connect } from 'react-redux'
 
+import { EmptyCard } from 'components/card/mobile/Card'
 import CategoryHeader from 'components/general/header/desktop/CategoryHeader'
 import Draggable from 'containers/dragndrop/Draggable'
 import { AppState } from 'store/types'
@@ -53,7 +54,7 @@ const DesktopCardContainer = ({
 
 const EmptyMobileCard = () => (
   <div className={styles.mobileCardContainer}>
-    <div className={styles.emptyMobileCard} />
+    <EmptyCard />
   </div>
 )
 


### PR DESCRIPTION
### Description

When there are two or fewer cards in a CardLineup, or an odd number of cards, the cards render incorrectly due to flex not positioning flex-items in a 2xn grid (the last card tries to take up the whole lower space, centering it). This fix addresses the case for two or fewer cards.

### How Has This Been Tested?

The issue can be reproduced on [staging](https://staging.audius.co/joey), and tested locally using the same user.
