### PR TITLE
[AUD-1196] Add icons/styling options to ActionDrawer

### DIFF
--- a/src/components/action-drawer/ActionDrawer.module.css
+++ b/src/components/action-drawer/ActionDrawer.module.css
@@ -41,6 +41,11 @@
   background-color: var(--neutral-light-9);
 }
 
+.actionIcon {
+  min-width: 35px;
+  display: inline-flex;
+}
+
 .destructiveAction {
   color: var(--accent-red);
 }

--- a/src/components/action-drawer/ActionDrawer.module.css
+++ b/src/components/action-drawer/ActionDrawer.module.css
@@ -42,7 +42,7 @@
 }
 
 .actionIcon {
-  min-width: 35px;
+  min-width: 44px;
   display: inline-flex;
 }
 

--- a/src/components/action-drawer/ActionDrawer.tsx
+++ b/src/components/action-drawer/ActionDrawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 import cn from 'classnames'
 
@@ -6,54 +6,76 @@ import Drawer from 'components/drawer/Drawer'
 import { isDarkMode } from 'utils/theme/theme'
 
 import styles from './ActionDrawer.module.css'
+import { ActionIcon } from './ActionIcon'
 
 type Action = {
   text: string
+  className?: string
+  icon?: ReactNode
   isDestructive?: boolean
 }
 
 type ActionSheetModalProps = {
+  id?: string
   didSelectRow: (index: number) => void
   actions: Action[]
   isOpen: boolean
   onClose: () => void
   title?: string
   renderTitle?: () => React.ReactNode
+  classes?: { actionItem?: string }
 }
 
 // `ActionDrawer` is a drawer that presents a list of clickable rows with text
 const ActionDrawer = ({
+  id,
   didSelectRow,
   actions,
   isOpen,
   onClose,
   title,
-  renderTitle
+  renderTitle,
+  classes = {}
 }: ActionSheetModalProps) => {
   const isDark = isDarkMode()
+  const headerId = id ? `${id}-header` : undefined
 
   return (
     <Drawer onClose={onClose} isOpen={isOpen} shouldClose={!isOpen}>
       <div className={styles.container}>
         <div className={styles.content}>
-          {renderTitle
-            ? renderTitle()
-            : title && <div className={styles.title}>{title}</div>}
-          {actions.map(({ text, isDestructive = false }, index) => (
-            <div
-              key={`${text}-${index}`}
-              onClick={() => {
-                didSelectRow(index)
-              }}
-              className={cn(
-                styles.row,
-                { [styles.darkAction]: isDark },
-                { [styles.destructiveAction]: isDestructive }
-              )}
-            >
-              {text}
-            </div>
-          ))}
+          <div id={headerId}>
+            {renderTitle
+              ? renderTitle()
+              : title && <div className={styles.title}>{title}</div>}
+          </div>
+          <ul aria-labelledby={headerId}>
+            {actions.map(
+              ({ text, isDestructive = false, className, icon }, index) => (
+                <li key={text}>
+                  <div
+                    role='button'
+                    tabIndex={0}
+                    onClick={() => {
+                      didSelectRow(index)
+                    }}
+                    className={cn(
+                      styles.row,
+                      classes.actionItem,
+                      className,
+                      { [styles.darkAction]: isDark },
+                      { [styles.destructiveAction]: isDestructive }
+                    )}
+                  >
+                    {icon ? (
+                      <div className={styles.actionIcon}>{icon}</div>
+                    ) : null}
+                    {text}
+                  </div>
+                </li>
+              )
+            )}
+          </ul>
         </div>
       </div>
     </Drawer>

--- a/src/components/action-drawer/ActionDrawer.tsx
+++ b/src/components/action-drawer/ActionDrawer.tsx
@@ -52,26 +52,25 @@ const ActionDrawer = ({
           <ul aria-labelledby={headerId}>
             {actions.map(
               ({ text, isDestructive = false, className, icon }, index) => (
-                <li key={text}>
-                  <div
-                    role='button'
-                    tabIndex={0}
-                    onClick={() => {
-                      didSelectRow(index)
-                    }}
-                    className={cn(
-                      styles.row,
-                      classes.actionItem,
-                      className,
-                      { [styles.darkAction]: isDark },
-                      { [styles.destructiveAction]: isDestructive }
-                    )}
-                  >
-                    {icon ? (
-                      <div className={styles.actionIcon}>{icon}</div>
-                    ) : null}
-                    {text}
-                  </div>
+                <li
+                  key={text}
+                  role='button'
+                  tabIndex={0}
+                  onClick={() => {
+                    didSelectRow(index)
+                  }}
+                  className={cn(
+                    styles.row,
+                    classes.actionItem,
+                    className,
+                    { [styles.darkAction]: isDark },
+                    { [styles.destructiveAction]: isDestructive }
+                  )}
+                >
+                  {icon ? (
+                    <div className={styles.actionIcon}>{icon}</div>
+                  ) : null}
+                  {text}
                 </li>
               )
             )}


### PR DESCRIPTION
### Description

In order to implement the [ShareModal](https://www.figma.com/file/E2CeYYlz4vc8csivJyJlle/Share-Menu?node-id=501%3A97), the ActionDrawer needs custom styling and icon options.
- Adds custom styling for each action and actions in general
- Reimplements actions to use list and button elements for improved a11y
- Adds optional `id` prop which enables proper list/list-title relationship, improving a11y.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Here is an example leveraging the features in this pr: 
![image](https://user-images.githubusercontent.com/8230000/148303446-1934c741-3ce5-4b1b-a00d-483174bf4291.png)

