### PR TITLE
[AUD-1288] Show reward claimed toast when identity claims on user's behalf

### DIFF
--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -17,8 +17,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.DISCOVERY_NODE_SELECTION_REQUEST_RETRIES]: 5,
   [IntKeys.ATTESTATION_QUORUM_SIZE]: 0,
   [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
-  [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 5000,
-  [IntKeys.REWARDS_WALLET_BALANCE_POLLING_FREQ_MS]: 5000
+  [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 15000,
+  [IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS]: 5000
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -80,9 +80,9 @@ export enum IntKeys {
   CHALLENGE_REFRESH_INTERVAL_MS = 'CHALLENGE_REFRESH_INTERVAL_MS',
 
   /**
-   * Frequency (in ms) to poll for user wallet balance on the audio rewards page
+   * The refresh interval in milliseconds for user challenges when the user is on the $AUDIO page
    */
-  REWARDS_WALLET_BALANCE_POLLING_FREQ_MS = 'REWARDS_WALLET_BALANCE_POLLING_FREQ_MS'
+  CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS = 'CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS'
 }
 
 export enum BooleanKeys {

--- a/src/common/store/pages/audio-rewards/selectors.ts
+++ b/src/common/store/pages/audio-rewards/selectors.ts
@@ -38,3 +38,6 @@ export const getCognitoFlowUrl = (state: CommonState) =>
 
 export const getCognitoFlowUrlStatus = (state: CommonState) =>
   state.pages.audioRewards.cognitoFlowUrlStatus
+
+export const getShowRewardClaimedToast = (state: CommonState) =>
+  state.pages.audioRewards.showRewardClaimedToast

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -164,8 +164,6 @@ const slice = createSlice({
     fetchCognitoFlowUrlFailed: state => {
       state.cognitoFlowUrlStatus = Status.ERROR
     },
-    refreshUserChallenges: () => {},
-    refreshUserBalance: () => {},
     reset: () => {}
   }
 })
@@ -189,8 +187,6 @@ export const {
   fetchCognitoFlowUrl,
   fetchCognitoFlowUrlFailed,
   fetchCognitoFlowUrlSucceeded,
-  refreshUserChallenges,
-  refreshUserBalance,
   reset
 } = slice.actions
 

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -51,6 +51,7 @@ type RewardsUIState = {
   cognitoFlowStatus: CognitoFlowStatus
   cognitoFlowUrlStatus?: Status
   cognitoFlowUrl?: string
+  showRewardClaimedToast: boolean
 }
 
 const initialState: RewardsUIState = {
@@ -61,7 +62,8 @@ const initialState: RewardsUIState = {
   loading: true,
   claimStatus: ClaimStatus.NONE,
   hCaptchaStatus: HCaptchaStatus.NONE,
-  cognitoFlowStatus: CognitoFlowStatus.CLOSED
+  cognitoFlowStatus: CognitoFlowStatus.CLOSED,
+  showRewardClaimedToast: false
 }
 
 const slice = createSlice({
@@ -163,6 +165,12 @@ const slice = createSlice({
     },
     fetchCognitoFlowUrlFailed: state => {
       state.cognitoFlowUrlStatus = Status.ERROR
+    },
+    showRewardClaimedToast: state => {
+      state.showRewardClaimedToast = true
+    },
+    hideRewardClaimedToast: state => {
+      state.showRewardClaimedToast = false
     }
   }
 })
@@ -185,7 +193,9 @@ export const {
   setCognitoFlowStatus,
   fetchCognitoFlowUrl,
   fetchCognitoFlowUrlFailed,
-  fetchCognitoFlowUrlSucceeded
+  fetchCognitoFlowUrlSucceeded,
+  showRewardClaimedToast,
+  hideRewardClaimedToast
 } = slice.actions
 
 export default slice

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -169,7 +169,7 @@ const slice = createSlice({
     showRewardClaimedToast: state => {
       state.showRewardClaimedToast = true
     },
-    hideRewardClaimedToast: state => {
+    resetRewardClaimedToast: state => {
       state.showRewardClaimedToast = false
     }
   }
@@ -195,7 +195,7 @@ export const {
   fetchCognitoFlowUrlFailed,
   fetchCognitoFlowUrlSucceeded,
   showRewardClaimedToast,
-  hideRewardClaimedToast
+  resetRewardClaimedToast
 } = slice.actions
 
 export default slice

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -185,8 +185,7 @@ export const {
   setCognitoFlowStatus,
   fetchCognitoFlowUrl,
   fetchCognitoFlowUrlFailed,
-  fetchCognitoFlowUrlSucceeded,
-  reset
+  fetchCognitoFlowUrlSucceeded
 } = slice.actions
 
 export default slice

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -163,8 +163,7 @@ const slice = createSlice({
     },
     fetchCognitoFlowUrlFailed: state => {
       state.cognitoFlowUrlStatus = Status.ERROR
-    },
-    reset: () => {}
+    }
   }
 })
 

--- a/src/components/reward-claimed-toast/RewardClaimedToast.module.css
+++ b/src/components/reward-claimed-toast/RewardClaimedToast.module.css
@@ -1,0 +1,19 @@
+.rewardClaimedToast {
+  display: flex;
+  justify-content: center;
+}
+
+.rewardClaimedToastIcon {
+  top: -2px !important;
+  position: relative;
+}
+
+.seeMoreCaret {
+  margin-left: 2px;
+  height: 12px;
+  width: 10px;
+}
+
+.seeMoreCaret path {
+  fill: var(--static-white);
+}

--- a/src/components/reward-claimed-toast/RewardClaimedToast.module.css
+++ b/src/components/reward-claimed-toast/RewardClaimedToast.module.css
@@ -1,11 +1,14 @@
 .rewardClaimedToast {
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 
 .rewardClaimedToastIcon {
-  top: -2px !important;
-  position: relative;
+  margin-inline-end: 8px;
+}
+.rewardClaimedToastIcon > :global(.emoji) {
+  margin-bottom: 0;
 }
 
 .seeMoreCaret {

--- a/src/components/reward-claimed-toast/RewardClaimedToast.tsx
+++ b/src/components/reward-claimed-toast/RewardClaimedToast.tsx
@@ -1,0 +1,56 @@
+import React, { useContext, useEffect } from 'react'
+
+import { useDispatch, useSelector } from 'react-redux'
+
+import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'
+import { getShowRewardClaimedToast } from 'common/store/pages/audio-rewards/selectors'
+import { hideRewardClaimedToast } from 'common/store/pages/audio-rewards/slice'
+import { ToastContext } from 'components/toast/ToastContext'
+import ToastLinkContent from 'components/toast/mobile/ToastLinkContent'
+import { getLocationPathname } from 'store/routing/selectors'
+import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
+import { AUDIO_PAGE } from 'utils/route'
+
+import styles from './RewardClaimedToast.module.css'
+
+const messages = {
+  challengeCompleted: 'You’ve Completed an $AUDIO Rewards Challenge!',
+  seeMore: 'See more'
+}
+
+export const RewardClaimedToast = () => {
+  const { toast } = useContext(ToastContext)
+  const dispatch = useDispatch()
+  const showToast = useSelector(getShowRewardClaimedToast)
+  const pathname = useSelector(getLocationPathname)
+
+  useEffect(() => {
+    if (showToast) {
+      const toastContent = (
+        <div className={styles.rewardClaimedToast}>
+          <span className={styles.rewardClaimedToastIcon}>
+            <i className='emoji face-with-party-horn-and-party-hat' />
+          </span>
+          &nbsp;&nbsp;
+          {pathname === AUDIO_PAGE ? (
+            messages.challengeCompleted
+          ) : (
+            <ToastLinkContent
+              text={messages.challengeCompleted}
+              linkText={messages.seeMore}
+              link={AUDIO_PAGE}
+              linkIcon={<IconCaretRight className={styles.seeMoreCaret} />}
+            />
+          )}
+        </div>
+      )
+
+      toast(toastContent, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
+      setTimeout(() => {
+        dispatch(hideRewardClaimedToast())
+      }, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
+    }
+  }, [toast, dispatch, showToast, pathname])
+
+  return null
+}

--- a/src/components/reward-claimed-toast/RewardClaimedToast.tsx
+++ b/src/components/reward-claimed-toast/RewardClaimedToast.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import React, { useContext, useEffect, useRef } from 'react'
 
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -23,9 +23,10 @@ export const RewardClaimedToast = () => {
   const dispatch = useDispatch()
   const showToast = useSelector(getShowRewardClaimedToast)
   const pathname = useSelector(getLocationPathname)
+  const isShowing = useRef(false)
 
   useEffect(() => {
-    if (showToast) {
+    if (showToast && !isShowing.current) {
       const toastContent = (
         <div className={styles.rewardClaimedToast}>
           <span className={styles.rewardClaimedToastIcon}>
@@ -45,11 +46,13 @@ export const RewardClaimedToast = () => {
       )
 
       toast(toastContent, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
+      isShowing.current = true
       setTimeout(() => {
         dispatch(hideRewardClaimedToast())
+        isShowing.current = false
       }, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
     }
-  }, [toast, dispatch, showToast, pathname])
+  }, [toast, dispatch, showToast, pathname, isShowing])
 
   return null
 }

--- a/src/components/reward-claimed-toast/RewardClaimedToast.tsx
+++ b/src/components/reward-claimed-toast/RewardClaimedToast.tsx
@@ -1,10 +1,10 @@
-import React, { useContext, useEffect, useRef } from 'react'
+import React, { useContext, useEffect } from 'react'
 
 import { useDispatch, useSelector } from 'react-redux'
 
 import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'
 import { getShowRewardClaimedToast } from 'common/store/pages/audio-rewards/selectors'
-import { hideRewardClaimedToast } from 'common/store/pages/audio-rewards/slice'
+import { resetRewardClaimedToast } from 'common/store/pages/audio-rewards/slice'
 import { ToastContext } from 'components/toast/ToastContext'
 import ToastLinkContent from 'components/toast/mobile/ToastLinkContent'
 import { getLocationPathname } from 'store/routing/selectors'
@@ -23,10 +23,9 @@ export const RewardClaimedToast = () => {
   const dispatch = useDispatch()
   const showToast = useSelector(getShowRewardClaimedToast)
   const pathname = useSelector(getLocationPathname)
-  const isShowing = useRef(false)
 
   useEffect(() => {
-    if (showToast && !isShowing.current) {
+    if (showToast) {
       const toastContent = (
         <div className={styles.rewardClaimedToast}>
           <span className={styles.rewardClaimedToastIcon}>
@@ -46,13 +45,9 @@ export const RewardClaimedToast = () => {
       )
 
       toast(toastContent, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
-      isShowing.current = true
-      setTimeout(() => {
-        dispatch(hideRewardClaimedToast())
-        isShowing.current = false
-      }, CLAIM_REWARD_TOAST_TIMEOUT_MILLIS)
+      dispatch(resetRewardClaimedToast())
     }
-  }, [toast, dispatch, showToast, pathname, isShowing])
+  }, [toast, dispatch, showToast, pathname])
 
   return null
 }

--- a/src/components/reward-claimed-toast/RewardClaimedToast.tsx
+++ b/src/components/reward-claimed-toast/RewardClaimedToast.tsx
@@ -31,7 +31,6 @@ export const RewardClaimedToast = () => {
           <span className={styles.rewardClaimedToastIcon}>
             <i className='emoji face-with-party-horn-and-party-hat' />
           </span>
-          &nbsp;&nbsp;
           {pathname === AUDIO_PAGE ? (
             messages.challengeCompleted
           ) : (

--- a/src/components/toast/mobile/ToastLinkContent.tsx
+++ b/src/components/toast/mobile/ToastLinkContent.tsx
@@ -10,20 +10,27 @@ type ToastLinkContentProps = {
   link: string
   linkText: string
   text: string
+  linkIcon?: JSX.Element
 }
 
 /**
  * This component can be used as the content of a Toast to render a link
  * in addition to text
  */
-const ToastLinkContent = ({ link, text }: ToastLinkContentProps) => {
+const ToastLinkContent = ({
+  link,
+  linkText,
+  text,
+  linkIcon
+}: ToastLinkContentProps) => {
   const { clear: clearToasts } = useContext(ToastContext)
 
   return (
     <div>
       <span className={styles.text}>{text}</span>
       <Link to={link} className={styles.link} onClick={clearToasts}>
-        View
+        {linkText}
+        {linkIcon || null}
       </Link>
     </div>
   )

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -34,6 +34,7 @@ import NotificationPage from 'components/notification/NotificationPage'
 import PinnedTrackConfirmation from 'components/pin-track-confirmation/PinTrackConfirmation'
 import PlayBarProvider from 'components/play-bar/PlayBarProvider'
 import ConnectedReachabilityBar from 'components/reachability-bar/ReachabilityBar'
+import { RewardClaimedToast } from 'components/reward-claimed-toast/RewardClaimedToast'
 import DesktopRoute from 'components/routes/DesktopRoute'
 import MobileRoute from 'components/routes/MobileRoute'
 import TrendingGenreSelectionPage from 'components/trending-genre-selection/TrendingGenreSelectionPage'
@@ -927,6 +928,11 @@ class App extends Component {
         {
           <Suspense fallback={null}>
             <ConnectedMusicConfetti />
+          </Suspense>
+        }
+        {
+          <Suspense fallback={null}>
+            <RewardClaimedToast />
           </Suspense>
         }
 

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -13,10 +13,7 @@ import {
 } from 'common/store/pages/audio-rewards/selectors'
 import {
   ChallengeRewardsModalType,
-  setChallengeRewardsModalType,
-  reset,
-  refreshUserBalance,
-  refreshUserChallenges
+  setChallengeRewardsModalType
 } from 'common/store/pages/audio-rewards/slice'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
@@ -147,15 +144,6 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
       setHaveChallengesLoaded(true)
     }
   }, [userChallengesLoading, haveChallengesLoaded])
-
-  // poll for user challenges and user balance to refresh
-  useEffect(() => {
-    dispatch(refreshUserChallenges())
-    dispatch(refreshUserBalance())
-    return () => {
-      dispatch(reset())
-    }
-  }, [dispatch])
 
   const openModal = (modalType: ChallengeRewardsModalType) => {
     dispatch(setChallengeRewardsModalType({ modalType }))

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -13,6 +13,7 @@ import {
 } from 'common/store/pages/audio-rewards/selectors'
 import {
   ChallengeRewardsModalType,
+  fetchUserChallenges,
   setChallengeRewardsModalType
 } from 'common/store/pages/audio-rewards/slice'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
@@ -144,6 +145,11 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
       setHaveChallengesLoaded(true)
     }
   }, [userChallengesLoading, haveChallengesLoaded])
+
+  useEffect(() => {
+    // Refresh user challenges on page visit
+    dispatch(fetchUserChallenges())
+  }, [dispatch])
 
   const openModal = (modalType: ChallengeRewardsModalType) => {
     dispatch(setChallengeRewardsModalType({ modalType }))

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -298,12 +298,23 @@ function* watchUpdateHCaptchaScore() {
 }
 
 function* userChallengePollingDaemon() {
+  // These config options have defaults, they can't be null
+  const defaultChallengePollingTimeout = remoteConfigInstance.getRemoteVar(
+    IntKeys.CHALLENGE_REFRESH_INTERVAL_MS
+  )!
+  const audioRewardsPageChallengePollingTimeout = remoteConfigInstance.getRemoteVar(
+    IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS
+  )!
   yield fork(function* () {
     yield* visibilityPollingDaemon(fetchUserChallenges())
   })
-  yield* foregroundPollingDaemon(fetchUserChallenges(), 15000, {
-    [AUDIO_PAGE]: 3000
-  })
+  yield* foregroundPollingDaemon(
+    fetchUserChallenges(),
+    defaultChallengePollingTimeout,
+    {
+      [AUDIO_PAGE]: audioRewardsPageChallengePollingTimeout
+    }
+  )
 }
 
 const sagas = () => {

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -43,7 +43,8 @@ import {
   setCognitoFlowStatus,
   setHCaptchaStatus,
   setUserChallengeDisbursed,
-  updateHCaptchaScore
+  updateHCaptchaScore,
+  showRewardClaimedToast
 } from 'common/store/pages/audio-rewards/slice'
 import { setVisibility } from 'common/store/ui/modals/slice'
 import { getBalance, increaseBalance } from 'common/store/wallet/slice'
@@ -270,8 +271,7 @@ export function* watchFetchUserChallenges() {
       if (newDisbursement) {
         yield put(getBalance())
         yield put(showMusicConfetti())
-        // TODO: showToast
-        // yield put(showToast())
+        yield put(showRewardClaimedToast())
       }
       yield put(fetchUserChallengesSucceeded({ userChallenges }))
     } catch (e) {

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -298,7 +298,7 @@ function* watchUpdateHCaptchaScore() {
 }
 
 function* userChallengePollingDaemon() {
-  // These config options have defaults, they can't be null
+  yield call(remoteConfigInstance.waitForRemoteConfig)
   const defaultChallengePollingTimeout = remoteConfigInstance.getRemoteVar(
     IntKeys.CHALLENGE_REFRESH_INTERVAL_MS
   )!

--- a/src/utils/sagaPollingDaemons.ts
+++ b/src/utils/sagaPollingDaemons.ts
@@ -1,0 +1,92 @@
+import { Action } from 'redux'
+import { delay, eventChannel } from 'redux-saga'
+import { select, put, take } from 'redux-saga/effects'
+
+import { getLocationPathname } from 'store/routing/selectors'
+
+import { isElectron } from './clientUtil'
+
+const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
+
+/**
+ * Starts a polling daemon that triggers an action once every delay period if the tab/app is in the foreground/focus
+ * @param action The action to "fire" when poll triggers
+ * @param defaultDelayTimeMs the default time to wait between polls
+ * @param customDelayTimeConfig a config that maps pathnames to delay times for custom delays depending on what page the user is on
+ */
+export function* foregroundPollingDaemon(
+  action: Action,
+  defaultDelayTimeMs: number,
+  customDelayTimeConfig?: Record<string, number>
+) {
+  let isBrowserInBackground = false
+  document.addEventListener(
+    'visibilitychange',
+    () => {
+      if (document.hidden) {
+        isBrowserInBackground = true
+      } else {
+        isBrowserInBackground = false
+      }
+    },
+    false
+  )
+
+  while (true) {
+    if (!isBrowserInBackground || isElectron()) {
+      yield put(action)
+    }
+    if (customDelayTimeConfig) {
+      const currentRoute: string = yield select(getLocationPathname)
+      if (customDelayTimeConfig[currentRoute]) {
+        yield delay(customDelayTimeConfig[currentRoute])
+      } else {
+        yield delay(defaultDelayTimeMs)
+      }
+    } else {
+      yield delay(defaultDelayTimeMs)
+    }
+  }
+}
+
+function createVisibilityChangeChannel() {
+  if (NATIVE_MOBILE) {
+    return eventChannel(emitter => {
+      // The focus and visibitychange events are wonky on native mobile webviews,
+      // so poll for visiblity change instead
+      let lastHidden = true
+      const interval = setInterval(() => {
+        if (!document.hidden && lastHidden) {
+          emitter(true)
+        }
+        lastHidden = document.hidden
+      }, 500)
+      return () => {
+        clearInterval(interval)
+      }
+    })
+  }
+  return eventChannel(emitter => {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        emitter(true)
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  })
+}
+
+/**
+ * A polling daemon that triggers an action every time the tab/app is brought back into focus
+ * @param action The action to "fire" when triggered
+ */
+export function* visibilityPollingDaemon(action: Action) {
+  const visibilityChannel = createVisibilityChangeChannel()
+  while (true) {
+    yield take(visibilityChannel)
+    yield put(action)
+  }
+}


### PR DESCRIPTION
### Description

- Show's a reward claimed toast if identity claims a reward on behalf of a user during a session.
- Moves polling to be during all pages, but is quicker on the $AUDIO page
- Only refresh wallet balance if a challenge was disbursed

Based largely on https://github.com/AudiusProject/audius-client/pull/799/files

Reviewer notes:
- Copies the notification polling daemon logic to a util that can be reused

### Dragons

### How Has This Been Tested?

Tested by mocking responses from discovery, flipping is_disbursed back and forth.

### How will this change be monitored?

N/A?
