### PR TITLE
Bump Libs to 1.2.84 and use processChallenges

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -79,9 +79,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.83",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.83.tgz",
-      "integrity": "sha512-Ps2TYEAnCbJIaAovtGEOUAbx9aIh4lJW5Y12+lrfcf3FLe8L4A7yTCWoaTcrH2pvYHtiAwnrn2TsrWpknzV3RQ==",
+      "version": "1.2.84",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.84.tgz",
+      "integrity": "sha512-ax7Q+GgCXjRaOakbmCd1c43veQYicJL70za4T95lpEe2iNvmOzX6XXSr14N7B3MoFL3kRt0ndC6I5bep0fzKIQ==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.0.10",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -79,9 +79,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.81",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.81.tgz",
-      "integrity": "sha512-/J9bskGuRvLZvww67no7TyNOY4QU7eIIsl4kgkciPR2rJXRKMv0Fy5zu2/IpFh9pyFAQAl36/njEP4ZeLC5deA==",
+      "version": "1.2.83",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.83.tgz",
+      "integrity": "sha512-Ps2TYEAnCbJIaAovtGEOUAbx9aIh4lJW5Y12+lrfcf3FLe8L4A7yTCWoaTcrH2pvYHtiAwnrn2TsrWpknzV3RQ==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.0.10",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.83",
+    "@audius/libs": "^1.2.84",
     "@audius/stems": "0.3.23",
     "@craco/craco": "6.4.3",
     "@hcaptcha/react-hcaptcha": "0.3.6",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.81",
+    "@audius/libs": "1.2.83",
     "@audius/stems": "0.3.23",
     "@craco/craco": "6.4.3",
     "@hcaptcha/react-hcaptcha": "0.3.6",

--- a/packages/web/src/services/AudiusBackend.js
+++ b/packages/web/src/services/AudiusBackend.js
@@ -2708,9 +2708,7 @@ class AudiusBackend {
       )
       if (res.errors) {
         console.error(
-          `Got errors in aggregate attestation flow: ${JSON.stringify(
-            res.errors
-          )}`
+          `Got errors in processChallenges: ${JSON.stringify(res.errors)}`
         )
         const hcaptchaOrCognito = res.errors.find(
           ({ error }) =>

--- a/packages/web/src/services/AudiusBackend.js
+++ b/packages/web/src/services/AudiusBackend.js
@@ -2683,72 +2683,8 @@ class AudiusBackend {
 
       const reporter = new ClientRewardsReporter(audiusLibs)
 
-      const userIdStr = `${userId}`
       const encodedUserId = encodeHashId(userId)
 
-      // If just a single challenge, use regular `submitAndEvaluate` route
-      if (challenges.length === 1) {
-        const res = await audiusLibs.Rewards.submitAndEvaluate({
-          challengeId: challenges[0].challenge_id,
-          specifier: challenges[0].specifier,
-          encodedUserId,
-          handle,
-          recipientEthAddress,
-          oracleEthAddress,
-          amount,
-          quorumSize,
-          endpoints,
-          AAOEndpoint,
-          feePayerOverride
-        })
-
-        // Log results -
-        // These calls are fire-and-forget (not awaited)
-        // TODO: Remove this logic when we consolidate all
-        // rewards attesting in the RewardsAttester path
-        if (res.error) {
-          if (
-            res.error === FailureReason.HCAPTCHA ||
-            res.error === FailureReason.COGNITO_FLOW
-          ) {
-            reporter.reportAAORejection({
-              userId: userIdStr,
-              challengeId: challenges[0].challenge_id,
-              specifier: challenges[0].specifier,
-              amount,
-              error: res.error
-            })
-          } else if (isFinalAttempt) {
-            reporter.reportFailure({
-              userId: userIdStr,
-              challengeId: challenges[0].challenge_id,
-              specifier: challenges[0].specifier,
-              amount,
-              error: res.error,
-              phase: res.phase
-            })
-          } else {
-            reporter.reportRetry({
-              userId: userIdStr,
-              challengeId: challenges[0].challenge_id,
-              specifier: challenges[0].specifier,
-              amount,
-              error: res.error,
-              phase: res.phase
-            })
-          }
-        } else {
-          reporter.reportSuccess({
-            userId: userIdStr,
-            challengeId: challenges[0].challenge_id,
-            specifier: challenges[0].specifier,
-            amount
-          })
-        }
-        return res
-      }
-
-      // If multiple challenges, use the RewardsAttester
       const attester = new AudiusLibs.RewardsAttester({
         libs: audiusLibs,
         parallelization,


### PR DESCRIPTION
### Description

- Bumps libs to 1.2.84 
- Stop using `submitAndEvaluate` and opt for `processChallenges` for all challenges

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Test error handling

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested locally against staging, but not against various errors.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
