### PR TITLE
Add 'Claim Rewards' button in nav

### DIFF
--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -19,7 +19,7 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
   [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 15000,
   [IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS]: 5000,
-  [IntKeys.MANUAL_CLAIM_PROMPT_DELAY_MS]: 2000
+  [IntKeys.MANUAL_CLAIM_PROMPT_DELAY_MS]: 15000
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -18,7 +18,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.ATTESTATION_QUORUM_SIZE]: 0,
   [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
   [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 15000,
-  [IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS]: 5000
+  [IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS]: 5000,
+  [IntKeys.MANUAL_CLAIM_PROMPT_DELAY_MS]: 2000
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -82,7 +82,14 @@ export enum IntKeys {
   /**
    * The refresh interval in milliseconds for user challenges when the user is on the $AUDIO page
    */
-  CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS = 'CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS'
+  CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS = 'CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS',
+
+  /**
+   * The time to wait after a challenge is marked completed before showing a claim reward prompt.
+   * Should be larger than both CHALLENGE_REFRESH_INTERVAL_MS and CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS
+   * to allow additional polls to check for disbursement
+   */
+  MANUAL_CLAIM_PROMPT_DELAY_MS = 'MANUAL_CLAIM_PROMPT_DELAY_MS'
 }
 
 export enum BooleanKeys {

--- a/src/common/store/pages/audio-rewards/selectors.ts
+++ b/src/common/store/pages/audio-rewards/selectors.ts
@@ -41,3 +41,6 @@ export const getCognitoFlowUrlStatus = (state: CommonState) =>
 
 export const getShowRewardClaimedToast = (state: CommonState) =>
   state.pages.audioRewards.showRewardClaimedToast
+
+export const getPendingAutoClaims = (state: CommonState) =>
+  state.pages.audioRewards.pendingAutoClaims

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -52,6 +52,7 @@ type RewardsUIState = {
   cognitoFlowUrlStatus?: Status
   cognitoFlowUrl?: string
   showRewardClaimedToast: boolean
+  pendingAutoClaims: Partial<Record<ChallengeRewardID, number>>
 }
 
 const initialState: RewardsUIState = {
@@ -63,7 +64,8 @@ const initialState: RewardsUIState = {
   claimStatus: ClaimStatus.NONE,
   hCaptchaStatus: HCaptchaStatus.NONE,
   cognitoFlowStatus: CognitoFlowStatus.CLOSED,
-  showRewardClaimedToast: false
+  showRewardClaimedToast: false,
+  pendingAutoClaims: {}
 }
 
 const slice = createSlice({
@@ -98,6 +100,7 @@ const slice = createSlice({
         ...state.userChallengesOverrides[challengeId],
         is_disbursed: true
       }
+      state.pendingAutoClaims[challengeId] = undefined
     },
     setTrendingRewardsModalType: (
       state,
@@ -171,6 +174,15 @@ const slice = createSlice({
     },
     resetRewardClaimedToast: state => {
       state.showRewardClaimedToast = false
+    },
+    addPendingAutoClaim: (state, action: PayloadAction<ChallengeRewardID>) => {
+      state.pendingAutoClaims[action.payload] = new Date().getTime()
+    },
+    removePendingAutoClaim: (
+      state,
+      action: PayloadAction<ChallengeRewardID>
+    ) => {
+      state.pendingAutoClaims[action.payload] = undefined
     }
   }
 })
@@ -195,7 +207,9 @@ export const {
   fetchCognitoFlowUrlFailed,
   fetchCognitoFlowUrlSucceeded,
   showRewardClaimedToast,
-  resetRewardClaimedToast
+  resetRewardClaimedToast,
+  addPendingAutoClaim,
+  removePendingAutoClaim
 } = slice.actions
 
 export default slice

--- a/src/components/nav/desktop/NavAudio.module.css
+++ b/src/components/nav/desktop/NavAudio.module.css
@@ -63,7 +63,18 @@
   letter-spacing: 0.1em;
   transition: all 0.07s ease-in-out;
 }
+
+.actionBubble:hover {
+  cursor: pointer;
+  transform: scale3d(1.04, 1.04, 1.04);
+}
+
+.actionBubble:active {
+  transform: scale3d(0.99, 0.99, 0.99);
+}
+
 .actionBubble.claimRewards {
+  transition: opacity 0.2s ease-in-out;
   background: var(--static-accent-green);
 }
 

--- a/src/components/nav/desktop/NavAudio.module.css
+++ b/src/components/nav/desktop/NavAudio.module.css
@@ -24,14 +24,6 @@
   opacity: 1;
 }
 
-.audio.show .earnAudio:hover {
-  transform: scale(1.03);
-}
-
-.audio.show .earnAudio:active {
-  transform: scale(0.97);
-}
-
 .audio.hasBalance {
   cursor: pointer;
 }
@@ -74,15 +66,14 @@
 
 .actionBubble:hover {
   cursor: pointer;
-  transform: scale3d(1.04, 1.04, 1.04);
+  transform: scale3d(1.03, 1.03, 1.03);
 }
 
 .actionBubble:active {
-  transform: scale3d(0.99, 0.99, 0.99);
+  transform: scale3d(0.97, 0.97, 0.97);
 }
 
 .actionBubble.claimRewards {
-  transition: opacity 0.2s ease-in-out;
   background: var(--static-accent-green);
 }
 

--- a/src/components/nav/desktop/NavAudio.module.css
+++ b/src/components/nav/desktop/NavAudio.module.css
@@ -49,6 +49,13 @@
   color: var(--neutral-light-3);
 }
 
+.bubbleContainer {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
 .actionBubble {
   display: flex;
   align-items: center;
@@ -62,6 +69,7 @@
   font-weight: var(--font-bold);
   letter-spacing: 0.1em;
   transition: all 0.07s ease-in-out;
+  position: absolute;
 }
 
 .actionBubble:hover {

--- a/src/components/nav/desktop/NavAudio.module.css
+++ b/src/components/nav/desktop/NavAudio.module.css
@@ -10,7 +10,7 @@
   width: 20px;
   height: 20px;
   position: absolute;
-  background-color:var(--neutral-light-4);
+  background-color: var(--neutral-light-4);
   left: -40px;
   border-radius: 4px;
 }
@@ -29,7 +29,7 @@
 }
 
 .audio.show .earnAudio:active {
-  transform: scale(.97);
+  transform: scale(0.97);
 }
 
 .audio.hasBalance {
@@ -49,7 +49,7 @@
   color: var(--neutral-light-3);
 }
 
-.earnAudio {
+.actionBubble {
   display: flex;
   align-items: center;
   margin-left: 12px;
@@ -57,18 +57,22 @@
   color: var(--static-white);
   background: var(--secondary);
   border-radius: 16px;
+  text-transform: uppercase;
   font-size: var(--font-2xs);
   font-weight: var(--font-bold);
   letter-spacing: 0.1em;
   transition: all 0.07s ease-in-out;
 }
+.actionBubble.claimRewards {
+  background: var(--static-accent-green);
+}
 
-.earnAudioCaret {
+.actionCaret {
   margin-left: 2px;
   height: 12px;
   width: 10px;
 }
 
-.earnAudioCaret path {
+.actionCaret path {
   fill: var(--static-white);
 }

--- a/src/components/nav/desktop/NavAudio.tsx
+++ b/src/components/nav/desktop/NavAudio.tsx
@@ -73,7 +73,6 @@ const NavAudio = () => {
     pendingAutoClaims,
     claimPromptDelayMs,
     positiveTotalBalance,
-    totalBalance,
     nonNullTotalBalance
   ])
 

--- a/src/components/nav/desktop/NavAudio.tsx
+++ b/src/components/nav/desktop/NavAudio.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement } from 'react'
+import React, { cloneElement, useCallback } from 'react'
 
 import BN from 'bn.js'
 import cn from 'classnames'
@@ -19,7 +19,8 @@ import { AUDIO_PAGE } from 'utils/route'
 import styles from './NavAudio.module.css'
 
 const messages = {
-  earnAudio: 'EARN $AUDIO'
+  earnAudio: 'EARN $AUDIO',
+  claimRewards: 'Claim Rewards'
 }
 
 const NavAudio = () => {
@@ -37,17 +38,26 @@ const NavAudio = () => {
   // so below null-coalescing is okay
   const { tier } = useSelectTierInfo(account?.user_id ?? 0)
   const audioBadge = audioTierMapPng[tier]
+  const unclaimedRewards = false
+
+  const goToAudioPage = useCallback(() => {
+    navigate(AUDIO_PAGE)
+  }, [navigate])
 
   if (!isEnabled || !account) {
     return null
   }
 
-  return positiveTotalBalance ? (
+  return nonNullTotalBalance ? (
     <div
-      onClick={() => navigate(AUDIO_PAGE)}
-      className={cn(styles.audio, styles.hasBalance, { [styles.show]: true })}
+      className={cn(
+        styles.audio,
+        { [styles.hasBalance]: positiveTotalBalance },
+        { [styles.show]: true }
+      )}
+      onClick={goToAudioPage}
     >
-      {audioBadge ? (
+      {positiveTotalBalance && audioBadge ? (
         cloneElement(audioBadge, {
           height: 16,
           width: 16
@@ -58,20 +68,18 @@ const NavAudio = () => {
       <span className={styles.audioAmount}>
         {formatWei(totalBalance!, true, 0)}
       </span>
-    </div>
-  ) : nonNullTotalBalance ? (
-    <div
-      className={cn(styles.audio, { [styles.show]: true })}
-      onClick={() => navigate(AUDIO_PAGE)}
-    >
-      <img alt='no tier' src={IconNoTierBadge} width='16' height='16' />
-      <span className={styles.audioAmount}>
-        {formatWei(totalBalance!, true, 0)}
-      </span>
-      <span className={styles.earnAudio}>
-        <span>{messages.earnAudio}</span>
-        <IconCaretRight className={styles.earnAudioCaret} />
-      </span>
+      {!positiveTotalBalance && !unclaimedRewards && (
+        <span className={styles.actionBubble}>
+          <span>{messages.earnAudio}</span>
+          <IconCaretRight className={styles.actionCaret} />
+        </span>
+      )}
+      {unclaimedRewards && (
+        <span className={cn(styles.actionBubble, styles.claimRewards)}>
+          <span>{messages.claimRewards}</span>
+          <IconCaretRight className={styles.actionCaret} />
+        </span>
+      )}
     </div>
   ) : (
     <div className={styles.audio} />

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -278,22 +278,19 @@ export function* watchFetchUserChallenges() {
           (!challengeOverrides || !challengeOverrides.is_disbursed) // we didn't claim this session
         ) {
           newDisbursement = true
+          if (pendingAutoClaim) {
+            yield put(removePendingAutoClaim(challenge.challenge_id))
+          }
         }
         // Check for newly completed, undisbursed challenges
         else if (
           challenge.is_complete &&
           prevChallenge &&
           !prevChallenge.is_complete &&
-          !challenge.is_complete &&
+          !challenge.is_disbursed &&
           (!challengeOverrides || !challengeOverrides.is_disbursed)
         ) {
           yield put(addPendingAutoClaim(challenge.challenge_id))
-        } else if (
-          pendingAutoClaim &&
-          (challenge.is_disbursed ||
-            (challengeOverrides && challengeOverrides.is_disbursed))
-        ) {
-          yield put(removePendingAutoClaim(challenge.challenge_id))
         }
       }
       if (newDisbursement) {

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -21,6 +21,7 @@ import { getAccountUser, getUserId } from 'common/store/account/selectors'
 import {
   getClaimStatus,
   getClaimToRetry,
+  getPendingAutoClaims,
   getUserChallenge,
   getUserChallenges,
   getUserChallengesOverrides
@@ -42,7 +43,9 @@ import {
   setHCaptchaStatus,
   setUserChallengeDisbursed,
   updateHCaptchaScore,
-  showRewardClaimedToast
+  showRewardClaimedToast,
+  addPendingAutoClaim,
+  removePendingAutoClaim
 } from 'common/store/pages/audio-rewards/slice'
 import { setVisibility } from 'common/store/ui/modals/slice'
 import { getBalance, increaseBalance } from 'common/store/wallet/slice'
@@ -258,10 +261,16 @@ export function* watchFetchUserChallenges() {
         ChallengeRewardID,
         UserChallenge
       >> = yield select(getUserChallengesOverrides)
+      const pendingAutoClaims: Partial<Record<
+        ChallengeRewardID,
+        number
+      >> = yield select(getPendingAutoClaims)
       let newDisbursement = false
       for (const challenge of userChallenges) {
         const prevChallenge = prevChallenges[challenge.challenge_id]
         const challengeOverrides = challengesOverrides[challenge.challenge_id]
+        const pendingAutoClaim = pendingAutoClaims[challenge.challenge_id]
+        // Check for new disbursements
         if (
           challenge.is_disbursed &&
           prevChallenge &&
@@ -269,6 +278,22 @@ export function* watchFetchUserChallenges() {
           (!challengeOverrides || !challengeOverrides.is_disbursed) // we didn't claim this session
         ) {
           newDisbursement = true
+        }
+        // Check for newly completed, undisbursed challenges
+        else if (
+          challenge.is_complete &&
+          prevChallenge &&
+          !prevChallenge.is_complete &&
+          !challenge.is_complete &&
+          (!challengeOverrides || !challengeOverrides.is_disbursed)
+        ) {
+          yield put(addPendingAutoClaim(challenge.challenge_id))
+        } else if (
+          pendingAutoClaim &&
+          (challenge.is_disbursed ||
+            (challengeOverrides && challengeOverrides.is_disbursed))
+        ) {
+          yield put(removePendingAutoClaim(challenge.challenge_id))
         }
       }
       if (newDisbursement) {

--- a/src/pages/audio-rewards-page/store/store.test.ts
+++ b/src/pages/audio-rewards-page/store/store.test.ts
@@ -16,6 +16,7 @@ import {
   getUserChallengesOverrides
 } from 'common/store/pages/audio-rewards/selectors'
 import {
+  addPendingAutoClaim,
   Claim,
   claimChallengeReward,
   claimChallengeRewardFailed,
@@ -26,6 +27,7 @@ import {
   fetchUserChallenges,
   fetchUserChallengesSucceeded,
   HCaptchaStatus,
+  removePendingAutoClaim,
   setCognitoFlowStatus,
   setHCaptchaStatus,
   setUserChallengeDisbursed,
@@ -373,13 +375,37 @@ describe('Rewards Page Sagas', () => {
         challenge_type: 'numeric',
         specifier: '1',
         user_id: '1'
+      },
+      {
+        challenge_id: 'referrals',
+        is_complete: true,
+        is_disbursed: false,
+        is_active: true,
+        amount: 1,
+        current_step_count: 5,
+        max_steps: 5,
+        challenge_type: 'numeric',
+        specifier: '1',
+        user_id: '1'
+      },
+      {
+        challenge_id: 'track-upload',
+        is_complete: true,
+        is_disbursed: true,
+        is_active: true,
+        amount: 1,
+        current_step_count: 3,
+        max_steps: 3,
+        challenge_type: 'numeric',
+        specifier: '1',
+        user_id: '1'
       }
     ]
     const fetchUserChallengesProvisions: StaticProvider[] = [
       [select(getIsReachable), true],
       [select(getUserId), testUser.user_id],
       [call.fn(apiClient.getUserChallenges), expectedUserChallengesResponse],
-      [select(getPendingAutoClaims), {}]
+      [select(getPendingAutoClaims), { 'track-upload': 200 }]
     ]
     const defaultState = {
       backend: { isSetup: true }
@@ -446,7 +472,7 @@ describe('Rewards Page Sagas', () => {
           [
             select(getUserChallenges),
             {
-              'profile-completion': {
+              referrals: {
                 is_complete: true,
                 is_disbursed: false
               }
@@ -455,13 +481,64 @@ describe('Rewards Page Sagas', () => {
           [
             select(getUserChallengesOverrides),
             {
-              'profile-completion': {
+              referrals: {
                 is_disbursed: true
               }
             }
           ]
         ])
         .not.put(showRewardClaimedToast())
+        .put(
+          fetchUserChallengesSucceeded({
+            userChallenges: expectedUserChallengesResponse
+          })
+        )
+        .silentRun()
+    })
+
+    it('should mark a challenge as pending auto claim when completed', () => {
+      return expectSaga(saga)
+        .dispatch(fetchUserChallenges())
+        .withState(defaultState)
+        .provide([
+          ...fetchUserChallengesProvisions,
+          [
+            select(getUserChallenges),
+            {
+              referrals: {
+                is_complete: false
+              }
+            }
+          ],
+          [select(getUserChallengesOverrides), {}]
+        ])
+        .put(addPendingAutoClaim('referrals'))
+        .put(
+          fetchUserChallengesSucceeded({
+            userChallenges: expectedUserChallengesResponse
+          })
+        )
+        .silentRun()
+    })
+
+    it('should unmark a challenge as pending auto claim when disbursed', () => {
+      return expectSaga(saga)
+        .dispatch(fetchUserChallenges())
+        .withState(defaultState)
+        .provide([
+          ...fetchUserChallengesProvisions,
+          [
+            select(getUserChallenges),
+            {
+              'track-upload': {
+                is_complete: true,
+                is_disbursed: false
+              }
+            }
+          ],
+          [select(getUserChallengesOverrides), {}]
+        ])
+        .put(removePendingAutoClaim('track-upload'))
         .put(
           fetchUserChallengesSucceeded({
             userChallenges: expectedUserChallengesResponse

--- a/src/pages/audio-rewards-page/store/store.test.ts
+++ b/src/pages/audio-rewards-page/store/store.test.ts
@@ -10,6 +10,7 @@ import { getAccountUser, getUserId } from 'common/store/account/selectors'
 import {
   getClaimStatus,
   getClaimToRetry,
+  getPendingAutoClaims,
   getUserChallenge,
   getUserChallenges,
   getUserChallengesOverrides
@@ -377,7 +378,8 @@ describe('Rewards Page Sagas', () => {
     const fetchUserChallengesProvisions: StaticProvider[] = [
       [select(getIsReachable), true],
       [select(getUserId), testUser.user_id],
-      [call.fn(apiClient.getUserChallenges), expectedUserChallengesResponse]
+      [call.fn(apiClient.getUserChallenges), expectedUserChallengesResponse],
+      [select(getPendingAutoClaims), {}]
     ]
     const defaultState = {
       backend: { isSetup: true }


### PR DESCRIPTION
### Description

Adds a "Claim Rewards" button to the nav after waiting for disbursement longer than the configured delay.

New `MANUAL_CLAIM_PROMPT_DELAY_MS` configures how long to delay before prompting the user to claim.

Also adds fade effects for the buttons and hover/active effects to make them button-like.

![image](https://user-images.githubusercontent.com/3690498/151287126-a2c9c609-93e0-4a4e-a574-12812a8bf78b.png)

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

- Needs to handle the case where both the balance is at 0 and the user has unclaimed challenges
- Rewrites a lot of the existing logic for `NavAudio`

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- Adds two additional test cases for testing that the `fetchUserChallenges` saga triggers the appropriate actions.
- Tested manually against stage by using the Redux Dev Tools to dispatch the events and set wallet balance.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

N/A