### PR TITLE
Don't reset UserChallenges state on polling refresh

### DIFF
--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -64,10 +64,7 @@ const slice = createSlice({
   name: 'rewards-page',
   initialState,
   reducers: {
-    fetchUserChallenges: state => {
-      state.userChallenges = {}
-      state.loading = true
-    },
+    fetchUserChallenges: state => {},
     fetchUserChallengesSucceeded: (
       state,
       action: PayloadAction<UserChallengesPayload>


### PR DESCRIPTION
### Description

Resetting the state of userChallenges was causing flickering in the Rewards modals.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Locally against stage (web and mobile)

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
