### PR TITLE
Fix profile completion selector for profile pic/cover photo

### DIFF
--- a/src/common/models/User.ts
+++ b/src/common/models/User.ts
@@ -60,6 +60,8 @@ export type ComputedUserProperties = {
   _profile_picture_color?: Color
   _artist_pick?: ID
   _has_reposted?: boolean
+  updatedProfilePicture: any
+  updatedCoverPhoto: any
 }
 
 export type User = UserMetadata & ComputedUserProperties

--- a/src/common/models/User.ts
+++ b/src/common/models/User.ts
@@ -60,8 +60,8 @@ export type ComputedUserProperties = {
   _profile_picture_color?: Color
   _artist_pick?: ID
   _has_reposted?: boolean
-  updatedProfilePicture: any
-  updatedCoverPhoto: any
+  updatedProfilePicture?: { file: File; url: string }
+  updatedCoverPhoto?: { file: File; url: string }
 }
 
 export type User = UserMetadata & ComputedUserProperties

--- a/src/common/store/challenges/selectors/profile-progress.ts
+++ b/src/common/store/challenges/selectors/profile-progress.ts
@@ -45,9 +45,8 @@ export const getProfilePictureExists = (state: CommonState) => {
   // we set the updatedProfilePicture field to an object (otherwise it's undefined).
   // If the profile picture was set in a previous session, we just have to check
   // if the profile_picture field is non-null.
-
   return (
-    !!curUser._profile_picture_sizes ||
+    !!curUser.updatedProfilePicture ||
     !!curUser.profile_picture ||
     !!curUser.profile_picture_sizes
   )
@@ -59,7 +58,7 @@ export const getCoverPhotoExists = (state: CommonState) => {
 
   // Same logic as getProfilePictureExists
   return (
-    !!curUser._cover_photo_sizes ||
+    !!curUser.updatedCoverPhoto ||
     !!curUser.cover_photo ||
     !!curUser.cover_photo_sizes
   )


### PR DESCRIPTION
### Description

Fixes a bug where profile pic/cover photo show as completed when unset

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally against stage

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
