### PR TITLE
Add new UI for verified challenges

### DIFF
--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -26,7 +26,7 @@ import styles from './RewardsTile.module.css'
 import ButtonWithArrow from './components/ButtonWithArrow'
 import { Tile } from './components/ExplainerTile'
 import { challengeRewardsConfig } from './config'
-import { useOptimisticUserChallenge } from './hooks'
+import { OptimisticUserChallenge, useOptimisticUserChallenge } from './hooks'
 
 const messages = {
   title: '$AUDIO REWARDS',
@@ -37,10 +37,18 @@ const messages = {
   claimReward: 'Claim Your Reward'
 }
 
+// For aggregate challenges, we show the total amount
+// you'd get when completing every step of the challenge
+// -- i.e. for referrals, show 1 audio x 5 steps = 5 audio
+export const getAmount = (challenge?: OptimisticUserChallenge) =>
+  challenge?.challenge_type === 'aggregate'
+    ? challenge.amount * challenge.max_steps
+    : challenge?.amount
+
 type RewardPanelProps = {
   title: string
   icon: ReactNode
-  description: (amount: number | undefined) => string
+  description: (challenge?: OptimisticUserChallenge) => string
   panelButtonText: string
   progressLabel: string
   stepCount: number
@@ -72,7 +80,7 @@ const RewardPanel = ({
         {title}
       </span>
       <span className={wm(styles.rewardDescription)}>
-        {description(challenge?.amount)}
+        {description(challenge)}
       </span>
       <div className={wm(styles.rewardProgress)}>
         <p

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -37,14 +37,6 @@ const messages = {
   claimReward: 'Claim Your Reward'
 }
 
-// For aggregate challenges, we show the total amount
-// you'd get when completing every step of the challenge
-// -- i.e. for referrals, show 1 audio x 5 steps = 5 audio
-export const getAmount = (challenge?: OptimisticUserChallenge) =>
-  challenge?.challenge_type === 'aggregate'
-    ? challenge.amount * challenge.max_steps
-    : challenge?.amount
-
 type RewardPanelProps = {
   title: string
   icon: ReactNode

--- a/src/pages/audio-rewards-page/components/PurpleBox.module.css
+++ b/src/pages/audio-rewards-page/components/PurpleBox.module.css
@@ -8,7 +8,7 @@
   padding: 24px 42px;
   display: inline-flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
 }
 
 .mobile.container {
@@ -24,6 +24,7 @@
   text-transform: uppercase;
   color: #C675FF;
   text-shadow: 0px 4px 15px rgba(0, 0, 0, 0.1);
+  margin-bottom: 6px;
 }
 .label.mobile {
   font-size: var(--font-s);

--- a/src/pages/audio-rewards-page/components/PurpleBox.module.css
+++ b/src/pages/audio-rewards-page/components/PurpleBox.module.css
@@ -24,7 +24,6 @@
   text-transform: uppercase;
   color: #C675FF;
   text-shadow: 0px 4px 15px rgba(0, 0, 0, 0.1);
-  margin-bottom: 6px;
 }
 .label.mobile {
   font-size: var(--font-s);

--- a/src/pages/audio-rewards-page/components/PurpleBox.tsx
+++ b/src/pages/audio-rewards-page/components/PurpleBox.tsx
@@ -7,7 +7,7 @@ import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
 import styles from './PurpleBox.module.css'
 
 type PurpleBoxProps = {
-  label: ReactNode
+  label?: ReactNode
   text: ReactNode
   className?: string
   onClick?: () => void
@@ -28,7 +28,7 @@ const PurpleBox = ({
       className={wm(styles.container, { [className!]: !!className })}
       onClick={onClick}
     >
-      <div className={wm(styles.label)}>{label}</div>
+      {label && <div className={wm(styles.label)}>{label}</div>}
       <div className={cn(wm(styles.text), { [styles.compact]: isCompact })}>
         {text}
       </div>

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
@@ -228,9 +228,6 @@
   flex: 0 0 24px;
   margin-right: 8px;
 }
-.inviteIcon.mobile {
-  height: 20px;
-}
 
 .inviteIcon path {
   fill: var(--static-white);

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
@@ -220,16 +220,16 @@
 
 .inviteLink {
   min-width: 0;
+  font-size: var(--font-m);
 }
 
 .inviteIcon {
   height: 24px;
   flex: 0 0 24px;
-  margin-left: 12px;
+  margin-right: 8px;
 }
 .inviteIcon.mobile {
   height: 20px;
-  margin-left: 8px;
 }
 
 .inviteIcon path {
@@ -353,7 +353,10 @@
 }
 
 .twitterButton .twitterText {
-  font-size: 16px;
+  font-size: var(--font-m);
+}
+.twitterButton .twitterIcon {
+  margin-right: 8px !important;
 }
 .twitterButton .twitterIcon svg {
   width: 24px;

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
@@ -196,10 +196,13 @@
   cursor: pointer;
   transition: all 0.07s ease-in-out;
   transform: scale3d(1, 1, 1);
+  min-width: unset;
+  min-height: 60px;
+  padding: unset;
 }
 .inviteButtonContainer.mobile {
-  min-height: 76px;
   padding: 16px;
+  margin-top: 8px;
 }
 .inviteButtonContainer:hover {
   transform: scale3d(1.03, 1.03, 1.03);
@@ -234,8 +237,11 @@
 }
 
 .toastContainer {
-  margin-top: 32px;
   position: relative;
+  flex: 1;
+}
+
+.toastContainer.mobile {
   width: 100%;
 }
 
@@ -305,4 +311,55 @@
   margin-top: 18px;
   color: var(--accent-red);
   font-weight: 500;
+}
+
+.verifiedChallenge {
+  display: flex;
+  align-items: center;
+}
+
+.verifiedChallenge svg {
+  height: 24px;
+  width: 24px;
+  margin-right: 10px;
+  margin-top: -3px;
+}
+
+.buttonContainer {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  margin-top: 32px;
+}
+
+.buttonContainer.mobile {
+  flex-direction: column;
+}
+
+.twitterButton {
+  min-height: 60px;
+  flex: 1;
+  padding: unset;
+  background-color: var(--static-twitter-blue);
+  border-radius: 6px;
+}
+
+.twitterButton.mobile {
+  width: 100%;
+}
+
+.twitterButton:hover {
+  background-color: var(--static-twitter-blue) !important;
+}
+
+.twitterButton .twitterText {
+  font-size: 16px;
+}
+.twitterButton .twitterIcon svg {
+  width: 24px;
+  height: 18px;
+}
+
+.buttonSpacer {
+  width: 10px;
 }

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -38,7 +38,6 @@ import { ToastContext } from 'components/toast/ToastContext'
 import Tooltip from 'components/tooltip/Tooltip'
 import { ComponentPlacement, MountPlacement } from 'components/types'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
-import { getAmount } from 'pages/audio-rewards-page/ChallengeRewardsTile'
 import { challengeRewardsConfig } from 'pages/audio-rewards-page/config'
 import { useOptimisticUserChallenge } from 'pages/audio-rewards-page/hooks'
 import { isMobile } from 'utils/clientUtil'
@@ -236,7 +235,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const progressReward = (
     <div className={wm(styles.progressReward)}>
       <h3>Reward</h3>
-      <h2>{getAmount(challenge)}</h2>
+      <h2>{challenge?.totalAmount}</h2>
       <h4>$AUDIO</h4>
     </div>
   )

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -1,6 +1,13 @@
-import React, { useCallback, useEffect, useContext } from 'react'
+import React, { useCallback, useEffect, useContext, useMemo } from 'react'
 
-import { Button, ButtonType, ProgressBar, IconCheck } from '@audius/stems'
+import {
+  Button,
+  ButtonType,
+  ProgressBar,
+  IconCheck,
+  IconVerified,
+  IconTwitterBird
+} from '@audius/stems'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import { useDispatch, useSelector } from 'react-redux'
@@ -31,12 +38,14 @@ import { ToastContext } from 'components/toast/ToastContext'
 import Tooltip from 'components/tooltip/Tooltip'
 import { ComponentPlacement, MountPlacement } from 'components/types'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
+import { getAmount } from 'pages/audio-rewards-page/ChallengeRewardsTile'
 import { challengeRewardsConfig } from 'pages/audio-rewards-page/config'
 import { useOptimisticUserChallenge } from 'pages/audio-rewards-page/hooks'
 import { isMobile } from 'utils/clientUtil'
 import { copyToClipboard } from 'utils/clipboardUtil'
 import { CLAIM_REWARD_TOAST_TIMEOUT_MILLIS } from 'utils/constants'
 import fillString from 'utils/fillString'
+import { openTwitterLink } from 'utils/tweet'
 
 import PurpleBox from '../PurpleBox'
 
@@ -61,22 +70,24 @@ export const useRewardsModalType = (): [
 const messages = {
   copyLabel: 'Copy to Clipboard',
   copiedLabel: 'Copied to Clipboard',
-  inviteLabel: 'Copy Invite Link',
+  inviteLabel: 'Copy Invite to Clipboard',
   inviteLink: 'audius.co/signup?ref=%0',
   qrText: 'Download the App',
   qrSubtext: 'Scan This QR Code with Your Phone Camera',
   rewardClaimed: 'Reward claimed successfully!',
   claimError: 'Oops, something’s gone wrong',
-  claimYourReward: 'Claim Your Reward'
+  claimYourReward: 'Claim Your Reward',
+  twitterShare: (modalType: 'referrals' | 'referrals-verified') =>
+    `Share Invite With Your ${modalType === 'referrals' ? 'Friends' : 'Fans'}`,
+  twitterCopy: `Come support me on @audiusproject! Use my link and we both earn $AUDIO when you sign up.\n\n #audius #audiorewards\n\n`
 }
 
 type InviteLinkProps = {
   className?: string
-  handle: string
+  inviteLink: string
 }
 
-const InviteLink = ({ className, handle }: InviteLinkProps) => {
-  const inviteLink = fillString(messages.inviteLink, handle)
+const InviteLink = ({ className, inviteLink }: InviteLinkProps) => {
   const wm = useWithMobileStyle(styles.mobile)
 
   const onButtonClick = useCallback(() => {
@@ -85,7 +96,7 @@ const InviteLink = ({ className, handle }: InviteLinkProps) => {
 
   return (
     <Tooltip text={messages.copyLabel} placement={'top'} mount={'parent'}>
-      <div className={cn(styles.toastContainer, { [className!]: !!className })}>
+      <div className={wm(styles.toastContainer, { [className!]: !!className })}>
         <Toast
           text={messages.copiedLabel}
           delay={2000}
@@ -94,19 +105,41 @@ const InviteLink = ({ className, handle }: InviteLinkProps) => {
           mount={MountPlacement.PARENT}
         >
           <PurpleBox
-            label={messages.inviteLabel}
             className={wm(styles.inviteButtonContainer)}
             onClick={onButtonClick}
             text={
               <div className={styles.inviteLinkContainer}>
-                <div className={styles.inviteLink}>{inviteLink}</div>
                 <IconCopy className={wm(styles.inviteIcon)} />
+                <div className={styles.inviteLink}>{messages.inviteLabel}</div>
               </div>
             }
           />
         </Toast>
       </div>
     </Tooltip>
+  )
+}
+
+type TwitterShareButtonProps = {
+  modalType: 'referrals' | 'referrals-verified'
+  inviteLink: string
+}
+
+const TwitterShareButton = ({
+  modalType,
+  inviteLink
+}: TwitterShareButtonProps) => {
+  const wm = useWithMobileStyle(styles.mobile)
+  return (
+    <Button
+      type={ButtonType.PRIMARY_ALT}
+      text={messages.twitterShare(modalType)}
+      leftIcon={<IconTwitterBird />}
+      onClick={() => openTwitterLink(inviteLink, messages.twitterCopy)}
+      className={wm(styles.twitterButton)}
+      textClassName={styles.twitterText}
+      iconClassName={styles.twitterIcon}
+    />
   )
 }
 
@@ -159,7 +192,8 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     fullDescription,
     progressLabel,
     stepCount,
-    modalButtonInfo
+    modalButtonInfo,
+    verifiedChallenge
   } = challengeRewardsConfig[modalType]
 
   const currentStepCount = challenge?.current_step_count || 0
@@ -184,15 +218,24 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
   const progressDescription = (
     <div className={wm(styles.progressDescription)}>
-      <h3>Task</h3>
-      <p>{fullDescription(challenge?.amount)}</p>
+      <h3>
+        {verifiedChallenge ? (
+          <div className={styles.verifiedChallenge}>
+            <IconVerified />
+            VERIFIED CHALLENGE
+          </div>
+        ) : (
+          'Task'
+        )}
+      </h3>
+      <p>{fullDescription(challenge)}</p>
     </div>
   )
 
   const progressReward = (
     <div className={wm(styles.progressReward)}>
       <h3>Reward</h3>
-      <h2>{challenge?.amount}</h2>
+      <h2>{getAmount(challenge)}</h2>
       <h4>$AUDIO</h4>
     </div>
   )
@@ -250,6 +293,11 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     }
   }, [claimStatus, toast])
 
+  const inviteLink = useMemo(
+    () => (userHandle ? fillString(messages.inviteLink, userHandle) : ''),
+    [userHandle]
+  )
+
   return (
     <div className={wm(styles.container)}>
       {displayMobileContent ? (
@@ -293,7 +341,11 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
       {userHandle &&
         (modalType === 'referrals' || modalType === 'referrals-verified') && (
-          <InviteLink handle={userHandle} />
+          <div className={wm(styles.buttonContainer)}>
+            <TwitterShareButton modalType={modalType} inviteLink={inviteLink} />
+            <div className={styles.buttonSpacer} />
+            <InviteLink inviteLink={inviteLink} />
+          </div>
         )}
       {modalType === 'mobile-install' && (
         <div className={wm(styles.qrContainer)}>

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -79,7 +79,8 @@ const messages = {
   claimYourReward: 'Claim Your Reward',
   twitterShare: (modalType: 'referrals' | 'referrals-verified') =>
     `Share Invite With Your ${modalType === 'referrals' ? 'Friends' : 'Fans'}`,
-  twitterCopy: `Come support me on @audiusproject! Use my link and we both earn $AUDIO when you sign up.\n\n #audius #audiorewards\n\n`
+  twitterCopy: `Come support me on @audiusproject! Use my link and we both earn $AUDIO when you sign up.\n\n #audius #audiorewards\n\n`,
+  verifiedChallenge: 'VERIFIED CHALLENGE'
 }
 
 type InviteLinkProps = {
@@ -222,7 +223,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         {verifiedChallenge ? (
           <div className={styles.verifiedChallenge}>
             <IconVerified />
-            VERIFIED CHALLENGE
+            {messages.verifiedChallenge}
           </div>
         ) : (
           'Task'

--- a/src/pages/audio-rewards-page/config.tsx
+++ b/src/pages/audio-rewards-page/config.tsx
@@ -15,7 +15,6 @@ import {
   UPLOAD_PAGE
 } from 'utils/route'
 
-import { getAmount } from './ChallengeRewardsTile'
 import { OptimisticUserChallenge } from './hooks'
 
 type LinkButtonType =
@@ -101,7 +100,7 @@ export const challengeRewardsConfig: Record<
     id: 'referrals-verified' as ChallengeRewardID,
     title: 'Invite your Fans',
     icon: <i className='emoji large incoming-envelope' />,
-    description: challenge => `Earn up to ${getAmount(challenge)} $AUDIO`,
+    description: challenge => `Earn up to ${challenge?.totalAmount} $AUDIO`,
     fullDescription: challenge =>
       `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
     progressLabel: '%0/%1 Invites',

--- a/src/pages/audio-rewards-page/config.tsx
+++ b/src/pages/audio-rewards-page/config.tsx
@@ -15,6 +15,9 @@ import {
   UPLOAD_PAGE
 } from 'utils/route'
 
+import { getAmount } from './ChallengeRewardsTile'
+import { OptimisticUserChallenge } from './hooks'
+
 type LinkButtonType =
   | 'trackUpload'
   | 'profile'
@@ -58,8 +61,8 @@ type ChallengeRewardsInfo = {
   id: ChallengeRewardID
   title: string
   icon: ReactNode
-  description: (amount: number | undefined) => string
-  fullDescription: (amount: number | undefined) => string
+  description: (amount: OptimisticUserChallenge | undefined) => string
+  fullDescription: (amount: OptimisticUserChallenge | undefined) => string
   progressLabel: string
   amount: number
   stepCount: number
@@ -69,6 +72,7 @@ type ChallengeRewardsInfo = {
     inProgress: LinkButtonInfo | null
     complete: LinkButtonInfo | null
   }
+  verifiedChallenge?: boolean
 }
 
 export const challengeRewardsConfig: Record<
@@ -79,9 +83,10 @@ export const challengeRewardsConfig: Record<
     id: 'referrals' as ChallengeRewardID,
     title: 'Invite your Friends',
     icon: <i className='emoji large incoming-envelope' />,
-    description: amount => `Earn ${amount} $AUDIO, for you and your friend`,
-    fullDescription: amount =>
-      `Invite your Friends! You’ll earn ${amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
+    description: challenge =>
+      `Earn ${challenge?.amount} $AUDIO, for you and your friend`,
+    fullDescription: challenge =>
+      `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
     progressLabel: '%0/%1 Invites',
     amount: amounts.referrals,
     stepCount: 5,
@@ -94,29 +99,31 @@ export const challengeRewardsConfig: Record<
   },
   'referrals-verified': {
     id: 'referrals-verified' as ChallengeRewardID,
-    title: 'Invite your Friends',
+    title: 'Invite your Fans',
     icon: <i className='emoji large incoming-envelope' />,
-    description: amount => `Earn ${amount} $AUDIO, for you and your friend`,
-    fullDescription: amount =>
-      `Invite your Friends! You’ll earn ${amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
+    description: challenge => `Earn up to ${getAmount(challenge)} $AUDIO`,
+    fullDescription: challenge =>
+      `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
     progressLabel: '%0/%1 Invites',
     amount: amounts.referrals,
     stepCount: 500,
-    panelButtonText: 'Invite your Friends',
+    panelButtonText: 'Invite your Fans',
     modalButtonInfo: {
       incomplete: null,
       inProgress: null,
       complete: null
-    }
+    },
+    verifiedChallenge: true
   },
   // This is used just for the notifications
   referred: {
     id: 'referrals' as ChallengeRewardID,
     title: 'Invite your Friends',
     icon: <i className='emoji large incoming-envelope' />,
-    description: amount => `Earn ${amount} $AUDIO, for you and your friend`,
-    fullDescription: amount =>
-      `Invite your Friends! You’ll earn ${amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
+    description: challenge =>
+      `Earn ${challenge?.amount} $AUDIO, for you and your friend`,
+    fullDescription: challenge =>
+      `Invite your Friends! You’ll earn ${challenge?.amount} $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)`,
     progressLabel: '%0/%1 Invites',
     amount: amounts.referrals,
     stepCount: 1,
@@ -131,8 +138,8 @@ export const challengeRewardsConfig: Record<
     id: 'connect-verified' as ChallengeRewardID,
     title: 'Link Verified Accounts',
     icon: <i className='emoji large white-heavy-check-mark' />,
-    description: amount =>
-      `Link your verified social media accounts to earn ${amount} $AUDIO`,
+    description: challenge =>
+      `Link your verified social media accounts to earn ${challenge?.amount} $AUDIO`,
     fullDescription: () =>
       'Get verified on Audius by linking your verified Twitter or Instagram account!',
     progressLabel: 'Not Linked',
@@ -149,8 +156,8 @@ export const challengeRewardsConfig: Record<
     id: 'listen-streak' as ChallengeRewardID,
     title: 'Listening Streak: 7 Days',
     icon: <i className='emoji large headphone' />,
-    description: amount =>
-      `Listen to one track a day for seven days to earn ${amount} $AUDIO`,
+    description: challenge =>
+      `Listen to one track a day for seven days to earn ${challenge?.amount} $AUDIO`,
     fullDescription: () =>
       'Sign in and listen to at least one track every day for 7 days',
     progressLabel: '%0/%1 Days',
@@ -167,7 +174,7 @@ export const challengeRewardsConfig: Record<
     id: 'mobile-install' as ChallengeRewardID,
     title: 'Get the Audius Mobile App',
     icon: <i className='emoji large mobile-phone-with-arrow' />,
-    description: amount => `Earn ${amount} $AUDIO`,
+    description: challenge => `Earn ${challenge?.amount} $AUDIO`,
     fullDescription: () =>
       'Install the Audius app for iPhone and Android and Sign in to your account!',
     progressLabel: 'Not Installed',
@@ -184,8 +191,8 @@ export const challengeRewardsConfig: Record<
     id: 'profile-completion' as ChallengeRewardID,
     title: 'Complete Your Profile',
     icon: <i className='emoji large white-heavy-check-mark' />,
-    description: amount =>
-      `Complete your Audius profile to earn ${amount} $AUDIO`,
+    description: challenge =>
+      `Complete your Audius profile to earn ${challenge?.amount} $AUDIO`,
     fullDescription: () =>
       'Fill out the missing details on your Audius profile and start interacting with tracks and artists!',
     progressLabel: '%0/%1 Complete',
@@ -202,7 +209,7 @@ export const challengeRewardsConfig: Record<
     id: 'track-upload' as ChallengeRewardID,
     title: 'Upload 3 Tracks',
     icon: <i className='emoji large multiple-musical-notes' />,
-    description: amount => `Earn ${amount} $AUDIO`,
+    description: challenge => `Earn ${challenge?.amount} $AUDIO`,
     fullDescription: () => 'Upload 3 tracks to your profile',
     progressLabel: '%0/%1 Uploaded',
     amount: amounts['track-upload'],

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -13,7 +13,7 @@ type UserChallengeState =
   | 'in_progress'
   | 'completed'
   | 'disbursed'
-type OptimisticUserChallenge = Omit<
+export type OptimisticUserChallenge = Omit<
   UserChallenge,
   'is_complete' | 'is_active' | 'is_disbursed'
 > & {

--- a/src/pages/audio-rewards-page/hooks.ts
+++ b/src/pages/audio-rewards-page/hooks.ts
@@ -19,6 +19,7 @@ export type OptimisticUserChallenge = Omit<
 > & {
   __isOptimistic: true
   state: UserChallengeState
+  totalAmount: number
 }
 /**
  * Gets the state of a user challenge, with the most progress dominating
@@ -80,7 +81,17 @@ export const useOptimisticUserChallenge = (
   const userChallengeOverrides =
     userChallengesOverrides[challenge?.challenge_id]
 
-  const challengeOverridden = { ...challenge, ...userChallengeOverrides }
+  const challengeOverridden = {
+    ...challenge,
+    ...userChallengeOverrides,
+    // For aggregate challenges, we show the total amount
+    // you'd get when completing every step of the challenge
+    // -- i.e. for referrals, show 1 audio x 5 steps = 5 audio
+    totalAmount:
+      challenge.challenge_type === 'aggregate'
+        ? challenge.amount * challenge.max_steps
+        : challenge.amount
+  }
 
   // The client is more up to date than Discovery Nodes, so override whenever possible.
   // Don't override if the challenge is already marked as completed on Discovery.


### PR DESCRIPTION
### Description

Adds a number of changes for referrals & referrals-verified challenges, documented on Figma and in Linear
- New share to twitter button
- For aggregate challenges, show amount as the max you'd get if every referral was completed
- Some verbiage changes for the verified version of the challenge

<img width="1119" alt="Screen Shot 2022-01-25 at 7 21 24 PM" src="https://user-images.githubusercontent.com/6780028/151098630-011ead29-e02e-46be-88d3-d200b3ae6d8f.png">


### Dragons

- I should probably QA this myself again tomorrow with less covid-brain
- Still needs native mobile changes

### How Has This Been Tested?

- Tested with nonverified + verified acounts

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
