### PR TITLE
[AUD-1478] Adds support for optimistic disbursements of aggregate challenges

### DIFF
--- a/src/common/models/AudioRewards.ts
+++ b/src/common/models/AudioRewards.ts
@@ -8,10 +8,12 @@ export type UserChallenge = {
   is_complete: boolean
   is_disbursed: boolean
   max_steps: number
-  specifier: string
+  specifier: Specifier
   user_id: string
   amount: number
 }
+
+export type Specifier = string
 
 export type ChallengeRewardID =
   | 'track-upload'
@@ -127,5 +129,5 @@ export type OptimisticUserChallenge = Omit<
   state: UserChallengeState
   totalAmount: number
   claimableAmount: number
-  undisbursedSpecifiers: string[]
+  undisbursedSpecifiers: Specifier[]
 }

--- a/src/common/models/AudioRewards.ts
+++ b/src/common/models/AudioRewards.ts
@@ -126,6 +126,6 @@ export type OptimisticUserChallenge = Omit<
   __isOptimistic: true
   state: UserChallengeState
   totalAmount: number
-  undisbursedAmount: number
+  claimableAmount: number
   undisbursedSpecifiers: string[]
 }

--- a/src/common/store/challenges/selectors/optimistic-challenges.ts
+++ b/src/common/store/challenges/selectors/optimistic-challenges.ts
@@ -76,19 +76,7 @@ const toOptimisticChallenge = (
 
   const challengeOverridden = {
     ...challenge,
-    ...userChallengeOverrides,
-    // For aggregate challenges, we show the total amount
-    // you'd get when completing every step of the challenge
-    // -- i.e. for referrals, show 1 audio x 5 steps = 5 audio
-    totalAmount:
-      challenge.challenge_type === 'aggregate'
-        ? challenge.amount * challenge.max_steps
-        : challenge.amount,
-    undisbursedAmount: undisbursed.reduce<number>(
-      (acc, val) => acc + val.amount,
-      0
-    ),
-    undisbursedSpecifiers: undisbursed.map(c => c.specifier)
+    ...userChallengeOverrides
   }
 
   // The client is more up to date than Discovery Nodes, so override whenever possible.
@@ -99,10 +87,27 @@ const toOptimisticChallenge = (
       currentStepCountOverride >= challengeOverridden.max_steps
   }
 
+  const state = getUserChallengeState(challengeOverridden)
+  // For aggregate challenges, we show the total amount
+  // you'd get when completing every step of the challenge
+  // -- i.e. for referrals, show 1 audio x 5 steps = 5 audio
+  const totalAmount =
+    challenge.challenge_type === 'aggregate'
+      ? challenge.amount * challenge.max_steps
+      : challenge.amount
+  const undisbursedAmount =
+    state === 'completed' && challengeOverridden.challenge_type !== 'aggregate'
+      ? totalAmount
+      : undisbursed.reduce<number>((acc, val) => acc + val.amount, 0)
+  const undisbursedSpecifiers = undisbursed.map(c => c.specifier)
+
   return {
     ...challengeOverridden,
     __isOptimistic: true,
-    state: getUserChallengeState(challengeOverridden)
+    state,
+    totalAmount,
+    undisbursedAmount,
+    undisbursedSpecifiers
   }
 }
 

--- a/src/common/store/challenges/selectors/optimistic-challenges.ts
+++ b/src/common/store/challenges/selectors/optimistic-challenges.ts
@@ -95,7 +95,7 @@ const toOptimisticChallenge = (
     challenge.challenge_type === 'aggregate'
       ? challenge.amount * challenge.max_steps
       : challenge.amount
-  const undisbursedAmount =
+  const claimableAmount =
     state === 'completed' && challengeOverridden.challenge_type !== 'aggregate'
       ? totalAmount
       : undisbursed.reduce<number>((acc, val) => acc + val.amount, 0)
@@ -106,7 +106,7 @@ const toOptimisticChallenge = (
     __isOptimistic: true,
     state,
     totalAmount,
-    undisbursedAmount,
+    claimableAmount,
     undisbursedSpecifiers
   }
 }

