### PR TITLE
Improve error handling for challenges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,9 +79,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.65",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.65.tgz",
-      "integrity": "sha512-8vsAv9UPWGGkU9WJRqt/VIDccGhU/BzSvAetfBdUULBt41L7E2V8fi27Y/jt9NRQFuMeuRSewqVw8e79nRKM2A==",
+      "version": "1.2.66",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.66.tgz",
+      "integrity": "sha512-5h64h0mSzX4AZ7t80yNGow2vbCwmk5It1y54qfa1vLQBMl7D/+YrkVHIYenRoPWV2fYUVIRqLW8yZ1uiYPZrbg==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.0.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.24.42",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.65",
+    "@audius/libs": "1.2.66",
     "@audius/stems": "0.3.21",
     "@craco/craco": "6.4.3",
     "@hcaptcha/react-hcaptcha": "0.3.6",

--- a/src/common/models/AudioRewards.ts
+++ b/src/common/models/AudioRewards.ts
@@ -44,6 +44,10 @@ export enum FailureReason {
   // The funds have already been sent, but we have not
   // indexed the challenge.
   ALREADY_SENT = 'ALREADY_SENT',
+  // UserChallenge doesn't exist on DN
+  MISSING_CHALLENGES = 'MISSING_CHALLENGES',
+  // UserChallenge is not in complete state
+  CHALLENGE_INCOMPLETE = 'CHALLENGE_INCOMPLETE',
   // An unknown error has occurred
   UNKNOWN_ERROR = 'UNKNOWN_ERROR'
 }

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -248,6 +248,7 @@ function* claimChallengeRewardAsync(
             yield put(claimChallengeRewardFailed())
             break
           case FailureReason.UNKNOWN_ERROR:
+          default:
             // If this was an aggregate challenges with multiple specifiers,
             // then libs handles the retries and we shouldn't retry here.
             if (specifiers.length > 1) {

--- a/src/pages/audio-rewards-page/store/sagas.ts
+++ b/src/pages/audio-rewards-page/store/sagas.ts
@@ -241,6 +241,12 @@ function* claimChallengeRewardAsync(
             break
           case FailureReason.BLOCKED:
             throw new Error('User is blocked from claiming')
+          // For these 'attestation aggregation errors',
+          // we've already retried in libs so unlikely to succeed here.
+          case FailureReason.MISSING_CHALLENGES:
+          case FailureReason.CHALLENGE_INCOMPLETE:
+            yield put(claimChallengeRewardFailed())
+            break
           case FailureReason.UNKNOWN_ERROR:
             // If this was an aggregate challenges with multiple specifiers,
             // then libs handles the retries and we shouldn't retry here.

--- a/src/services/AudiusBackend.js
+++ b/src/services/AudiusBackend.js
@@ -2697,14 +2697,24 @@ class AudiusBackend {
           wallet: recipientEthAddress
         }))
       )
-      // If any of the errors are HCAPTCHA or Cognito, return that one
       if (res.errors) {
-        console.error(`Got errors in aggreagte attestation flow: ${res.errors}`)
-        const hcaptchaOrCognito = res.errors.find(
-          e => e === FailureReason.HCAPTCHA || e === FailureReason.COGNITO_FLOW
+        console.error(
+          `Got errors in aggregate attestation flow: ${JSON.stringify(
+            res.errors
+          )}`
         )
+        const hcaptchaOrCognito = res.errors.find(
+          ({ error }) =>
+            error === FailureReason.HCAPTCHA ||
+            error === FailureReason.COGNITO_FLOW
+        )
+
+        // If any of the errors are HCAPTCHA or Cognito, return that one
         // Otherwise, just return the first error we saw
-        return hcaptchaOrCognito || res.errors[0]
+        const error = hcaptchaOrCognito
+          ? hcaptchaOrCognito.error
+          : res.errors[0].error
+        return { error }
       }
       return res
     } catch (e) {


### PR DESCRIPTION
### Description

- Consumes latest libs
- Had some typing confusion issues in AudiusBackend messing up the error handling for aggregate challenges.
- Not explicitly handling missing / incomplete challenge errors

### Dragons

None


### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
