### PR TITLE
Lazy-load sign-in page, reinstate analyzeBundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3398,6 +3398,11 @@
         }
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.21",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
+      "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
+    },
     "@project-serum/sol-wallet-adapter": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@project-serum/sol-wallet-adapter/-/sol-wallet-adapter-0.2.5.tgz",
@@ -21260,6 +21265,11 @@
         }
       }
     },
+    "mrmime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.0.tgz",
+      "integrity": "sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -27412,6 +27422,16 @@
         }
       }
     },
+    "sirv": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
+      "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
+      "requires": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^1.0.0"
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -29758,6 +29778,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g=="
+    },
     "touch-pinch": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/touch-pinch/-/touch-pinch-1.0.1.tgz",
@@ -31761,6 +31786,47 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.5.0.tgz",
+      "integrity": "sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==",
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^7.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+        },
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        },
+        "gzip-size": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+          "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+          "requires": {
+            "duplexer": "^0.1.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "wasm-loader": "^1.3.0",
     "web-vitals": "0.2.2",
     "web3modal": "1.9.3",
-    "webgl-context": "2.2.0"
+    "webgl-context": "2.2.0",
+    "webpack-bundle-analyzer": "^4.5.0"
   },
   "main": "src/electron.js",
   "scripts": {
@@ -148,7 +149,7 @@
     "dist:win:linux-publish-production": "node ./scripts/dist.js --win --linux --publish always --env production",
     "write-sha": "./scripts/writeSHA.sh",
     "analyze": "source-map-explorer build-production/static/js/*.js",
-    "analyzeBundle": "npm run build:prod && node ./scripts/analyzeBundle.js",
+    "analyzeBundle": "node ./scripts/analyzeBundle.js",
     "typecheck": "tsc -w --allowJs",
     "update-ipfs-build:dev": "node ./scripts/updateIpfsBuild.js dev",
     "update-ipfs-build:stage": "node ./scripts/updateIpfsBuild.js stage",

--- a/scripts/analyzeBundle.js
+++ b/scripts/analyzeBundle.js
@@ -1,13 +1,18 @@
-process.env.NODE_ENV = 'production';
+process.env.NODE_ENV = 'production'
 
-const webpack = require('webpack');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const webpackConfigProd = require('react-scripts/config/webpack.config')('production');
+const webpackConfigProd = require('react-scripts/config/webpack.config')(
+  'production'
+)
+const webpack = require('webpack')
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin
 
-webpackConfigProd.plugins.push(new BundleAnalyzerPlugin());
+webpackConfigProd.plugins.push(new BundleAnalyzerPlugin())
+webpackConfigProd.output.filename = 'static/js/[name].js'
+webpackConfigProd.output.chunkFilename = 'static/js/[name].chunk.js'
 
 webpack(webpackConfigProd, (err, stats) => {
   if (err || stats.hasErrors()) {
-    console.error(err);
+    console.error(err)
   }
-});
+})

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -167,9 +167,7 @@ import SmartCollectionPage from './smart-collection/SmartCollectionPage'
 
 const MOBILE_BANNER_LOCAL_STORAGE_KEY = 'dismissMobileAppBanner'
 
-const SignOn = React.lazy(() =>
-  import(/* webpackChunkName: "sign-on-page" */ 'pages/sign-on/SignOn')
-)
+const SignOn = React.lazy(() => import('pages/sign-on/SignOn'))
 
 const SettingsPage = lazyWithPreload(
   () => import('pages/settings-page/SettingsPage'),

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -55,7 +55,6 @@ import RepostsPage from 'pages/reposts-page/RepostsPage'
 import RequiresUpdate from 'pages/requires-update/RequiresUpdate'
 import SavedPage from 'pages/saved-page/SavedPage'
 import SearchPage from 'pages/search-page/SearchPage'
-import SignOn from 'pages/sign-on/SignOn'
 import {
   openSignOn,
   updateRouteOnCompletion as updateRouteOnSignUpCompletion
@@ -167,6 +166,10 @@ import { SubPage } from './settings-page/components/mobile/SettingsPage'
 import SmartCollectionPage from './smart-collection/SmartCollectionPage'
 
 const MOBILE_BANNER_LOCAL_STORAGE_KEY = 'dismissMobileAppBanner'
+
+const SignOn = React.lazy(() =>
+  import(/* webpackChunkName: "sign-on-page" */ 'pages/sign-on/SignOn')
+)
 
 const SettingsPage = lazyWithPreload(
   () => import('pages/settings-page/SettingsPage'),


### PR DESCRIPTION
### Description

Improves load time by preventing large sign-in dependencies from downloading when user already logged in

before:
<img width="243" alt="8 7 MB  9 9 MB transferred" src="https://user-images.githubusercontent.com/8230000/150421624-f6afea84-84f3-4c3f-8766-155b22385fb3.png">

after:
<img width="243" alt="8 3 MB  9 5 MB transferre" src="https://user-images.githubusercontent.com/8230000/150421646-ea7ffad1-c33c-41b5-bf39-56abcd078c59.png">
 