### PR TITLE
[AUD-1428] Upgrade antd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,39 +30,40 @@
       }
     },
     "@ant-design/colors": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",
-      "integrity": "sha512-YKgNbG2dlzqMhA9NtI3/pbY16m3Yl/EeWBRa+lB1X1YaYxHrxNexiQYCLTWO/uDvAjLFMEDU+zR901waBtMtjQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-6.0.0.tgz",
+      "integrity": "sha512-qAZRvPzfdWHtfameEGP2Qvuf838NhergR35o+EuVyB5XvSA98xod5r4utvi4TJ3ywmevm290g9nsCG5MryrdWQ==",
       "requires": {
-        "tinycolor2": "^1.4.1"
+        "@ctrl/tinycolor": "^3.4.0"
       }
-    },
-    "@ant-design/create-react-context": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@ant-design/create-react-context/-/create-react-context-0.2.5.tgz",
-      "integrity": "sha512-1rMAa4qgP2lfl/QBH9i78+Gjxtj9FTMpMyDGZsEBW5Kih72EuUo9958mV8PgpRkh4uwPSQ7vVZWXeyNZXVAFDg==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
-    },
-    "@ant-design/css-animation": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/css-animation/-/css-animation-1.7.3.tgz",
-      "integrity": "sha512-LrX0OGZtW+W6iLnTAqnTaoIsRelYeuLZWsrmBJFUXDALQphPsN8cE5DCsmoSlL0QYb94BQxINiuS70Ar/8BNgA=="
     },
     "@ant-design/icons": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-2.1.1.tgz",
-      "integrity": "sha512-jCH+k2Vjlno4YWl6g535nHR09PwCEmTBKAG6VqF+rhkrSPRLfgpU2maagwbZPLjaHuU5Jd1DFQ2KJpQuI6uG8w=="
-    },
-    "@ant-design/icons-react": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-react/-/icons-react-2.0.1.tgz",
-      "integrity": "sha512-r1QfoltMuruJZqdiKcbPim3d8LNsVPB733U0gZEUSxBLuqilwsW28K2rCTWSMTjmFX7Mfpf+v/wdiFe/XCqThw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.7.0.tgz",
+      "integrity": "sha512-aoB4Z7JA431rt6d4u+8xcNPPCrdufSRMUOpxa1ab6mz1JCQZOEVolj2WVs/tDFmN62zzK30mNelEsprLYsSF3g==",
       "requires": {
-        "@ant-design/colors": "^3.1.0",
-        "babel-runtime": "^6.26.0"
+        "@ant-design/colors": "^6.0.0",
+        "@ant-design/icons-svg": "^4.2.1",
+        "@babel/runtime": "^7.11.2",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.9.4"
+      }
+    },
+    "@ant-design/icons-svg": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz",
+      "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
+    },
+    "@ant-design/react-slick": {
+      "version": "0.28.4",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.28.4.tgz",
+      "integrity": "sha512-j9eAHTn7GxbXUFNknJoHS2ceAsqrQi2j8XykjZE1IXCD8kJF+t28EvhBLniDpbOsBk/3kjalnhriTfZcjBHNqg==",
+      "requires": {
+        "@babel/runtime": "^7.10.4",
+        "classnames": "^2.2.5",
+        "json2mq": "^0.2.0",
+        "lodash": "^4.17.21",
+        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "@audius/hedgehog": {
@@ -1546,6 +1547,11 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
+    },
+    "@ctrl/tinycolor": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz",
+      "integrity": "sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ=="
     },
     "@develar/schema-utils": {
       "version": "2.6.5",
@@ -5072,7 +5078,8 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.5",
@@ -5183,26 +5190,6 @@
         "@types/react-router": "*"
       }
     },
-    "@types/react-slick": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.5.tgz",
-      "integrity": "sha512-dQ/HwsLpnWXD5d+52WwXIQTfNCRpgd+0CKb+aA8g2CaIpA9T9COdjVYb9KI40Osb4rIgqR7u2AqtL2/HGbBMpg==",
-      "requires": {
-        "@types/react": "*"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "17.0.25",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.25.tgz",
-          "integrity": "sha512-IXrzSOr3CVbEQgmjEdCWF57J7CVaJ7lL/n4penxHm8h0XIcr0AxqGucogh2zj3qRxgk4M4JImOP/MfomkPOhvQ==",
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        }
-      }
-    },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
@@ -5210,11 +5197,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/secp256k1": {
       "version": "4.0.3",
@@ -6487,14 +6469,6 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
-    "add-dom-event-listener": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.1.0.tgz",
-      "integrity": "sha512-WCxx1ixHT0GQU9hb0KI/mhgRQhnU+U3GvwY6ZvVjYq8rsihIGoaIOUbY0yMPBxLH5MDtr0kz3fisWGNcbWW7Jw==",
-      "requires": {
-        "object-assign": "4.x"
-      }
-    },
     "add-line-numbers": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
