### PR TITLE
[AUD-1281] Add config for referred challenge for notifications

### DIFF
--- a/src/common/models/AudioRewards.ts
+++ b/src/common/models/AudioRewards.ts
@@ -16,6 +16,7 @@ export type UserChallenge = {
 export type ChallengeRewardID =
   | 'track-upload'
   | 'referrals'
+  | 'referred'
   | 'mobile-install'
   | 'connect-verified'
   | 'listen-streak'
@@ -87,6 +88,7 @@ export type FlowSessionEvent =
  */
 export const amounts: Record<ChallengeRewardID, number> = {
   referrals: 1,
+  referred: 1,
   'connect-verified': 5,
   'listen-streak': 1,
   'mobile-install': 1,

--- a/src/pages/audio-rewards-page/config.tsx
+++ b/src/pages/audio-rewards-page/config.tsx
@@ -102,7 +102,7 @@ export const challengeRewardsConfig: Record<
       `Invite your Friends! You’ll earn ${amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
     progressLabel: '%0/%1 Invites',
     amount: amounts.referrals,
-    stepCount: 5,
+    stepCount: 1,
     panelButtonText: 'Invite your Friends',
     modalButtonInfo: {
       incomplete: null,

--- a/src/pages/audio-rewards-page/config.tsx
+++ b/src/pages/audio-rewards-page/config.tsx
@@ -92,6 +92,24 @@ export const challengeRewardsConfig: Record<
       complete: null
     }
   },
+  // This is used just for the notifications
+  referred: {
+    id: 'referrals' as ChallengeRewardID,
+    title: 'Invite your Friends',
+    icon: <i className='emoji large incoming-envelope' />,
+    description: amount => `Earn ${amount} $AUDIO, for you and your friend`,
+    fullDescription: amount =>
+      `Invite your Friends! You’ll earn ${amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
+    progressLabel: '%0/%1 Invites',
+    amount: amounts.referrals,
+    stepCount: 5,
+    panelButtonText: 'Invite your Friends',
+    modalButtonInfo: {
+      incomplete: null,
+      inProgress: null,
+      complete: null
+    }
+  },
   'connect-verified': {
     id: 'connect-verified' as ChallengeRewardID,
     title: 'Link Verified Accounts',


### PR DESCRIPTION
### Description

Follows #795 

AUD-1281

Adds config for "referred" challenge despite it not having a modal, as it is needed for the title and amount of the corresponding notification on web.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

N/A

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Manually against staging

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

N/A