### PR TITLE
[AUD-1328] Reward amounts should be numbers

### DIFF
--- a/src/common/models/AudioRewards.ts
+++ b/src/common/models/AudioRewards.ts
@@ -10,7 +10,7 @@ export type UserChallenge = {
   max_steps: number
   specifier: string
   user_id: string
-  amount: string
+  amount: number
 }
 
 export type ChallengeRewardID =

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -18,7 +18,7 @@ export enum ClaimStatus {
 export type Claim = {
   challengeId: ChallengeRewardID
   specifier: string
-  amount: string
+  amount: number
 }
 
 export enum HCaptchaStatus {

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -41,7 +41,7 @@ const messages = {
 type RewardPanelProps = {
   title: string
   icon: ReactNode
-  description: (amount: string | undefined) => string
+  description: (amount: number | undefined) => string
   panelButtonText: string
   progressLabel: string
   stepCount: number

--- a/src/pages/audio-rewards-page/config.tsx
+++ b/src/pages/audio-rewards-page/config.tsx
@@ -58,8 +58,8 @@ type ChallengeRewardsInfo = {
   id: ChallengeRewardID
   title: string
   icon: ReactNode
-  description: (amount: string | undefined) => string
-  fullDescription: (amount: string | undefined) => string
+  description: (amount: number | undefined) => string
+  fullDescription: (amount: number | undefined) => string
   progressLabel: string
   amount: number
   stepCount: number

--- a/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/src/services/audius-api-client/AudiusAPIClient.ts
@@ -316,7 +316,21 @@ type GetUserChallengesArgs = {
   userID: number
 }
 
-type UserChallengesResponse = {}
+type UserChallengesResponse = [
+  {
+    challenge_id: string
+    user_id: string
+    specifier: string
+    is_complete: boolean
+    is_active: boolean
+    is_disbursed: boolean
+    current_step_count: number
+    max_steps: number
+    challenge_type: string
+    amount: string
+    metadata: object
+  }
+]
 
 export type GetSocialFeedArgs = QueryParams & {
   filter: string
@@ -1192,7 +1206,14 @@ class AudiusAPIClient {
     )
 
     if (!userChallenges) return null
-    return userChallenges.data
+    // DN may have amount as a string
+    const challenges = userChallenges.data.map(challenge => {
+      return {
+        ...challenge,
+        amount: Number(challenge.amount)
+      }
+    })
+    return challenges
   }
 
   async getBlockConfirmation(blockhash: string, blocknumber: number) {


### PR DESCRIPTION
### Description

Discovery Node returns the amount for a reward as a string, but it should be a number. Convert at the root API call so that the client has the amount as a number throughout.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested manually against stage - checked UI, claimed reward.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
