### PR TITLE
Only override current step count if challenge is not complete

### DIFF
--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -67,7 +67,8 @@ const RewardPanel = ({
   const openRewardModal = () => openModal(id)
 
   const challenge = userChallenges[id]
-  const shouldOverrideCurrentStepCount = currentStepCountOverride !== undefined
+  const shouldOverrideCurrentStepCount =
+    !challenge?.is_complete && currentStepCountOverride !== undefined
   const currentStepCount = shouldOverrideCurrentStepCount
     ? currentStepCountOverride!
     : challenge?.current_step_count || 0

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -166,7 +166,8 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
   const currentStepCountOverrides = useOptimisticChallengeCompletionStepCounts()
   const currentStepCountOverride = currentStepCountOverrides[modalType]
-  const shouldOverrideCurrentStepCount = currentStepCountOverride !== undefined
+  const shouldOverrideCurrentStepCount =
+    !challenge?.is_complete && currentStepCountOverride !== undefined
   const currentStepCount = shouldOverrideCurrentStepCount
     ? currentStepCountOverride!
     : challenge?.current_step_count || 0


### PR DESCRIPTION
### Description

Do not optimistically override the challenge current step count if the challenge is already/has already been complete

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

locally against staging

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
