### PR TITLE
Add types to the sagas for the explore page

### DIFF
--- a/src/pages/smart-collection/store/sagas.ts
+++ b/src/pages/smart-collection/store/sagas.ts
@@ -1,9 +1,8 @@
-import { takeEvery, put, call, select } from 'redux-saga/effects'
+import { takeEvery, put, call, select } from 'typed-redux-saga'
 
-import { ID } from 'common/models/Identifiers'
 import { SmartCollectionVariant } from 'common/models/SmartCollectionVariant'
 import Status from 'common/models/Status'
-import { Track, UserTrack, UserTrackMetadata } from 'common/models/Track'
+import { Track, UserTrack } from 'common/models/Track'
 import { getAccountStatus, getUserId } from 'common/store/account/selectors'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { fetchUsers as retrieveUsers } from 'common/store/cache/users/sagas'
@@ -28,17 +27,15 @@ import { fetchSmartCollection, fetchSmartCollectionSucceeded } from './slice'
 const COLLECTIONS_LIMIT = 25
 
 function* fetchHeavyRotation() {
-  const topListens = yield call(Explore.getTopUserListens)
+  const topListens = yield* call(Explore.getTopUserListens)
 
-  const users = yield call(
+  const users = yield* call(
     retrieveUsers,
-    topListens.map((t: any) => t.userId)
+    topListens.map(t => t.userId)
   )
   const trackIds = topListens
-    .filter(
-      (track: any) => !(users.entries[track.userId]?.is_deactivated ?? true)
-    )
-    .map((listen: any) => ({
+    .filter(track => !(users.entries[track.userId]?.is_deactivated ?? true))
+    .map(listen => ({
       track: listen.trackId
     }))
 
@@ -51,16 +48,16 @@ function* fetchHeavyRotation() {
 }
 
 function* fetchBestNewReleases() {
-  const tracks = yield call(Explore.getTopFolloweeTracksFromWindow, 'month')
+  const tracks = yield* call(Explore.getTopFolloweeTracksFromWindow, 'month')
 
   const trackIds = tracks
-    .filter((track: UserTrack) => !track.user.is_deactivated)
+    .filter(track => !track.user.is_deactivated)
     .map((track: Track) => ({
       time: track.created_at,
       track: track.track_id
     }))
 
-  yield call(processAndCacheTracks, tracks)
+  yield* call(processAndCacheTracks, tracks)
 
   return {
     ...BEST_NEW_RELEASES,
@@ -71,7 +68,7 @@ function* fetchBestNewReleases() {
 }
 
 function* fetchUnderTheRadar() {
-  const tracks = yield call(Explore.getFeedNotListenedTo)
+  const tracks = yield* call(Explore.getFeedNotListenedTo)
 
   const trackIds = tracks
     .filter((track: UserTrack) => !track.user.is_deactivated)
@@ -80,7 +77,7 @@ function* fetchUnderTheRadar() {
       track: track.track_id
     }))
 
-  yield call(processAndCacheTracks, tracks)
+  yield* call(processAndCacheTracks, tracks)
 
   // feed minus listened
   return {
@@ -92,10 +89,10 @@ function* fetchUnderTheRadar() {
 }
 
 function* fetchMostLoved() {
-  const tracks = yield call(Explore.getTopFolloweeSaves)
+  const tracks = yield* call(Explore.getTopFolloweeSaves)
 
   const trackIds = tracks
-    .filter((track: UserTrack) => !track.user.is_deactivated)
+    .filter(track => !track.user.is_deactivated)
     .map((track: Track) => ({
       time: track.created_at,
       track: track.track_id
@@ -112,10 +109,10 @@ function* fetchMostLoved() {
 }
 
 function* fetchFeelingLucky() {
-  const tracks = yield call(getLuckyTracks, COLLECTIONS_LIMIT)
+  const tracks = yield* call(getLuckyTracks, COLLECTIONS_LIMIT)
 
   const trackIds = tracks
-    .filter((track: UserTrack) => !track.user.is_deactivated)
+    .filter(track => !track.user.is_deactivated)
     .map((track: Track) => ({
       time: track.created_at,
       track: track.track_id
@@ -130,8 +127,11 @@ function* fetchFeelingLucky() {
 }
 
 function* fetchRemixables() {
-  const currentUserId: ID = yield select(getUserId)
-  const tracks: UserTrackMetadata[] = yield call(
+  const currentUserId = yield* select(getUserId)
+  if (currentUserId == null) {
+    return
+  }
+  const tracks = yield* call(
     Explore.getRemixables,
     currentUserId,
     75 // limit
@@ -153,7 +153,7 @@ function* fetchRemixables() {
     return artistCount[id] <= artistLimit
   })
 
-  const processedTracks: Track[] = yield call(
+  const processedTracks = yield* call(
     processAndCacheTracks,
     filteredTracks.slice(0, COLLECTIONS_LIMIT)
   )
@@ -206,7 +206,7 @@ function* watchFetch() {
 
     const { variant } = action.payload
 
-    const collection = yield call(fetchMap[variant])
+    const collection = yield* call(fetchMap[variant])
 
     yield put(
       fetchSmartCollectionSucceeded({

--- a/src/pages/smart-collection/store/sagas.ts
+++ b/src/pages/smart-collection/store/sagas.ts
@@ -34,7 +34,11 @@ function* fetchHeavyRotation() {
     topListens.map(t => t.userId)
   )
   const trackIds = topListens
-    .filter(track => !(users.entries[track.userId]?.is_deactivated ?? true))
+    .filter(
+      track =>
+        users.entries[track.userId] &&
+        !users.entries[track.userId].is_deactivated
+    )
     .map(listen => ({
       track: listen.trackId
     }))

--- a/src/services/audius-backend/Explore.ts
+++ b/src/services/audius-backend/Explore.ts
@@ -16,7 +16,7 @@ const libs = () => window.audiusLibs
 const scoreComparator = <T extends { score: number }>(a: T, b: T) =>
   b.score - a.score
 
-export type TopUserListen = {
+type TopUserListen = {
   userId: number
   trackId: number
 }

--- a/src/services/audius-backend/Explore.ts
+++ b/src/services/audius-backend/Explore.ts
@@ -1,7 +1,7 @@
 import { Collection } from 'common/models/Collection'
 import FeedFilter from 'common/models/FeedFilter'
 import { ID } from 'common/models/Identifiers'
-import { Track, TrackMetadata } from 'common/models/Track'
+import { Track, UserTrack } from 'common/models/Track'
 import AudiusBackend, {
   IDENTITY_SERVICE,
   AuthHeaders
@@ -16,7 +16,7 @@ const libs = () => window.audiusLibs
 const scoreComparator = <T extends { score: number }>(a: T, b: T) =>
   b.score - a.score
 
-type TopUserListen = {
+export type TopUserListen = {
   userId: number
   trackId: number
 }
@@ -65,7 +65,7 @@ class Explore {
   static async getTopFolloweeTracksFromWindow(
     window: string,
     limit = 25
-  ): Promise<Track[]> {
+  ): Promise<UserTrack[]> {
     try {
       const tracks = await libs().discoveryProvider.getTopFolloweeWindowed(
         'track',
@@ -80,9 +80,9 @@ class Explore {
     }
   }
 
-  static async getFeedNotListenedTo(limit = 25): Promise<Track[]> {
+  static async getFeedNotListenedTo(limit = 25) {
     try {
-      const tracks = await AudiusBackend.getSocialFeed({
+      const tracks: UserTrack[] = await AudiusBackend.getSocialFeed({
         filter: FeedFilter.ORIGINAL,
         offset: 0,
         limit: 100,
@@ -104,10 +104,7 @@ class Explore {
     }
   }
 
-  static async getRemixables(
-    currentUserId: ID,
-    limit = 25
-  ): Promise<TrackMetadata[]> {
+  static async getRemixables(currentUserId: ID, limit = 25) {
     try {
       const tracks = await apiClient.getRemixables({
         limit,
@@ -121,9 +118,9 @@ class Explore {
     }
   }
 
-  static async getTopFolloweeSaves(limit = 25): Promise<Track[]> {
+  static async getTopFolloweeSaves(limit = 25) {
     try {
-      const tracks = await libs().discoveryProvider.getTopFolloweeSaves(
+      const tracks: UserTrack[] = await libs().discoveryProvider.getTopFolloweeSaves(
         'track',
         limit,
         true

--- a/src/store/recommendation/sagas.ts
+++ b/src/store/recommendation/sagas.ts
@@ -1,7 +1,7 @@
-import { call } from 'redux-saga/effects'
+import { call } from 'typed-redux-saga'
 
 import { ID } from 'common/models/Identifiers'
-import { Track } from 'common/models/Track'
+import { UserTrack } from 'common/models/Track'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { Nullable } from 'common/utils/typeUtils'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
@@ -13,27 +13,27 @@ export function* getRecommendedTracks(
   genre: string,
   exclusionList: number[],
   currentUserId: Nullable<ID>
-): Generator<any, Track[], any> {
-  const tracks = yield apiClient.getRecommended({
+) {
+  const tracks = yield* call([apiClient, apiClient.getRecommended], {
     genre,
     exclusionList,
     currentUserId
   })
-  yield call(processAndCacheTracks, tracks)
-  return tracks as Track[]
+  yield* call(processAndCacheTracks, tracks)
+  return tracks
 }
 
-export function* getLuckyTracks(limit: number): Generator<any, Track[], any> {
-  const latestTrackID = yield call(Explore.getLatestTrackID)
+export function* getLuckyTracks(limit: number) {
+  const latestTrackID = yield* call(Explore.getLatestTrackID)
   const ids = Array.from({ length: limit }, () =>
     Math.floor(Math.random() * latestTrackID)
   )
-  const tracks = yield call(AudiusBackend.getAllTracks, {
+  const tracks: UserTrack[] = yield* call(AudiusBackend.getAllTracks, {
     offset: 0,
     limit,
     idsArray: ids,
     filterDeletes: true
   })
-  yield call(processAndCacheTracks, tracks)
-  return tracks as Track[]
+  yield* call(processAndCacheTracks, tracks)
+  return tracks
 }


### PR DESCRIPTION
### Description

Use `typed-redux-saga` on the explore page to prevent type errors and to keep types closer to the API client and AudiusBackend.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

I did my best to confirm that all the places I used `UserTrack` actually call with `withUsers = true`. But there is a chance I missed one and it's lying.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tests passed, tested against prod on each explore page tile. Triggered recommendations manually and saw the action put to the store.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

N/A
