### PR TITLE
[AUD-1009] Add TiersExplainerDrawer

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -5755,7 +5755,7 @@
     "audius-client": {
       "version": "file:../web",
       "requires": {
-        "@audius/libs": "1.2.74",
+        "@audius/libs": "1.2.75",
         "@audius/stems": "0.3.21",
         "@craco/craco": "6.4.3",
         "@hcaptcha/react-hcaptcha": "0.3.6",
@@ -50753,6 +50753,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.11.2.tgz",
+      "integrity": "sha512-reW2Y2Mpn0QNA/5fvtm5doROLwDPu2zOm5RtY7xQQS05Q7xgC8MOZ3yPNaP9m/s/sNjjFQtHo7VCNqYW2iI+Ig==",
+      "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -150,6 +150,7 @@
     "react-test-renderer": "16.9.0",
     "redux-devtools-extension": "2.13.9",
     "standard": "16.0.3",
+    "type-fest": "^2.11.2",
     "typescript": "4.4.4"
   },
   "jest": {

--- a/packages/mobile/src/Drawers.tsx
+++ b/packages/mobile/src/Drawers.tsx
@@ -1,5 +1,6 @@
 import { AddToPlaylistDrawer } from 'app/components/add-to-playlist-drawer'
 import { ApiRewardsDrawer } from 'app/components/api-rewards-drawer/ApiRewardsDrawer'
+import { TiersExplainerDrawer } from 'app/components/audio-rewards'
 import { ChallengeRewardsDrawer } from 'app/components/challenge-rewards-drawer'
 import { CognitoDrawer } from 'app/components/cognito-drawer/CognitoDrawer'
 import { CollectibleDetailsDrawer } from 'app/components/collectible-details-drawer'
@@ -40,6 +41,7 @@ export const Drawers = () => {
       <ForgotPasswordDrawer />
       <FeedFilterDrawer />
       <TrendingFilterDrawer />
+      <TiersExplainerDrawer />
       {/* Disable the audio breakdown drawer until we get
       the feature flags to work for native mobile */}
       {/* <AudioBreakdownDrawer /> */}

--- a/packages/mobile/src/components/audio-rewards/TierText.tsx
+++ b/packages/mobile/src/components/audio-rewards/TierText.tsx
@@ -1,0 +1,30 @@
+import { GradientText, GradientTextProps } from 'app/components/core'
+
+import { AudioTier } from './audioTier'
+
+const tierGradientMap = {
+  none: {
+    colors: []
+  },
+  bronze: {
+    colors: ['rgba(141, 48, 8, 0.5)', 'rgba(182, 97, 11, 1)']
+  },
+  silver: {
+    colors: ['rgba(179, 182, 185, 0.5)', 'rgba(189, 189, 189, 1)']
+  },
+  gold: {
+    colors: ['rgba(231, 154, 7, 0.5)', 'rgba(236, 173, 11, 1)']
+  },
+  platinum: {
+    colors: ['#B3ECF9', '#57C2D7']
+  }
+}
+
+type TierTextProps = GradientTextProps & {
+  tier: AudioTier
+}
+
+export const TierText = (props: TierTextProps) => {
+  const { tier, ...other } = props
+  return <GradientText {...other} colors={tierGradientMap[tier].colors} />
+}

--- a/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
+++ b/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
@@ -1,5 +1,5 @@
 import { getProfileUser } from 'audius-client/src/common/store/pages/profile/selectors'
-import { Text, TextStyle, View } from 'react-native'
+import { Text, View } from 'react-native'
 
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'

--- a/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
+++ b/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
@@ -1,0 +1,107 @@
+import { getProfileUser } from 'audius-client/src/common/store/pages/profile/selectors'
+import { Text, TextStyle, View } from 'react-native'
+
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { makeStyles } from 'app/styles'
+
+import { AppDrawer } from '../drawer/AppDrawer'
+
+import { IconAudioBadge } from './IconAudioBadge'
+import { TierText } from './TierText'
+import {
+  audioTierRequirements,
+  getAudioTierRank,
+  getUserAudioTier
+} from './audioTier'
+
+import { AudioTierRequirement } from '.'
+
+export const MODAL_NAME = 'TiersExplainer'
+
+const messages = {
+  tier: 'Tier',
+  explainer1: 'Unlock $AUDIO VIP Tiers by simply holding more $AUDIO.',
+  explainer2:
+    'Advancing to a new tier will earn you a profile badge, visible throughout the app, and unlock various new features, as they are released.',
+  learnMore: 'LEARN MORE'
+}
+
+const useStyles = makeStyles(({ spacing, typography, palette }) => ({
+  top: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: spacing(12)
+  },
+  tierTextGroup: { marginLeft: spacing(4) },
+  tierRank: {
+    ...typography.h2,
+    marginBottom: 0,
+    color: palette.neutralLight6,
+    textTransform: 'uppercase',
+    letterSpacing: 3
+  },
+  tierText: {
+    fontSize: 28,
+    textTransform: 'uppercase',
+    marginTop: spacing(0.5),
+    marginBottom: spacing(1)
+  },
+  minAudio: {
+    ...typography.h3,
+    marginBottom: 0,
+    color: palette.secondary
+  },
+  explainerRoot: {
+    marginTop: spacing(6),
+    paddingHorizontal: spacing(12)
+  },
+  tierExplainer: {
+    fontSize: 16,
+    fontFamily: typography.fontByWeight.demiBold,
+    color: palette.neutral,
+    lineHeight: 25,
+    marginBottom: spacing(7)
+  }
+}))
+
+export const TiersExplainerDrawer = () => {
+  const styles = useStyles()
+
+  const profile = useSelectorWeb(getProfileUser)
+  if (!profile) return null
+
+  const tier = getUserAudioTier(profile)
+  const tierRank = getAudioTierRank(tier)
+  const { minAudio } = audioTierRequirements.find(
+    tierReq => tierReq.tier === tier
+  ) as AudioTierRequirement
+
+  const minAudioText = minAudio.toString()
+
+  return (
+    <AppDrawer modalName={MODAL_NAME}>
+      <View style={styles.top}>
+        <IconAudioBadge tier={tier} height={108} width={108} />
+        <View style={styles.tierTextGroup}>
+          <Text style={styles.tierRank}>
+            {messages.tier} {tierRank}
+          </Text>
+          <TierText style={styles.tierText} tier={tier}>
+            {tier}
+          </TierText>
+          <Text
+            accessibilityLabel={`${minAudioText} or more audio tokens`}
+            style={styles.minAudio}
+          >
+            {minAudio.toString()}+ $AUDIO
+          </Text>
+        </View>
+      </View>
+      <View style={styles.explainerRoot}>
+        <Text style={styles.tierExplainer}>{messages.explainer1}</Text>
+        <Text style={styles.tierExplainer}>{messages.explainer2}</Text>
+      </View>
+    </AppDrawer>
+  )
+}

--- a/packages/mobile/src/components/audio-rewards/audioTier.ts
+++ b/packages/mobile/src/components/audio-rewards/audioTier.ts
@@ -5,7 +5,9 @@ export const WEI = new BN('1000000000000000000')
 
 export type AudioTier = 'none' | 'bronze' | 'silver' | 'gold' | 'platinum'
 
-const audioTierRequirements: { tier: AudioTier; minAudio: BN }[] = [
+export type AudioTierRequirement = { tier: AudioTier; minAudio: BN }
+
+export const audioTierRequirements: AudioTierRequirement[] = [
   {
     tier: 'platinum',
     minAudio: new BN('100000')

--- a/packages/mobile/src/components/audio-rewards/index.ts
+++ b/packages/mobile/src/components/audio-rewards/index.ts
@@ -1,2 +1,3 @@
 export * from './IconAudioBadge'
 export * from './audioTier'
+export * from './TiersExplainerDrawer'

--- a/packages/mobile/src/components/core/GradientText.tsx
+++ b/packages/mobile/src/components/core/GradientText.tsx
@@ -1,21 +1,29 @@
 import MaskedView from '@react-native-masked-view/masked-view'
 import { TextProps } from 'react-native'
-import LinearGradient from 'react-native-linear-gradient'
+import LinearGradient, {
+  LinearGradientProps
+} from 'react-native-linear-gradient'
 
 import Text from 'app/components/text'
 import { useThemeColors } from 'app/utils/theme'
 
-type GradientTextProps = TextProps
+export type GradientTextProps = TextProps &
+  Partial<Omit<LinearGradientProps, 'style'>>
 
 /**
  * Diagonal gradient text in the Audius colors
  */
 export const GradientText = (props: GradientTextProps) => {
-  const { style, children, ...other } = props
   const {
     pageHeaderGradientColor1,
     pageHeaderGradientColor2
   } = useThemeColors()
+  const {
+    style,
+    children,
+    colors = [pageHeaderGradientColor1, pageHeaderGradientColor2],
+    ...other
+  } = props
 
   return (
     <MaskedView
@@ -26,7 +34,7 @@ export const GradientText = (props: GradientTextProps) => {
       }
     >
       <LinearGradient
-        colors={[pageHeaderGradientColor1, pageHeaderGradientColor2]}
+        colors={colors}
         start={{ x: 1, y: 1 }}
         end={{ x: 0, y: 0 }}
       >

--- a/packages/mobile/src/components/drawer/AppDrawer.tsx
+++ b/packages/mobile/src/components/drawer/AppDrawer.tsx
@@ -1,0 +1,29 @@
+import { useCallback } from 'react'
+
+import {
+  getModalVisibility,
+  Modals,
+  setVisibility
+} from 'audius-client/src/common/store/ui/modals/slice'
+import type { SetOptional } from 'type-fest'
+
+import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+
+import { Drawer, DrawerProps } from './Drawer'
+
+type AppDrawerProps = SetOptional<DrawerProps, 'isOpen' | 'onClose'> & {
+  modalName: Modals
+}
+
+export const AppDrawer = (props: AppDrawerProps) => {
+  const { modalName, ...other } = props
+  const dispatchWeb = useDispatchWeb()
+  const isOpen = useSelectorWeb(state => getModalVisibility(state, modalName))
+
+  const handleClose = useCallback(() => {
+    dispatchWeb(setVisibility({ modal: modalName, visible: false }))
+  }, [dispatchWeb, modalName])
+
+  return <Drawer isOpen={isOpen} onClose={handleClose} {...other} />
+}

--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -297,7 +297,7 @@ type DrawerComponent = {
   (props: DrawerProps & { title: string }): React.ReactElement
   (props: Omit<DrawerProps, 'titleIcon'>): React.ReactElement
 }
-const Drawer: DrawerComponent = ({
+export const Drawer: DrawerComponent = ({
   isOpen,
   children,
   onClose,

--- a/packages/mobile/src/screens/edit-profile-screen/index.ts
+++ b/packages/mobile/src/screens/edit-profile-screen/index.ts
@@ -1,0 +1,1 @@
+export { EditProfileScreen } from './EditProfileScreen'

--- a/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
@@ -1,4 +1,7 @@
+import { useCallback } from 'react'
+
 import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { setVisibility } from 'audius-client/src/common/store/ui/modals/slice'
 import { View, Text } from 'react-native'
 
 import {
@@ -6,7 +9,9 @@ import {
   getUserAudioTier,
   IconAudioBadge
 } from 'app/components/audio-rewards'
+import { MODAL_NAME } from 'app/components/audio-rewards/TiersExplainerDrawer'
 import { Tile } from 'app/components/core'
+import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { makeStyles } from 'app/styles/makeStyles'
 
 const messages = {
@@ -15,16 +20,14 @@ const messages = {
 
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   root: {
-    width: 208,
-    height: 56,
+    width: 200,
     marginRight: spacing(8)
   },
   content: {
-    display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    paddingVertical: spacing(2)
+    paddingVertical: spacing(1)
   },
   badge: {
     marginRight: spacing(3)
@@ -51,11 +54,19 @@ export const ProfileBadge = ({ profile }: ProfileBadgeProps) => {
   const styles = useStyles()
   const tier = getUserAudioTier(profile)
   const tierRank = getAudioTierRank(tier)
+  const dispatchWeb = useDispatchWeb()
+
+  const handlePress = useCallback(() => {
+    dispatchWeb(setVisibility({ modal: MODAL_NAME, visible: true }))
+  }, [dispatchWeb])
 
   if (tier === 'none') return null
 
   return (
-    <Tile styles={{ root: styles.root, content: styles.content }}>
+    <Tile
+      styles={{ root: styles.root, content: styles.content }}
+      onPress={handlePress}
+    >
       <IconAudioBadge tier={tier} height={28} width={28} style={styles.badge} />
       <View>
         <Text style={styles.tierNumber}>


### PR DESCRIPTION
### Description

- Adds `TiersExplainerDrawer`
- Adds `LinearGradientProps` to `GradientText`
- Adds `AppDrawer` to handle the `isOpen` and `onClose` logic. Can eventually use this for every drawer.
- Adds `type-fest` type library to help with various things. Using `SetOptional` to help with prop modification in this PR