### PR TITLE
Remove import of unused React

### DIFF
--- a/src/pages/audio-rewards-page/components/modals/CognitoModal.tsx
+++ b/src/pages/audio-rewards-page/components/modals/CognitoModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { useDispatch } from 'react-redux'
 


### PR DESCRIPTION
### Description

Fixes eslint error for an unused variable. React is unnecessary in this component as we're not even using JSX.