### PR TITLE
Check for empty endpoint config

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/store/sagas.ts
+++ b/packages/web/src/pages/audio-rewards-page/store/sagas.ts
@@ -202,7 +202,7 @@ function* claimChallengeRewardAsync(
   // When endpoints is unset, `submitAndEvaluateAttestations` picks for us
   const endpoints =
     rewardsAttestationEndpoints && rewardsAttestationEndpoints !== ''
-      ? rewardsAttestationEndpoints?.split(',')
+      ? rewardsAttestationEndpoints.split(',')
       : null
   const hasConfig =
     oracleEthAddress &&

--- a/packages/web/src/pages/audio-rewards-page/store/sagas.ts
+++ b/packages/web/src/pages/audio-rewards-page/store/sagas.ts
@@ -200,7 +200,10 @@ function* claimChallengeRewardAsync(
   const feePayerOverride: string = yield select(getFeePayer)
 
   // When endpoints is unset, `submitAndEvaluateAttestations` picks for us
-  const endpoints = rewardsAttestationEndpoints?.split(',') || null
+  const endpoints =
+    rewardsAttestationEndpoints && rewardsAttestationEndpoints !== ''
+      ? rewardsAttestationEndpoints?.split(',')
+      : null
   const hasConfig =
     oracleEthAddress &&
     AAOEndpoint &&


### PR DESCRIPTION
### Description

Allows us to remove the config from optimizely by setting it to be empty and allowing libs to select for us.

### Dragons

Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.

Tested against stage with stage having empty endpoints config.

### How will this change be monitored?

For features that are critical or could fail silently please describe the monitoring/alerting being added.

We have an amplitude dashboard [here](https://analytics.amplitude.com/audius/dashboard/0ebjc1d), and one of those charts shows [error counts by type](https://analytics.amplitude.com/audius/chart/76f22tw). If we see a spike of INSUFFICIENT_DISCOVERY_NODES when setting the config to an empty string, we know that the change is not working as intended and we need to instead remove the variable in optimizely entirely.

If we don't actively watch the chart, there's an alert set up to send a slack message (and an email to me) if the claim failure rate goes above 80% (we're working on fixing some outstanding unknown errors still and will tweak that threshold)