### PR TITLE
[AUD-1218] Add copy-link-to-track action to ShareDrawer

### DIFF
--- a/src/common/store/ui/share-modal/sagas.ts
+++ b/src/common/store/ui/share-modal/sagas.ts
@@ -10,13 +10,13 @@ import { open, requestOpen } from './slice'
 import { RequestOpenAction } from './types'
 
 function* handleRequestOpen(action: RequestOpenAction) {
-  const { trackId } = action.payload
+  const { trackId, source } = action.payload
 
   const track: Track = yield select((state: AppState) =>
     getTrack(state, { id: trackId })
   )
 
-  yield put(open({ track }))
+  yield put(open({ track, source }))
   yield put(setVisibility({ modal: 'Share', visible: true }))
 }
 

--- a/src/common/store/ui/share-modal/selectors.ts
+++ b/src/common/store/ui/share-modal/selectors.ts
@@ -1,0 +1,8 @@
+import { createSelector } from '@reduxjs/toolkit'
+
+import { CommonState } from 'common/store'
+
+const shareModalState = (state: CommonState) => state.ui.shareModal
+
+export const getTrack = createSelector(shareModalState, state => state.track)
+export const getSource = createSelector(shareModalState, state => state.source)

--- a/src/common/store/ui/share-modal/slice.ts
+++ b/src/common/store/ui/share-modal/slice.ts
@@ -10,8 +10,9 @@ const slice = createSlice({
   reducers: {
     requestOpen: (state, action: RequestOpenAction) => {},
     open: (state, action: OpenAction) => {
-      const { track } = action.payload
+      const { track, source } = action.payload
       state.track = track
+      state.source = source
     }
   }
 })

--- a/src/common/store/ui/share-modal/types.ts
+++ b/src/common/store/ui/share-modal/types.ts
@@ -1,16 +1,20 @@
 import { PayloadAction } from '@reduxjs/toolkit'
 
+import { ShareSource } from 'common/models/Analytics'
 import { ID } from 'common/models/Identifiers'
 import { Track } from 'common/models/Track'
 
 export type ShareModalState = {
   track?: Track
+  source?: ShareSource
 }
 
 export type RequestOpenAction = PayloadAction<{
   trackId: ID
+  source: ShareSource
 }>
 
 export type OpenAction = PayloadAction<{
   track: Track
+  source: ShareSource
 }>

--- a/src/components/action-drawer/ActionDrawer.tsx
+++ b/src/components/action-drawer/ActionDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react'
+import React, { MouseEventHandler, ReactNode } from 'react'
 
 import cn from 'classnames'
 
@@ -12,6 +12,7 @@ type Action = {
   className?: string
   icon?: ReactNode
   isDestructive?: boolean
+  onClick?: MouseEventHandler
 }
 
 type ActionSheetModalProps = {
@@ -50,12 +51,16 @@ const ActionDrawer = ({
           </div>
           <ul aria-labelledby={headerId}>
             {actions.map(
-              ({ text, isDestructive = false, className, icon }, index) => (
+              (
+                { text, isDestructive = false, className, icon, onClick },
+                index
+              ) => (
                 <li
                   key={text}
                   role='button'
                   tabIndex={0}
-                  onClick={() => {
+                  onClick={event => {
+                    onClick?.(event)
                     didSelectRow(index)
                   }}
                   className={cn(

--- a/src/containers/share-modal/components/ShareDrawer.module.css
+++ b/src/containers/share-modal/components/ShareDrawer.module.css
@@ -2,3 +2,11 @@
   justify-content: left;
   padding-left: 25px;
 }
+
+.copyLinkAction {
+  color: var(--secondary);
+}
+
+.copyLinkAction svg path {
+  fill: var(--secondary);
+}

--- a/src/containers/share-modal/components/ShareDrawer.tsx
+++ b/src/containers/share-modal/components/ShareDrawer.tsx
@@ -1,17 +1,40 @@
-import React from 'react'
+import React, { useContext } from 'react'
+
+import { IconLink } from '@audius/stems'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { useModalState } from 'common/hooks/useModalState'
+import { shareTrack } from 'common/store/social/tracks/actions'
+import { getSource, getTrack } from 'common/store/ui/share-modal/selectors'
 import ActionDrawer from 'components/action-drawer/ActionDrawer'
+import { ToastContext } from 'components/toast/ToastContext'
+import { SHARE_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
 
 import styles from './ShareDrawer.module.css'
 
 export const ShareDrawer = () => {
   const [isOpen, setIsOpen] = useModalState('Share')
+  const { toast } = useContext(ToastContext)
+  const dispatch = useDispatch()
+  const track = useSelector(getTrack)
+  const source = useSelector(getSource)
 
   return (
     <ActionDrawer
       title='Share Track'
-      actions={[]}
+      actions={[
+        {
+          text: 'Copy Link to Track',
+          icon: <IconLink height={26} width={26} />,
+          className: styles.copyLinkAction,
+          onClick: () => {
+            if (track && source) {
+              dispatch(shareTrack(track.track_id, source))
+              toast('Copied Link to Track', SHARE_TOAST_TIMEOUT_MILLIS)
+            }
+          }
+        }
+      ]}
       didSelectRow={() => {}}
       onClose={() => setIsOpen(false)}
       isOpen={isOpen}


### PR DESCRIPTION
### Description

- Adds copy-link-track action ui to the ShareDrawer
- Extends ActionDrawer to allow each action to provide `onClick` callback to simplify action api
- Adds ShareSource to share slice.
