### PR TITLE
Fix sentry state pruner

### DIFF
--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -29,6 +29,7 @@ export const initializeSentry = () => {
       })
     ],
 
+    normalizeDepth: 5,
     maxBreadcrumbs: MAX_BREADCRUMBS,
     beforeBreadcrumb: (breadCrumb, hint) => {
       // filter out analytics events

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -55,18 +55,15 @@ const statePruner = (state: AppState) => {
       status: state.account.status,
       userId: state.account.userId
     },
-    application: {
-      pages: {
-        profile: {
-          handle: state.application.pages.profile.handle,
-          status: state.application.pages.profile.status,
-          updateError: state.application.pages.profile.updateError,
-          updateSuccess: state.application.pages.profile.updateSuccess,
-          updating: state.application.pages.profile.updating,
-          userId: state.application.pages.profile.userId
-        }
-      },
-      ui: state.application.ui
+    pages: {
+      profile: {
+        handle: state.pages.profile.handle,
+        status: state.pages.profile.status,
+        updateError: state.pages.profile.updateError,
+        updateSuccess: state.pages.profile.updateSuccess,
+        updating: state.pages.profile.updating,
+        userId: state.pages.profile.userId
+      }
     },
     router: {
       action: state.router.action,

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -2,7 +2,6 @@ import { RouterState } from 'connected-react-router'
 
 import { CommonState } from 'common/store'
 import averageColor from 'common/store/average-color/slice'
-import { ProfilePageState } from 'common/store/pages/profile/types'
 import RemoteConfigReducer from 'common/store/remote-config/slice'
 import StemsUploadReducer from 'common/store/stems-upload/slice'
 import { CreatePlaylistModalState } from 'common/store/ui/createPlaylistModal/types'
@@ -108,7 +107,6 @@ export type AppState = CommonState & {
       notificationUsers: NotificationUsersPageState
       unfollowConfirmation: UnfollowConfirmationModalState
       nowPlaying: NowPlayingState
-      profile: ProfilePageState
       smartCollection: SmartCollectionState
       remixes: ReturnType<typeof RemixesPageReducer>
       deleted: ReturnType<typeof DeletedPageReducer>


### PR DESCRIPTION
### Description
* Fixes the type `AppState` to remove application > pages > profile bc it was moved to the `CommonState` pages > profile 
* Updates sentry to allow deeper nested objects as part of the additional data
* Updates the sentry statepruner to point to the updated profile page state

### Dragons

### How Has This Been Tested?
manually triggered error locally against stage and saw it in sentry

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
