### PR TITLE
Add profile completion optimistic update and refresh user challenges periodically

### DIFF
--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -18,8 +18,7 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.ATTESTATION_QUORUM_SIZE]: 0,
   [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
   [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 5000,
-  [IntKeys.REWARDS_WALLET_BALANCE_POLLING_FREQ_MS]: 5000,
-  [IntKeys.CHALLENGE_COMPLETION_CHECK_DELAY_MS]: 5000
+  [IntKeys.REWARDS_WALLET_BALANCE_POLLING_FREQ_MS]: 5000
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -18,7 +18,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.ATTESTATION_QUORUM_SIZE]: 0,
   [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
   [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 5000,
-  [IntKeys.REWARDS_WALLET_BALANCE_POLLING_FREQ_MS]: 5000
+  [IntKeys.REWARDS_WALLET_BALANCE_POLLING_FREQ_MS]: 5000,
+  [IntKeys.CHALLENGE_COMPLETION_CHECK_DELAY_MS]: 5000
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -17,7 +17,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.DISCOVERY_NODE_SELECTION_REQUEST_RETRIES]: 5,
   [IntKeys.ATTESTATION_QUORUM_SIZE]: 0,
   [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
-  [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 5000
+  [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 5000,
+  [IntKeys.REWARDS_WALLET_BALANCE_POLLING_FREQ_MS]: 5000
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -16,7 +16,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.DISCOVERY_NODE_SELECTION_REQUEST_TIMEOUT]: 30000,
   [IntKeys.DISCOVERY_NODE_SELECTION_REQUEST_RETRIES]: 5,
   [IntKeys.ATTESTATION_QUORUM_SIZE]: 0,
-  [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5
+  [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
+  [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 5000
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -72,7 +72,12 @@ export enum IntKeys {
   /**
    * The minimum amount of AUDIO needed to be sent
    */
-  MIN_AUDIO_SEND_AMOUNT = 'MIN_AUDIO_SEND_AMOUNT'
+  MIN_AUDIO_SEND_AMOUNT = 'MIN_AUDIO_SEND_AMOUNT',
+
+  /**
+   * The refresh interval in milliseconds for user challenges
+   */
+  CHALLENGE_REFRESH_INTERVAL_MS = 'CHALLENGE_REFRESH_INTERVAL_MS'
 }
 
 export enum BooleanKeys {

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -82,13 +82,7 @@ export enum IntKeys {
   /**
    * Frequency (in ms) to poll for user wallet balance on the audio rewards page
    */
-  REWARDS_WALLET_BALANCE_POLLING_FREQ_MS = 'REWARDS_WALLET_BALANCE_POLLING_FREQ_MS',
-
-  /**
-   * The time delay in milliseconds to wait before checking whether a challenge
-   * for a claim attempt is marked as complete in the discovery provider
-   */
-  CHALLENGE_COMPLETION_CHECK_DELAY_MS = 'CHALLENGE_COMPLETION_CHECK_DELAY_MS'
+  REWARDS_WALLET_BALANCE_POLLING_FREQ_MS = 'REWARDS_WALLET_BALANCE_POLLING_FREQ_MS'
 }
 
 export enum BooleanKeys {

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -82,7 +82,13 @@ export enum IntKeys {
   /**
    * Frequency (in ms) to poll for user wallet balance on the audio rewards page
    */
-  REWARDS_WALLET_BALANCE_POLLING_FREQ_MS = 'REWARDS_WALLET_BALANCE_POLLING_FREQ_MS'
+  REWARDS_WALLET_BALANCE_POLLING_FREQ_MS = 'REWARDS_WALLET_BALANCE_POLLING_FREQ_MS',
+
+  /**
+   * The time delay in milliseconds to wait before checking whether a challenge
+   * for a claim attempt is marked as complete in the discovery provider
+   */
+  CHALLENGE_COMPLETION_CHECK_DELAY_MS = 'CHALLENGE_COMPLETION_CHECK_DELAY_MS'
 }
 
 export enum BooleanKeys {

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -77,7 +77,12 @@ export enum IntKeys {
   /**
    * The refresh interval in milliseconds for user challenges
    */
-  CHALLENGE_REFRESH_INTERVAL_MS = 'CHALLENGE_REFRESH_INTERVAL_MS'
+  CHALLENGE_REFRESH_INTERVAL_MS = 'CHALLENGE_REFRESH_INTERVAL_MS',
+
+  /**
+   * Frequency (in ms) to poll for user wallet balance on the audio rewards page
+   */
+  REWARDS_WALLET_BALANCE_POLLING_FREQ_MS = 'REWARDS_WALLET_BALANCE_POLLING_FREQ_MS'
 }
 
 export enum BooleanKeys {

--- a/src/common/store/pages/audio-rewards/selectors.ts
+++ b/src/common/store/pages/audio-rewards/selectors.ts
@@ -12,8 +12,8 @@ export const getUserChallenges = (state: CommonState) =>
 
 export const getUserChallenge = (
   state: CommonState,
-  challengeId: ChallengeRewardID
-) => state.pages.audioRewards.userChallenges[challengeId]
+  props: { challengeId: ChallengeRewardID }
+) => state.pages.audioRewards.userChallenges[props.challengeId]
 
 export const getUserChallengesLoading = (state: CommonState) =>
   state.pages.audioRewards.loading

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -166,7 +166,10 @@ const slice = createSlice({
     },
     fetchCognitoFlowUrlFailed: state => {
       state.cognitoFlowUrlStatus = Status.ERROR
-    }
+    },
+    refreshUserChallenges: () => {},
+    refreshUserBalance: () => {},
+    reset: () => {}
   }
 })
 
@@ -189,7 +192,10 @@ export const {
   setCognitoFlowStatus,
   fetchCognitoFlowUrl,
   fetchCognitoFlowUrlFailed,
-  fetchCognitoFlowUrlSucceeded
+  fetchCognitoFlowUrlSucceeded,
+  refreshUserChallenges,
+  refreshUserBalance,
+  reset
 } = slice.actions
 
 export default slice

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -72,7 +72,7 @@ const RewardPanel = ({
     ? currentStepCountOverride!
     : challenge?.current_step_count || 0
   const isComplete = shouldOverrideCurrentStepCount
-    ? currentStepCountOverride === stepCount
+    ? currentStepCountOverride >= stepCount
     : !!challenge?.is_complete
 
   return (

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -68,7 +68,9 @@ const RewardPanel = ({
 
   const challenge = userChallenges[id]
   const currentStepCount =
-    currentStepCountOverride || challenge?.current_step_count || 0
+    currentStepCountOverride === undefined
+      ? challenge?.current_step_count || 0
+      : currentStepCountOverride
   const isComplete = !!challenge?.is_complete
 
   return (

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { useSetVisibility } from 'common/hooks/useModalState'
 import { ChallengeRewardID } from 'common/models/AudioRewards'
-import { IntKeys, StringKeys } from 'common/services/remote-config'
+import { StringKeys } from 'common/services/remote-config'
 import {
   getUserChallenges,
   getUserChallengesLoading

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -5,23 +5,23 @@ import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useSetVisibility } from 'common/hooks/useModalState'
+import { ChallengeRewardID } from 'common/models/AudioRewards'
 import { IntKeys, StringKeys } from 'common/services/remote-config'
 import {
   getUserChallenges,
   getUserChallengesLoading
 } from 'common/store/pages/audio-rewards/selectors'
+import {
+  ChallengeRewardsModalType,
+  setChallengeRewardsModalType,
+  reset,
+  refreshUserBalance,
+  refreshUserChallenges
+} from 'common/store/pages/audio-rewards/slice'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
-import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import fillString from 'utils/fillString'
-
-import { ChallengeRewardID } from '../../common/models/AudioRewards'
-import {
-  fetchUserChallenges,
-  ChallengeRewardsModalType,
-  setChallengeRewardsModalType
-} from '../../common/store/pages/audio-rewards/slice'
 
 import styles from './RewardsTile.module.css'
 import ButtonWithArrow from './components/ButtonWithArrow'
@@ -146,8 +146,6 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
   const rewardIds = useRewardIds()
   const userChallengesLoading = useSelector(getUserChallengesLoading)
   const currentStepCountOverrides = useOptimisticChallengeCompletionStepCounts()
-  const refreshInterval = useRemoteVar(IntKeys.CHALLENGE_REFRESH_INTERVAL_MS)
-
   const [haveChallengesLoaded, setHaveChallengesLoaded] = useState(false)
 
   useEffect(() => {
@@ -156,18 +154,14 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
     }
   }, [userChallengesLoading, haveChallengesLoaded])
 
+  // poll for user challenges and user balance to refresh
   useEffect(() => {
-    if (!haveChallengesLoaded) {
-      dispatch(fetchUserChallenges())
-    }
-    const interval = setInterval(() => {
-      dispatch(fetchUserChallenges())
-    }, refreshInterval)
-
+    dispatch(refreshUserChallenges())
+    dispatch(refreshUserBalance())
     return () => {
-      clearInterval(interval)
+      dispatch(reset())
     }
-  }, [dispatch, haveChallengesLoaded, refreshInterval])
+  }, [dispatch])
 
   const openModal = (modalType: ChallengeRewardsModalType) => {
     dispatch(setChallengeRewardsModalType({ modalType }))

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -67,11 +67,13 @@ const RewardPanel = ({
   const openRewardModal = () => openModal(id)
 
   const challenge = userChallenges[id]
-  const currentStepCount =
-    currentStepCountOverride === undefined
-      ? challenge?.current_step_count || 0
-      : currentStepCountOverride
-  const isComplete = !!challenge?.is_complete
+  const shouldOverrideCurrentStepCount = currentStepCountOverride !== undefined
+  const currentStepCount = shouldOverrideCurrentStepCount
+    ? currentStepCountOverride!
+    : challenge?.current_step_count || 0
+  const isComplete = shouldOverrideCurrentStepCount
+    ? currentStepCountOverride === stepCount
+    : !!challenge?.is_complete
 
   return (
     <div className={wm(styles.rewardPanelContainer)} onClick={openRewardModal}>

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -174,7 +174,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const isIncomplete = currentStepCount === 0
   const isInProgress = currentStepCount > 0 && currentStepCount !== stepCount
   const isComplete = shouldOverrideCurrentStepCount
-    ? currentStepCountOverride === stepCount
+    ? currentStepCountOverride >= stepCount
     : !!challenge?.is_complete
   const isDisbursed = challenge?.is_disbursed ?? false
   const specifier = challenge?.specifier ?? ''

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -166,14 +166,16 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
   const currentStepCountOverrides = useOptimisticChallengeCompletionStepCounts()
   const currentStepCountOverride = currentStepCountOverrides[modalType]
-  const currentStepCount =
-    currentStepCountOverride === undefined
-      ? challenge?.current_step_count || 0
-      : currentStepCountOverride
+  const shouldOverrideCurrentStepCount = currentStepCountOverride !== undefined
+  const currentStepCount = shouldOverrideCurrentStepCount
+    ? currentStepCountOverride!
+    : challenge?.current_step_count || 0
 
   const isIncomplete = currentStepCount === 0
-  const isComplete = challenge?.is_complete
-  const isInProgress = currentStepCount > 0 && !isComplete
+  const isInProgress = currentStepCount > 0 && currentStepCount !== stepCount
+  const isComplete = shouldOverrideCurrentStepCount
+    ? currentStepCountOverride === stepCount
+    : !!challenge?.is_complete
   const isDisbursed = challenge?.is_disbursed ?? false
   const specifier = challenge?.specifier ?? ''
 

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -172,7 +172,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     : challenge?.current_step_count || 0
 
   const isIncomplete = currentStepCount === 0
-  const isInProgress = currentStepCount > 0 && currentStepCount !== stepCount
+  const isInProgress = currentStepCount > 0 && currentStepCount < stepCount
   const isComplete = shouldOverrideCurrentStepCount
     ? currentStepCountOverride >= stepCount
     : !!challenge?.is_complete

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -165,8 +165,11 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   } = challengeRewardsConfig[modalType]
 
   const currentStepCountOverrides = useOptimisticChallengeCompletionStepCounts()
+  const currentStepCountOverride = currentStepCountOverrides[modalType]
   const currentStepCount =
-    currentStepCountOverrides[modalType] || challenge?.current_step_count || 0
+    currentStepCountOverride === undefined
+      ? challenge?.current_step_count || 0
+      : currentStepCountOverride
 
   const isIncomplete = currentStepCount === 0
   const isComplete = challenge?.is_complete

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -33,6 +33,7 @@ import Tooltip from 'components/tooltip/Tooltip'
 import { ComponentPlacement, MountPlacement } from 'components/types'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
 import { challengeRewardsConfig } from 'pages/audio-rewards-page/config'
+import { useOptimisticChallengeCompletionStepCounts } from 'pages/audio-rewards-page/hooks'
 import { isMobile } from 'utils/clientUtil'
 import { copyToClipboard } from 'utils/clipboardUtil'
 import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
@@ -163,7 +164,10 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     modalButtonInfo
   } = challengeRewardsConfig[modalType]
 
-  const currentStepCount = challenge?.current_step_count || 0
+  const currentStepCountOverrides = useOptimisticChallengeCompletionStepCounts()
+  const currentStepCount =
+    currentStepCountOverrides[modalType] || challenge?.current_step_count || 0
+
   const isIncomplete = currentStepCount === 0
   const isComplete = challenge?.is_complete
   const isInProgress = currentStepCount > 0 && !isComplete

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux'
+
+import { ChallengeRewardID } from 'common/models/AudioRewards'
+import { getCompletionStages } from 'components/profile-progress/store/selectors'
+
+type OptimisticChallengeCompletionResponse = Partial<
+  Record<ChallengeRewardID, number>
+>
+
+export const useOptimisticChallengeCompletionStepCounts = () => {
+  const profileCompletionStages = useSelector(getCompletionStages)
+  const profileCompletion = Object.values(profileCompletionStages).filter(
+    Boolean
+  ).length
+
+  const completion: OptimisticChallengeCompletionResponse = {
+    'profile-completion': profileCompletion
+  }
+
+  return completion
+}

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -1,5 +1,12 @@
 import { User } from '@sentry/browser'
-import { call, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects'
+import {
+  call,
+  put,
+  select,
+  take,
+  takeEvery,
+  takeLatest
+} from 'redux-saga/effects'
 
 import {
   ChallengeRewardID,
@@ -33,9 +40,8 @@ import {
   refreshUserBalance
 } from 'common/store/pages/audio-rewards/slice'
 import { setVisibility } from 'common/store/ui/modals/slice'
-import { increaseBalance } from 'common/store/wallet/slice'
+import { increaseBalance, getBalance } from 'common/store/wallet/slice'
 import { stringAudioToStringWei } from 'common/utils/wallet'
-import { getBalance } from 'common/store/wallet/slice'
 import mobileSagas from 'pages/audio-rewards-page/store/mobileSagas'
 import AudiusBackend from 'services/AudiusBackend'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'


### PR DESCRIPTION
### Description

Add hook that will return optimistic (client state) version of challenge completions. For now it only includes the profile-completion challenge as others are fine as-is.

Also fetch user challenges periodically to get latest DN challenge state for the user.

### Dragons

This means that if the profile completion is complete from the client perspective but incomplete from DN sides, the reward claim will fail. As-is, we just let it fail and the user can try again.

### How Has This Been Tested?

Manually, running client against stage.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
