### PR TITLE
Cancel reward claim on modal close

### DIFF
--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -107,13 +107,6 @@ const slice = createSlice({
       const { modalType } = action.payload
       state.challengeRewardsModalType = modalType
     },
-    setClaimStatus: (state, action: PayloadAction<{ status: ClaimStatus }>) => {
-      const { status } = action.payload
-      state.claimStatus = status
-    },
-    resetClaimStatus: state => {
-      state.claimStatus = ClaimStatus.NONE
-    },
     setHCaptchaStatus: (
       state,
       action: PayloadAction<{ status: HCaptchaStatus }>
@@ -128,6 +121,9 @@ const slice = createSlice({
       state,
       action: PayloadAction<{ token: string }>
     ) => {},
+    resetAndCancelClaimReward: state => {
+      state.claimStatus = ClaimStatus.NONE
+    },
     claimChallengeReward: (
       state,
       _action: PayloadAction<{
@@ -176,9 +172,8 @@ export const {
   fetchUserChallengesFailed,
   setTrendingRewardsModalType,
   setChallengeRewardsModalType,
-  setClaimStatus,
   setUserChallengeDisbursed,
-  resetClaimStatus,
+  resetAndCancelClaimReward,
   setHCaptchaStatus,
   resetHCaptchaStatus,
   updateHCaptchaScore,

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -2,6 +2,7 @@ import { User } from '@sentry/browser'
 import {
   call,
   put,
+  race,
   select,
   take,
   takeEvery,
@@ -22,6 +23,7 @@ import {
   getUserChallenge
 } from 'common/store/pages/audio-rewards/selectors'
 import {
+  resetAndCancelClaimReward,
   claimChallengeReward,
   claimChallengeRewardFailed,
   claimChallengeRewardSucceeded,

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -220,7 +220,16 @@ function* watchSetCognitoFlowStatus() {
 }
 
 function* watchClaimChallengeReward() {
-  yield takeLatest(claimChallengeReward.type, claimChallengeRewardAsync)
+  yield takeLatest(claimChallengeReward.type, function* (
+    args: ReturnType<typeof claimChallengeReward>
+  ) {
+    // Race the claim against the user clicking "close" on the modal,
+    // so that the claim saga gets canceled if the modal is closed
+    yield race({
+      task: call(claimChallengeRewardAsync, args),
+      cancel: take(resetAndCancelClaimReward.type)
+    })
+  })
 }
 
 export function* watchFetchUserChallenges() {


### PR DESCRIPTION
### Description

Fixes a bug introduced by the move to using sagas for the claim rewards button. Since the button was being unmounted whenever the modal was closed, it didn't have this problem. But now, the claim is processed in the background and needs to be explicitly stopped on unmount.

Prior to this change, if the claim took sufficiently long, its resolution could come while the user has a different modal open. This could cause the user to see an error on the wrong modal, for instance.

Also removes unnecessary state for `displayError` and `setDisplayError`. As we no longer need to reset the state post-claim, we can simply check the claim state instead.

### Dragons

~The HCaptcha modal sets visibility to false for the challenge reward modal, but should not cancel the claim.~ ✅ 

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested manually on web against staging

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

N/A