### PR TITLE
Support Multiple Fee Payers

### DIFF
--- a/src/common/store/index.ts
+++ b/src/common/store/index.ts
@@ -27,6 +27,7 @@ import tokenDashboardSlice from 'common/store/pages/token-dashboard/slice'
 import track from 'common/store/pages/track/reducer'
 import TrackPageState from 'common/store/pages/track/types'
 import remoteConfigSagas from 'common/store/remote-config/sagas'
+import solanaReducer from 'common/store/solana/slice'
 import stemsUpload from 'common/store/stems-upload/slice'
 import addToPlaylistReducer, {
   AddToPlaylistState
@@ -107,6 +108,9 @@ export const reducers = {
     track
   }),
 
+  // Solana
+  solana: solanaReducer,
+
   stemsUpload
 }
 
@@ -139,6 +143,7 @@ export const sagas = {
   // pages/user-list/following/sagas.ts
   // pages/user-list/reposts/sagas.ts
   // pages/user-list/favorites/sagas.ts
+  // store/solana/sagas.ts
 }
 
 export type CommonState = {
@@ -182,6 +187,8 @@ export type CommonState = {
     track: TrackPageState
     profile: ProfilePageState
   }
+
+  solana: ReturnType<typeof solanaReducer>
 
   stemsUpload: ReturnType<typeof stemsUpload>
 }

--- a/src/common/store/solana/selectors.ts
+++ b/src/common/store/solana/selectors.ts
@@ -1,0 +1,3 @@
+import { CommonState } from 'common/store'
+
+export const getFeePayer = (state: CommonState) => state.solana.feePayer

--- a/src/common/store/solana/slice.ts
+++ b/src/common/store/solana/slice.ts
@@ -1,0 +1,24 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+const initialState = {
+  feePayer: null as string | null
+}
+
+type SetFeePayerPayload = {
+  feePayer: string
+}
+
+const slice = createSlice({
+  name: 'solana',
+  initialState,
+  reducers: {
+    setFeePayer: (state, action: PayloadAction<SetFeePayerPayload>) => {
+      const { feePayer } = action.payload
+      state.feePayer = feePayer
+    }
+  }
+})
+
+export const { setFeePayer } = slice.actions
+
+export default slice.reducer

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -52,6 +52,7 @@ import {
   setUndisbursedChallenges,
   UndisbursedUserChallenge
 } from 'common/store/pages/audio-rewards/slice'
+import { getFeePayer } from 'common/store/solana/selectors'
 import { setVisibility } from 'common/store/ui/modals/slice'
 import { getBalance, increaseBalance } from 'common/store/wallet/slice'
 import { stringAudioToStringWei } from 'common/utils/wallet'
@@ -176,6 +177,7 @@ function* claimChallengeRewardAsync(
   } = getClaimingConfig()
 
   const currentUser: User = yield select(getAccountUser)
+  const feePayerOverride: string = yield select(getFeePayer)
 
   // When endpoints is unset, `submitAndEvaluateAttestations` picks for us
   const endpoints = rewardsAttestationEndpoints?.split(',') || null
