### PR TITLE
[AUD-1429] Clicking "Visit Track Page" from artist dashboard not redirecting bug fix

### DIFF
--- a/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
+++ b/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
@@ -143,6 +143,7 @@ const makeColumns = (account: User, isUnlisted: boolean) => {
             isUnlisted={record.is_unlisted}
             index={index}
             trackTitle={val.name}
+            trackPermalink={val.permalink}
             hiddenUntilHover={false}
             includeEmbed={!isUnlisted && !record.is_delete}
             includeAddToPlaylist={!isUnlisted}


### PR DESCRIPTION
### Description
Previously on the dashboard page, when looking at a specific track and clicking ... -> Visit Track Page, it would not redirect to the track page. This PR fixes that and will redirect to the track page now. 

### Dragons

### How Has This Been Tested?
By clicking visit track page on both hidden and public tracks on the artist dashboard page.

### How will this change be monitored?