@@ -6695,68 +6669,63 @@
       }
     },
     "antd": {
-      "version": "3.20.4",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-3.20.4.tgz",
-      "integrity": "sha512-Wgd9KuOgYCBlV9OLe2ijewW8LWv2lP7AgVUXE4RzGTS1xYtBTUOtdaFd3t1hN6+Ya0je2h/mxVNr0pRZoBDz1g==",
+      "version": "4.18.5",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-4.18.5.tgz",
+      "integrity": "sha512-5fN3C2lWAzonhOYYlNpzIw2OHl7vxFZ+4cJ7DK/XZrV+75OY61Y+OkanqMJwrFtDDamIez35OM7cAezGko9tew==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
-        "@ant-design/icons": "~2.1.1",
-        "@ant-design/icons-react": "~2.0.1",
-        "@types/react-slick": "^0.23.4",
-        "array-tree-filter": "^2.1.0",
-        "babel-runtime": "6.x",
-        "classnames": "~2.2.6",
+        "@ant-design/colors": "^6.0.0",
+        "@ant-design/icons": "^4.7.0",
+        "@ant-design/react-slick": "~0.28.1",
+        "@babel/runtime": "^7.12.5",
+        "@ctrl/tinycolor": "^3.4.0",
+        "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.2.0",
-        "css-animation": "^1.5.0",
-        "dom-closest": "^0.2.0",
-        "enquire.js": "^2.1.6",
-        "lodash": "^4.17.13",
-        "moment": "^2.24.0",
-        "omit.js": "^1.0.2",
-        "prop-types": "^15.7.2",
-        "raf": "^3.4.1",
-        "rc-animate": "^2.8.3",
-        "rc-calendar": "~9.15.0",
-        "rc-cascader": "~0.17.4",
-        "rc-checkbox": "~2.1.6",
-        "rc-collapse": "~1.11.3",
-        "rc-dialog": "~7.5.2",
-        "rc-drawer": "~2.0.1",
-        "rc-dropdown": "~2.4.1",
-        "rc-editor-mention": "^1.1.13",
-        "rc-form": "^2.4.5",
-        "rc-input-number": "~4.4.5",
-        "rc-mentions": "~0.3.1",
-        "rc-menu": "~7.4.23",
-        "rc-notification": "~3.3.1",
-        "rc-pagination": "~1.20.1",
-        "rc-progress": "~2.5.0",
-        "rc-rate": "~2.5.0",
-        "rc-select": "~9.2.0",
-        "rc-slider": "~8.6.11",
-        "rc-steps": "~3.4.1",
-        "rc-switch": "~1.9.0",
-        "rc-table": "~6.6.0",
-        "rc-tabs": "~9.6.4",
-        "rc-time-picker": "~3.7.1",
-        "rc-tooltip": "~3.7.3",
-        "rc-tree": "~2.1.0",
-        "rc-tree-select": "~2.9.1",
-        "rc-trigger": "^2.6.2",
-        "rc-upload": "~2.6.7",
-        "rc-util": "^4.6.0",
-        "react-lazy-load": "^3.0.13",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-slick": "~0.24.0",
-        "resize-observer-polyfill": "^1.5.1",
-        "shallowequal": "^1.1.0",
-        "warning": "~4.0.3"
+        "lodash": "^4.17.21",
+        "memoize-one": "^6.0.0",
+        "moment": "^2.25.3",
+        "rc-cascader": "~3.2.1",
+        "rc-checkbox": "~2.3.0",
+        "rc-collapse": "~3.1.0",
+        "rc-dialog": "~8.6.0",
+        "rc-drawer": "~4.4.2",
+        "rc-dropdown": "~3.2.0",
+        "rc-field-form": "~1.22.0-2",
+        "rc-image": "~5.2.5",
+        "rc-input-number": "~7.3.0",
+        "rc-mentions": "~1.6.1",
+        "rc-menu": "~9.2.1",
+        "rc-motion": "^2.4.4",
+        "rc-notification": "~4.5.7",
+        "rc-pagination": "~3.1.9",
+        "rc-picker": "~2.5.17",
+        "rc-progress": "~3.2.1",
+        "rc-rate": "~2.9.0",
+        "rc-resize-observer": "^1.2.0",
+        "rc-select": "~14.0.0-alpha.15",
+        "rc-slider": "~9.7.4",
+        "rc-steps": "~4.1.0",
+        "rc-switch": "~3.2.0",
+        "rc-table": "~7.22.2",
+        "rc-tabs": "~11.10.0",
+        "rc-textarea": "~0.3.0",
+        "rc-tooltip": "~5.1.1",
+        "rc-tree": "~5.4.3",
+        "rc-tree-select": "~5.1.1",
+        "rc-trigger": "^5.2.10",
+        "rc-upload": "~4.3.0",
+        "rc-util": "^5.14.0",
+        "scroll-into-view-if-needed": "^2.2.25"
       },
       "dependencies": {
-        "classnames": {
-          "version": "2.2.6",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-          "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+        "memoize-one": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+          "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
+        },
+        "moment": {
+          "version": "2.29.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+          "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
         }
       }
     },
@@ -7258,9 +7227,9 @@
       }
     },
     "async-validator": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-1.11.5.tgz",
-      "integrity": "sha512-XNtCsMAeAH1pdLMEg1z8/Bb3a8cdCbui9QbJATRFHHHW5kT6+NPI3zSVQUXgikTFITzsg+kYY5NTWhM2Orwt9w=="
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.0.7.tgz",
+      "integrity": "sha512-Pj2IR7u8hmUEDOwB++su6baaRi+QvsgajuFB9j95foM1N2gy5HM4z60hfusIO0fBPG5uLAEl6yCJr1jNSVugEQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -9480,23 +9449,10 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
-    "component-classes": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
-      "integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=",
-      "requires": {
-        "component-indexof": "0.0.3"
-      }
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-    },
-    "component-indexof": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
-      "integrity": "sha1-EdCRMSI5648yyPJa6csAL/6NPCQ="
     },
     "compose-function": {
       "version": "3.0.3",
@@ -9547,6 +9503,11 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
+    },
+    "compute-scroll-into-view": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -9927,15 +9888,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -10020,15 +9972,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
-      }
-    },
-    "css-animation": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.6.1.tgz",
-      "integrity": "sha512-/48+/BaEaHRY6kNQ2OIPzKf9A6g8WjZYjhiNDNuIVbsm5tXCGIAsHDjB4Xu1C4vXJtUWZo26O68OQkDpNBaPog==",
-      "requires": {
-        "babel-runtime": "6.x",
-        "component-classes": "^1.2.5"
       }
     },
     "css-blank-pseudo": {
@@ -10387,7 +10330,8 @@
     "csstype": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
+      "dev": true
     },
     "cwise-compiler": {
       "version": "1.1.3",
@@ -10458,6 +10402,11 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dayjs": {
       "version": "1.10.7",
@@ -10987,14 +10936,6 @@
       "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.2.tgz",
       "integrity": "sha512-pHuazgqrsTFrGU2WLDdXxCFabkdQDx72ddkraZNih1KsMcN5qsRSTR9O4VJRlwTPCPb5COYg3LOfiMHHcPInHg=="
     },
-    "dom-closest": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dom-closest/-/dom-closest-0.2.0.tgz",
-      "integrity": "sha1-69n5HRvyLo1vR3h2u80+yQIWwM8=",
-      "requires": {
-        "dom-matches": ">=1.0.1"
-      }
-    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -11002,16 +10943,6 @@
       "requires": {
         "utila": "~0.4"
       }
