### PR TITLE
Start fetching challenges on get account

### DIFF
--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -18,6 +18,7 @@ import {
 } from 'common/models/AudioRewards'
 import { StringAudio } from 'common/models/Wallet'
 import { IntKeys, StringKeys } from 'common/services/remote-config'
+import { fetchAccountSucceeded } from 'common/store/account/reducer'
 import { getAccountUser, getUserId } from 'common/store/account/selectors'
 import {
   getClaimStatus,
@@ -350,6 +351,8 @@ function* userChallengePollingDaemon() {
   const audioRewardsPageChallengePollingTimeout = remoteConfigInstance.getRemoteVar(
     IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS
   )!
+
+  yield take(fetchAccountSucceeded.type)
   yield fork(function* () {
     yield call(visibilityPollingDaemon, fetchUserChallenges())
   })


### PR DESCRIPTION
### Description
Starts the fetching of challenges / polling daemon on fetch account
The actions are currently being triggered even for non-signed in users

### Dragons

### How Has This Been Tested?
Ran locally against stage and ensured it started on page refresh when signed in, after signing in, and after signing up and not when not signed in

### How will this change be monitored?
