### PR TITLE
Add 'Claim Your Reward' button text for undisbursed challenges

### DIFF
--- a/src/containers/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/containers/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -32,7 +32,8 @@ const messages = {
   description1: 'Complete tasks to earn $AUDIO tokens!',
   description2:
     'Opportunities to earn $AUDIO will change, so check back often for more chances to earn!',
-  completeLabel: 'COMPLETE'
+  completeLabel: 'COMPLETE',
+  claimReward: 'Claim Your Reward'
 }
 
 type RewardPanelProps = {
@@ -96,7 +97,11 @@ const RewardPanel = ({
       </div>
       <ButtonWithArrow
         className={wm(styles.panelButton)}
-        text={panelButtonText}
+        text={
+          challenge?.is_complete && !challenge?.is_disbursed
+            ? messages.claimReward
+            : panelButtonText
+        }
         onClick={openRewardModal}
         textClassName={styles.panelButtonText}
       />


### PR DESCRIPTION
### Description
Add 'Claim Your Reward' button text for undisbursed challenges

### How Has This Been Tested?

Manually tested.

Complete but undisbursed:
<img width="526" alt="Screen Shot 2022-01-11 at 6 52 26 PM" src="https://user-images.githubusercontent.com/23732287/149039928-9bd8c93e-e3ad-4455-abfe-a7a807680fc4.png">

Complete and disbursed:
<img width="527" alt="Screen Shot 2022-01-11 at 6 52 55 PM" src="https://user-images.githubusercontent.com/23732287/149039930-7aa85a59-360e-463d-843a-e3d41f870d9b.png">