-    },
-    "dom-matches": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-matches/-/dom-matches-2.0.0.tgz",
-      "integrity": "sha1-0nKLQWqHUzmA6wibhI0lPPI6dYw="
-    },
-    "dom-scroll-into-view": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
-      "integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4="
     },
     "dom-serializer": {
       "version": "1.3.2",
@@ -11116,16 +11047,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dprop/-/dprop-1.0.0.tgz",
       "integrity": "sha1-X0WmCmD6OsHQ9otrQ1gx8v9mVGg="
-    },
-    "draft-js": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.10.5.tgz",
-      "integrity": "sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==",
-      "requires": {
-        "fbjs": "^0.8.15",
-        "immutable": "~3.7.4",
-        "object-assign": "^4.1.0"
-      }
     },
     "dtype": {
       "version": "1.0.0",
@@ -11673,24 +11594,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -11751,11 +11654,6 @@
           }
         }
       }
-    },
-    "enquire.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
-      "integrity": "sha1-PoeAybi4NQhMP2DhZtvDwqPImBQ="
     },
     "enquirer": {
       "version": "2.3.6",
@@ -13419,11 +13317,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-    },
-    "eventlistener": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/eventlistener/-/eventlistener-0.0.1.tgz",
-      "integrity": "sha1-7Suqu4UiJ68rz4iRUscsY8pTLrg="
     },
     "events": {
       "version": "3.3.0",
@@ -15490,27 +15383,6 @@
         "bser": "2.1.1"
       }
     },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        }
-      }
-    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -16639,11 +16511,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -16659,11 +16526,6 @@
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
       }
-    },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -17405,11 +17267,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.9.tgz",
       "integrity": "sha512-SyCYnAuiRf67Lvk0VkwFvwtDoEiCMjeamnHvRfnVDyc7re1/rQrNxuL+jJ7lA3WvdC4uznrvbmm+clJ9+XXatg=="
     },
-    "immutable": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
-    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -18143,31 +18000,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "isomorphic-ws": {
       "version": "4.0.1",
@@ -21840,24 +21672,6 @@
       "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
       "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ="
     },
-    "mini-store": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mini-store/-/mini-store-2.0.0.tgz",
-      "integrity": "sha512-EG0CuwpQmX+XL4QVS0kxNwHW5ftSbhygu1qxQH0pipugjnPkbvkalCdQbEihMwtQY6d3MTN+MS0q+aurs+RfLQ==",
-      "requires": {
-        "hoist-non-react-statics": "^2.3.1",
-        "prop-types": "^15.6.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.0.2"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -22319,11 +22133,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-0.0.2.tgz",
       "integrity": "sha1-bwe9ihEF5wnCb8iUIMtZMMJFhf4="
-    },
-    "mutationobserver-shim": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/mutationobserver-shim/-/mutationobserver-shim-0.3.7.tgz",
-      "integrity": "sha512-oRIDTyZQU96nAiz2AQyngwx1e89iApl2hN5AOYwyxLUB47UYsU3Wv9lJWqH5y/QdiYkc5HQLi23ZNB3fELdHcQ=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -22893,14 +22702,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
       "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
-    },
-    "omit.js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-1.0.2.tgz",
-      "integrity": "sha512-/QPc6G2NS+8d4L/cQhbk6Yit1WTB6Us2g84A7A/1+w9d/eRGHyEqC5kkQtHVoHZ5NFWGG7tUGgrhVZwgZanKrQ==",
-      "requires": {
-        "babel-runtime": "^6.23.0"
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -24721,14 +24522,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -25191,473 +24984,391 @@
       }
     },
     "rc-align": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.4.5.tgz",
-      "integrity": "sha512-nv9wYUYdfyfK+qskThf4BQUSIadeI/dCsfaMZfNEoxm9HwOIioQ+LyqmMK6jWHAZQgOzMLaqawhuBXlF63vgjw==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.11.tgz",
+      "integrity": "sha512-n9mQfIYQbbNTbefyQnRHZPWuTEwG1rY4a9yKlIWHSTbgwI+XUMGRYd0uJ5pE2UbrNX0WvnMBA1zJ3Lrecpra/A==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "dom-align": "^1.7.0",
-        "prop-types": "^15.5.8",
-        "rc-util": "^4.0.4"
-      }
-    },
-    "rc-animate": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.11.1.tgz",
-      "integrity": "sha512-1NyuCGFJG/0Y+9RKh5y/i/AalUCA51opyyS/jO2seELpgymZm2u9QV3xwODwEuzkmeQ1BDPxMLmYLcTJedPlkQ==",
-      "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "css-animation": "^1.3.2",
-        "prop-types": "15.x",
-        "raf": "^3.4.0",
-        "rc-util": "^4.15.3",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "rc-calendar": {
-      "version": "9.15.11",
-      "resolved": "https://registry.npmjs.org/rc-calendar/-/rc-calendar-9.15.11.tgz",
-      "integrity": "sha512-qv0VXfAAnysMWJigxaP6se4bJHvr17D9qsLbi8BOpdgEocsS0RkgY1IUiFaOVYKJDy/EyLC447O02sV/y5YYBg==",
-      "requires": {
-        "babel-runtime": "6.x",
+        "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "moment": "2.x",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.0",
-        "rc-util": "^4.1.1",
-        "react-lifecycles-compat": "^3.0.4"
+        "dom-align": "^1.7.0",
+        "lodash": "^4.17.21",
+        "rc-util": "^5.3.0",
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "rc-cascader": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-0.17.5.tgz",
-      "integrity": "sha512-WYMVcxU0+Lj+xLr4YYH0+yXODumvNXDcVEs5i7L1mtpWwYkubPV/zbQpn+jGKFCIW/hOhjkU4J1db8/P/UKE7A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.2.1.tgz",
+      "integrity": "sha512-Raxam9tFzBL4TCgHoyVcf7+Q2KSFneUk3FZXi9w1tfxEihLlezSH0oCNMjHJN8hxWwwx9ZbI9UzWTfFImjXc0Q==",
       "requires": {
+        "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.0",
-        "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallow-equal": "^1.0.0",
-        "warning": "^4.0.1"
+        "classnames": "^2.3.1",
+        "rc-select": "~14.0.0-alpha.23",
+        "rc-tree": "~5.4.3",
+        "rc-util": "^5.6.1"
+      },
+      "dependencies": {
+        "classnames": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+          "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+        }
       }
     },
     "rc-checkbox": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.1.8.tgz",
-      "integrity": "sha512-6qOgh0/by0nVNASx6LZnhRTy17Etcgav+IrI7kL9V9kcDZ/g7K14JFlqrtJ3NjDq/Kyn+BPI1st1XvbkhfaJeg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-2.3.2.tgz",
+      "integrity": "sha512-afVi1FYiGv1U0JlpNH/UaEXdh6WUJjcWokj/nUN2TgG80bfG+MDdbfHKlLcNNba94mbjy2/SXJ1HDgrOkXGAjg==",
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "classnames": "2.x",
-        "prop-types": "15.x",
-        "react-lifecycles-compat": "^3.0.4"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1"
       }
     },
     "rc-collapse": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-1.11.8.tgz",
