### PR TITLE
Fetch balance refresh on reward notification

### DIFF
--- a/src/components/notification/store/sagas.ts
+++ b/src/components/notification/store/sagas.ts
@@ -294,7 +294,7 @@ export function* parseAndProcessNotifications(
 /**
  * Run side effects for new notifications
  */
-export function* processNewNotifications(
+export function* handleNewNotifications(
   notifications: Notification[]
 ): Generator<any, void, any> {
   const hasRewardsNotification = notifications.some(
@@ -530,7 +530,7 @@ export function* getNotifications(isFirstFetch: boolean) {
               hasMore
             )
           )
-          yield processNewNotifications(notificationItems)
+          yield handleNewNotifications(notificationItems)
         }
       } else if (status !== Status.SUCCESS) {
         yield put(

--- a/src/components/notification/store/sagas.ts
+++ b/src/components/notification/store/sagas.ts
@@ -21,6 +21,7 @@ import { getUserId, getHasAccount } from 'common/store/account/selectors'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
 import { retrieveTracks } from 'common/store/cache/tracks/utils'
 import { fetchUsers } from 'common/store/cache/users/sagas'
+import { getBalance } from 'common/store/wallet/slice'
 import AudiusBackend from 'services/AudiusBackend'
 import { ResetNotificationsBadgeCount } from 'services/native-mobile-interface/notifications'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
@@ -290,6 +291,20 @@ export function* parseAndProcessNotifications(
   return processedNotifications
 }
 
+/**
+ * Run side effects for new notifications
+ */
+export function* processNewNotifications(
+  notifications: Notification[]
+): Generator<any, void, any> {
+  const hasRewardsNotification = notifications.some(
+    notification => notification.type === NotificationType.ChallengeReward
+  )
+  if (hasRewardsNotification) {
+    yield put(getBalance)
+  }
+}
+
 export function* fetchNotificationUsers(
   action: notificationActions.FetchNotificationUsers
 ) {
@@ -515,6 +530,7 @@ export function* getNotifications(isFirstFetch: boolean) {
               hasMore
             )
           )
+          yield processNewNotifications(notificationItems)
         }
       } else if (status !== Status.SUCCESS) {
         yield put(


### PR DESCRIPTION
### Description
When new notification are set, check for ChallengeReward type and trigger a balance refresh if found

Fixes AUD-1393

### Dragons

### How Has This Been Tested?
Ran locally against stage

### How will this change be monitored?
