### PR TITLE
Bump libs to v1.2.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.52",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.52.tgz",
-      "integrity": "sha512-9JIxm3Xu4ELeYYGKXFiNQ5nZqDUENhKlkIcRmt+ksWDphanu/DYKUGche5xv9p9KRHhTypplaGoeIhyMICUoRw==",
+      "version": "1.2.54",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.54.tgz",
+      "integrity": "sha512-klIJlccVED3Cy8rxtqoCukhTO8Tv/xzsrG98BH1BxYNjPms9KtO110QOy4spXcX2CGHrKkBJh+OviDV6xwfp2Q==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.0.10",
@@ -27393,9 +27393,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.20.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-          "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
+          "version": "3.20.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
+          "integrity": "sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag=="
         },
         "simplebar": {
           "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.39",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.52",
+    "@audius/libs": "1.2.54",
     "@audius/stems": "0.3.18",
     "@craco/craco": "6.4.2",
     "@hcaptcha/react-hcaptcha": "0.3.6",


### PR DESCRIPTION
### Description
Bump libs to v1.2.54 from v1.5

Diff between last libs bump and current
```
[8220dcd7] Bump libs version to v0.1.2.54 (#2337) Dheeraj Manjunath
[7b480847] Automatically reconnect if content node returns invalid auth token error (#2224) Dheeraj Manjunath
[608a013d] 1.2.53 (#2334) Michael Piazza
[8d35dd5a] [AUD-1309][AUD-1291] Improve Identity challenge attestation (#2332) Michael Piazza
```

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