-      "integrity": "sha512-8EhfPyScTYljkbRuIoHniSwZagD5UPpZ3CToYgoNYWC85L2qCbPYF7+OaC713FOrIkp6NbfNqXsITNxmDAmxog==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.1.2.tgz",
+      "integrity": "sha512-HujcKq7mghk/gVKeI6EjzTbb8e19XUZpakrYazu1MblEZ3Hu3WBMSN4A3QmvbF6n1g7x6lUlZvsHZ5shABWYOQ==",
       "requires": {
+        "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "css-animation": "1.x",
-        "prop-types": "^15.5.6",
-        "rc-animate": "2.x",
-        "react-is": "^16.7.0",
-        "react-lifecycles-compat": "^3.0.4",
+        "rc-motion": "^2.3.4",
+        "rc-util": "^5.2.1",
         "shallowequal": "^1.1.0"
       }
     },
     "rc-dialog": {
-      "version": "7.5.14",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-7.5.14.tgz",
-      "integrity": "sha512-gmEukl2iU2K74G2g66rVH6yOCwvLbVWqmEClbRO47Iec/stFyaDXCkvJmBb5vJcAWomQwaU4yZ9muRBW4u9AfA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.6.0.tgz",
+      "integrity": "sha512-GSbkfqjqxpZC5/zc+8H332+q5l/DKUhpQr0vdX2uDsxo5K0PhvaMEVjyoJUTkZ3+JstEADQji1PVLVb/2bJeOQ==",
       "requires": {
-        "babel-runtime": "6.x",
-        "rc-animate": "2.x",
-        "rc-util": "^4.8.1"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.6",
+        "rc-motion": "^2.3.0",
+        "rc-util": "^5.6.1"
       }
     },
     "rc-drawer": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-2.0.9.tgz",
-      "integrity": "sha512-7qwEND3TLvJeyuUvZfMDkL2pHsR/XHX5HvoaBlIH9mTcFWBmMNrvYGDuGHgGsdNKZZgIBwlkvl5vhckydTUc9Q==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-4.4.3.tgz",
+      "integrity": "sha512-FYztwRs3uXnFOIf1hLvFxIQP9MiZJA+0w+Os8dfDh/90X7z/HqP/Yg+noLCIeHEbKln1Tqelv8ymCAN24zPcfQ==",
       "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.5",
-        "rc-util": "^4.7.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.7.0"
       }
     },
     "rc-dropdown": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-2.4.1.tgz",
-      "integrity": "sha512-p0XYn0wrOpAZ2fUGE6YJ6U8JBNc5ASijznZ6dkojdaEfQJAeZtV9KMEewhxkVlxGSbbdXe10ptjBlTEW9vEwEg==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.2.5.tgz",
+      "integrity": "sha512-dVO2eulOSbEf+F4OyhCY5iGiMVhUYY/qeXxL7Ex2jDBt/xc89jU07mNoowV6aWxwVOc70pxEINff0oM2ogjluA==",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.5.1",
-        "react-lifecycles-compat": "^3.0.2"
+        "rc-trigger": "^5.0.4"
       }
     },
-    "rc-editor-core": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/rc-editor-core/-/rc-editor-core-0.8.10.tgz",
-      "integrity": "sha512-T3aHpeMCIYA1sdAI7ynHHjXy5fqp83uPlD68ovZ0oClTSc3tbHmyCxXlA+Ti4YgmcpCYv7avF6a+TIbAka53kw==",
+    "rc-field-form": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.22.1.tgz",
+      "integrity": "sha512-LweU7nBeqmC5r3HDUjRprcOXXobHXp/TGIxD7ppBq5FX6Iptt3ibdpRVg4RSyNulBNGHOuknHlRcguuIpvVMVg==",
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "classnames": "^2.2.5",
-        "draft-js": "^0.10.0",
-        "immutable": "^3.7.4",
-        "lodash": "^4.16.5",
-        "prop-types": "^15.5.8",
-        "setimmediate": "^1.0.5"
+        "@babel/runtime": "^7.8.4",
+        "async-validator": "^4.0.2",
+        "rc-util": "^5.8.0"
       }
     },
-    "rc-editor-mention": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/rc-editor-mention/-/rc-editor-mention-1.1.13.tgz",
-      "integrity": "sha512-3AOmGir91Fi2ogfRRaXLtqlNuIwQpvla7oUnGHS1+3eo7b+fUp5IlKcagqtwUBB5oDNofoySXkLBxzWvSYNp/Q==",
+    "rc-image": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-5.2.5.tgz",
+      "integrity": "sha512-qUfZjYIODxO0c8a8P5GeuclYXZjzW4hV/5hyo27XqSFo1DmTCs2HkVeQObkcIk5kNsJtgsj1KoPThVsSc/PXOw==",
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "classnames": "^2.2.5",
-        "dom-scroll-into-view": "^1.2.0",
-        "draft-js": "~0.10.0",
-        "immutable": "~3.7.4",
-        "prop-types": "^15.5.8",
-        "rc-animate": "^2.3.0",
-        "rc-editor-core": "~0.8.3"
-      }
-    },
-    "rc-form": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/rc-form/-/rc-form-2.4.12.tgz",
-      "integrity": "sha512-sHfyWRrnjCHkeCYfYAGop2GQBUC6CKMPcJF9h/gL/vTmZB/RN6fNOGKjXrXjFbwFwKXUWBoPtIDDDmXQW9xNdw==",
-      "requires": {
-        "async-validator": "~1.11.3",
-        "babel-runtime": "6.x",
-        "create-react-class": "^15.5.3",
-        "dom-scroll-into-view": "1.x",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.4",
-        "rc-util": "^4.15.3",
-        "react-is": "^16.13.1",
-        "warning": "^4.0.3"
-      }
-    },
-    "rc-hammerjs": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/rc-hammerjs/-/rc-hammerjs-0.6.10.tgz",
-      "integrity": "sha512-Vgh9qIudyN5CHRop4M+v+xUniQBFWXKrsJxQRVtJOi2xgRrCeI52/bkpaL5HWwUhqTK9Ayq0n7lYTItT6ld5rg==",
-      "requires": {
-        "babel-runtime": "6.x",
-        "hammerjs": "^2.0.8",
-        "prop-types": "^15.5.9"
+        "@babel/runtime": "^7.11.2",
+        "classnames": "^2.2.6",
+        "rc-dialog": "~8.6.0",
+        "rc-util": "^5.0.6"
       }
     },
     "rc-input-number": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-4.4.5.tgz",
