### PR TITLE
Bump libs 1.2.65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.64",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.64.tgz",
-      "integrity": "sha512-Ftfri2Lr+vFMgANp+96aByCtHyY5lINGbfmTTzswNUfpP53Xmt7ku+pnfiSYUOcd9TWIutB08YGxnKFM3Plwbg==",
+      "version": "1.2.65",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.65.tgz",
+      "integrity": "sha512-8vsAv9UPWGGkU9WJRqt/VIDccGhU/BzSvAetfBdUULBt41L7E2V8fi27Y/jt9NRQFuMeuRSewqVw8e79nRKM2A==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.0.10",
@@ -18378,9 +18378,9 @@
           "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
         },
         "@types/node": {
-          "version": "12.20.43",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.43.tgz",
-          "integrity": "sha512-HCfJdaYqJX3BCzeihgZrD7b85Cu05OC/GVJ4kEYIflwUs4jbnUlLLWoq7hw1LBcdvUyehO+gr6P5JQ895/2ZfA=="
+          "version": "12.20.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.45.tgz",
+          "integrity": "sha512-1Jg2Qv5tuxBqgQV04+wO5u+wmSHbHgpORCJdeCLM+E+YdPElpdHhgywU+M1V1InL8rfOtpqtOjswk+uXTKwx7w=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -24840,9 +24840,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.16.tgz",
-          "integrity": "sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA=="
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.17.tgz",
+          "integrity": "sha512-e8PUNQy1HgJGV3iU/Bp2+D/DXh3PYeyli8LgIwsQcs1Ar1LoaWHSIT6Rw+H2rNJmiq6SNWiDytfx8+gYj7wDHw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.42",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.64",
+    "@audius/libs": "1.2.65",
     "@audius/stems": "0.3.21",
     "@craco/craco": "6.4.3",
     "@hcaptcha/react-hcaptcha": "0.3.6",


### PR DESCRIPTION
### Description
This change includes using `/track_content_status` instead of `/async_processing_status` when polling for track upload updates

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

No

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

- ran local dapp against staging 
- upload track and worked

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
