### PR TITLE
Update audio balances on /audio page

### DIFF
--- a/src/services/wallet-client/WalletClient.ts
+++ b/src/services/wallet-client/WalletClient.ts
@@ -49,12 +49,16 @@ class WalletClient {
       const associatedWallets = await apiClient.getAssociatedWallets({
         userID
       })
+
       if (associatedWallets === null) throw new Error('Unable to fetch wallets')
-      const balances = await Promise.all(
-        associatedWallets.wallets.map(wallet =>
+      const balances = await Promise.all([
+        ...associatedWallets.wallets.map(wallet =>
           AudiusBackend.getAddressTotalStakedBalance(wallet, bustCache)
+        ),
+        ...associatedWallets.sol_wallets.map(wallet =>
+          AudiusBackend.getAddressWAudioBalance(wallet)
         )
-      )
+      ])
 
       const totalBalance = balances.reduce(
         (sum, walletBalance) => sum.add(walletBalance),

--- a/src/store/wallet/sagas.ts
+++ b/src/store/wallet/sagas.ts
@@ -127,8 +127,11 @@ function* fetchBalanceAsync() {
   const localBalanceChange: ReturnType<typeof getLocalBalanceDidChange> = yield select(
     getLocalBalanceDidChange
   )
-  const currentBalance: BNWei = yield call(() =>
+  const currentEthAudioWeiBalance: BNWei = yield call(() =>
     walletClient.getCurrentBalance(/* bustCache */ localBalanceChange)
+  )
+  const currentSolAudioWeiBalance: BNWei = yield call(() =>
+    walletClient.getCurrentWAudioBalance()
   )
   const associatedWalletBalance: BNWei = yield call(() =>
     walletClient.getAssociatedWalletBalance(
@@ -136,10 +139,14 @@ function* fetchBalanceAsync() {
       /* bustCache */ localBalanceChange
     )
   )
-  const totalBalance = currentBalance.add(associatedWalletBalance) as BNWei
+  const audioWeiBalance = currentEthAudioWeiBalance.add(
+    currentSolAudioWeiBalance
+  ) as BNWei
+
+  const totalBalance = audioWeiBalance.add(associatedWalletBalance) as BNWei
   yield put(
     setBalance({
-      balance: weiToString(currentBalance),
+      balance: weiToString(audioWeiBalance),
       totalBalance: weiToString(totalBalance)
     })
   )

--- a/src/store/wallet/sagas.ts
+++ b/src/store/wallet/sagas.ts
@@ -127,12 +127,16 @@ function* fetchBalanceAsync() {
   const localBalanceChange: ReturnType<typeof getLocalBalanceDidChange> = yield select(
     getLocalBalanceDidChange
   )
-  const currentEthAudioWeiBalance: BNWei = yield call(() =>
-    walletClient.getCurrentBalance(/* bustCache */ localBalanceChange)
-  )
-  const currentSolAudioWeiBalance: BNWei = yield call(() =>
-    walletClient.getCurrentWAudioBalance()
-  )
+  const [currentEthAudioWeiBalance, currentSolAudioWeiBalance]: [
+    BNWei,
+    BNWei
+  ] = yield [
+    call(() =>
+      walletClient.getCurrentBalance(/* bustCache */ localBalanceChange)
+    ),
+    call(() => walletClient.getCurrentWAudioBalance())
+  ]
+
   const associatedWalletBalance: BNWei = yield call(() =>
     walletClient.getAssociatedWalletBalance(
       account.user_id,


### PR DESCRIPTION
### Description
Update the total balance on the /audio page to include the solana user bank account balance
Also fixes the associated solana wallet balance 

Closes AUD-1173

NOTE: needs libs change to get balance from root account

### Dragons

### How Has This Been Tested?
Ran locally against prod 

### How will this change be monitored?