-      "integrity": "sha512-Dt20e8Ylc/N/6oXiPUlwDVdx3fz7W5umUOa4z5pBuWFG7NPlBVXRWkq7+nbnTyaK24UxN67PVpmD3+Omo+QRZQ==",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.4.tgz",
+      "integrity": "sha512-W9uqSzuvJUnz8H8vsVY4kx+yK51SsAxNTwr8SNH4G3XqQNocLVmKIibKFRjocnYX1RDHMND9FFbgj2h7E7nvGA==",
       "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.0",
-        "prop-types": "^15.5.7",
-        "rc-util": "^4.5.1",
-        "rmc-feedback": "^2.0.0"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.5",
+        "rc-util": "^5.9.8"
       }
     },
     "rc-mentions": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-0.3.1.tgz",
-      "integrity": "sha512-fa5dN3IMTahJfAga1nmma9OymK/ZBV/MZfV11h4kjDmCAVETv5EbAlV0mn6Y+JajvXS6n/XFoPUSF+nwK/AeWw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.6.1.tgz",
+      "integrity": "sha512-LDzGI8jJVGnkhpTZxZuYBhMz3avcZZqPGejikchh97xPni/g4ht714Flh7DVvuzHQ+BoKHhIjobHnw1rcP8erg==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
-        "babel-runtime": "^6.23.0",
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
-        "rc-menu": "^7.4.22",
-        "rc-trigger": "^2.6.2",
-        "rc-util": "^4.6.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "rc-menu": "^9.0.0",
+        "rc-textarea": "^0.3.0",
+        "rc-trigger": "^5.0.4",
+        "rc-util": "^5.0.1"
       }
     },
     "rc-menu": {
-      "version": "7.4.32",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-7.4.32.tgz",
-      "integrity": "sha512-9/ySqniMdvhUhfiUFmqK3hLffYIdeR2nrDDNvXksTCc2ZYd1JmOWF16yO7iYyDPLZM33NU3Qw6EPZd21+FxJsQ==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.2.1.tgz",
+      "integrity": "sha512-UbEtn3rflJ8zS+etYGTVQuzy7Fm+yWXR5c0Rl6ecNTS/dPknRyWAyhJcbeR0Hu1+RdQT+0VCqrUPrgKnm4iY+w==",
       "requires": {
+        "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "dom-scroll-into-view": "1.x",
-        "mini-store": "^2.0.0",
-        "mutationobserver-shim": "^0.3.2",
-        "rc-animate": "2.x",
-        "rc-trigger": "^2.3.0",
-        "rc-util": "^4.13.0",
-        "resize-observer-polyfill": "^1.5.0"
+        "rc-motion": "^2.4.3",
+        "rc-overflow": "^1.2.0",
+        "rc-trigger": "^5.1.2",
+        "rc-util": "^5.12.0",
+        "shallowequal": "^1.1.0"
+      }
+    },
+    "rc-motion": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.4.4.tgz",
+      "integrity": "sha512-ms7n1+/TZQBS0Ydd2Q5P4+wJTSOrhIrwNxLXCZpR7Fa3/oac7Yi803HDALc2hLAKaCTQtw9LmQeB58zcwOsqlQ==",
+      "requires": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.2.1"
       }
     },
     "rc-notification": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-3.3.1.tgz",
-      "integrity": "sha512-U5+f4BmBVfMSf3OHSLyRagsJ74yKwlrQAtbbL5ijoA0F2C60BufwnOcHG18tVprd7iaIjzZt1TKMmQSYSvgrig==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-4.5.7.tgz",
+      "integrity": "sha512-zhTGUjBIItbx96SiRu3KVURcLOydLUHZCPpYEn1zvh+re//Tnq/wSxN4FKgp38n4HOgHSVxcLEeSxBMTeBBDdw==",
       "requires": {
-        "babel-runtime": "6.x",
+        "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "prop-types": "^15.5.8",
-        "rc-animate": "2.x",
-        "rc-util": "^4.0.4"
+        "rc-motion": "^2.2.0",
+        "rc-util": "^5.0.1"
+      }
+    },
+    "rc-overflow": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.2.2.tgz",
+      "integrity": "sha512-X5kj9LDU1ue5wHkqvCprJWLKC+ZLs3p4He/oxjZ1Q4NKaqKBaYf5OdSzRSgh3WH8kSdrfU8LjvlbWnHgJOEkNQ==",
+      "requires": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.5.1"
       }
     },
     "rc-pagination": {
-      "version": "1.20.15",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-1.20.15.tgz",
-      "integrity": "sha512-/Xr4/3GOa1DtL8iCYl7qRUroEMrRDhZiiuHwcVFfSiwa9LYloMlUWcOJsnr8LN6A7rLPdm3/CHStUNeYd+2pKw==",
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.1.15.tgz",
+      "integrity": "sha512-4L3fot8g4E+PjWEgoVGX0noFCg+8ZFZmeLH4vsnZpB3O2T2zThtakjNxG+YvSaYtyMVT4B+GLayjKrKbXQpdAg==",
       "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.6",
-        "prop-types": "^15.5.7",
-        "react-lifecycles-compat": "^3.0.4"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1"
+      }
+    },
+    "rc-picker": {
+      "version": "2.5.19",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.5.19.tgz",
+      "integrity": "sha512-u6myoCu/qiQ0vLbNzSzNrzTQhs7mldArCpPHrEI6OUiifs+IPXmbesqSm0zilJjfzrZJLgYeyyOMSznSlh0GKA==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "date-fns": "2.x",
+        "dayjs": "1.x",
+        "moment": "^2.24.0",
+        "rc-trigger": "^5.0.4",
+        "rc-util": "^5.4.0",
+        "shallowequal": "^1.1.0"
       }
     },
     "rc-progress": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-2.5.3.tgz",