--- a/src/common/store/pages/audio-rewards/selectors.ts
+++ b/src/common/store/pages/audio-rewards/selectors.ts
@@ -11,7 +11,11 @@ export const getUserChallenges = (state: CommonState) =>
   state.pages.audioRewards.userChallenges
 
 export const getUndisbursedUserChallenges = (state: CommonState) =>
-  state.pages.audioRewards.undisbursedChallenges
+  state.pages.audioRewards.undisbursedChallenges.filter(challenge => {
+    return !(
+      state.pages.audioRewards.disbursedChallenges[challenge.challenge_id] ?? []
+    ).includes(challenge.specifier)
+  })
 
 export const getUserChallenge = (
   state: CommonState,

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -2,7 +2,11 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import Status from 'common/models/Status'
 
-import { UserChallenge, ChallengeRewardID } from '../../../models/AudioRewards'
+import {
+  UserChallenge,
+  ChallengeRewardID,
+  Specifier
+} from '../../../models/AudioRewards'
 
 export type TrendingRewardsModalType = 'tracks' | 'playlists' | 'underground'
 export type ChallengeRewardsModalType = ChallengeRewardID
@@ -18,7 +22,7 @@ export enum ClaimStatus {
 
 export type Claim = {
   challengeId: ChallengeRewardID
-  specifiers: string[]
+  specifiers: Specifier[]
   amount: number
 }
 
@@ -46,8 +50,6 @@ export type UndisbursedUserChallenge = Pick<
   handle: string
   wallet: string
 }
-
-type Specifier = string
 
 type RewardsUIState = {
   loading: boolean
@@ -115,7 +117,7 @@ const slice = createSlice({
       state,
       action: PayloadAction<{
         challengeId: ChallengeRewardID
-        specifiers: string[]
+        specifiers: Specifier[]
       }>
     ) => {
       const { challengeId, specifiers } = action.payload

--- a/src/common/store/pages/audio-rewards/slice.ts
+++ b/src/common/store/pages/audio-rewards/slice.ts
@@ -47,6 +47,8 @@ export type UndisbursedUserChallenge = Pick<
   wallet: string
 }
 
+type Specifier = string
+
 type RewardsUIState = {
   loading: boolean
   trendingRewardsModalType: TrendingRewardsModalType
@@ -56,7 +58,7 @@ type RewardsUIState = {
   userChallengesOverrides: Partial<
     Record<ChallengeRewardID, Partial<UserChallenge>>
   >
-  disbursedChallenges: Partial<Record<ChallengeRewardID, string[]>>
+  disbursedChallenges: Partial<Record<ChallengeRewardID, Specifier[]>>
   claimStatus: ClaimStatus
   claimToRetry?: Claim
   hCaptchaStatus: HCaptchaStatus

--- a/src/components/nav/desktop/NavAudio.tsx
+++ b/src/components/nav/desktop/NavAudio.tsx
@@ -45,7 +45,7 @@ const NavAudio = () => {
 
   const userChallenges = useSelector(getOptimisticUserChallenges)
   const hasClaimableTokens = Object.values(userChallenges).some(
-    challenge => challenge && challenge.undisbursedAmount > 0
+    challenge => challenge && challenge.claimableAmount > 0
   )
 
   const [bubbleType, setBubbleType] = useState<BubbleType>('none')

--- a/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -71,7 +71,7 @@ const RewardPanel = ({
   const challenge = userChallenges[id]
   const shouldShowCompleted =
     challenge?.state === 'completed' || challenge?.state === 'disbursed'
-  const needsDisbursement = challenge && challenge.undisbursedAmount > 0
+  const needsDisbursement = challenge && challenge.claimableAmount > 0
   const shouldShowProgressBar =
     stepCount > 1 && challenge?.challenge_type !== 'aggregate'
 

--- a/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -281,7 +281,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   let audioToClaim = 0
   let audioClaimedSoFar = 0
   if (challenge?.challenge_type === 'aggregate') {
-    audioToClaim = challenge.undisbursedAmount
+    audioToClaim = challenge.claimableAmount
     audioClaimedSoFar =
       challenge.amount * challenge.current_step_count - audioToClaim
   } else if (challenge?.state === 'completed') {

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -42,7 +42,7 @@ import {
   HCaptchaStatus,
   setCognitoFlowStatus,
   setHCaptchaStatus,
-  setUserChallengeDisbursed,
+  setUserChallengesDisbursed,
   updateHCaptchaScore,
   showRewardClaimedToast,
   claimChallengeRewardAlreadyClaimed,
@@ -266,7 +266,7 @@ function* claimChallengeRewardAsync(
           amount: stringAudioToStringWei(amount.toString() as StringAudio)
         })
       )
-      yield put(setUserChallengeDisbursed({ challengeId }))
+      yield put(setUserChallengesDisbursed({ challengeId, specifiers }))
       yield put(claimChallengeRewardSucceeded())
     }
   } catch (e) {

--- a/src/pages/audio-rewards-page/store/store.test.ts
+++ b/src/pages/audio-rewards-page/store/store.test.ts
@@ -367,7 +367,12 @@ describe('Rewards Page Sagas', () => {
               amount: stringAudioToStringWei('10' as StringAudio)
             })
           )
-          .put(setUserChallengesDisbursed(testClaim))
+          .put(
+            setUserChallengesDisbursed({
+              challengeId: testClaim.challengeId,
+              specifiers: testClaim.specifiers
+            })
+          )
           .put(claimChallengeRewardSucceeded())
           .silentRun()
       )
@@ -397,7 +402,12 @@ describe('Rewards Page Sagas', () => {
           ])
           // Assertions
           .not.call(AudiusBackend.submitAndEvaluateAttestations)
-          .not.put(setUserChallengesDisbursed(testClaim))
+          .not.put(
+            setUserChallengesDisbursed({
+              challengeId: testClaim.challengeId,
+              specifiers: testClaim.specifiers
+            })
+          )
           .not.put(claimChallengeRewardSucceeded())
           .silentRun()
       )

--- a/src/pages/audio-rewards-page/store/store.test.ts
+++ b/src/pages/audio-rewards-page/store/store.test.ts
@@ -34,7 +34,7 @@ import {
   resetUserChallengeCurrentStepCount,
   setCognitoFlowStatus,
   setHCaptchaStatus,
-  setUserChallengeDisbursed,
+  setUserChallengesDisbursed,
   showRewardClaimedToast
 } from 'common/store/pages/audio-rewards/slice'
 import { setVisibility } from 'common/store/ui/modals/slice'
@@ -367,7 +367,7 @@ describe('Rewards Page Sagas', () => {
               amount: stringAudioToStringWei('10' as StringAudio)
             })
           )
-          .put(setUserChallengeDisbursed({ challengeId: 'connect-verified' }))
+          .put(setUserChallengesDisbursed(testClaim))
           .put(claimChallengeRewardSucceeded())
           .silentRun()
       )
@@ -397,11 +397,7 @@ describe('Rewards Page Sagas', () => {
           ])
           // Assertions
           .not.call(AudiusBackend.submitAndEvaluateAttestations)
-          .not.put(
-            setUserChallengeDisbursed({
-              challengeId: testUserChallenge.challenge_id
-            })
-          )
+          .not.put(setUserChallengesDisbursed(testClaim))
           .not.put(claimChallengeRewardSucceeded())
           .silentRun()
       )


### PR DESCRIPTION
### Description

Tracks the individually disbursed challenges so that they can be coalesced into the optimistic challenge and calculate the claimable amount accordingly.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

Not that I can think of

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally against stage, mocking the response of the backend

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

Tons of manual testing