### PR TITLE
Add no tier icon to nav audio balance

### DIFF
--- a/src/containers/nav/desktop/NavAudio.tsx
+++ b/src/containers/nav/desktop/NavAudio.tsx
@@ -47,11 +47,14 @@ const NavAudio = () => {
       onClick={() => navigate(AUDIO_PAGE)}
       className={cn(styles.audio, styles.hasBalance, { [styles.show]: true })}
     >
-      {audioBadge &&
+      {audioBadge ? (
         cloneElement(audioBadge, {
           height: 16,
           width: 16
-        })}
+        })
+      ) : (
+        <img alt='no tier' src={IconNoTierBadge} width='16' height='16' />
+      )}
       <span className={styles.audioAmount}>
         {formatWei(totalBalance!, true, 0)}
       </span>


### PR DESCRIPTION
### Description
Adds no tier icon to nav if user does not have a tier

![Screen Shot 2022-01-13 at 9 03 46 AM](https://user-images.githubusercontent.com/7064122/149344441-9394deba-258a-4704-8ab1-d654c29a81d6.png)

Fixes AUD-1267

### Dragons


### How Has This Been Tested?
ran against stage

### How will this change be monitored?
