### PR TITLE
Handle referrals-verified challenge

### DIFF
--- a/src/common/models/AudioRewards.ts
+++ b/src/common/models/AudioRewards.ts
@@ -16,6 +16,7 @@ export type UserChallenge = {
 export type ChallengeRewardID =
   | 'track-upload'
   | 'referrals'
+  | 'referrals-verified'
   | 'referred'
   | 'mobile-install'
   | 'connect-verified'
@@ -89,6 +90,7 @@ export type FlowSessionEvent =
 export const amounts: Record<ChallengeRewardID, number> = {
   referrals: 1,
   referred: 1,
+  'referrals-verified': 1,
   'connect-verified': 5,
   'listen-streak': 1,
   'mobile-install': 1,

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -16,6 +16,7 @@ import {
   fetchUserChallenges,
   setChallengeRewardsModalType
 } from 'common/store/pages/audio-rewards/slice'
+import { removeNullable } from 'common/utils/typeUtils'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
@@ -116,6 +117,7 @@ type RewardsTileProps = {
 const validRewardIds: Set<ChallengeRewardID> = new Set([
   'track-upload',
   'referrals',
+  'referrals-verified',
   'mobile-install',
   'connect-verified',
   'listen-streak',
@@ -138,6 +140,7 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
   const dispatch = useDispatch()
   const rewardIds = useRewardIds()
   const userChallengesLoading = useSelector(getUserChallengesLoading)
+  const userChallenges = useSelector(getUserChallenges)
   const [haveChallengesLoaded, setHaveChallengesLoaded] = useState(false)
 
   useEffect(() => {
@@ -157,10 +160,13 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
   }
 
   const rewardsTiles = rewardIds
-    .map(id => challengeRewardsConfig[id])
-    .map(props => (
-      <RewardPanel {...props} openModal={openModal} key={props.id} />
-    ))
+    // Filter out challenges that DN didn't return
+    .map(id => userChallenges[id]?.challenge_id)
+    .filter(removeNullable)
+    .map(id => {
+      const props = challengeRewardsConfig[id]
+      return <RewardPanel {...props} openModal={openModal} key={props.id} />
+    })
 
   const wm = useWithMobileStyle(styles.mobile)
 

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -291,9 +291,10 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         </div>
       )}
 
-      {userHandle && modalType === 'referrals' && (
-        <InviteLink handle={userHandle} />
-      )}
+      {userHandle &&
+        (modalType === 'referrals' || modalType === 'referrals-verified') && (
+          <InviteLink handle={userHandle} />
+        )}
       {modalType === 'mobile-install' && (
         <div className={wm(styles.qrContainer)}>
           <img className={styles.qr} src={QRCode} alt='QR Code' />

--- a/src/pages/audio-rewards-page/config.tsx
+++ b/src/pages/audio-rewards-page/config.tsx
@@ -92,6 +92,23 @@ export const challengeRewardsConfig: Record<
       complete: null
     }
   },
+  'referrals-verified': {
+    id: 'referrals-verified' as ChallengeRewardID,
+    title: 'Invite your Friends',
+    icon: <i className='emoji large incoming-envelope' />,
+    description: amount => `Earn ${amount} $AUDIO, for you and your friend`,
+    fullDescription: amount =>
+      `Invite your Friends! You’ll earn ${amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
+    progressLabel: '%0/%1 Invites',
+    amount: amounts.referrals,
+    stepCount: 500,
+    panelButtonText: 'Invite your Friends',
+    modalButtonInfo: {
+      incomplete: null,
+      inProgress: null,
+      complete: null
+    }
+  },
   // This is used just for the notifications
   referred: {
     id: 'referrals' as ChallengeRewardID,


### PR DESCRIPTION
### Description
- Support DN's new challenge type, referrals-verified, which is the same as a regular referral challenge but with a higher max referral count.
- DN now returns different lists of challenges per user (verified/not-verified), incorporate that into the display logic

### Dragons

None

### How Has This Been Tested?

Tested with verified + unverified accounts against staging

### How will this change be monitored?

n/a
