### PR TITLE
Fix height of mobile reward challenges

### DIFF
--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -179,7 +179,7 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
       </div>
       <div className={styles.rewardsContainer}>
         {userChallengesLoading && !haveChallengesLoaded ? (
-          <LoadingSpinner />
+          <LoadingSpinner className={wm(styles.loadingRewardsTile)} />
         ) : (
           rewardsTiles
         )}

--- a/src/pages/audio-rewards-page/RewardsTile.module.css
+++ b/src/pages/audio-rewards-page/RewardsTile.module.css
@@ -139,3 +139,8 @@
   font-weight: var(--font-bold);
   letter-spacing: 0;
 }
+
+.loadingRewardsTile.mobile {
+  height: 48px;
+  width: 48px;
+}


### PR DESCRIPTION
### Description
Sets height of the loading spinning on the mobile rewards challenges tile

![Screen Shot 2022-01-26 at 11 20 21 AM](https://user-images.githubusercontent.com/7064122/151203248-df5d1f2e-1a81-4a82-973a-980d3ca6f715.png)

Fixes AUD-1325

### Dragons


### How Has This Been Tested?

### How will this change be monitored?
