### PR TITLE
Consolidate audio-rewards

### DIFF
--- a/packages/mobile/src/components/audio-rewards/IconAudioBadge.tsx
+++ b/packages/mobile/src/components/audio-rewards/IconAudioBadge.tsx
@@ -1,0 +1,29 @@
+import { ComponentType } from 'react'
+
+import { SvgProps } from 'react-native-svg'
+
+import IconBronzeBadge from 'app/assets/images/IconBronzeBadge.svg'
+import IconGoldBadge from 'app/assets/images/IconGoldBadge.svg'
+import IconPlatinumBadge from 'app/assets/images/IconPlatinumBadge.svg'
+import IconSilverBadge from 'app/assets/images/IconSilverBadge.svg'
+
+import { AudioTier } from './audioTier'
+
+const audioTierMap: Record<AudioTier, ComponentType<SvgProps> | null> = {
+  none: null,
+  bronze: IconBronzeBadge,
+  silver: IconSilverBadge,
+  gold: IconGoldBadge,
+  platinum: IconPlatinumBadge
+}
+
+type IconBadgeProps = SvgProps & {
+  tier: AudioTier
+}
+
+export const IconAudioBadge = (props: IconBadgeProps) => {
+  const { tier, ...other } = props
+  const AudioBadge = audioTierMap[tier]
+
+  return AudioBadge ? <AudioBadge {...other} /> : null
+}

--- a/packages/mobile/src/components/audio-rewards/audioTier.ts
+++ b/packages/mobile/src/components/audio-rewards/audioTier.ts
@@ -5,7 +5,7 @@ export const WEI = new BN('1000000000000000000')
 
 export type AudioTier = 'none' | 'bronze' | 'silver' | 'gold' | 'platinum'
 