-      "integrity": "sha512-K2fa4CnqGehLZoMrdmBeZ86ONSTVcdk5FlqetbwJ3R/+42XfqhwQVOjWp2MH4P7XSQOMAGcNOy1SFfCP3415sg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.2.4.tgz",
+      "integrity": "sha512-M9WWutRaoVkPUPIrTpRIDpX0SPSrVHzxHdCRCbeoBFrd9UFWTYNWRlHsruJM5FH1AZI+BwB4wOJUNNylg/uFSw==",
       "requires": {
-        "babel-runtime": "6.x",
-        "prop-types": "^15.5.8"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.16.1"
       }
     },
     "rc-rate": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.5.1.tgz",
-      "integrity": "sha512-3iJkNJT8xlHklPCdeZtUZmJmRVUbr6AHRlfSsztfYTXVlHrv2TcPn3XkHsH+12j812WVB7gvilS2j3+ffjUHXg==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.9.1.tgz",
+      "integrity": "sha512-MmIU7FT8W4LYRRHJD1sgG366qKtSaKb67D0/vVvJYR0lrCuRrCiVQ5qhfT5ghVO4wuVIORGpZs7ZKaYu+KMUzA==",
       "requires": {
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "prop-types": "^15.5.8",
-        "rc-util": "^4.3.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "rc-util": "^5.0.1"
+      }
+    },
+    "rc-resize-observer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.2.0.tgz",
+      "integrity": "sha512-6W+UzT3PyDM0wVCEHfoW3qTHPTvbdSgiA43buiy8PzmeMnfgnDeb9NjdimMXMl3/TcrvvWl5RRVdp+NqcR47pQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.15.0",
+        "resize-observer-polyfill": "^1.5.1"
       }
     },
     "rc-select": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-9.2.3.tgz",
-      "integrity": "sha512-WhswxOMWiNnkXRbxyrj0kiIvyCfo/BaRPaYbsDetSIAU2yEDwKHF798blCP5u86KLOBKBvtxWLFCkSsQw1so5w==",
+      "version": "14.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.0.0-alpha.25.tgz",
+      "integrity": "sha512-U9AMzXsOCCdtn96YIZdUrYbxk+5u6uWUCaYH2129X3FTjQITqAjEPYHfPcxU/G7+lwiD0pIaU95W0NMkg+26qw==",
       "requires": {
-        "babel-runtime": "^6.23.0",
+        "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "component-classes": "1.x",
-        "dom-scroll-into-view": "1.x",
-        "prop-types": "^15.5.8",
-        "raf": "^3.4.0",
-        "rc-animate": "2.x",
-        "rc-menu": "^7.3.0",
-        "rc-trigger": "^2.5.4",
-        "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.2",
-        "warning": "^4.0.2"
+        "rc-motion": "^2.0.1",
+        "rc-overflow": "^1.0.0",
+        "rc-trigger": "^5.0.4",
+        "rc-util": "^5.16.1",
+        "rc-virtual-list": "^3.2.0"
       }
     },
     "rc-slider": {
-      "version": "8.6.13",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-8.6.13.tgz",
-      "integrity": "sha512-fCUe8pPn8n9pq1ARX44nN2nzJoATtna4x/PdskUrxIvZXN8ja7HuceN/hq6kokZjo3FBD2B1yMZvZh6oi68l6Q==",
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-9.7.5.tgz",
+      "integrity": "sha512-LV/MWcXFjco1epPbdw1JlLXlTgmWpB9/Y/P2yinf8Pg3wElHxA9uajN21lJiWtZjf5SCUekfSP6QMJfDo4t1hg==",
       "requires": {
-        "babel-runtime": "6.x",
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "prop-types": "^15.5.4",
-        "rc-tooltip": "^3.7.0",
-        "rc-util": "^4.0.4",
-        "shallowequal": "^1.0.1",
-        "warning": "^4.0.3"
+        "rc-tooltip": "^5.0.1",
+        "rc-util": "^5.16.1",
+        "shallowequal": "^1.1.0"
       }
     },
     "rc-steps": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-3.4.1.tgz",
-      "integrity": "sha512-zdeOFmFqiXlXCQyHet1qrDDbGKZ7OQTrlzn8DP5N6M/WqN7HaYoUDy1fZ+NY2htL5WzzVFQpDRKzjiOiHaSqgw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-4.1.4.tgz",
+      "integrity": "sha512-qoCqKZWSpkh/b03ASGx1WhpKnuZcRWmvuW+ZUu4mvMdfvFzVxblTwUM+9aBd0mlEUFmt6GW8FXhMpHkK3Uzp3w==",
       "requires": {
-        "babel-runtime": "^6.23.0",
+        "@babel/runtime": "^7.10.2",
         "classnames": "^2.2.3",
-        "lodash": "^4.17.5",
-        "prop-types": "^15.5.7"
+        "rc-util": "^5.0.1"
       }
     },
     "rc-switch": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-1.9.2.tgz",
-      "integrity": "sha512-qaK7mY4FLDKy99Hq3A1tf8CcqfzKtHp9LPX8WTnZ0MzdHCTneSARb1XD7Eqeu8BactasYGsi2bF9p18Q+/5JEw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-3.2.2.tgz",
+      "integrity": "sha512-+gUJClsZZzvAHGy1vZfnwySxj+MjLlGRyXKXScrtCTcmiYNPzxDFOxdQ/3pK1Kt/0POvwJ/6ALOR8gwdXGhs+A==",
       "requires": {
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
-        "prop-types": "^15.5.6",
-        "react-lifecycles-compat": "^3.0.4"
+        "rc-util": "^5.0.1"
       }
     },
     "rc-table": {
-      "version": "6.6.8",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-6.6.8.tgz",
-      "integrity": "sha512-G/ICx/jVgWEpnXwVD+WWTm8BjATN0DAWtNFx1O1lxCVs9IY50fZy/GumBpwf91hnWFqlo96Dd/SN50P2O3EM0w==",
+      "version": "7.22.2",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.22.2.tgz",
+      "integrity": "sha512-Ng2gNkGi6ybl6dzneRn2H4Gp8XhIbRa5rXQ7ZhZcgWVmfVMok70UHGPXcf68tXW6O0/qckTf/eOVsoviSvK4sw==",
       "requires": {
-        "babel-runtime": "6.x",
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "component-classes": "^1.2.6",
-        "lodash": "^4.17.5",
-        "mini-store": "^2.0.0",
-        "prop-types": "^15.5.8",
-        "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.2",
-        "shallowequal": "^1.0.2",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
+        "rc-resize-observer": "^1.1.0",
+        "rc-util": "^5.14.0",
+        "shallowequal": "^1.1.0"
       }
     },
     "rc-tabs": {
-      "version": "9.6.7",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-9.6.7.tgz",
-      "integrity": "sha512-OXbDOgaqv2MGK9QaDi6cdva6bNz3XGw+M9BHQpm1gTGmVQEGx5VcclDClH/3xobIzooxy8hrxg/s0rTlgDnC2w==",
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.10.5.tgz",
+      "integrity": "sha512-DDuUdV6b9zGRYLtjI5hyejWLKoz1QiLWNgMeBzc3aMeQylZFhTYnFGdDc6HRqj5IYearNTsFPVSA+6VIT8g5cg==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
-        "babel-runtime": "6.x",
+        "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
-        "lodash": "^4.17.5",
-        "prop-types": "15.x",
-        "raf": "^3.4.1",
-        "rc-hammerjs": "~0.6.0",
-        "rc-util": "^4.0.4",
-        "react-lifecycles-compat": "^3.0.4",
-        "resize-observer-polyfill": "^1.5.1",
-        "warning": "^4.0.3"
+        "rc-dropdown": "^3.2.0",
+        "rc-menu": "^9.0.0",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.5.0"
       }
     },
