### PR TITLE
Decouple HCaptcha modal from Rewards

### DIFF
--- a/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
+++ b/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
@@ -23,15 +23,17 @@ export const HCaptchaModal = () => {
   const [isOpen, setOpen] = useModalState('HCaptcha')
   const dispatch = useDispatch()
 
-  // here, we can also instead use a prop e.g. onClose to handle re-opening the reward modal if we want to decouple rewards and hcaptcha
-  const [, setRewardModalOpen] = useModalState('ChallengeRewardsExplainer')
-
-  const handleClose = useCallback(() => {
-    if (isOpen) {
-      setRewardModalOpen(true)
-      setOpen(false)
-    }
-  }, [setRewardModalOpen, isOpen, setOpen])
+  const handleClose = useCallback(
+    (userInitiated = true) => {
+      if (isOpen) {
+        if (userInitiated) {
+          dispatch(setHCaptchaStatus({ status: HCaptchaStatus.USER_CLOSED }))
+        }
+        setOpen(false)
+      }
+    },
+    [isOpen, setOpen, dispatch]
+  )
 
   const onVerify = useCallback(
     async (token: string) => {
@@ -41,7 +43,7 @@ export const HCaptchaModal = () => {
       } else {
         dispatch(setHCaptchaStatus({ status: HCaptchaStatus.SUCCESS }))
       }
-      handleClose()
+      handleClose(false)
     },
     [dispatch, handleClose]
   )
@@ -49,10 +51,7 @@ export const HCaptchaModal = () => {
   return sitekey ? (
     <ModalDrawer
       isOpen={isOpen}
-      onClose={() => {
-        dispatch(setHCaptchaStatus({ status: HCaptchaStatus.USER_CLOSED }))
-        handleClose()
-      }}
+      onClose={handleClose}
       title={messages.title}
       showTitleHeader
       dismissOnClickOutside

--- a/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
+++ b/src/pages/audio-rewards-page/components/modals/HCaptchaModal.tsx
@@ -25,14 +25,12 @@ export const HCaptchaModal = () => {
 
   const handleClose = useCallback(
     (userInitiated = true) => {
-      if (isOpen) {
-        if (userInitiated) {
-          dispatch(setHCaptchaStatus({ status: HCaptchaStatus.USER_CLOSED }))
-        }
-        setOpen(false)
+      if (userInitiated) {
+        dispatch(setHCaptchaStatus({ status: HCaptchaStatus.USER_CLOSED }))
       }
+      setOpen(false)
     },
-    [isOpen, setOpen, dispatch]
+    [setOpen, dispatch]
   )
 
   const onVerify = useCallback(


### PR DESCRIPTION
### Description

- Decouples the HCaptcha modal from rewards (note: depends on #773 going in in order to keep current behavior)
- fixes minor nit: Use `useCallback` instead of recreating a callback function every render

### Dragons

N/A

### How Has This Been Tested?

Tested manually against stage on top of #773 - HCaptcha modal only reopens if that was the source

### How will this change be monitored?

N/A