@@ -208,7 +210,8 @@ function* claimChallengeRewardAsync(
         quorumSize,
         endpoints,
         AAOEndpoint,
-        parallelization
+        parallelization,
+        feePayerOverride
       }
     )
     if (response.error) {

--- a/src/pages/audio-rewards-page/store/store.test.ts
+++ b/src/pages/audio-rewards-page/store/store.test.ts
@@ -37,6 +37,7 @@ import {
   setUserChallengesDisbursed,
   showRewardClaimedToast
 } from 'common/store/pages/audio-rewards/slice'
+import { getFeePayer } from 'common/store/solana/selectors'
 import { setVisibility } from 'common/store/ui/modals/slice'
 import { getBalance, increaseBalance } from 'common/store/wallet/slice'
 import { stringAudioToStringWei } from 'common/utils/wallet'
@@ -76,6 +77,7 @@ const testUserChallenge = {
   amount: 1,
   is_complete: true
 }
+const testFeePayer = '9AwMCALjKFp2ZQW97rnjJUzUiukzkGAH4HDz5V2uhW3D'
 
 const claimAsyncProvisions: StaticProvider[] = [
   [select(getAccountUser), testUser],
@@ -85,7 +87,8 @@ const claimAsyncProvisions: StaticProvider[] = [
       args: [{ challengeId: testUserChallenge.challenge_id }]
     }),
     testUserChallenge
-  ]
+  ],
+  [select(getFeePayer), testFeePayer]
 ]
 
 const retryClaimProvisions: StaticProvider[] = [
@@ -105,7 +108,8 @@ const expectedRequestArgs = {
   quorumSize: 1,
   endpoints: ['rewards attestation endpoints'],
   AAOEndpoint: 'oracle endpoint',
-  parallelization: 20
+  parallelization: 20,
+  feePayerOverride: testFeePayer
 }
 beforeAll(() => {
   // Setup remote config

--- a/src/pages/sign-on/store/sagas.js
+++ b/src/pages/sign-on/store/sagas.js
@@ -23,6 +23,7 @@ import { getUsers } from 'common/store/cache/users/selectors'
 import { processAndCacheUsers } from 'common/store/cache/users/utils'
 import { saveCollection } from 'common/store/social/collections/actions'
 import * as socialActions from 'common/store/social/users/actions'
+import { getFeePayer } from 'common/store/solana/selectors'
 import { ELECTRONIC_SUBGENRES, Genre } from 'common/utils/genres'
 import { getIGUserUrl } from 'components/instagram-auth/InstagramAuth'
 import AudiusBackend from 'services/AudiusBackend'
@@ -290,6 +291,8 @@ function* signUp() {
   const alreadyExisted = signOn.accountAlreadyExisted
   const referrer = signOn.referrer
 
+  const feePayerOverride = yield select(getFeePayer)
+
   yield put(
     confirmerActions.requestConfirmation(
       handle,
@@ -301,7 +304,8 @@ function* signUp() {
             password,
             formFields: createUserMetadata,
             hasWallet: alreadyExisted,
-            referrer
+            referrer,
+            feePayerOverride
           }
         )
 

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -2441,13 +2441,10 @@ class AudiusBackend {
   }
 
   static async getRandomFeePayer() {
+    await waitForLibsInit()
     try {
-      return fetch(`${IDENTITY_SERVICE}/solana/random_fee_payer`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      }).then(res => res.json())
+      const feePayer = await audiusLibs.solanaWeb3Manager.getRandomFeePayer()
+      return { feePayer }
     } catch (err) {
       console.error(err.message)
       return { error: true }

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -2441,10 +2441,6 @@ class AudiusBackend {
   }
 
   static async getRandomFeePayer() {
-    await waitForLibsInit()
-    const account = audiusLibs.Account.getCurrentUser()
-    if (!account) return { error: true }
-
     try {
       return fetch(`${IDENTITY_SERVICE}/solana/random_fee_payer`, {
         method: 'GET',

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -1693,7 +1693,8 @@ class AudiusBackend {
     password,
     formFields,
     hasWallet = false,
-    referrer = null
+    referrer = null,
+    feePayerOverride = null
   }) {
     await waitForLibsInit()
     const metadata = schemas.newUserMetadata()
@@ -1740,7 +1741,8 @@ class AudiusBackend {
         Request: Name.CREATE_USER_BANK_REQUEST,
         Success: Name.CREATE_USER_BANK_SUCCESS,
         Failure: Name.CREATE_USER_BANK_FAILURE
-      }
+      },
+      feePayerOverride
     )
   }
 
@@ -2438,6 +2440,24 @@ class AudiusBackend {
     }
   }
 
+  static async getRandomFeePayer() {
+    await waitForLibsInit()
+    const account = audiusLibs.Account.getCurrentUser()
+    if (!account) return { error: true }
+
+    try {
+      return fetch(`${IDENTITY_SERVICE}/solana/random_fee_payer`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }).then(res => res.json())
+    } catch (err) {
+      console.error(err.message)
+      return { error: true }
+    }
+  }
+
   /**
    * Retrieves the claim distribution amount
    * @returns {BN} amount The claim amount
@@ -2655,7 +2675,8 @@ class AudiusBackend {
     quorumSize,
     endpoints,
     AAOEndpoint,
-    parallelization
+    parallelization,
+    feePayerOverride
   }) {
     await waitForLibsInit()
     try {
@@ -2684,7 +2705,8 @@ class AudiusBackend {
         quorumSize,
         aaoEndpoint: AAOEndpoint,
         aaoAddress: oracleEthAddress,
-        endpoints: endpoints
+        endpoints: endpoints,
+        feePayerOverride
       })
 
       const res = await attester.processChallenges(

--- a/src/services/audius-backend/waudio.ts
+++ b/src/services/audius-backend/waudio.ts
@@ -26,12 +26,12 @@ export const checkIsCreatedTokenAccount = async (addr: string) => {
   return tokenAccount != null
 }
 
-export const createUserBank = async () => {
+export const createUserBank = async (feePayerOverride = null) => {
   await waitForLibsInit()
-  return libs().solanaWeb3Manager.createUserBank()
+  return libs().solanaWeb3Manager.createUserBank(feePayerOverride)
 }
 
-export const createUserBankIfNeeded = async () => {
+export const createUserBankIfNeeded = async (feePayerOverride = null) => {
   await waitForLibsInit()
   const userbankEnabled = remoteConfigInstance.getFeatureEnabled(
     FeatureFlags.CREATE_WAUDIO_USER_BANK_ON_SIGN_UP
@@ -43,7 +43,7 @@ export const createUserBankIfNeeded = async () => {
     if (userbankExists) return
     console.warn(`Userbank doesn't exist, attempting to create...`)
     await track(Name.CREATE_USER_BANK_REQUEST, { userId })
-    const { error, errorCode } = await createUserBank()
+    const { error, errorCode } = await createUserBank(feePayerOverride)
     if (error || errorCode) {
       console.error(
         `Failed to create userbank, with err: ${error}, ${errorCode}`

--- a/src/store/account/sagas.js
+++ b/src/store/account/sagas.js
@@ -17,6 +17,7 @@ import * as cacheActions from 'common/store/cache/actions'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
 import * as errorActions from 'common/store/errors/actions'
 import { Level } from 'common/store/errors/level'
+import { getFeePayer } from 'common/store/solana/selectors'
 import {
   getModalIsOpen,
   getModalVisibility,
@@ -95,7 +96,9 @@ function* onFetchAccount(account) {
   yield fork(addPlaylistsNotInLibrary)
 
   yield fork(initAudioChecks)
-  yield call(createUserBankIfNeeded)
+
+  const feePayerOverride = yield select(getFeePayer)
+  yield call(createUserBankIfNeeded, feePayerOverride)
 }
 
 /**

--- a/src/store/sagas.ts
+++ b/src/store/sagas.ts
@@ -62,6 +62,7 @@ import queueSagas from 'store/queue/sagas'
 import reachabilitySagas from 'store/reachability/sagas'
 import routingSagas from 'store/routing/sagas'
 import socialSagas from 'store/social/sagas'
+import solanaSagas from 'store/solana/sagas'
 import tokenDashboardSagas from 'store/token-dashboard/sagas'
 import walletSagas from 'store/wallet/sagas'
 
@@ -146,6 +147,9 @@ export default function* rootSaga() {
 
     // Remote config
     remoteConfigSagas(remoteConfigInstance),
+
+    // Solana
+    solanaSagas(),
 
     // Error
     errorSagas()

--- a/src/store/solana/sagas.ts
+++ b/src/store/solana/sagas.ts
@@ -1,13 +1,13 @@
 import { put, call, take, select } from 'typed-redux-saga'
 
-import { fetchAccountSucceeded } from 'common/store/account/reducer'
 import { getFeePayer } from 'common/store/solana/selectors'
 import { setFeePayer } from 'common/store/solana/slice'
 import AudiusBackend from 'services/AudiusBackend'
+import * as backendActions from 'store/backend/actions'
 
 function* watchForFeePayer() {
   console.log('watching for fee payer')
-  yield take(fetchAccountSucceeded.type)
+  yield take(backendActions.SETUP_BACKEND_SUCCEEDED)
   const { feePayer, error } = yield* call(AudiusBackend.getRandomFeePayer)
   if (!error) {
     yield put(setFeePayer({ feePayer }))

--- a/src/store/solana/sagas.ts
+++ b/src/store/solana/sagas.ts
@@ -1,17 +1,16 @@
-import { put, call, take, select } from 'typed-redux-saga'
+import { put, call, take } from 'typed-redux-saga'
 
-import { getFeePayer } from 'common/store/solana/selectors'
 import { setFeePayer } from 'common/store/solana/slice'
 import AudiusBackend from 'services/AudiusBackend'
 import * as backendActions from 'store/backend/actions'
 
 function* watchForFeePayer() {
-  console.log('watching for fee payer')
   yield take(backendActions.SETUP_BACKEND_SUCCEEDED)
   const { feePayer, error } = yield* call(AudiusBackend.getRandomFeePayer)
-  if (!error) {
+  if (error) {
+    console.error('Could not get fee payer.')
+  } else {
     yield put(setFeePayer({ feePayer }))
-    console.log('the fee payer', yield* select(getFeePayer))
   }
 }
 

--- a/src/store/solana/sagas.ts
+++ b/src/store/solana/sagas.ts
@@ -1,0 +1,22 @@
+import { put, call, take, select } from 'typed-redux-saga'
+
+import { fetchAccountSucceeded } from 'common/store/account/reducer'
+import { getFeePayer } from 'common/store/solana/selectors'
+import { setFeePayer } from 'common/store/solana/slice'
+import AudiusBackend from 'services/AudiusBackend'
+
+function* watchForFeePayer() {
+  console.log('watching for fee payer')
+  yield take(fetchAccountSucceeded.type)
+  const { feePayer, error } = yield* call(AudiusBackend.getRandomFeePayer)
+  if (!error) {
+    yield put(setFeePayer({ feePayer }))
+    console.log('the fee payer', yield* select(getFeePayer))
+  }
+}
+
+const sagas = () => {
+  return [watchForFeePayer]
+}
+
+export default sagas


### PR DESCRIPTION
### Description

Fetch random solana fee payer from identity and send it through solana relay for rewards and user bank creation.

Here is the protocol counterpart PR: https://github.com/AudiusProject/audius-protocol/pull/2453

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Locally by spinning up all services and the client and making sure we get the random fee payer and that it's passed in the right places and that those functionalities still work.

Also updated unit test.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
