### PR TITLE
[AUD-1678] Update blank image to correct path

### DIFF
--- a/packages/web/src/components/card/desktop/Card.tsx
+++ b/packages/web/src/components/card/desktop/Card.tsx
@@ -3,7 +3,7 @@ import React, { MouseEvent, useState, useEffect, useCallback } from 'react'
 import cn from 'classnames'
 
 import { ReactComponent as IconKebabHorizontal } from 'assets/img/iconKebabHorizontal.svg'
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import { ID } from 'common/models/Identifiers'
 import {
   ProfilePictureSizes,

--- a/packages/web/src/components/card/desktop/CollectionArtCard.tsx
+++ b/packages/web/src/components/card/desktop/CollectionArtCard.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 
 import { ReactComponent as IconKebabHorizontal } from 'assets/img/iconKebabHorizontal.svg'
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import { ID } from 'common/models/Identifiers'
 import { SquareSizes } from 'common/models/ImageSizes'
 import { getUserId } from 'common/store/account/selectors'

--- a/packages/web/src/components/card/desktop/UserArtCard.tsx
+++ b/packages/web/src/components/card/desktop/UserArtCard.tsx
@@ -5,7 +5,7 @@ import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import { ID } from 'common/models/Identifiers'
 import { SquareSizes } from 'common/models/ImageSizes'
 import { getUser } from 'common/store/cache/users/selectors'

--- a/packages/web/src/components/card/mobile/Card.tsx
+++ b/packages/web/src/components/card/mobile/Card.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import cn from 'classnames'
 
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import { ID } from 'common/models/Identifiers'
 import {
   ProfilePictureSizes,

--- a/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
+++ b/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 
 import { ReactComponent as IconCamera } from 'assets/img/iconCamera.svg'
-import placeholderCoverArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderCoverArt from 'assets/img/imageBlank2x.png'
 import { CreatePlaylistSource } from 'common/models/Analytics'
 import { Collection } from 'common/models/Collection'
 import { ID } from 'common/models/Identifiers'

--- a/packages/web/src/components/search-bar/ConnectedSearchBar.js
+++ b/packages/web/src/components/search-bar/ConnectedSearchBar.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { matchPath } from 'react-router'
 import { withRouter } from 'react-router-dom'
 
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import profilePicEmpty from 'assets/img/imageProfilePicEmpty2X.png'
 import { Name } from 'common/models/Analytics'
 import { SquareSizes } from 'common/models/ImageSizes'

--- a/packages/web/src/components/search/SearchBarResult.js
+++ b/packages/web/src/components/search/SearchBarResult.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect, memo } from 'react'
 import cn from 'classnames'
 import PropTypes from 'prop-types'
 
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import Kind from 'common/models/Kind'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import UserBadges from 'components/user-badges/UserBadges'

--- a/packages/web/src/components/upload/UploadArtwork.js
+++ b/packages/web/src/components/upload/UploadArtwork.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import Lottie from 'react-lottie'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import ImageSelectionButton from 'components/image-selection/ImageSelectionButton'
 import Toast from 'components/toast/Toast'
 

--- a/packages/web/src/hooks/useCollectionCoverArt.ts
+++ b/packages/web/src/hooks/useCollectionCoverArt.ts
@@ -1,6 +1,6 @@
 import { useDispatch } from 'react-redux'
 
-import imageEmpty from 'assets/img/imageCoverPhotoBlank.jpg'
+import imageEmpty from 'assets/img/imageBlank2x.png'
 import { useImageSize } from 'common/hooks/useImageSize'
 import { CoverArtSizes, SquareSizes } from 'common/models/ImageSizes'
 import { fetchCoverArt } from 'common/store/cache/collections/actions'

--- a/packages/web/src/hooks/useTrackCoverArt.ts
+++ b/packages/web/src/hooks/useTrackCoverArt.ts
@@ -1,6 +1,6 @@
 import { useDispatch } from 'react-redux'
 
-import imageEmpty from 'assets/img/imageCoverPhotoBlank.jpg'
+import imageEmpty from 'assets/img/imageBlank2x.png'
 import { useImageSize } from 'common/hooks/useImageSize'
 import { CoverArtSizes, SquareSizes } from 'common/models/ImageSizes'
 import { fetchCoverArt } from 'common/store/cache/tracks/actions'

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonType, IconPause, IconPlay } from '@audius/stems'
 import cn from 'classnames'
 import Linkify from 'linkifyjs/react'
 
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import { Name } from 'common/models/Analytics'
 import { CID, ID } from 'common/models/Identifiers'
 import { SquareSizes, CoverArtSizes } from 'common/models/ImageSizes'

--- a/packages/web/src/pages/upload-page/components/FinishPage.js
+++ b/packages/web/src/pages/upload-page/components/FinishPage.js
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import PropTypes from 'prop-types'
 
 import { ReactComponent as IconArrow } from 'assets/img/iconArrow.svg'
-import placeholderArt from 'assets/img/imageCoverPhotoBlank.jpg'
+import placeholderArt from 'assets/img/imageBlank2x.png'
 import { DefaultSizes } from 'common/models/ImageSizes'
 import Toast from 'components/toast/Toast'
 import {


### PR DESCRIPTION
### Description

Somehow, during the course of the monorepo work, most of the blank image paths got changed to the default cover photo path. I don't know how this happened, I'll be in the corner

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
