### PR TITLE
Display toast when identity claims reward on behalf of user

### DIFF
--- a/src/common/store/pages/audio-rewards/selectors.ts
+++ b/src/common/store/pages/audio-rewards/selectors.ts
@@ -35,3 +35,9 @@ export const getCognitoFlowUrl = (state: CommonState) =>
 
 export const getCognitoFlowUrlStatus = (state: CommonState) =>
   state.pages.audioRewards.cognitoFlowUrlStatus
+
+export const getUndisbursedChallenges = (state: CommonState) =>
+  state.pages.audioRewards.undisbursedChallenges
+
+export const getShowToast = (state: CommonState) =>
+  state.pages.audioRewards.showToast

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -168,7 +168,7 @@ const slice = createSlice({
     fetchCognitoFlowUrlFailed: state => {
       state.cognitoFlowUrlStatus = Status.ERROR
     },
-    refreshUserChallenges: () => {},
+    pollForUserChallenges: () => {},
     reset: () => {},
     setUndisbursedChallenges: (
       state,
@@ -205,7 +205,7 @@ export const {
   fetchCognitoFlowUrl,
   fetchCognitoFlowUrlFailed,
   fetchCognitoFlowUrlSucceeded,
-  refreshUserChallenges,
+  pollForUserChallenges,
   reset,
   setUndisbursedChallenges,
   showRewardsToast,

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -37,6 +37,10 @@ type UserChallengesPayload = {
   userChallenges: UserChallenge[] | null
 }
 
+type UndisbursedChallenges = {
+  undisbursedChallenges: ChallengeRewardID[]
+}
+
 type RewardsUIState = {
   loading: boolean
   trendingRewardsModalType: TrendingRewardsModalType
@@ -48,6 +52,8 @@ type RewardsUIState = {
   cognitoFlowStatus: CognitoFlowStatus
   cognitoFlowUrlStatus?: Status
   cognitoFlowUrl?: string
+  undisbursedChallenges: ChallengeRewardID[] | null
+  showToast: boolean
 }
 
 const initialState: RewardsUIState = {
@@ -57,7 +63,9 @@ const initialState: RewardsUIState = {
   loading: true,
   claimStatus: ClaimStatus.NONE,
   hCaptchaStatus: HCaptchaStatus.NONE,
-  cognitoFlowStatus: CognitoFlowStatus.CLOSED
+  cognitoFlowStatus: CognitoFlowStatus.CLOSED,
+  undisbursedChallenges: null,
+  showToast: false
 }
 
 const slice = createSlice({
@@ -161,8 +169,20 @@ const slice = createSlice({
       state.cognitoFlowUrlStatus = Status.ERROR
     },
     refreshUserChallenges: () => {},
-    refreshUserBalance: () => {},
-    reset: () => {}
+    reset: () => {},
+    setUndisbursedChallenges: (
+      state,
+      action: PayloadAction<UndisbursedChallenges>
+    ) => {
+      const { undisbursedChallenges } = action.payload
+      state.undisbursedChallenges = undisbursedChallenges
+    },
+    showRewardsToast: state => {
+      state.showToast = true
+    },
+    hideRewardsToast: state => {
+      state.showToast = false
+    }
   }
 })
 
@@ -186,8 +206,10 @@ export const {
   fetchCognitoFlowUrlFailed,
   fetchCognitoFlowUrlSucceeded,
   refreshUserChallenges,
-  refreshUserBalance,
-  reset
+  reset,
+  setUndisbursedChallenges,
+  showRewardsToast,
+  hideRewardsToast
 } = slice.actions
 
 export default slice

--- a/src/components/toast/mobile/ToastLinkContent.tsx
+++ b/src/components/toast/mobile/ToastLinkContent.tsx
@@ -10,13 +10,19 @@ type ToastLinkContentProps = {
   link: string
   linkText: string
   text: string
+  linkIcon?: JSX.Element
 }
 
 /**
  * This component can be used as the content of a Toast to render a link
  * in addition to text
  */
-const ToastLinkContent = ({ link, linkText, text }: ToastLinkContentProps) => {
+const ToastLinkContent = ({
+  link,
+  linkText,
+  text,
+  linkIcon
+}: ToastLinkContentProps) => {
   const { clear: clearToasts } = useContext(ToastContext)
 
   return (
@@ -24,6 +30,7 @@ const ToastLinkContent = ({ link, linkText, text }: ToastLinkContentProps) => {
       <span className={styles.text}>{text}</span>
       <Link to={link} className={styles.link} onClick={clearToasts}>
         {linkText}
+        {linkIcon || null}
       </Link>
     </div>
   )

--- a/src/components/toast/mobile/ToastLinkContent.tsx
+++ b/src/components/toast/mobile/ToastLinkContent.tsx
@@ -16,14 +16,14 @@ type ToastLinkContentProps = {
  * This component can be used as the content of a Toast to render a link
  * in addition to text
  */
-const ToastLinkContent = ({ link, text }: ToastLinkContentProps) => {
+const ToastLinkContent = ({ link, linkText, text }: ToastLinkContentProps) => {
   const { clear: clearToasts } = useContext(ToastContext)
 
   return (
     <div>
       <span className={styles.text}>{text}</span>
       <Link to={link} className={styles.link} onClick={clearToasts}>
-        View
+        {linkText}
       </Link>
     </div>
   )

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -21,7 +21,7 @@ import {
 } from 'common/store/account/selectors'
 import {
   reset as resetRewardsPolling,
-  refreshUserChallenges
+  pollForUserChallenges
 } from 'common/store/pages/audio-rewards/slice'
 import AppRedirectListener from 'components/app-redirect-popover/AppRedirectListener'
 import AppRedirectPopover from 'components/app-redirect-popover/components/AppRedirectPopover'
@@ -372,7 +372,7 @@ class App extends Component {
     }
 
     if (this.props.hasAccount && !this.state.isPollingUserChallenges) {
-      this.props.refreshUserChallenges()
+      this.props.pollForUserChallenges()
       this.setState({ isPollingUserChallenges: true })
     }
   }
@@ -997,8 +997,8 @@ const mapDispatchToProps = dispatch => ({
   showAppCTAModal: () => {
     dispatch(setAppModalCTAVisibility({ isOpen: true }))
   },
-  refreshUserChallenges: () => {
-    dispatch(refreshUserChallenges())
+  pollForUserChallenges: () => {
+    dispatch(pollForUserChallenges())
   },
   resetRewardsPolling: () => {
     dispatch(resetRewardsPolling())

--- a/src/pages/App.module.css
+++ b/src/pages/App.module.css
@@ -64,3 +64,23 @@ body {
   margin-top: calc(env(safe-area-inset-top, 0px) + 40px);
   margin-bottom: 0;
 }
+
+.rewardClaimedToast {
+  display: flex;
+  justify-content: center;
+}
+
+.rewardClaimedToastIcon {
+  top: -2px !important;
+  position: relative;
+}
+
+.seeMoreCaret {
+  margin-left: 2px;
+  height: 12px;
+  width: 10px;
+}
+
+.seeMoreCaret path {
+  fill: var(--static-white);
+}

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -4,6 +4,7 @@ import { ProgressBar } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'
 import { useSetVisibility } from 'common/hooks/useModalState'
 import { ChallengeRewardID } from 'common/models/AudioRewards'
 import { StringKeys } from 'common/services/remote-config'
@@ -90,11 +91,18 @@ const RewardPanel = ({
   useEffect(() => {
     if (!wasChallengeComplete && !!challenge?.is_complete) {
       toast(
-        <ToastLinkContent
-          text={messages.challengeCompleted}
-          linkText={messages.seeMore}
-          link={AUDIO_PAGE}
-        />,
+        <div className={styles.rewardClaimedToast}>
+          <span className={styles.rewardClaimedToastIcon}>
+            <i className='emoji face-with-party-horn-and-party-hat' />
+          </span>
+          &nbsp;&nbsp;
+          <ToastLinkContent
+            text={messages.challengeCompleted}
+            linkText={messages.seeMore}
+            link={AUDIO_PAGE}
+            linkIcon={<IconCaretRight className={styles.seeMoreCaret} />}
+          />
+        </div>,
         CLAIM_REWARD_TOAST_TIMEOUT_MILLIS
       )
       setWasChallengeComplete(true)

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useContext, useEffect, useState } from 'react'
 
 import { ProgressBar } from '@audius/stems'
 import cn from 'classnames'
@@ -19,9 +19,13 @@ import {
   refreshUserChallenges
 } from 'common/store/pages/audio-rewards/slice'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+import { ToastContext } from 'components/toast/ToastContext'
+import ToastLinkContent from 'components/toast/mobile/ToastLinkContent'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
+import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
 import fillString from 'utils/fillString'
+import { AUDIO_PAGE } from 'utils/route'
 
 import styles from './RewardsTile.module.css'
 import ButtonWithArrow from './components/ButtonWithArrow'
@@ -35,7 +39,9 @@ const messages = {
   description2:
     'Opportunities to earn $AUDIO will change, so check back often for more chances to earn!',
   completeLabel: 'COMPLETE',
-  claimReward: 'Claim Your Reward'
+  claimReward: 'Claim Your Reward',
+  challengeCompleted: 'You’ve Completed an $AUDIO Rewards Challenge!',
+  seeMore: 'See more'
 }
 
 type RewardPanelProps = {
@@ -61,6 +67,8 @@ const RewardPanel = ({
   stepCount,
   currentStepCountOverride
 }: RewardPanelProps) => {
+  const { toast } = useContext(ToastContext)
+
   const wm = useWithMobileStyle(styles.mobile)
   const userChallenges = useSelector(getUserChallenges)
 
@@ -75,6 +83,23 @@ const RewardPanel = ({
   const isComplete = shouldOverrideCurrentStepCount
     ? currentStepCountOverride! >= stepCount
     : !!challenge?.is_complete
+  const [wasChallengeComplete, setWasChallengeComplete] = useState(
+    !!challenge?.is_complete
+  )
+
+  useEffect(() => {
+    if (!wasChallengeComplete && !!challenge?.is_complete) {
+      toast(
+        <ToastLinkContent
+          text={messages.challengeCompleted}
+          linkText={messages.seeMore}
+          link={AUDIO_PAGE}
+        />,
+        CLAIM_REWARD_TOAST_TIMEOUT_MILLIS
+      )
+      setWasChallengeComplete(true)
+    }
+  }, [wasChallengeComplete, challenge, toast])
 
   return (
     <div className={wm(styles.rewardPanelContainer)} onClick={openRewardModal}>

--- a/src/pages/audio-rewards-page/RewardClaimedToast.tsx
+++ b/src/pages/audio-rewards-page/RewardClaimedToast.tsx
@@ -1,0 +1,61 @@
+import React, { useContext, useEffect } from 'react'
+
+import { useDispatch, useSelector } from 'react-redux'
+
+import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'
+import { getShowToast } from 'common/store/pages/audio-rewards/selectors'
+import { hideRewardsToast } from 'common/store/pages/audio-rewards/slice'
+import { ToastContext } from 'components/toast/ToastContext'
+import ToastLinkContent from 'components/toast/mobile/ToastLinkContent'
+import { getLocationPathname } from 'store/routing/selectors'
+import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
+import { AUDIO_PAGE } from 'utils/route'
+
+import styles from '../App.module.css'
+
+const messages = {
+  challengeCompleted: 'You’ve Completed an $AUDIO Rewards Challenge!',
+  seeMore: 'See more'
+}
+
+export const RewardClaimedToast = () => {
+  const { toast } = useContext(ToastContext)
+  const dispatch = useDispatch()
+  const showToast = useSelector(getShowToast)
+  const pathname = useSelector(getLocationPathname)
+
+  useEffect(() => {
+    if (showToast) {
+      const toastContent =
+        pathname === AUDIO_PAGE ? (
+          <div className={styles.rewardClaimedToast}>
+            <span className={styles.rewardClaimedToastIcon}>
+              <i className='emoji face-with-party-horn-and-party-hat' />
+            </span>
+            &nbsp;&nbsp;
+            {messages.challengeCompleted}
+          </div>
+        ) : (
+          <div className={styles.rewardClaimedToast}>
+            <span className={styles.rewardClaimedToastIcon}>
+              <i className='emoji face-with-party-horn-and-party-hat' />
+            </span>
+            &nbsp;&nbsp;
+            <ToastLinkContent
+              text={messages.challengeCompleted}
+              linkText={messages.seeMore}
+              link={AUDIO_PAGE}
+              linkIcon={<IconCaretRight className={styles.seeMoreCaret} />}
+            />
+          </div>
+        )
+
+      toast(toastContent, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
+      setTimeout(() => {
+        dispatch(hideRewardsToast())
+      }, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
+    }
+  }, [toast, dispatch, showToast, pathname])
+
+  return null
+}

--- a/src/pages/audio-rewards-page/RewardsTile.module.css
+++ b/src/pages/audio-rewards-page/RewardsTile.module.css
@@ -139,3 +139,23 @@
   font-weight: var(--font-bold);
   letter-spacing: 0;
 }
+
+.rewardClaimedToast {
+  display: flex;
+  justify-content: center;
+}
+
+.rewardClaimedToastIcon {
+  top: -2px !important;
+  position: relative;
+}
+
+.seeMoreCaret {
+  margin-left: 2px;
+  height: 12px;
+  width: 10px;
+}
+
+.seeMoreCaret path {
+  fill: var(--static-white);
+}

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -1,6 +1,8 @@
+import { useEffect, useState } from 'react'
+
 import { useSelector } from 'react-redux'
 
-import { ChallengeRewardID } from 'common/models/AudioRewards'
+import { ChallengeRewardID, UserChallenge } from 'common/models/AudioRewards'
 import { getCompletionStages } from 'components/profile-progress/store/selectors'
 
 type OptimisticChallengeCompletionResponse = Partial<
@@ -18,4 +20,33 @@ export const useOptimisticChallengeCompletionStepCounts = () => {
   }
 
   return completion
+}
+
+// This holds the logic for when a challenge is considered claimable.
+// A challenge is considered claimable when:
+// - it is complete and not disbursed, or
+// - it is undefined (happens during challenge polling) and was previously complete but not disbursed
+export const useCheckClaimable = (
+  challenge: UserChallenge | undefined,
+  isComplete: boolean
+) => {
+  const isDisbursed = challenge?.is_disbursed ?? false
+
+  const [wasPreviouslyComplete, setWasPreviouslyComplete] = useState(false)
+  const [wasPreviouslyDisbursed, setWasPreviouslyDisbursed] = useState(false)
+
+  useEffect(() => {
+    if (isComplete && !wasPreviouslyComplete) {
+      setWasPreviouslyComplete(true)
+    }
+    if (isDisbursed && !wasPreviouslyDisbursed) {
+      setWasPreviouslyDisbursed(true)
+    }
+  }, [isComplete, wasPreviouslyComplete, isDisbursed, wasPreviouslyDisbursed])
+
+  return {
+    isClaimable:
+      (!challenge && wasPreviouslyComplete && !wasPreviouslyDisbursed) ||
+      (challenge && isComplete && !isDisbursed)
+  }
 }

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -36,7 +36,7 @@ import {
   fetchUserChallengesFailed,
   fetchUserChallengesSucceeded,
   HCaptchaStatus,
-  refreshUserChallenges,
+  pollForUserChallenges,
   reset,
   setCognitoFlowStatus,
   setHCaptchaStatus,
@@ -317,8 +317,8 @@ function* pollForChallenges(): any {
   }
 }
 
-function* watchRefreshUserChallenges() {
-  yield takeEvery(refreshUserChallenges.type, pollForChallenges)
+function* watchPollForUserChallenges() {
+  yield takeEvery(pollForUserChallenges.type, pollForChallenges)
 }
 
 const sagas = () => {
@@ -328,7 +328,7 @@ const sagas = () => {
     watchSetHCaptchaStatus,
     watchSetCognitoFlowStatus,
     watchUpdateHCaptchaScore,
-    watchRefreshUserChallenges
+    watchPollForUserChallenges
   ]
   return NATIVE_MOBILE ? sagas.concat(mobileSagas()) : sagas
 }


### PR DESCRIPTION
### Description

Display toast and confetti when identity claims reward on behalf of user

- shows see more link in toast if user is not on rewards page
- does not shows see more link in toast if user is on rewards page

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Locally against staging

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
