### PR TITLE
Fix challenges flashing

### DIFF
--- a/src/common/services/remote-config/feature-flags.ts
+++ b/src/common/services/remote-config/feature-flags.ts
@@ -73,7 +73,7 @@ export const flagCohortType: {
   [FeatureFlags.REMIXABLES_WEB]: FeatureFlagCohortType.USER_ID,
   [FeatureFlags.TRANSFER_AUDIO_TO_WAUDIO_ON_LOAD]:
     FeatureFlagCohortType.USER_ID,
-  [FeatureFlags.CHALLENGE_REWARDS_UI]: FeatureFlagCohortType.USER_ID,
+  [FeatureFlags.CHALLENGE_REWARDS_UI]: FeatureFlagCohortType.SESSION_ID,
   [FeatureFlags.NFT_IMAGE_PICKER_TAB]: FeatureFlagCohortType.USER_ID,
   [FeatureFlags.SOL_WALLET_AUDIO_ENABLED]: FeatureFlagCohortType.USER_ID,
   [FeatureFlags.ARTIST_RECOMMENDATIONS_ENABLED]: FeatureFlagCohortType.USER_ID,


### PR DESCRIPTION
### Description
When loading the /audio page, the challenges do not appear at first and flash in after a second. 
This was due to the challenges component being gated by the feature flag with cohort user-id - which means that the default is returned until the the user id is loaded in, thus causing the delay and subsequent challenges box appearing. 

Fix: Update the cohort to be sessionID - as it shouldn't matter because we're not rolling it out incrementally. 

Fixes AUD-1266

### Dragons
none

### How Has This Been Tested?
manually

### How will this change be monitored?
