### PR TITLE
Fix rewards progress exceeds total steps

### DIFF
--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -65,7 +65,8 @@ const messages = {
   inviteLink: 'audius.co/signup?ref=%0',
   qrText: 'Download the App',
   qrSubtext: 'Scan This QR Code with Your Phone Camera',
-  rewardClaimed: 'Reward claimed successfully!'
+  rewardClaimed: 'Reward claimed successfully!',
+  claimError: 'Oops, something’s gone wrong'
 }
 
 type InviteLinkProps = {
@@ -163,8 +164,8 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
   const currentStepCount = challenge?.current_step_count || 0
   const isIncomplete = currentStepCount === 0
-  const isInProgress = currentStepCount > 0 && currentStepCount !== stepCount
-  const isComplete = currentStepCount === stepCount
+  const isComplete = challenge?.is_complete
+  const isInProgress = currentStepCount > 0 && !isComplete
   const isDisbursed = challenge?.is_disbursed ?? false
   const specifier = challenge?.specifier ?? ''
 
@@ -341,7 +342,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         )}
       </div>
       {displayClaimError && (
-        <div className={styles.claimError}>Oops, something’s gone wrong</div>
+        <div className={styles.claimError}>{messages.claimError}</div>
       )}
     </div>
   )


### PR DESCRIPTION
### Description

- Prior to this change, if you referred more than the total number of referrals or uploaded more tracks than required for disbursement, the UI shows eg. 5/3 and as though it is in progress. 
- Also brings the text for the error to the `messages` object

Uses the `challenge.is_complete` member instead to determine challenge completion. Steps should never be complete without the challenge being complete, as they're pulled from the same response object.

### Dragons

N/A

### How Has This Been Tested?

Manually against stage

### How will this change be monitored?

N/A
