### PR TITLE
Add amplitude user bank tracking

### DIFF
--- a/src/common/models/Analytics.ts
+++ b/src/common/models/Analytics.ts
@@ -197,7 +197,12 @@ export enum Name {
   DEACTIVATE_ACCOUNT_PAGE_VIEW = 'Deactivate Account: Page View',
   DEACTIVATE_ACCOUNT_REQUEST = 'Deactivate Account: Request',
   DEACTIVATE_ACCOUNT_SUCCESS = 'Deactivate Account: Success',
-  DEACTIVATE_ACCOUNT_FAILURE = 'Deactivate Account: Failure'
+  DEACTIVATE_ACCOUNT_FAILURE = 'Deactivate Account: Failure',
+
+  // Create User Bank
+  CREATE_USER_BANK_REQUEST = 'Create User Bank: Request',
+  CREATE_USER_BANK_SUCCESS = 'Create User Bank: Success',
+  CREATE_USER_BANK_FAILURE = 'Create User Bank: Failure'
 }
 
 type PageView = {
@@ -925,6 +930,23 @@ type DeactivateAccountFailure = {
   eventName: Name.DEACTIVATE_ACCOUNT_FAILURE
 }
 
+type CreateUserBankRequest = {
+  eventName: Name.CREATE_USER_BANK_REQUEST
+  userId: ID
+}
+
+type CreateUserBankSuccess = {
+  eventName: Name.CREATE_USER_BANK_SUCCESS
+  userId: ID
+}
+
+type CreateUserBankFailure = {
+  eventName: Name.CREATE_USER_BANK_FAILURE
+  userId: ID
+  errorCode: string
+  error: string
+}
+
 export type BaseAnalyticsEvent = { type: typeof ANALYTICS_TRACK_EVENT }
 
 export type AllTrackingEvents =
@@ -1052,3 +1074,6 @@ export type AllTrackingEvents =
   | DeactivateAccountRequest
   | DeactivateAccountSuccess
   | DeactivateAccountFailure
+  | CreateUserBankRequest
+  | CreateUserBankSuccess
+  | CreateUserBankFailure

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1742,7 +1742,8 @@ class AudiusBackend {
       AudiusBackend._getHostUrl(),
       remoteConfigInstance.getFeatureEnabled(
         FeatureFlags.CREATE_WAUDIO_USER_BANK_ON_SIGN_UP
-      )
+      ),
+      track
     )
   }
 

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1743,7 +1743,12 @@ class AudiusBackend {
       remoteConfigInstance.getFeatureEnabled(
         FeatureFlags.CREATE_WAUDIO_USER_BANK_ON_SIGN_UP
       ),
-      track
+      track,
+      {
+        Request: Name.CREATE_USER_BANK_REQUEST,
+        Success: Name.CREATE_USER_BANK_SUCCESS,
+        Failure: Name.CREATE_USER_BANK_FAILURE
+      }
     )
   }
 

--- a/src/services/audius-backend/waudio.ts
+++ b/src/services/audius-backend/waudio.ts
@@ -1,10 +1,12 @@
 import { AccountInfo } from '@solana/spl-token'
 import { PublicKey } from '@solana/web3.js'
 
+import { Name } from 'common/models/Analytics'
 import { FeatureFlags } from 'common/services/remote-config'
 import { Nullable } from 'common/utils/typeUtils'
 import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { track } from 'store/analytics/providers'
 
 // @ts-ignore
 const libs = () => window.audiusLibs
@@ -29,19 +31,31 @@ export const createUserBankIfNeeded = async () => {
     FeatureFlags.CREATE_WAUDIO_USER_BANK_ON_SIGN_UP
   )
   if (!userbankEnabled) return
+  const userId = libs().Account.getCurrentUser().user_id
   try {
     const userbankExists = await doesUserBankExist()
     if (userbankExists) return
     console.warn(`Userbank doesn't exist, attempting to create...`)
+    await track(Name.CREATE_USER_BANK_REQUEST, { userId })
     const { error, errorCode } = await createUserBank()
     if (error || errorCode) {
       console.error(
         `Failed to create userbank, with err: ${error}, ${errorCode}`
       )
+      await track(Name.CREATE_USER_BANK_FAILURE, {
+        userId,
+        errorCode,
+        error: (error as any).toString()
+      })
     } else {
       console.log(`Successfully created userbank!`)
     }
+    await track(Name.CREATE_USER_BANK_SUCCESS, { userId })
   } catch (err) {
+    await track(Name.CREATE_USER_BANK_FAILURE, {
+      userId,
+      errorMessage: (err as any).toString()
+    })
     console.error(`Failed to create userbank, with err: ${err}`)
   }
 }


### PR DESCRIPTION
### Description
Adds amplitude tracks for user bank creation.
Since signup also creates a user bank account and is nested in libs, the track method is passed to the signup method which tracks it. Handled in https://github.com/AudiusProject/audius-protocol/pull/2387

Fixes AUD-1324

### Dragons
none

### How Has This Been Tested?
ran locally

### How will this change be monitored?
