### PR TITLE
Add feature flag enable_spl_audio

### DIFF
--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -69,6 +69,5 @@ export const remoteConfigBooleanDefaults: {
   [BooleanKeys.DISPLAY_WEB3_PROVIDER_WALLET_LINK]: true,
   [BooleanKeys.DISPLAY_SOLANA_WEB3_PROVIDER_PHANTOM]: true,
   [BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK]: false,
-  [BooleanKeys.USE_AMPLITUDE]: true,
-  [BooleanKeys.USE_SPL_AUDIO]: true
+  [BooleanKeys.USE_AMPLITUDE]: true
 }

--- a/src/common/services/remote-config/feature-flags.ts
+++ b/src/common/services/remote-config/feature-flags.ts
@@ -16,7 +16,8 @@ export enum FeatureFlags {
   SURFACE_AUDIO_ENABLED = 'surface_audio_enabled',
   PREFER_HIGHER_PATCH_FOR_PRIMARY = 'prefer_higher_patch_for_primary',
   PREFER_HIGHER_PATCH_FOR_SECONDARIES = 'prefer_higher_patch_for_secondaries',
-  REWARDS_NOTIFICATIONS_ENABLED = 'rewards_notifications_enabled'
+  REWARDS_NOTIFICATIONS_ENABLED = 'rewards_notifications_enabled',
+  ENABLE_SPL_AUDIO = 'enable_spl_audio'
 }
 
 /**
@@ -39,7 +40,8 @@ export const flagDefaults: { [key in FeatureFlags]: boolean } = {
   [FeatureFlags.SURFACE_AUDIO_ENABLED]: false,
   [FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY]: true,
   [FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES]: true,
-  [FeatureFlags.REWARDS_NOTIFICATIONS_ENABLED]: false
+  [FeatureFlags.REWARDS_NOTIFICATIONS_ENABLED]: false,
+  [FeatureFlags.ENABLE_SPL_AUDIO]: false
 }
 
 export enum FeatureFlagCohortType {
@@ -80,5 +82,7 @@ export const flagCohortType: {
     FeatureFlagCohortType.SESSION_ID,
   [FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES]:
     FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.REWARDS_NOTIFICATIONS_ENABLED]: FeatureFlagCohortType.SESSION_ID
+  [FeatureFlags.REWARDS_NOTIFICATIONS_ENABLED]:
+    FeatureFlagCohortType.SESSION_ID,
+  [FeatureFlags.ENABLE_SPL_AUDIO]: FeatureFlagCohortType.SESSION_ID
 }

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -119,12 +119,7 @@ export enum BooleanKeys {
   /**
    * Boolean to use amplitude as the metrics tracking.
    */
-  USE_AMPLITUDE = 'USE_AMPLITUDE',
-
-  /**
-   * Boolean to use solana wrapped audio instead of erc20 audio for the audio page send/receive.
-   */
-  USE_SPL_AUDIO = 'USE_SPL_AUDIO'
+  USE_AMPLITUDE = 'USE_AMPLITUDE'
 }
 
 export enum DoubleKeys {

--- a/src/pages/audio-rewards-page/WalletModal.tsx
+++ b/src/pages/audio-rewards-page/WalletModal.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as IconReceive } from 'assets/img/iconReceive.svg'
 import { ReactComponent as IconSend } from 'assets/img/iconSend.svg'
 import { Chain } from 'common/models/Chain'
 import { BNWei, StringWei, WalletAddress } from 'common/models/Wallet'
