### PR TITLE
Remove resumable upload flag

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -465,9 +465,6 @@ class AudiusBackend {
         useTrackContentPolling: remoteConfigInstance.getFeatureEnabled(
           FeatureFlags.USE_TRACK_CONTENT_POLLING
         ),
-        useResumableTrackUpload: remoteConfigInstance.getFeatureEnabled(
-          FeatureFlags.USE_RESUMABLE_TRACK_UPLOAD
-        ),
         preferHigherPatchForPrimary: remoteConfigInstance.getFeatureEnabled(
           FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY
         ),


### PR DESCRIPTION
### Description

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

This PR is to remove the resumable upload flag since the code is now removed in the protocol dir.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Uploaded track with this key removed and was successful

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

If track uploads fail, we have sentry and amplitude to catch errors.
