### PR TITLE
Use native challenge rewards drawer

### DIFF
--- a/src/pages/audio-rewards-page/components/modals/RewardsModals.tsx
+++ b/src/pages/audio-rewards-page/components/modals/RewardsModals.tsx
@@ -20,7 +20,7 @@ const RewardsModals = () => {
   return (
     <>
       <TrendingRewardsModal />
-      <ChallengeRewardsModal />
+      {!IS_NATIVE_MOBILE && <ChallengeRewardsModal />}
       <VerifiedUpload />
       <TopAPIModal />
       {!IS_NATIVE_MOBILE && (


### PR DESCRIPTION
### Description

Hide mobile rewards drawer from web client on native mobile, as the native drawer will pop instead.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

iOS simulator with changes from https://github.com/AudiusProject/audius-mobile-client/pull/213

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