-export const audioTierRequirements: { tier: AudioTier; minAudio: BN }[] = [
+const audioTierRequirements: { tier: AudioTier; minAudio: BN }[] = [
   {
     tier: 'platinum',
     minAudio: new BN('100000')

--- a/packages/mobile/src/components/audio-rewards/audioTier.ts
+++ b/packages/mobile/src/components/audio-rewards/audioTier.ts
@@ -3,8 +3,9 @@ import BN from 'bn.js'
 
 export const WEI = new BN('1000000000000000000')
 
-export type BadgeTier = 'none' | 'bronze' | 'silver' | 'gold' | 'platinum'
-export const badgeTiers: { tier: BadgeTier; minAudio: BN }[] = [
+export type AudioTier = 'none' | 'bronze' | 'silver' | 'gold' | 'platinum'
+
+export const audioTierRequirements: { tier: AudioTier; minAudio: BN }[] = [
   {
     tier: 'platinum',
     minAudio: new BN('100000')
@@ -27,7 +28,7 @@ export const badgeTiers: { tier: BadgeTier; minAudio: BN }[] = [
   }
 ]
 
-export const tierLevels: BadgeTier[] = [
+export const audioTierOrder: AudioTier[] = [
   'none',
   'bronze',
   'silver',
@@ -35,23 +36,21 @@ export const tierLevels: BadgeTier[] = [
   'platinum'
 ]
 
-export const getTierLevel = (tier: BadgeTier) => {
-  return tierLevels.indexOf(tier)
+export const getAudioTierRank = (tier: AudioTier) => {
+  return audioTierOrder.indexOf(tier)
 }
 
-export const getBadgeTier = (
+export const getUserAudioTier = (
   user: Pick<User, 'balance' | 'associated_wallets_balance'>
 ) => {
   const totalBalance = new BN(user.balance ?? '0')
     .add(new BN(user.associated_wallets_balance ?? '0'))
     .div(WEI)
 
-  const index = badgeTiers.findIndex(t => {
+  const index = audioTierRequirements.findIndex(t => {
     return t.minAudio.lte(totalBalance)
   })
 
-  const tier = index === -1 ? 'none' : badgeTiers[index].tier
+  const tier = index === -1 ? 'none' : audioTierRequirements[index].tier
   return tier
 }
-
-export default getBadgeTier

--- a/packages/mobile/src/components/audio-rewards/index.ts
+++ b/packages/mobile/src/components/audio-rewards/index.ts
@@ -1,0 +1,3 @@
+export * from './TierExplainerDrawer'
+export * from './IconAudioBadge'
+export * from './audioTier'

--- a/packages/mobile/src/components/notifications/NotificationBlock.tsx
+++ b/packages/mobile/src/components/notifications/NotificationBlock.tsx
@@ -24,13 +24,13 @@ import IconStars from 'app/assets/images/iconStars.svg'
 import IconTrending from 'app/assets/images/iconTrending.svg'
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
 import IconUser from 'app/assets/images/iconUser.svg'
+import { AudioTier } from 'app/components/audio-rewards'
 import {
   Entity as EntityType,
   Notification,
   NotificationType,
   TierChange
 } from 'app/store/notifications/types'
-import { BadgeTier } from 'app/utils/badgeTier'
 import { useColor, useTheme } from 'app/utils/theme'
 
 import NotificationContent from './content/NotificationContent'
@@ -39,7 +39,7 @@ import { getNotificationRoute } from './routeUtil'
 const IS_IOS = Platform.OS === 'ios'
 
 const tierInfoMap: Record<
-  BadgeTier,
+  AudioTier,
   { title: string; icon: React.FC<SvgProps> }
 > = {
   none: {

--- a/packages/mobile/src/components/notifications/content/TierChange.tsx
+++ b/packages/mobile/src/components/notifications/content/TierChange.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, Text, View } from 'react-native'
 
+import { AudioTier } from 'app/components/audio-rewards'
 import { TierChange as TierChangeType } from 'app/store/notifications/types'
-import { BadgeTier } from 'app/utils/badgeTier'
 import { useTheme } from 'app/utils/theme'
 
 import TwitterShare from './TwitterShare'
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
 })
 
 export const tierInfoMap: Record<
-  BadgeTier,
+  AudioTier,
   { label: string; amount: number }
 > = {
   none: {

--- a/packages/mobile/src/components/notifications/content/TwitterShare.tsx
+++ b/packages/mobile/src/components/notifications/content/TwitterShare.tsx
@@ -5,6 +5,7 @@ import { User } from 'audius-client/src/common/models/User'
 import { Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import IconTwitterBird from 'app/assets/images/iconTwitterBird.svg'
+import { AudioTier } from 'app/components/audio-rewards'
 import {
   Achievement,
   ChallengeReward,
@@ -16,7 +17,6 @@ import {
   TierChange,
   TrendingTrack
 } from 'app/store/notifications/types'
-import { BadgeTier } from 'app/utils/badgeTier'
 import { getUserRoute } from 'app/utils/routes'
 import { getTwitterLink } from 'app/utils/twitter'
 
@@ -130,7 +130,7 @@ export const getRewardsText = (notification: ChallengeReward) => ({
   link: null
 })
 
-const tierInfoMap: Record<BadgeTier, { label: string; icon: string }> = {
+const tierInfoMap: Record<AudioTier, { label: string; icon: string }> = {
   none: { label: 'None', icon: '' },
   bronze: { label: 'Bronze', icon: '🥉' },
   silver: { label: 'Silver', icon: '🥈' },

--- a/packages/mobile/src/components/user-badges/UserBadges.tsx
+++ b/packages/mobile/src/components/user-badges/UserBadges.tsx
@@ -1,16 +1,8 @@
-import { ComponentType } from 'react'
-
 import { User } from 'audius-client/src/common/models/User'
-import { Nullable } from 'audius-client/src/common/utils/typeUtils'
 import { StyleSheet, View, Text } from 'react-native'
-import { SvgProps } from 'react-native-svg'
 
-import IconBronzeBadge from 'app/assets/images/IconBronzeBadge.svg'
-import IconGoldBadge from 'app/assets/images/IconGoldBadge.svg'
-import IconPlatinumBadge from 'app/assets/images/IconPlatinumBadge.svg'
-import IconSilverBadge from 'app/assets/images/IconSilverBadge.svg'
 import IconVerified from 'app/assets/images/iconVerified.svg'
-import getBadgeTier, { BadgeTier } from 'app/utils/badgeTier'
+import { IconAudioBadge, getUserAudioTier } from 'app/components/audio-rewards'
 
 type UserBadgesProps = {
   user: Pick<
@@ -25,7 +17,6 @@ type UserBadgesProps = {
 
 const styles = StyleSheet.create({
   container: {
-    display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-start'
@@ -35,47 +26,30 @@ const styles = StyleSheet.create({
   }
 })
 
-export const badgeByTier: Record<
-  BadgeTier,
-  Nullable<ComponentType<SvgProps>>
-> = {
-  none: null,
-  bronze: IconBronzeBadge,
-  silver: IconSilverBadge,
-  gold: IconGoldBadge,
-  platinum: IconPlatinumBadge
-}
+const UserBadges = (props: UserBadgesProps) => {
+  const { user, badgeSize = 14, style, nameStyle, hideName } = props
+  const tier = getUserAudioTier(user)
 
-const UserBadges: React.FC<UserBadgesProps> = ({
-  user,
-  badgeSize = 14,
-  style = {},
-  nameStyle = {},
-  hideName
-}) => {
-  const tier = getBadgeTier(user)
-  const Badge = badgeByTier[tier]
   return (
     <View style={[styles.container, style]}>
-      {!hideName && (
+      {hideName ? null : (
         <Text style={nameStyle} numberOfLines={1}>
           {user.name}
         </Text>
       )}
-      {user.is_verified && (
+      {user.is_verified ? (
         <IconVerified
           height={badgeSize}
           width={badgeSize}
           style={styles.badge}
         />
-      )}
-      {Badge && (
-        <Badge
-          style={styles.badge}
-          height={badgeSize + 2}
-          width={badgeSize + 2}
-        />
-      )}
+      ) : null}
+      <IconAudioBadge
+        tier={tier}
+        style={styles.badge}
+        height={badgeSize + 2}
+        width={badgeSize + 2}
+      />
     </View>
   )
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
@@ -1,10 +1,13 @@
 import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
 import { View, Text } from 'react-native'
 
+import {
+  getAudioTierRank,
+  getUserAudioTier,
+  IconAudioBadge
+} from 'app/components/audio-rewards'
 import { Tile } from 'app/components/core'
-import { badgeByTier } from 'app/components/user-badges/UserBadges'
 import { makeStyles } from 'app/styles/makeStyles'
-import getBadgeTier, { getTierLevel } from 'app/utils/badgeTier'
 
 const messages = {
   tier: 'tier'
@@ -46,18 +49,17 @@ type ProfileBadgeProps = {
 
 export const ProfileBadge = ({ profile }: ProfileBadgeProps) => {
   const styles = useStyles()
-  const tier = getBadgeTier(profile)
-  const tierLevel = getTierLevel(tier)
-  const Badge = badgeByTier[tier]
+  const tier = getUserAudioTier(profile)
+  const tierRank = getAudioTierRank(tier)
 
-  if (!Badge) return null
+  if (tier === 'none') return null
 
   return (
     <Tile styles={{ root: styles.root, content: styles.content }}>
-      <Badge height={28} width={28} style={styles.badge} />
+      <IconAudioBadge tier={tier} height={28} width={28} style={styles.badge} />
       <View>
         <Text style={styles.tierNumber}>
-          {messages.tier} {tierLevel}
+          {messages.tier} {tierRank}
         </Text>
         <Text style={styles.tierText}>{tier}</Text>
       </View>

--- a/packages/mobile/src/screens/profile-screen/constants.ts
+++ b/packages/mobile/src/screens/profile-screen/constants.ts
@@ -1,3 +1,3 @@
-import { BadgeTier } from 'app/utils/badgeTier'
+import { AudioTier } from 'app/components/audio-rewards'
 
-export const MIN_COLLECTIBLES_TIER: BadgeTier = 'silver'
+export const MIN_COLLECTIBLES_TIER: AudioTier = 'silver'

--- a/packages/mobile/src/store/notifications/types.ts
+++ b/packages/mobile/src/store/notifications/types.ts
@@ -3,7 +3,7 @@ import { Collection } from 'audius-client/src/common/models/Collection'
 import { Track } from 'audius-client/src/common/models/Track'
 import { User } from 'audius-client/src/common/models/User'
 
-import { BadgeTier } from 'app/utils/badgeTier'
+import { AudioTier } from 'app/components/audio-rewards'
 
 export type ID = number
 
@@ -166,7 +166,7 @@ export type ChallengeReward = BaseNotification & {
 
 export type TierChange = BaseNotification & {
   type: NotificationType.TierChange
-  tier: BadgeTier
+  tier: AudioTier
 }
 
 export type Notification =


### PR DESCRIPTION
### Description

- Moves common audio-rewards code into `components/audio-rewards`
- Simplifies usage of AudioBadges with IconAudioBadge
- Renames some helpers to be more clear
- Prep work for TierExplainerDrawer