### PR TITLE
Change 2020 to current year on home page

### DIFF
--- a/src/components/public-site/Footer.tsx
+++ b/src/components/public-site/Footer.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { IconInstagram, IconTwitterBird, IconDiscord } from '@audius/stems'
 import cn from 'classnames'
-import moment from 'moment'
 
 import horizontalLogo from 'assets/img/publicSite/Horizontal-Logo-Full-Color@2x.png'
 import {
@@ -144,7 +143,7 @@ const Footer = (props: FooterProps) => {
             ))}
           </div>
           <div className={styles.rightsContainer}>
-            <div>{messages.copyright(moment().year())}</div>
+            <div>{messages.copyright(new Date().getFullYear())}</div>
             <div>
               <span>{messages.madeWith}</span>
               <span className={styles.heart}>{messages.love}</span>

--- a/src/components/public-site/Footer.tsx
+++ b/src/components/public-site/Footer.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { IconInstagram, IconTwitterBird, IconDiscord } from '@audius/stems'
 import cn from 'classnames'
+import moment from 'moment'
 
 import horizontalLogo from 'assets/img/publicSite/Horizontal-Logo-Full-Color@2x.png'
 import {
@@ -81,7 +82,8 @@ const socialLinks = [
 
 const messages = {
   startListening: 'Start Listening Free',
-  copyright: '© 2020 Audius, Inc. All Rights Reserved.',
+  copyright: (year: number | string) =>
+    `© ${year} Audius, Inc. All Rights Reserved.`,
   madeWith: 'Made with',
   love: '♥︎',
   location: 'in SF & LA'
@@ -142,7 +144,7 @@ const Footer = (props: FooterProps) => {
             ))}
           </div>
           <div className={styles.rightsContainer}>
-            <div>{messages.copyright}</div>
+            <div>{messages.copyright(moment().year())}</div>
             <div>
               <span>{messages.madeWith}</span>
               <span className={styles.heart}>{messages.love}</span>


### PR DESCRIPTION
### Description
See title
Before:
<img width="1174" alt="Screen Shot 2022-02-07 at 8 52 43 AM" src="https://user-images.githubusercontent.com/36916764/152834617-c7e64751-63f5-455e-bdd4-199eb71ea945.png">

After:
<img width="1186" alt="Screen Shot 2022-02-07 at 8 52 38 AM" src="https://user-images.githubusercontent.com/36916764/152834637-14eb97aa-802a-4e8f-8882-ec628637ca62.png">

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?
Tested in browser

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
