### PR TITLE
[AUD-1249] Remove extranous shareTikTok references

### DIFF
--- a/src/components/tracks-table/TableOptionsButton.js
+++ b/src/components/tracks-table/TableOptionsButton.js
@@ -22,12 +22,9 @@ class TableOptionsButton extends Component {
       isOwner,
       isOwnerDeactivated,
       isArtistPick,
-      isReposted,
       onRemove,
       removeText,
-      hiddenUntilHover,
-      trackPermalink,
-      isUnlisted
+      hiddenUntilHover
     } = this.props
 
     const removeMenuItem = {
@@ -40,7 +37,6 @@ class TableOptionsButton extends Component {
         type: 'track',
         mount: 'page',
         includeShare: true,
-        includeShareToTikTok: !isUnlisted,
         isOwner,
         isOwnerDeactivated,
         isArtistPick,

--- a/src/containers/now-playing/NowPlaying.tsx
+++ b/src/containers/now-playing/NowPlaying.tsx
@@ -285,8 +285,6 @@ const NowPlaying = g(
       clickOverflow,
       has_current_user_saved,
       has_current_user_reposted,
-      isShareSoundToTikTokEnabled,
-      track,
       onClose
     ])
 


### PR DESCRIPTION
### Description

These variables were missed with the pr to remove all tiktok references in overflow menus: https://github.com/AudiusProject/audius-client/pull/751. 

It's also breaking the build!