### PR TITLE
Go to new line if audio amount too large in nav column

### DIFF
--- a/src/components/nav/desktop/NavAudio.module.css
+++ b/src/components/nav/desktop/NavAudio.module.css
@@ -2,6 +2,7 @@
   opacity: 0;
   position: relative;
   min-height: 16px;
+  flex-wrap: wrap;
 }
 
 .audio:hover:before {
@@ -19,7 +20,6 @@
   display: flex;
   align-items: center;
   padding-left: 8px;
-  height: 16px;
   transition: opacity ease-in-out 0.5s;
   opacity: 1;
 }
@@ -41,17 +41,25 @@
   color: var(--neutral-light-3);
 }
 
+.amountContainer {
+  display: flex;
+  align-items: center;
+  margin-right: 12px;
+  margin-top: 12px;
+}
+
 .bubbleContainer {
   flex: 1;
   position: relative;
   display: flex;
   align-items: center;
+  min-width: 136px;
+  margin-top: 12px;
 }
 
 .actionBubble {
   display: flex;
   align-items: center;
-  margin-left: 12px;
   padding: 4px 8px;
   color: var(--static-white);
   background: var(--secondary);
@@ -61,7 +69,6 @@
   font-weight: var(--font-bold);
   letter-spacing: 0.1em;
   transition: all 0.07s ease-in-out;
-  position: absolute;
 }
 
 .actionBubble:hover {

--- a/src/components/nav/desktop/NavAudio.tsx
+++ b/src/components/nav/desktop/NavAudio.tsx
@@ -85,17 +85,19 @@ const NavAudio = () => {
       )}
       onClick={goToAudioPage}
     >
-      {positiveTotalBalance && audioBadge ? (
-        cloneElement(audioBadge, {
-          height: 16,
-          width: 16
-        })
-      ) : (
-        <img alt='no tier' src={IconNoTierBadge} width='16' height='16' />
-      )}
-      <span className={styles.audioAmount}>
-        {formatWei(totalBalance!, true, 0)}
-      </span>
+      <div className={styles.amountContainer}>
+        {positiveTotalBalance && audioBadge ? (
+          cloneElement(audioBadge, {
+            height: 16,
+            width: 16
+          })
+        ) : (
+          <img alt='no tier' src={IconNoTierBadge} width='16' height='16' />
+        )}
+        <span className={styles.audioAmount}>
+          {formatWei(totalBalance!, true, 0)}
+        </span>
+      </div>
       <div className={styles.bubbleContainer}>
         <Transition
           items={bubbleType}

--- a/src/components/nav/desktop/NavColumn.module.css
+++ b/src/components/nav/desktop/NavColumn.module.css
@@ -72,7 +72,7 @@ svg.logo path {
 
 .navColumn .accountWrapper {
   display: block;
-  margin-bottom: 16px;
+  margin-bottom: 4px;
 
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
### Description

Drop the nav column rewards pill to next line if audio amount is taking up a lot of space.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Spin up dapp locally and play with diff $audio amounts and verify display

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
