### PR TITLE
Optimize happy path $AUDIO nav balance

### DIFF
--- a/packages/web/src/common/models/User.ts
+++ b/packages/web/src/common/models/User.ts
@@ -48,6 +48,7 @@ export type UserMetadata = {
   twitterVerified?: boolean
   instagramVerified?: boolean
   balance?: Nullable<StringWei>
+  total_balance?: Nullable<StringWei>
   associated_wallets_balance?: Nullable<StringWei>
   playlist_library?: PlaylistLibrary
   userBank?: SolanaWalletAddress

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -28,10 +28,6 @@ const messages = {
 }
 
 const NavAudio = () => {
-  // TODO: remove this feature flag ASAP as rewards launches because we could show $AUDIO far earlier
-  // but need to wait for remote config
-  const { isEnabled } = useFlag(FeatureFlags.SURFACE_AUDIO_ENABLED)
-
   const navigate = useNavigateToPage()
   const account = useSelector(getAccountUser)
   const totalBalance = useSelector(getAccountTotalBalance)
@@ -69,7 +65,7 @@ const NavAudio = () => {
     positiveTotalBalance
   ])
 
-  if (!isEnabled || !account) {
+  if (!account) {
     return null
   }
   if (!nonNullTotalBalance) {

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -6,7 +6,7 @@ import { animated, Transition } from 'react-spring/renderprops'
 
 import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'
 import IconNoTierBadge from 'assets/img/tokenBadgeNoTier.png'
-import { FeatureFlags } from 'common/services/remote-config/feature-flags'
+import { BNWei } from 'common/models/Wallet'
 import { getAccountUser } from 'common/store/account/selectors'
 import { getOptimisticUserChallenges } from 'common/store/challenges/selectors/optimistic-challenges'
 import { getAccountTotalBalance } from 'common/store/wallet/selectors'
@@ -14,7 +14,6 @@ import { formatWei } from 'common/utils/wallet'
 import { audioTierMapPng } from 'components/user-badges/UserBadges'
 import { useSelectTierInfo } from 'components/user-badges/hooks'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
-import { useFlag } from 'hooks/useRemoteConfig'
 import { useSelector } from 'utils/reducer'
 import { AUDIO_PAGE } from 'utils/route'
 
@@ -30,8 +29,12 @@ const messages = {
 const NavAudio = () => {
   const navigate = useNavigateToPage()
   const account = useSelector(getAccountUser)
-  const totalBalance = useSelector(getAccountTotalBalance)
+  let totalBalance = useSelector(getAccountTotalBalance)
+  if (totalBalance === null && account?.total_balance) {
+    totalBalance = new BN(account?.total_balance) as BNWei
+  }
   const nonNullTotalBalance = totalBalance !== null
+
   const positiveTotalBalance =
     nonNullTotalBalance && totalBalance!.gt(new BN(0))
   // we only show the audio balance and respective badge when there is an account

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -14,7 +14,6 @@ import {
 } from 'common/store/pages/token-dashboard/slice'
 import {
   getAccountBalance,
-  getAccountTotalBalance,
   getLocalBalanceDidChange
 } from 'common/store/wallet/selectors'
 import {
@@ -132,16 +131,6 @@ function* getWalletBalanceAndWallets() {
 
 function* fetchBalanceAsync() {
   const account = yield select(getAccountUser)
-  const currentTotalBalanceFromStore = yield select(getAccountTotalBalance)
-  if (!currentTotalBalanceFromStore && account.total_balance) {
-    // If we haven't set total balance yet, pull it from the account itself
-    yield put(
-      setBalance({
-        totalBalance: account.total_balance,
-        balance: account.balance
-      })
-    )
-  }
   const localBalanceChange: ReturnType<typeof getLocalBalanceDidChange> = yield select(
     getLocalBalanceDidChange
   )

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -14,6 +14,7 @@ import {
 } from 'common/store/pages/token-dashboard/slice'
 import {
   getAccountBalance,
+  getAccountTotalBalance,
   getLocalBalanceDidChange
 } from 'common/store/wallet/selectors'
 import {
@@ -131,6 +132,16 @@ function* getWalletBalanceAndWallets() {
 
 function* fetchBalanceAsync() {
   const account = yield select(getAccountUser)
+  const currentTotalBalanceFromStore = yield select(getAccountTotalBalance)
+  if (!currentTotalBalanceFromStore && account.total_balance) {
+    // If we haven't set total balance yet, pull it from the account itself
+    yield put(
+      setBalance({
+        totalBalance: account.total_balance,
+        balance: account.balance
+      })
+    )
+  }
   const localBalanceChange: ReturnType<typeof getLocalBalanceDidChange> = yield select(
     getLocalBalanceDidChange
   )


### PR DESCRIPTION
### Description

Follows TODO and relies on stored `account.total_balance` field if the wallet manager has not recovered balance (yet).
This avoids some of the "popping" in. Of course the "Claim Rewards >" pops in

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Locally vs. prod on my account

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.
