### PR TITLE
Fix Heavy Rotation

### DIFF
--- a/src/pages/smart-collection/store/sagas.ts
+++ b/src/pages/smart-collection/store/sagas.ts
@@ -6,6 +6,7 @@ import Status from 'common/models/Status'
 import { Track, UserTrack, UserTrackMetadata } from 'common/models/Track'
 import { getAccountStatus, getUserId } from 'common/store/account/selectors'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
+import { fetchUsers as retrieveUsers } from 'common/store/cache/users/sagas'
 import { setSmartCollection } from 'pages/collection-page/store/actions'
 import Explore from 'services/audius-backend/Explore'
 import { waitForBackendSetup } from 'store/backend/sagas'
@@ -29,8 +30,12 @@ const COLLECTIONS_LIMIT = 25
 function* fetchHeavyRotation() {
   const topListens = yield call(Explore.getTopUserListens)
 
+  const users = yield call(
+    retrieveUsers,
+    topListens.map((t: any) => t.userId)
+  )
   const trackIds = topListens
-    .filter((track: UserTrack) => !track.user.is_deactivated)
+    .filter((track: any) => !users[track.userId].is_deactivated)
     .map((listen: any) => ({
       track: listen.trackId
     }))

--- a/src/pages/smart-collection/store/sagas.ts
+++ b/src/pages/smart-collection/store/sagas.ts
@@ -35,7 +35,7 @@ function* fetchHeavyRotation() {
     topListens.map((t: any) => t.userId)
   )
   const trackIds = topListens
-    .filter((track: any) => !users[track.userId].is_deactivated)
+    .filter((track: any) => !(users[track.userId]?.is_deactivated ?? true))
     .map((listen: any) => ({
       track: listen.trackId
     }))

--- a/src/pages/smart-collection/store/sagas.ts
+++ b/src/pages/smart-collection/store/sagas.ts
@@ -35,7 +35,9 @@ function* fetchHeavyRotation() {
     topListens.map((t: any) => t.userId)
   )
   const trackIds = topListens
-    .filter((track: any) => !(users[track.userId]?.is_deactivated ?? true))
+    .filter(
+      (track: any) => !(users.entries[track.userId]?.is_deactivated ?? true)
+    )
     .map((listen: any) => ({
       track: listen.trackId
     }))


### PR DESCRIPTION
### Description

`Explore.getTopUserListens` does _not_ return an array of `UserTrack`s. It hits identity and does not have user objects, but `userIds`. My guess is this failed to break on staging because the users would exist in the cache whenever I would visit the Heavy Rotation page?

This fix adds a fetch to get the users to check for deactivated accounts.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested against prod. Bug no longer repros for me.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
