### PR TITLE
Refactor IconButton to use button element

### DIFF
--- a/src/components/general/IconButton.module.css
+++ b/src/components/general/IconButton.module.css
@@ -1,4 +1,5 @@
 .container {
+  all: unset;
   cursor: pointer;
   display: flex;
   opacity: 1;

--- a/src/components/general/IconButton.tsx
+++ b/src/components/general/IconButton.tsx
@@ -26,16 +26,10 @@ const IconButton = forwardRef(
       icon,
       disabled = false
     }: IconButtonProps,
-    ref?: React.Ref<HTMLDivElement>
+    ref?: React.Ref<HTMLButtonElement>
   ) => {
-    const handleClick = (event: React.MouseEvent) => {
-      if (!disabled && onClick) {
-        onClick(event)
-      }
-    }
-
     return (
-      <div
+      <button
         className={cn(
           styles.container,
           className,
@@ -43,10 +37,11 @@ const IconButton = forwardRef(
           { [styles.disabled]: disabled }
         )}
         ref={ref}
-        onClick={handleClick}
+        disabled={disabled}
+        onClick={onClick}
       >
         {icon}
-      </div>
+      </button>
     )
   }
 )


### PR DESCRIPTION
### Description

Small change to ensure icon buttons use the button html attribute. This helps with a11y, and also enables a small refactor to add the `disabled` prop directly to the button element, which is a bit cleaner.

### Dragons

I wanted to separate this pr, since it affects a lot of elements on the page.
