### PR TITLE
Validate sol token address

### DIFF
--- a/src/services/audius-backend/waudio.ts
+++ b/src/services/audius-backend/waudio.ts
@@ -14,8 +14,14 @@ const libs = () => window.audiusLibs
 export const doesUserBankExist = async () => {
   await waitForLibsInit()
   const userBank: PublicKey = await libs().solanaWeb3Manager.getUserBank()
+  const doesExist = await checkIsCreatedTokenAccount(userBank.toString())
+  return doesExist
+}
+
+export const checkIsCreatedTokenAccount = async (addr: string) => {
+  await waitForLibsInit()
   const tokenAccount: Nullable<AccountInfo> = await libs().solanaWeb3Manager.getAssociatedTokenAccountInfo(
-    userBank.toString()
+    addr
   )
   return tokenAccount != null
 }

--- a/src/store/wallet/sagas.ts
+++ b/src/store/wallet/sagas.ts
@@ -25,6 +25,7 @@ import {
   decreaseBalance
 } from 'common/store/wallet/slice'
 import { stringWeiToBN, weiToString } from 'common/utils/wallet'
+import { checkIsCreatedTokenAccount } from 'services/audius-backend/waudio'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import walletClient from 'services/wallet-client/WalletClient'
 import { make } from 'store/analytics/actions'
@@ -63,6 +64,18 @@ function* sendAsync({
     const totalBalance = waudioWeiAmount.add(weiBNBalance)
     if (weiBNAmount.gt(totalBalance)) {
       yield put(sendFailed({ error: 'Not enough $AUDIO' }))
+      return
+    }
+    const isValidRecipientWallet: boolean = yield call(
+      checkIsCreatedTokenAccount,
+      recipientWallet
+    )
+    if (!isValidRecipientWallet) {
+      yield put(
+        sendFailed({
+          error: 'Invalid Recipient Address: Token Account does not exist'
+        })
+      )
       return
     }
   }


### PR DESCRIPTION
### Description
Validate the recipient address when sending SOL 

### Dragons

### How Has This Been Tested?
Ran locally against prod trying to send to a user bank account that was created and not created

### How will this change be monitored?
