### PR TITLE
Add basic helper for typing saga call return types

### DIFF
--- a/src/common/utils/sagaTypeUtils.ts
+++ b/src/common/utils/sagaTypeUtils.ts
@@ -1,0 +1,30 @@
+/**
+ * @file Utility methods for typing Sagas
+ * @author Drew Colthorp (@dcolthorp)
+ * Taken/Adapted from:
+ * https://spin.atomicobject.com/2020/08/06/redux-saga-call-effect/
+ */
+
+import { Effect } from 'redux-saga'
+
+/** Strip any saga effects from a type; this is typically useful to get the return type of a saga. */
+type StripEffects<T> = T extends IterableIterator<infer E>
+  ? E extends Effect
+    ? never
+    : E
+  : never
+
+/** Unwrap the type to be consistent with the runtime behavior of a call. */
+type DecideReturn<T> = T extends Promise<infer R>
+  ? R // If it's a promise, return the promised type.
+  : T extends IterableIterator<any>
+  ? StripEffects<T> // If it's a generator, strip any effects to get the return type.
+  : T // Otherwise, it's a normal function and the return type is unaffected.
+
+/**
+ * Determine the return type of yielding a call effect to the provided function.
+ * @example const foo: CallReturnType<typeof func> = yield call(func, ...)
+ */
+export type CallReturnType<T extends (...args: any[]) => any> = DecideReturn<
+  ReturnType<T>
+>


### PR DESCRIPTION
### Description

Adds a helper to make typing sagas easier.

Related: [AUD-1215](https://linear.app/audius/issue/AUD-1215/explore-typed-redux-saga)

Taken from:
https://spin.atomicobject.com/2020/08/06/redux-saga-call-effect/

Example:
```ts
const foo: CallReturnType<typeof func> = yield call(func, ...)
```

### Dragons

N/A

### How Has This Been Tested?

N/A

### How will this change be monitored?

N/A