-import { BooleanKeys } from 'common/services/remote-config'
+import { FeatureFlags } from 'common/services/remote-config'
 import { getAccountUser } from 'common/store/account/selectors'
 import {
   getHasAssociatedWallets,
@@ -46,7 +46,7 @@ import SendInputSuccess from './components/SendInputSuccess'
 import SendingModalBody from './components/SendingModalBody'
 import ModalDrawer from './components/modals/ModalDrawer'
 
-const { getRemoteVar } = remoteConfigInstance
+const { getFeatureEnabled } = remoteConfigInstance
 const DISCORD_URL = ' https://discord.gg/audius'
 
 const messages = {
@@ -98,7 +98,9 @@ const titlesMap = {
   },
   RECEIVE: {
     KEY_DISPLAY: () => {
-      const useSolSPLAudio = getRemoteVar(BooleanKeys.USE_SPL_AUDIO) as boolean
+      const useSolSPLAudio = getFeatureEnabled(
+        FeatureFlags.ENABLE_SPL_AUDIO
+      ) as boolean
       return (
         <TitleWrapper
           label={useSolSPLAudio ? messages.receiveSPL : messages.receive}
@@ -198,7 +200,9 @@ const ModalContent = ({
   const account = useSelector(getAccountUser)
   const amountPendingTransfer = useSelector(getSendData)
   const discordCode = useSelector(getDiscordCode)
-  const useSolSPLAudio = getRemoteVar(BooleanKeys.USE_SPL_AUDIO) as boolean
+  const useSolSPLAudio = getFeatureEnabled(
+    FeatureFlags.ENABLE_SPL_AUDIO
+  ) as boolean
 
   if (!modalState || !account || (useSolSPLAudio && !account.userBank)) {
     return null

--- a/src/pages/audio-rewards-page/components/ReceiveBody.tsx
+++ b/src/pages/audio-rewards-page/components/ReceiveBody.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonType, LogoSol } from '@audius/stems'
 import cn from 'classnames'
 
 import { SolanaWalletAddress, WalletAddress } from 'common/models/Wallet'
-import { BooleanKeys } from 'common/services/remote-config'
+import { FeatureFlags } from 'common/services/remote-config'
 import { useLocalStorage } from 'hooks/useLocalStorage'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 
@@ -18,7 +18,7 @@ type ReceiveBodyProps = {
   solWallet: SolanaWalletAddress
 }
 
-const { getRemoteVar } = remoteConfigInstance
+const { getFeatureEnabled } = remoteConfigInstance
 const messages = {
   warning: 'PROCEED WITH CAUTION',
   warning2: 'If $AUDIO is sent to the wrong address it will be lost.',
@@ -49,7 +49,9 @@ const useLocalStorageClickedReceiveUnderstand = (): [boolean, () => void] => {
 }
 
 const ReceiveBody = ({ wallet, solWallet }: ReceiveBodyProps) => {
-  const useSolSPLAudio = getRemoteVar(BooleanKeys.USE_SPL_AUDIO) as boolean
+  const useSolSPLAudio = getFeatureEnabled(
+    FeatureFlags.ENABLE_SPL_AUDIO
+  ) as boolean
   const [
     hasClickedUnderstand,
     onClickUnderstand

--- a/src/pages/audio-rewards-page/components/SendInputBody.tsx
+++ b/src/pages/audio-rewards-page/components/SendInputBody.tsx
@@ -18,7 +18,7 @@ import {
   StringWei,
   WalletAddress
 } from 'common/models/Wallet'
-import { BooleanKeys, IntKeys } from 'common/services/remote-config'
+import { FeatureFlags, IntKeys } from 'common/services/remote-config'
 import { convertFloatToWei } from 'common/utils/formatUtil'
 import { Nullable } from 'common/utils/typeUtils'
 import {
@@ -35,7 +35,7 @@ import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
 import DashboardTokenValueSlider from './DashboardTokenValueSlider'
 import styles from './SendInputBody.module.css'
 
-const { getRemoteVar } = remoteConfigInstance
+const { getRemoteVar, getFeatureEnabled } = remoteConfigInstance
 
 const messages = {
   warningTitle: 'PROCEED WITH CAUTION',
@@ -220,7 +220,9 @@ const SendInputBody = ({
     [addressError, setAddressError, setDestinationAddress]
   )
 
-  const useSolSPLAudio = getRemoteVar(BooleanKeys.USE_SPL_AUDIO) as boolean
+  const useSolSPLAudio = getFeatureEnabled(
+    FeatureFlags.ENABLE_SPL_AUDIO
+  ) as boolean
   const minAudioSendAmount = getRemoteVar(
     IntKeys.MIN_AUDIO_SEND_AMOUNT
   ) as number


### PR DESCRIPTION
### Description
Adds feature flag for enable spl audio and replaces the remote-config enable spl audio variable
If enabled
* adds the user_bank_spl audio to the user's balance
* Update the /audio page to display the solana user bank address instead of the user's eth wallet 
* Update the /audio page to send using sol audio instead of eth audio

Closes AUD-1335

### Dragons
none

### How Has This Been Tested?
Ran against stage

### How will this change be monitored?
