### PR TITLE
Consolidate stepCountOverride into useOptimisticUserChallenge hook

### DIFF
--- a/src/common/store/pages/audio-rewards/selectors.ts
+++ b/src/common/store/pages/audio-rewards/selectors.ts
@@ -15,6 +15,9 @@ export const getUserChallenge = (
   props: { challengeId: ChallengeRewardID }
 ) => state.pages.audioRewards.userChallenges[props.challengeId]
 
+export const getUserChallengesOverrides = (state: CommonState) =>
+  state.pages.audioRewards.userChallengesOverrides
+
 export const getUserChallengesLoading = (state: CommonState) =>
   state.pages.audioRewards.loading
 

--- a/src/common/store/pages/audio-rewards/selectors.ts
+++ b/src/common/store/pages/audio-rewards/selectors.ts
@@ -15,9 +15,6 @@ export const getUserChallenge = (
   props: { challengeId: ChallengeRewardID }
 ) => state.pages.audioRewards.userChallenges[props.challengeId]
 
-export const getUserChallengesOverrides = (state: CommonState) =>
-  state.pages.audioRewards.userChallengesOverrides
-
 export const getUserChallengesLoading = (state: CommonState) =>
   state.pages.audioRewards.loading
 

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -42,6 +42,9 @@ type RewardsUIState = {
   trendingRewardsModalType: TrendingRewardsModalType
   challengeRewardsModalType: ChallengeRewardsModalType
   userChallenges: Partial<Record<ChallengeRewardID, UserChallenge>>
+  userChallengesOverrides: Partial<
+    Record<ChallengeRewardID, Partial<UserChallenge>>
+  >
   claimStatus: ClaimStatus
   claimToRetry?: Claim
   hCaptchaStatus: HCaptchaStatus
@@ -54,6 +57,7 @@ const initialState: RewardsUIState = {
   trendingRewardsModalType: 'tracks',
   challengeRewardsModalType: 'track-upload',
   userChallenges: {},
+  userChallengesOverrides: {},
   loading: true,
   claimStatus: ClaimStatus.NONE,
   hCaptchaStatus: HCaptchaStatus.NONE,
@@ -88,9 +92,9 @@ const slice = createSlice({
       action: PayloadAction<{ challengeId: ChallengeRewardID }>
     ) => {
       const { challengeId } = action.payload
-      const challenge = state.userChallenges[challengeId]
-      if (challenge !== undefined) {
-        challenge.is_disbursed = true
+      state.userChallengesOverrides[challengeId] = {
+        ...state.userChallengesOverrides[challengeId],
+        is_disbursed: true
       }
     },
     setTrendingRewardsModalType: (

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -74,12 +74,7 @@ const slice = createSlice({
         state.userChallenges = {}
       } else {
         state.userChallenges = userChallenges.reduce((acc, challenge) => {
-          acc[challenge.challenge_id] = {
-            ...challenge,
-            is_disbursed:
-              state.userChallenges[challenge.challenge_id]?.is_disbursed ||
-              challenge.is_disbursed
-          }
+          acc[challenge.challenge_id] = challenge
           return acc
         }, {} as Partial<Record<ChallengeRewardID, UserChallenge>>)
       }

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -42,9 +42,6 @@ type RewardsUIState = {
   trendingRewardsModalType: TrendingRewardsModalType
   challengeRewardsModalType: ChallengeRewardsModalType
   userChallenges: Partial<Record<ChallengeRewardID, UserChallenge>>
-  userChallengesOverrides: Partial<
-    Record<ChallengeRewardID, Partial<UserChallenge>>
-  >
   claimStatus: ClaimStatus
   claimToRetry?: Claim
   hCaptchaStatus: HCaptchaStatus
@@ -57,7 +54,6 @@ const initialState: RewardsUIState = {
   trendingRewardsModalType: 'tracks',
   challengeRewardsModalType: 'track-upload',
   userChallenges: {},
-  userChallengesOverrides: {},
   loading: true,
   claimStatus: ClaimStatus.NONE,
   hCaptchaStatus: HCaptchaStatus.NONE,
@@ -92,9 +88,9 @@ const slice = createSlice({
       action: PayloadAction<{ challengeId: ChallengeRewardID }>
     ) => {
       const { challengeId } = action.payload
-      state.userChallengesOverrides[challengeId] = {
-        ...state.userChallengesOverrides[challengeId],
-        is_disbursed: true
+      const challenge = state.userChallenges[challengeId]
+      if (challenge !== undefined) {
+        challenge.is_disbursed = true
       }
     },
     setTrendingRewardsModalType: (

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -74,7 +74,12 @@ const slice = createSlice({
         state.userChallenges = {}
       } else {
         state.userChallenges = userChallenges.reduce((acc, challenge) => {
-          acc[challenge.challenge_id] = challenge
+          acc[challenge.challenge_id] = {
+            ...challenge,
+            is_disbursed:
+              state.userChallenges[challenge.challenge_id]?.is_disbursed ||
+              challenge.is_disbursed
+          }
           return acc
         }, {} as Partial<Record<ChallengeRewardID, UserChallenge>>)
       }

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -27,7 +27,7 @@ import styles from './RewardsTile.module.css'
 import ButtonWithArrow from './components/ButtonWithArrow'
 import { Tile } from './components/ExplainerTile'
 import { challengeRewardsConfig } from './config'
-import { useOptimisticChallengeCompletionStepCounts } from './hooks'
+import { useOptimisticUserChallenge } from './hooks'
 
 const messages = {
   title: '$AUDIO REWARDS',
@@ -47,7 +47,6 @@ type RewardPanelProps = {
   stepCount: number
   openModal: (modalType: ChallengeRewardsModalType) => void
   id: ChallengeRewardID
-  currentStepCountOverride?: number
 }
 
 const RewardPanel = ({
@@ -58,23 +57,14 @@ const RewardPanel = ({
   openModal,
   progressLabel,
   icon,
-  stepCount,
-  currentStepCountOverride
+  stepCount
 }: RewardPanelProps) => {
   const wm = useWithMobileStyle(styles.mobile)
   const userChallenges = useSelector(getUserChallenges)
 
   const openRewardModal = () => openModal(id)
 
-  const challenge = userChallenges[id]
-  const shouldOverrideCurrentStepCount =
-    !challenge?.is_complete && currentStepCountOverride !== undefined
-  const currentStepCount = shouldOverrideCurrentStepCount
-    ? currentStepCountOverride!
-    : challenge?.current_step_count || 0
-  const isComplete = shouldOverrideCurrentStepCount
-    ? currentStepCountOverride! >= stepCount
-    : !!challenge?.is_complete
+  const challenge = useOptimisticUserChallenge(userChallenges[id])
 
   return (
     <div className={wm(styles.rewardPanelContainer)} onClick={openRewardModal}>
@@ -88,21 +78,21 @@ const RewardPanel = ({
       <div className={wm(styles.rewardProgress)}>
         <p
           className={cn(styles.rewardProgressLabel, {
-            [styles.complete]: isComplete
+            [styles.complete]: challenge?.is_complete
           })}
         >
-          {isComplete
+          {challenge?.is_complete
             ? messages.completeLabel
             : fillString(
                 progressLabel,
-                currentStepCount.toString(),
+                challenge?.current_step_count?.toString() ?? '',
                 stepCount.toString()
               )}
         </p>
         {stepCount > 1 && (
           <ProgressBar
             className={styles.rewardProgressBar}
-            value={currentStepCount}
+            value={challenge?.current_step_count ?? 0}
             max={stepCount}
           />
         )}
@@ -150,7 +140,6 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
   const dispatch = useDispatch()
   const rewardIds = useRewardIds()
   const userChallengesLoading = useSelector(getUserChallengesLoading)
-  const currentStepCountOverrides = useOptimisticChallengeCompletionStepCounts()
   const [haveChallengesLoaded, setHaveChallengesLoaded] = useState(false)
 
   useEffect(() => {
@@ -176,12 +165,7 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
   const rewardsTiles = rewardIds
     .map(id => challengeRewardsConfig[id])
     .map(props => (
-      <RewardPanel
-        {...props}
-        currentStepCountOverride={currentStepCountOverrides[props.id]}
-        openModal={openModal}
-        key={props.id}
-      />
+      <RewardPanel {...props} openModal={openModal} key={props.id} />
     ))
 
   const wm = useWithMobileStyle(styles.mobile)

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -78,10 +78,10 @@ const RewardPanel = ({
       <div className={wm(styles.rewardProgress)}>
         <p
           className={cn(styles.rewardProgressLabel, {
-            [styles.complete]: challenge?.is_complete
+            [styles.complete]: challenge?.state === 'completed'
           })}
         >
-          {challenge?.is_complete
+          {challenge?.state === 'completed'
             ? messages.completeLabel
             : fillString(
                 progressLabel,
@@ -100,7 +100,7 @@ const RewardPanel = ({
       <ButtonWithArrow
         className={wm(styles.panelButton)}
         text={
-          challenge?.is_complete && !challenge?.is_disbursed
+          challenge?.state === 'completed'
             ? messages.claimReward
             : panelButtonText
         }

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -32,7 +32,7 @@ import Tooltip from 'components/tooltip/Tooltip'
 import { ComponentPlacement, MountPlacement } from 'components/types'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
 import { challengeRewardsConfig } from 'pages/audio-rewards-page/config'
-import { useOptimisticChallengeCompletionStepCounts } from 'pages/audio-rewards-page/hooks'
+import { useOptimisticUserChallenge } from 'pages/audio-rewards-page/hooks'
 import { isMobile } from 'utils/clientUtil'
 import { copyToClipboard } from 'utils/clipboardUtil'
 import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
@@ -153,7 +153,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const wm = useWithMobileStyle(styles.mobile)
   const displayMobileContent = isMobile()
 
-  const challenge = userChallenges[modalType]
+  const challenge = useOptimisticUserChallenge(userChallenges[modalType])
 
   const {
     fullDescription,
@@ -162,19 +162,10 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     modalButtonInfo
   } = challengeRewardsConfig[modalType]
 
-  const currentStepCountOverrides = useOptimisticChallengeCompletionStepCounts()
-  const currentStepCountOverride = currentStepCountOverrides[modalType]
-  const shouldOverrideCurrentStepCount =
-    !challenge?.is_complete && currentStepCountOverride !== undefined
-  const currentStepCount = shouldOverrideCurrentStepCount
-    ? currentStepCountOverride!
-    : challenge?.current_step_count || 0
-
+  const currentStepCount = challenge?.current_step_count || 0
   const isIncomplete = currentStepCount === 0
   const isInProgress = currentStepCount > 0 && currentStepCount < stepCount
-  const isComplete = shouldOverrideCurrentStepCount
-    ? currentStepCountOverride! >= stepCount
-    : !!challenge?.is_complete
+  const isComplete = !!challenge?.is_complete
   const isDisbursed = challenge?.is_disbursed ?? false
   const specifier = challenge?.specifier ?? ''
 

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -163,16 +163,12 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   } = challengeRewardsConfig[modalType]
 
   const currentStepCount = challenge?.current_step_count || 0
-  const isIncomplete = currentStepCount === 0
-  const isInProgress = currentStepCount > 0 && currentStepCount < stepCount
-  const isComplete = !!challenge?.is_complete
-  const isDisbursed = challenge?.is_disbursed ?? false
   const specifier = challenge?.specifier ?? ''
 
   let linkType: 'complete' | 'inProgress' | 'incomplete'
-  if (isComplete) {
+  if (challenge?.state === 'completed') {
     linkType = 'complete'
-  } else if (isInProgress) {
+  } else if (challenge?.state === 'in_progress') {
     linkType = 'inProgress'
   } else {
     linkType = 'incomplete'
@@ -204,14 +200,18 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const progressStatusLabel = (
     <div
       className={cn(styles.progressStatus, {
-        [styles.incomplete]: isIncomplete,
-        [styles.inProgress]: isInProgress,
-        [styles.complete]: isComplete
+        [styles.incomplete]: challenge?.state === 'incomplete',
+        [styles.inProgress]: challenge?.state === 'in_progress',
+        [styles.complete]: challenge?.state === 'completed'
       })}
     >
-      {isIncomplete && <h3 className={styles.incomplete}>Incomplete</h3>}
-      {isComplete && <h3 className={styles.complete}>Complete</h3>}
-      {isInProgress && (
+      {challenge?.state === 'incomplete' && (
+        <h3 className={styles.incomplete}>Incomplete</h3>
+      )}
+      {challenge?.state === 'completed' && (
+        <h3 className={styles.complete}>Complete</h3>
+      )}
+      {challenge?.state === 'in_progress' && (
         <h3 className={styles.inProgress}>
           {fillString(
             progressLabel,
@@ -308,7 +308,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
           <Button
             className={wm(styles.button)}
             type={
-              isComplete && !isDisbursed
+              challenge?.state === 'completed'
                 ? ButtonType.COMMON
                 : ButtonType.PRIMARY_ALT
             }
@@ -318,7 +318,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
             rightIcon={buttonInfo?.rightIcon}
           />
         )}
-        {challenge && isComplete && !isDisbursed && (
+        {challenge && challenge?.state === 'completed' && (
           <Button
             text={messages.claimYourReward}
             className={wm(styles.button)}

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -33,7 +33,8 @@ const getUserChallengeState = (
   }
   if (
     challenge.is_complete ||
-    challenge.current_step_count >= challenge.max_steps
+    (challenge.max_steps !== null &&
+      challenge.current_step_count >= challenge.max_steps)
   ) {
     return 'completed'
   }

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -1,7 +1,6 @@
 import { useSelector } from 'react-redux'
 
 import { ChallengeRewardID, UserChallenge } from 'common/models/AudioRewards'
-import { getUserChallengesOverrides } from 'common/store/pages/audio-rewards/selectors'
 import { getCompletionStages } from 'components/profile-progress/store/selectors'
 
 type OptimisticChallengeCompletionResponse = Partial<
@@ -71,16 +70,13 @@ export const useOptimisticUserChallenge = (
   challenge?: UserChallenge
 ): OptimisticUserChallenge | undefined => {
   const stepCountOverrides = useOptimisticChallengeCompletionStepCounts()
-  const userChallengesOverrides = useSelector(getUserChallengesOverrides)
 
   if (!challenge) {
     return challenge
   }
   const currentStepCountOverride = stepCountOverrides[challenge?.challenge_id]
-  const userChallengeOverrides =
-    userChallengesOverrides[challenge?.challenge_id]
 
-  const challengeOverridden = { ...challenge, ...userChallengeOverrides }
+  const challengeOverridden = { ...challenge }
 
   // The client is more up to date than Discovery Nodes, so override whenever possible.
   // Don't override if the challenge is already marked as completed on Discovery.

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux'
 
 import { ChallengeRewardID, UserChallenge } from 'common/models/AudioRewards'
+import { getUserChallengesOverrides } from 'common/store/pages/audio-rewards/selectors'
 import { getCompletionStages } from 'components/profile-progress/store/selectors'
 
 type OptimisticChallengeCompletionResponse = Partial<
@@ -70,13 +71,16 @@ export const useOptimisticUserChallenge = (
   challenge?: UserChallenge
 ): OptimisticUserChallenge | undefined => {
   const stepCountOverrides = useOptimisticChallengeCompletionStepCounts()
+  const userChallengesOverrides = useSelector(getUserChallengesOverrides)
 
   if (!challenge) {
     return challenge
   }
   const currentStepCountOverride = stepCountOverrides[challenge?.challenge_id]
+  const userChallengeOverrides =
+    userChallengesOverrides[challenge?.challenge_id]
 
-  const challengeOverridden = { ...challenge }
+  const challengeOverridden = { ...challenge, ...userChallengeOverrides }
 
   // The client is more up to date than Discovery Nodes, so override whenever possible.
   // Don't override if the challenge is already marked as completed on Discovery.

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux'
 
-import { ChallengeRewardID } from 'common/models/AudioRewards'
+import { ChallengeRewardID, UserChallenge } from 'common/models/AudioRewards'
 import { getCompletionStages } from 'components/profile-progress/store/selectors'
 
 type OptimisticChallengeCompletionResponse = Partial<
@@ -18,4 +18,34 @@ export const useOptimisticChallengeCompletionStepCounts = () => {
   }
 
   return completion
+}
+
+type OptimisticUserChallenge = UserChallenge & { __isOptimistic: true }
+/**
+ * Given a challenge, returns a challenge that uses an optimistic
+ * is_complete and current_step_count based on what the client knows
+ * @param challenge The user challenge to get the optimistic state for
+ * @returns the same challenge with is_complete and current_step_count overridden as necessary
+ */
+export const useOptimisticUserChallenge = (
+  challenge?: UserChallenge
+): OptimisticUserChallenge | undefined => {
+  const stepCountOverrides = useOptimisticChallengeCompletionStepCounts()
+
+  if (!challenge) {
+    return challenge
+  }
+  const currentStepCountOverride = stepCountOverrides[challenge?.challenge_id]
+
+  // The client is more up to date than Discovery Nodes, so override whenever possible.
+  // Don't override if the challenge is already marked as completed on Discovery.
+  if (!challenge?.is_complete && currentStepCountOverride !== undefined) {
+    return {
+      __isOptimistic: true,
+      ...challenge,
+      current_step_count: currentStepCountOverride,
+      is_complete: currentStepCountOverride >= challenge.max_steps
+    }
+  }
+  return { ...challenge, __isOptimistic: true }
 }


### PR DESCRIPTION
### Description

Uses a new hook to make it clearer how challenge progress is overridden by an optimistic client, and consolidates that logic.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested manually against stage

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
