### PR TITLE
Adds retry claim with exponential backoff

### DIFF
--- a/src/common/services/remote-config/defaults.ts
+++ b/src/common/services/remote-config/defaults.ts
@@ -19,7 +19,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.MIN_AUDIO_SEND_AMOUNT]: 5,
   [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 15000,
   [IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS]: 5000,
-  [IntKeys.MANUAL_CLAIM_PROMPT_DELAY_MS]: 15000
+  [IntKeys.MANUAL_CLAIM_PROMPT_DELAY_MS]: 15000,
+  [IntKeys.MAX_CLAIM_RETRIES]: 5
 }
 
 export const remoteConfigStringDefaults: {

--- a/src/common/services/remote-config/types.ts
+++ b/src/common/services/remote-config/types.ts
@@ -89,7 +89,13 @@ export enum IntKeys {
    * Should be larger than both CHALLENGE_REFRESH_INTERVAL_MS and CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS
    * to allow additional polls to check for disbursement
    */
-  MANUAL_CLAIM_PROMPT_DELAY_MS = 'MANUAL_CLAIM_PROMPT_DELAY_MS'
+  MANUAL_CLAIM_PROMPT_DELAY_MS = 'MANUAL_CLAIM_PROMPT_DELAY_MS',
+
+  /**
+   * The maximum number of times to retry the claim method for a reward on the client
+   * Note: Exponential backoff is used between retries
+   */
+  MAX_CLAIM_RETRIES = 'MAX_CLAIM_RETRIES'
 }
 
 export enum BooleanKeys {

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -165,6 +165,7 @@ const slice = createSlice({
       _action: PayloadAction<{
         claim: Claim
         retryOnFailure: boolean
+        retryCount?: number
       }>
     ) => {
       state.claimStatus = ClaimStatus.CLAIMING

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -112,10 +112,16 @@ function* retryClaimChallengeReward(errorResolved: boolean) {
   }
 }
 
+// Returns the number of ms to wait before next retry using exponential backoff
+// ie. 400 ms, 800 ms, 1.6 sec, 3.2 sec, 6.4 sec
+export const getBackoff = (retryCount: number) => {
+  return 200 * 2 ** (retryCount + 1)
+}
+
 function* claimChallengeRewardAsync(
   action: ReturnType<typeof claimChallengeReward>
 ) {
-  const { claim, retryOnFailure } = action.payload
+  const { claim, retryOnFailure, retryCount = 0 } = action.payload
   const { specifier, challengeId, amount } = claim
 
   // Do not proceed to claim if challenge is not complete from a DN perspective.
@@ -136,6 +142,11 @@ function* claimChallengeRewardAsync(
   const quorumSize = remoteConfigInstance.getRemoteVar(
     IntKeys.ATTESTATION_QUORUM_SIZE
   )
+
+  const maxClaimRetries = remoteConfigInstance.getRemoteVar(
+    IntKeys.MAX_CLAIM_RETRIES
+  )
+
   const { oracleEthAddress, AAOEndpoint } = getOracleConfig()
 
   const rewardsAttestationEndpoints = remoteConfigInstance.getRemoteVar(
@@ -146,7 +157,12 @@ function* claimChallengeRewardAsync(
   // When endpoints is unset, `submitAndEvaluateAttestations` picks for us
   const endpoints = rewardsAttestationEndpoints?.split(',') || null
   const hasConfig =
-    oracleEthAddress && AAOEndpoint && quorumSize && quorumSize > 0
+    oracleEthAddress &&
+    AAOEndpoint &&
+    quorumSize &&
+    quorumSize > 0 &&
+    maxClaimRetries &&
+    !isNaN(maxClaimRetries)
 
   if (!hasConfig) {
     console.error('Error claiming rewards: Config is missing')
@@ -169,7 +185,7 @@ function* claimChallengeRewardAsync(
       }
     )
     if (response.error) {
-      if (retryOnFailure) {
+      if (retryOnFailure && retryCount < maxClaimRetries!) {
         switch (response.error) {
           case FailureReason.HCAPTCHA:
             // Hide the Challenge Rewards Modal because the HCaptcha modal doesn't look good on top of it.
@@ -200,7 +216,14 @@ function* claimChallengeRewardAsync(
           case FailureReason.UNKNOWN_ERROR:
             // Retry once in the case of generic failure, otherwise log error and abort
             if (retryOnFailure) {
-              yield put(claimChallengeReward({ claim, retryOnFailure: false }))
+              yield delay(getBackoff(retryCount))
+              yield put(
+                claimChallengeReward({
+                  claim,
+                  retryOnFailure: true,
+                  retryCount: retryCount + 1
+                })
+              )
             } else {
               throw new Error(`Unknown Error: ${response.error}`)
             }

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -214,19 +214,14 @@ function* claimChallengeRewardAsync(
           case FailureReason.BLOCKED:
             throw new Error('User is blocked from claiming')
           case FailureReason.UNKNOWN_ERROR:
-            // Retry once in the case of generic failure, otherwise log error and abort
-            if (retryOnFailure) {
-              yield delay(getBackoff(retryCount))
-              yield put(
-                claimChallengeReward({
-                  claim,
-                  retryOnFailure: true,
-                  retryCount: retryCount + 1
-                })
-              )
-            } else {
-              throw new Error(`Unknown Error: ${response.error}`)
-            }
+            yield delay(getBackoff(retryCount))
+            yield put(
+              claimChallengeReward({
+                claim,
+                retryOnFailure: true,
+                retryCount: retryCount + 1
+              })
+            )
         }
       } else {
         yield put(claimChallengeRewardFailed())

--- a/src/pages/audio-rewards-page/store/store.test.ts
+++ b/src/pages/audio-rewards-page/store/store.test.ts
@@ -92,6 +92,8 @@ const retryClaimProvisions: StaticProvider[] = [
   [select(getClaimToRetry), testClaim]
 ]
 
+const MAX_CLAIM_RETRIES = 5
+
 const expectedRequestArgs = {
   ...testClaim,
   encodedUserId: undefined,
@@ -110,7 +112,8 @@ beforeAll(() => {
     [StringKeys.ORACLE_ENDPOINT]: 'oracle endpoint',
     [StringKeys.REWARDS_ATTESTATION_ENDPOINTS]: 'rewards attestation endpoints',
     [IntKeys.CHALLENGE_REFRESH_INTERVAL_AUDIO_PAGE_MS]: 100000000000,
-    [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 1000000000000
+    [IntKeys.CHALLENGE_REFRESH_INTERVAL_MS]: 1000000000000,
+    [IntKeys.MAX_CLAIM_RETRIES]: MAX_CLAIM_RETRIES
   })
   remoteConfigInstance.waitForRemoteConfig = jest.fn()
 
@@ -277,6 +280,68 @@ describe('Rewards Page Sagas', () => {
             args: [expectedRequestArgs]
           })
           .put(claimChallengeRewardAlreadyClaimed())
+          .silentRun()
+      )
+    })
+
+    it('should attempt retry if below max retries', () => {
+      const provideDelay = ({ fn }: any, next: any) =>
+        fn.name === 'delayP' ? null : next()
+      return (
+        expectSaga(saga)
+          .dispatch(
+            claimChallengeReward({
+              claim: testClaim,
+              retryOnFailure: true
+            })
+          )
+          .provide([
+            ...claimAsyncProvisions,
+            { call: provideDelay },
+            [
+              call.fn(AudiusBackend.submitAndEvaluateAttestations),
+              { error: FailureReason.UNKNOWN_ERROR }
+            ]
+          ])
+          // Assertions
+          .call.like({
+            fn: AudiusBackend.submitAndEvaluateAttestations,
+            args: [expectedRequestArgs]
+          })
+          .put(
+            claimChallengeReward({
+              claim: testClaim,
+              retryOnFailure: true,
+              retryCount: 1
+            })
+          )
+          .silentRun()
+      )
+    })
+
+    it('should not attempt retry if at max retries', () => {
+      return (
+        expectSaga(saga)
+          .dispatch(
+            claimChallengeReward({
+              claim: testClaim,
+              retryOnFailure: true,
+              retryCount: MAX_CLAIM_RETRIES
+            })
+          )
+          .provide([
+            ...claimAsyncProvisions,
+            [
+              call.fn(AudiusBackend.submitAndEvaluateAttestations),
+              { error: FailureReason.UNKNOWN_ERROR }
+            ]
+          ])
+          // Assertions
+          .call.like({
+            fn: AudiusBackend.submitAndEvaluateAttestations,
+            args: [expectedRequestArgs]
+          })
+          .put(claimChallengeRewardFailed())
           .silentRun()
       )
     })

--- a/src/pages/audio-rewards-page/store/store.test.ts
+++ b/src/pages/audio-rewards-page/store/store.test.ts
@@ -1,3 +1,4 @@
+import delayP from '@redux-saga/delay-p'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga-test-plan/matchers'
 import { StaticProvider } from 'redux-saga-test-plan/providers'
@@ -285,8 +286,6 @@ describe('Rewards Page Sagas', () => {
     })
 
     it('should attempt retry if below max retries', () => {
-      const provideDelay = ({ fn }: any, next: any) =>
-        fn.name === 'delayP' ? null : next()
       return (
         expectSaga(saga)
           .dispatch(
@@ -297,7 +296,7 @@ describe('Rewards Page Sagas', () => {
           )
           .provide([
             ...claimAsyncProvisions,
-            { call: provideDelay },
+            [call.fn(delayP), null],
             [
               call.fn(AudiusBackend.submitAndEvaluateAttestations),
               { error: FailureReason.UNKNOWN_ERROR }


### PR DESCRIPTION
### Description
Adds max retry count to claiming logic (instead of a single retry) with exponential backoff

### Dragons
check that it can't infinite loop or break the claim flow

### How Has This Been Tested?
Ran locally against stage and manually forced `AudiusBackend.submitAndEvaluateAttestations` to return unknown error
Also wrote a couple tests

### How will this change be monitored?
