### PR TITLE
Fix earn audio balance for total balance

### DIFF
--- a/src/containers/nav/desktop/NavAudio.tsx
+++ b/src/containers/nav/desktop/NavAudio.tsx
@@ -7,7 +7,8 @@ import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'
 import IconNoTierBadge from 'assets/img/tokenBadgeNoTier.png'
 import { FeatureFlags } from 'common/services/remote-config/feature-flags'
 import { getAccountUser } from 'common/store/account/selectors'
-import { formatWei, stringWeiToBN } from 'common/utils/wallet'
+import { getAccountTotalBalance } from 'common/store/wallet/selectors'
+import { formatWei } from 'common/utils/wallet'
 import { audioTierMapPng } from 'containers/user-badges/UserBadges'
 import { useSelectTierInfo } from 'containers/user-badges/hooks'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
@@ -28,8 +29,7 @@ const NavAudio = () => {
 
   const navigate = useNavigateToPage()
   const account = useSelector(getAccountUser)
-  const totalBalance =
-    account && account.balance ? stringWeiToBN(account.balance) : null
+  const totalBalance = useSelector(getAccountTotalBalance)
   const nonNullTotalBalance = totalBalance !== null
   const positiveTotalBalance =
     nonNullTotalBalance && totalBalance!.gt(new BN(0))


### PR DESCRIPTION
### Description
Fixes AUDIO Balance to include solana wrapped wormhole audio in the top left nav

![Screen Shot 2022-01-12 at 9 58 44 AM](https://user-images.githubusercontent.com/7064122/149164866-a361e2a2-5d2a-4ba0-b5c7-d155fdb2501e.png)


Closes AUD-1219

### Dragons


### How Has This Been Tested?
Ran against stage

### How will this change be monitored?
