### PR TITLE
[AUD-1522] [AUD-1470] [AUD-1467] Fix profile completion stages display

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -5749,7 +5749,7 @@
     "audius-client": {
       "version": "file:../web",
       "requires": {
-        "@audius/libs": "1.2.61",
+        "@audius/libs": "1.2.69",
         "@audius/stems": "0.3.21",
         "@craco/craco": "6.4.3",
         "@hcaptcha/react-hcaptcha": "0.3.6",

--- a/packages/mobile/src/components/challenge-rewards-drawer/ProfileCompletionChecks.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ProfileCompletionChecks.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 
 import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
-import { getHasFavoritedItem } from 'audius-client/src/common/store/challenges/selectors/profile-progress'
+import { getCompletionStages } from 'audius-client/src/common/store/challenges/selectors/profile-progress'
 import { profilePage, AUDIO_PAGE } from 'audius-client/src/utils/route'
 import { StyleSheet, View } from 'react-native'
 
@@ -64,7 +64,7 @@ export const ProfileCompletionChecks = ({
   onClose: () => void
 }) => {
   const currentUser = useSelectorWeb(getAccountUser)
-  const hasFavoritedItem = !!useSelectorWeb(getHasFavoritedItem)
+  const completionStages = useSelectorWeb(getCompletionStages)
   const pushRouteWeb = usePushRouteWeb()
   const styles = useThemedStyles(createStyles)
   const goToProfile = useCallback(() => {
@@ -78,13 +78,14 @@ export const ProfileCompletionChecks = ({
     return null
   }
   const config: Record<string, boolean> = {
-    [messages.profileCheckNameAndHandle]: !!currentUser.name,
-    [messages.profileCheckProfilePicture]: !!currentUser.profile_picture_sizes,
-    [messages.profileCheckCoverPhoto]: !!currentUser.cover_photo_sizes,
-    [messages.profileCheckProfileDescription]: !!currentUser.bio,
-    [messages.profileCheckFavorite]: hasFavoritedItem,
-    [messages.profileCheckRepost]: currentUser.repost_count >= 1,
-    [messages.profileCheckFollow]: currentUser.followee_count >= 5
+    [messages.profileCheckNameAndHandle]: completionStages.hasNameAndHandle,
+    [messages.profileCheckProfilePicture]: completionStages.hasProfilePicture,
+    [messages.profileCheckCoverPhoto]: completionStages.hasCoverPhoto,
+    [messages.profileCheckProfileDescription]:
+      completionStages.hasProfileDescription,
+    [messages.profileCheckFavorite]: completionStages.hasFavoritedItem,
+    [messages.profileCheckRepost]: !!completionStages.hasReposted,
+    [messages.profileCheckFollow]: completionStages.hasFollowedAccounts
   }
   return (
     <View>


### PR DESCRIPTION
### Description

Various places we display the profile completion stages were not consuming the selector from the `profile-progress` selectors but rather recreating it, and they got out of sync.

Would have opted to use `getOrderedCompletionStages` but didn't want to reorder the stages close to launch.

Also fixes progress bar being hidden when challenges complete on desktop.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested against stage on desktop, having issues testing mobile standby

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
