### PR TITLE
Always release staging electron app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -892,22 +892,8 @@ workflows:
               only: /(^release.*)$/
 
       # Distribute staging desktop binaries.
-      - hold-dist-mac-staging:
-          type: approval
-          requires:
-            - build-staging
-          filters:
-            branches:
-              only: /(^master)$/
       - dist-mac-staging:
           context: Audius Client
-          requires:
-            - hold-dist-mac-staging
-          filters:
-            branches:
-              only: /(^master)$/
-      - hold-dist-win-staging:
-          type: approval
           requires:
             - build-staging
           filters:
@@ -916,21 +902,14 @@ workflows:
       - dist-win-staging:
           context: Audius Client
           requires:
-              - hold-dist-win-staging
-          filters:
-            branches:
-              only: /(^master)$/
-      - hold-dist-linux-staging:
-          type: approval
-          requires:
-            - build-staging
+              - build-staging
           filters:
             branches:
               only: /(^master)$/
       - dist-linux-staging:
           context: Audius Client
           requires:
-            - hold-dist-linux-staging
+            - build-staging
           filters:
             branches:
               only: /(^master)$/


### PR DESCRIPTION
### Description

Update CI to always release the staging desktop apps from master. This will 1. not have a hold on each `master` push that we never do anything about and 2. hopefully see issues in desktop builds earlier (#1 being linux builds are currently breaking!)

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

CI

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
