### PR TITLE
Force libs make request on 404 of resource with optimistic api client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.42",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.42.tgz",
-      "integrity": "sha512-8HlG3UbfOjmvEnLUJnZWLI7OEk487m4TpiN9lEXwQGjoIi03Jg/Z24IvdOYlXMHmSjmjU+wMuSy3nT31AChLwQ==",
+      "version": "1.2.43",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.43.tgz",
+      "integrity": "sha512-OQS16G9L2I/o4TdC/qTi+QSgBtuZ92H+wKbRkGOKckmGJvP4ZpY2goFh4G4gOK14ZISafvDUbdCIspJGVlU9pg==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.1.1",
@@ -17536,9 +17536,9 @@
           "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
         },
         "@types/node": {
-          "version": "12.20.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.40.tgz",
-          "integrity": "sha512-RX6hFa0hxkFuktu5629zJEkWK5e0HreW4vpNSLn4nWkOui7CTGCjtKiKpvtZ4QwCZ2Am5uhrb5ULHKNyunYYqg=="
+          "version": "12.20.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
+          "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -23994,9 +23994,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "17.0.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.7.tgz",
-          "integrity": "sha512-1QUk+WAUD4t8iR+Oj+UgI8oJa6yyxaB8a8pHaC8uqM6RrS1qbL7bf3Pwl5rHv0psm2CuDErgho6v5N+G+5fwtQ=="
+          "version": "17.0.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.8.tgz",
+          "integrity": "sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.38",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.42",
+    "@audius/libs": "1.2.43",
     "@audius/stems": "0.3.18",
     "@craco/craco": "6.4.2",
     "@hcaptcha/react-hcaptcha": "0.3.6",

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1368,7 +1368,6 @@ class AudiusAPIClient {
     try {
       const response = await fetch(resource, { headers })
       if (!response.ok) {
-        if (response.status === 404) return null
         throw new Error(response.statusText)
       }
       return response.json()


### PR DESCRIPTION
### Description
Relies on changes from - https://github.com/AudiusProject/audius-protocol/pull/2219
if the optimistic api client sees a 404, have it wait for the libs init and use the libs discovery make request method - which retries on another node

### Dragons

### How Has This Been Tested?
Ran manually

### How will this change be monitored?
