### PR TITLE
remove polling flag from audiusbackend

### DIFF
--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -462,9 +462,6 @@ class AudiusBackend {
           ? undefined
           : { siteKey: RECAPTCHA_SITE_KEY },
         isServer: false,
-        useTrackContentPolling: remoteConfigInstance.getFeatureEnabled(
-          FeatureFlags.USE_TRACK_CONTENT_POLLING
-        ),
         preferHigherPatchForPrimary: remoteConfigInstance.getFeatureEnabled(
           FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY
         ),


### PR DESCRIPTION
### Description

This is to remove the polling flag, since any libs version >=1.2.46 will not require this flag and default to the async upload.

Followup: remove `USE_TRACK_CONTENT_POLLING` and `USE_RESUMABLE_TRACK_UPLOAD` from feature-flags.ts (when?)

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

There shouldn't be any with the bump in libs. This flag will not be used.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.
- Uploaded this track with local dapp pointed towards staging successfully https://staging.audius.co/testcm123/plain-street-1

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

- Will monitor sentry/amplitude for track upload success rates dropping