-    "rc-time-picker": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/rc-time-picker/-/rc-time-picker-3.7.3.tgz",
-      "integrity": "sha512-Lv1Mvzp9fRXhXEnRLO4nW6GLNxUkfAZ3RsiIBsWjGjXXvMNjdr4BX/ayElHAFK0DoJqOhm7c5tjmIYpEOwcUXg==",
+    "rc-textarea": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-0.3.7.tgz",
+      "integrity": "sha512-yCdZ6binKmAQB13hc/oehh0E/QRwoPP1pjF21aHBxlgXO3RzPF6dUu4LG2R4FZ1zx/fQd2L1faktulrXOM/2rw==",
       "requires": {
-        "classnames": "2.x",
-        "moment": "2.x",
-        "prop-types": "^15.5.8",
-        "raf": "^3.4.1",
-        "rc-trigger": "^2.2.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.1",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.7.0",
+        "shallowequal": "^1.1.0"
       }
     },
     "rc-tooltip": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.7.3.tgz",
-      "integrity": "sha512-dE2ibukxxkrde7wH9W8ozHKUO4aQnPZ6qBHtrTH9LoO836PjDdiaWO73fgPB05VfJs9FbZdmGPVEbXCeOP99Ww==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.1.1.tgz",
+      "integrity": "sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==",
       "requires": {
-        "babel-runtime": "6.x",
-        "prop-types": "^15.5.8",
-        "rc-trigger": "^2.2.2"
+        "@babel/runtime": "^7.11.2",
+        "rc-trigger": "^5.0.0"
       }
     },
     "rc-tree": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-2.1.4.tgz",
-      "integrity": "sha512-Xey794Iavgs8YldFlXcZLOhfcIhlX5Oz/yfKufknBXf2AlZCOkc7aHqSM9uTF7fBPtTGPhPxNEfOqHfY7b7xng==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.4.3.tgz",
+      "integrity": "sha512-WAHV8FkBerulj9J/+61+Qn0TD/Zo37PrDG8/45WomzGTYavxFMur9YguKjQj/J+NxjVJzrJL3lvdSZsumfdbiA==",
       "requires": {
-        "@ant-design/create-react-context": "^0.2.4",
+        "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "prop-types": "^15.5.8",
-        "rc-animate": "^2.6.0",
-        "rc-util": "^4.5.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "warning": "^4.0.3"
+        "rc-motion": "^2.0.1",
+        "rc-util": "^5.16.1",
+        "rc-virtual-list": "^3.4.1"
       }
     },
     "rc-tree-select": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-2.9.4.tgz",
-      "integrity": "sha512-0HQkXAN4XbfBW20CZYh3G+V+VMrjX42XRtDCpyv6PDUm5vikC0Ob682ZBCVS97Ww2a5Hf6Ajmu0ahWEdIEpwhg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.1.2.tgz",
+      "integrity": "sha512-sTulyQZB1SgF2HzAR49i4vjMNvV/tfPxCTc+qNuWOwaAtSm2bwGH6/wfi3k3Dw2/5PPOGpRRpgCMltoP9aG0+w==",
       "requires": {
-        "classnames": "^2.2.1",
-        "dom-scroll-into-view": "^1.2.1",
-        "prop-types": "^15.5.8",
-        "raf": "^3.4.0",
-        "rc-animate": "^2.8.2",
-        "rc-tree": "~2.1.0",
-        "rc-trigger": "^3.0.0",
-        "rc-util": "^4.5.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.0.2",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "rc-trigger": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-3.0.0.tgz",
-          "integrity": "sha512-hQxbbJpo23E2QnYczfq3Ec5J5tVl2mUDhkqxrEsQAqk16HfADQg+iKNWzEYXyERSncdxfnzYuaBgy764mNRzTA==",
-          "requires": {
-            "babel-runtime": "6.x",
-            "classnames": "^2.2.6",
-            "prop-types": "15.x",
-            "raf": "^3.4.0",
-            "rc-align": "^2.4.1",
-            "rc-animate": "^3.0.0-rc.1",
-            "rc-util": "^4.15.7"
-          },
-          "dependencies": {
-            "rc-animate": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-3.1.1.tgz",
-              "integrity": "sha512-8wg2Zg3EETy0k/9kYuis30NJNQg1D6/WSQwnCiz6SvyxQXNet/rVraRz3bPngwY6rcU2nlRvoShiYOorXyF7Sg==",
-              "requires": {
-                "@ant-design/css-animation": "^1.7.2",
-                "classnames": "^2.2.6",
-                "raf": "^3.4.0",
-                "rc-util": "^4.15.3"
-              }
-            }
-          }
-        }
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-select": "~14.0.0-alpha.8",
+        "rc-tree": "~5.4.3",
+        "rc-util": "^5.16.1"
       }
     },
     "rc-trigger": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-2.6.5.tgz",
-      "integrity": "sha512-m6Cts9hLeZWsTvWnuMm7oElhf+03GOjOLfTuU0QmdB9ZrW7jR2IpI5rpNM7i9MvAAlMAmTx5Zr7g3uu/aMvZAw==",
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.2.10.tgz",
+      "integrity": "sha512-FkUf4H9BOFDaIwu42fvRycXMAvkttph9AlbCZXssZDVzz2L+QZ0ERvfB/4nX3ZFPh1Zd+uVGr1DEDeXxq4J1TA==",
       "requires": {
-        "babel-runtime": "6.x",
+        "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
-        "prop-types": "15.x",
-        "rc-align": "^2.4.0",
-        "rc-animate": "2.x",
-        "rc-util": "^4.4.0",
-        "react-lifecycles-compat": "^3.0.4"
+        "rc-align": "^4.0.0",
+        "rc-motion": "^2.0.0",
+        "rc-util": "^5.5.0"
       }
     },
     "rc-upload": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-2.6.8.tgz",
-      "integrity": "sha512-Uz7hys+FdIfS8qIm+VnCUZ21sY+/VaCjyMKw6cANmgBIbemFNOxEPEfgEBZH1YHt89HCGNPSpIK976ndsuc2YQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.3.3.tgz",
+      "integrity": "sha512-YoJ0phCRenMj1nzwalXzciKZ9/FAaCrFu84dS5pphwucTC8GUWClcDID/WWNGsLFcM97NqIboDqrV82rVRhW/w==",
       "requires": {
-        "babel-runtime": "6.x",
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "prop-types": "^15.5.7",
-        "warning": "4.x"
+        "rc-util": "^5.2.0"
       }
     },
     "rc-util": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.21.1.tgz",
-      "integrity": "sha512-Z+vlkSQVc1l8O2UjR3WQ+XdWlhj5q9BMQNLk2iOBch75CqPfrJyGtcWMcnhRlNuDu0Ndtt4kLVO8JI8BrABobg==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.17.0.tgz",
+      "integrity": "sha512-HWuTIKzBeZQQ7IBqdokE0wMp/xx39/KfUJ0gcquBigoldDCrf3YBcWFHrrQlJG7sI82Wg8mwp1uAKV3zMGfAgg==",
       "requires": {
-        "add-dom-event-listener": "^1.1.0",
-        "prop-types": "^15.5.10",
+        "@babel/runtime": "^7.12.5",
         "react-is": "^16.12.0",
-        "react-lifecycles-compat": "^3.0.4",
         "shallowequal": "^1.1.0"
+      }
+    },
+    "rc-virtual-list": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.4.2.tgz",
+      "integrity": "sha512-OyVrrPvvFcHvV0ssz5EDZ+7Rf5qLat/+mmujjchNw5FfbJWNDwkpQ99EcVE6+FtNRmX9wFa1LGNpZLUTvp/4GQ==",
+      "requires": {
+        "classnames": "^2.2.6",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.0.7"
       }
     },
     "react": {
@@ -26061,17 +25772,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-lazy-load": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/react-lazy-load/-/react-lazy-load-3.1.13.tgz",
-      "integrity": "sha512-eAVNUn3vhNj79Iv04NOCwy/sCLyqDEhL3j9aJKV7VJuRBDg6rCiB+BIWHuG7VXJGCgb//6nX/soR8PTyWRhFvQ==",
-      "requires": {
-        "eventlistener": "0.0.1",
-        "lodash.debounce": "^4.0.0",
-        "lodash.throttle": "^4.0.0",
-        "prop-types": "^15.5.8"
-      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -26630,18 +26330,6 @@
       "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
       "requires": {
         "shallowequal": "^1.0.1"
-      }
-    },
-    "react-slick": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.24.0.tgz",
-      "integrity": "sha512-Pvo0B74ohumQdYOf0qP+pdQpj9iUbAav7+2qiF3uTc5XeQp/Y/cnIeDBM2tB3txthfSe05jKIqLMJTS6qVvt5g==",
-      "requires": {
-        "classnames": "^2.2.5",
-        "enquire.js": "^2.1.6",
-        "json2mq": "^0.2.0",
-        "lodash.debounce": "^4.0.8",
-        "resize-observer-polyfill": "^1.5.0"
       }
     },
     "react-spring": {
@@ -27542,15 +27230,6 @@
         "bn.js": "^4.11.1"
       }
     },
-    "rmc-feedback": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rmc-feedback/-/rmc-feedback-2.0.0.tgz",
-      "integrity": "sha512-5PWOGOW7VXks/l3JzlOU9NIxRpuaSS8d9zA3UULUCuTKnpwBHNvv1jSJzxgbbCQeYzROWUpgKI4za3X4C/mKmQ==",
-      "requires": {
-        "babel-runtime": "6.x",
-        "classnames": "^2.2.5"
-      }
-    },
     "roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -27948,6 +27627,14 @@
       "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
       "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
     },
+    "scroll-into-view-if-needed": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.29.tgz",
+      "integrity": "sha512-hxpAR6AN+Gh53AdAimHM6C8oTN1ppwVZITihix+WqalywBeFcQ6LdQP5ABNl26nX8GTEL7VT+b8lKpdqq65wXg==",
+      "requires": {
+        "compute-scroll-into-view": "^1.0.17"
+      }
+    },
     "scrollbar-width": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/scrollbar-width/-/scrollbar-width-3.1.1.tgz",
@@ -28197,11 +27884,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
-    },
-    "shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -31545,11 +31227,6 @@
         "typescript-compare": "^0.0.2"
       }
     },
-    "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
-    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -32109,14 +31786,6 @@
           "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.14.tgz",
           "integrity": "sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ=="
         }
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "wasm-dce": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@sentry/integrations": "6.16.1",
     "@walletconnect/web3-provider": "1.4.1",
     "amplitude-js": "8.10.0",
-    "antd": "3.20.4",
+    "antd": "4.18.5",
     "array-pack-2d": "0.1.1",
     "array-range": "1.0.1",
     "bitski": "0.10.9",


### PR DESCRIPTION
### Description

Upgrades antd dependency to next major version, which includes a massive bundle-size improvement (they now properly tree-shake their icons)

Before:
<img width="420" alt="@ant-design" src="https://user-images.githubusercontent.com/8230000/152266828-553ca200-32bb-451d-9481-ac8d6263165e.png">
+ 
<img width="298" alt="(concaten" src="https://user-images.githubusercontent.com/8230000/152266835-35704103-ca27-4b10-a0d3-4d697601804f.png">


After: 
<img width="376" alt="antd" src="https://user-images.githubusercontent.com/8230000/152266848-53570fb7-a355-46d9-ba6f-5a7593fbd33a.png">


### Dragons

There were slight core styling changes, so we should do a smoke test the components that use ant