### PR TITLE
Migrate lineup action to ts, implement play/pause in lineup

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -99,8 +99,6 @@ export const Lineup = ({
   lineup,
   loadMore,
   header,
-  playTrack,
-  pauseTrack,
   rankIconCount = 0,
   refresh,
   refreshing,
@@ -163,7 +161,7 @@ export const Lineup = ({
   const togglePlay = useCallback(
     (uid: UID, id: ID, source?: PlaybackSource) => {
       if (uid !== playingUid || (uid === playingUid && !playing)) {
-        playTrack(uid)
+        actions.play(uid)
         track(
           make({
             eventName: Name.PLAYBACK_PLAY,
@@ -172,7 +170,7 @@ export const Lineup = ({
           })
         )
       } else if (uid === playingUid && playing) {
-        pauseTrack()
+        actions.pause()
         track(
           make({
             eventName: Name.PLAYBACK_PAUSE,
@@ -182,7 +180,7 @@ export const Lineup = ({
         )
       }
     },
-    [playTrack, pauseTrack, playing, playingUid]
+    [actions, playing, playingUid]
   )
 
   const renderItem = ({

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -75,16 +75,6 @@ export type LineupProps = {
   refreshing?: boolean
 
   /**
-   * Function called to pause playback
-   */
-  pauseTrack: () => void
-
-  /**
-   * Function called to play a track
-   */
-  playTrack: (uid: UID) => void
-
-  /**
    * How many icons to show for top ranked entries in the lineup. Defaults to 0, showing none
    */
   rankIconCount?: number

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -50,14 +50,6 @@ export const FeedScreen = ({ navigation }: Props) => {
     dispatchWeb(feedActions.refreshInView(true))
   }
 
-  const playTrack = (uid?: string) => {
-    dispatchWeb(feedActions.play(uid))
-  }
-
-  const pauseTrack = () => {
-    dispatchWeb(feedActions.pause())
-  }
-
   const handleFilterButtonPress = useCallback(() => {
     dispatchWeb(setVisibility({ modal: 'FeedFilter', visible: true }))
   }, [dispatchWeb])
@@ -77,8 +69,6 @@ export const FeedScreen = ({ navigation }: Props) => {
         loadMore={loadMore}
         refresh={refresh}
         refreshing={isRefreshing && feedLineup.isMetadataLoading}
-        pauseTrack={pauseTrack}
-        playTrack={playTrack}
         selfLoad
       />
     </>

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -1,12 +1,9 @@
-import { useCallback } from 'react'
-
 import { feedActions } from 'audius-client/src/common/store/pages/profile/lineups/feed/actions'
 import { getProfileFeedLineup } from 'audius-client/src/common/store/pages/profile/selectors'
 import { Text } from 'react-native'
 
 import { EmptyCard } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
-import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { getProfile } from './selectors'
@@ -18,18 +15,6 @@ const messages = {
 export const RepostsTab = () => {
   const { profile } = useSelectorWeb(getProfile)
   const lineup = useSelectorWeb(getProfileFeedLineup)
-  const dispatchWeb = useDispatchWeb()
-
-  const handlePlayTrack = useCallback(
-    (uid: string) => {
-      dispatchWeb(feedActions.play(uid))
-    },
-    [dispatchWeb]
-  )
-
-  const handlePauseTrack = useCallback(() => {
-    dispatchWeb(feedActions.pause())
-  }, [dispatchWeb])
 
   if (!profile) return null
 
@@ -42,12 +27,6 @@ export const RepostsTab = () => {
   }
 
   return (
-    <Lineup
-      listKey='profile-reposts'
-      actions={feedActions}
-      lineup={lineup}
-      playTrack={handlePlayTrack}
-      pauseTrack={handlePauseTrack}
-    />
+    <Lineup listKey='profile-reposts' actions={feedActions} lineup={lineup} />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -1,12 +1,9 @@
-import { useCallback } from 'react'
-
 import { tracksActions } from 'audius-client/src/common/store/pages/profile/lineups/tracks/actions'
 import { getProfileTracksLineup } from 'audius-client/src/common/store/pages/profile/selectors'
 import { Text } from 'react-native'
 
 import { EmptyCard } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
-import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { getProfile } from './selectors'
@@ -18,18 +15,6 @@ const messages = {
 export const TracksTab = () => {
   const { profile } = useSelectorWeb(getProfile)
   const lineup = useSelectorWeb(getProfileTracksLineup)
-  const dispatchWeb = useDispatchWeb()
-
-  const handlePlayTrack = useCallback(
-    (uid: string) => {
-      dispatchWeb(tracksActions.play(uid))
-    },
-    [dispatchWeb]
-  )
-
-  const handlePauseTrack = useCallback(() => {
-    dispatchWeb(tracksActions.pause())
-  }, [dispatchWeb])
 
   if (!profile) return null
 
@@ -42,12 +27,6 @@ export const TracksTab = () => {
   }
 
   return (
-    <Lineup
-      listKey='profile-tracks'
-      actions={tracksActions}
-      lineup={lineup}
-      playTrack={handlePlayTrack}
-      pauseTrack={handlePauseTrack}
-    />
+    <Lineup listKey='profile-tracks' actions={tracksActions} lineup={lineup} />
   )
 }

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from 'react'
-
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { LineupState } from 'audius-client/src/common/models/Lineup'
 import { Track } from 'audius-client/src/common/models/Track'
@@ -19,7 +17,6 @@ import { StyleSheet, View } from 'react-native'
 import { BaseStackParamList } from 'app/components/app-navigator/types'
 import { Lineup } from 'app/components/lineup'
 import Text from 'app/components/text'
-import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { usePushRouteWeb } from 'app/hooks/usePushRouteWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { useThemedStyles } from 'app/hooks/useThemedStyles'
@@ -124,21 +121,9 @@ const TrackScreenMainContent = ({
  * `TrackScreen` displays a single track and a Lineup of more tracks by the artist
  */
 export const TrackScreen = ({ route, navigation }: Props) => {
-  const dispatchWeb = useDispatchWeb()
   const lineup = useSelectorWeb(getMoreByArtistLineup, isEqual)
   const track = useSelectorWeb(getTrack)
   const user = useSelectorWeb(getUser)
-
-  const playTrack = useCallback(
-    (uid?: string) => {
-      dispatchWeb(tracksActions.play(uid))
-    },
-    [dispatchWeb]
-  )
-
-  const pauseTrack = useCallback(() => {
-    dispatchWeb(tracksActions.pause())
-  }, [dispatchWeb])
 
   return (
     <View>
@@ -150,8 +135,6 @@ export const TrackScreen = ({ route, navigation }: Props) => {
           ) : null
         }
         lineup={lineup}
-        pauseTrack={pauseTrack}
-        playTrack={playTrack}
       />
     </View>
   )

--- a/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
+++ b/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
@@ -75,17 +75,6 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
     dispatchWeb(trendingActions.refreshInView(true))
   }, [dispatchWeb, trendingActions])
 
-  const handlePlayTrack = useCallback(
-    (uid?: string) => {
-      dispatchWeb(trendingActions.play(uid))
-    },
-    [dispatchWeb, trendingActions]
-  )
-
-  const handlePauseTrack = useCallback(() => {
-    dispatchWeb(trendingActions.pause())
-  }, [dispatchWeb, trendingActions])
-
   const handleLoadMore = useCallback(
     (offset: number, limit: number, overwrite: boolean) => {
       dispatchWeb(
@@ -104,8 +93,6 @@ export const TrendingLineup = (props: TrendingLineupProps) => {
       refresh={handleRefresh}
       refreshing={isRefreshing && trendingLineup.isMetadataLoading}
       loadMore={handleLoadMore}
-      playTrack={handlePlayTrack}
-      pauseTrack={handlePauseTrack}
       {...other}
     />
   )

--- a/packages/web/src/common/store/lineup/actions.ts
+++ b/packages/web/src/common/store/lineup/actions.ts
@@ -1,3 +1,6 @@
+import { ID, UID } from 'common/models/Identifiers'
+import { TrackMetadata } from 'common/models/Track'
+
 export const FETCH_LINEUP_METADATAS = 'FETCH_LINEUP_METADATAS'
 export const FETCH_LINEUP_METADATAS_REQUESTED =
   'FETCH_LINEUP_METADATAS_REQUESTED'
@@ -33,11 +36,11 @@ export const SET_LOADING = 'SET_LOADING'
 
 export const SET_PAGE = 'SET_PAGE'
 
-export const addPrefix = (prefix, actionType) => {
+export const addPrefix = (prefix: string, actionType: string) => {
   return `${prefix}_${actionType}`
 }
 
-export const stripPrefix = (prefix, actionType) => {
+export const stripPrefix = (prefix: string, actionType: string) => {
   return actionType.replace(`${prefix}_`, '')
 }
 
@@ -56,7 +59,10 @@ export const stripPrefix = (prefix, actionType) => {
  *  export const playlistActions = new PlaylistActions()
  */
 export class LineupActions {
-  constructor(prefix, removeDeleted = false) {
+  prefix: string
+  removeDeleted: boolean
+
+  constructor(prefix: string, removeDeleted = false) {
     this.prefix = prefix
     this.removeDeleted = removeDeleted
   }
@@ -73,7 +79,12 @@ export class LineupActions {
    * @param {boolean} [overwrite] a boolean indicating whether to overwrite cached entries the fetch may be refetching
    * @param {*} [payload] keyword args payload to send to the "get tracks" query
    */
-  fetchLineupMetadatas(offset = 0, limit = 10, overwrite = false, payload) {
+  fetchLineupMetadatas(
+    offset = 0,
+    limit = 10,
+    overwrite = false,
+    payload?: unknown
+  ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS),
       offset,
@@ -87,7 +98,7 @@ export class LineupActions {
     offset = 0,
     limit = 10,
     overwrite = false,
-    payload
+    payload: unknown
   ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS_REQUESTED),
@@ -98,7 +109,12 @@ export class LineupActions {
     }
   }
 
-  fetchLineupMetadatasSucceeded(entries, offset, limit, deleted) {
+  fetchLineupMetadatasSucceeded(
+    entries: unknown,
+    offset: number,
+    limit: number,
+    deleted: boolean
+  ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS_SUCCEEDED),
       entries,
@@ -114,14 +130,14 @@ export class LineupActions {
     }
   }
 
-  fetchTrackAudio(trackMetadata) {
+  fetchTrackAudio(trackMetadata: TrackMetadata) {
     return {
       type: addPrefix(this.prefix, FETCH_TRACK_AUDIO),
       trackMetadata: trackMetadata
     }
   }
 
-  fetchTrackAudioRequested(index, trackId) {
+  fetchTrackAudioRequested(index: number, trackId: ID) {
     return {
       type: addPrefix(this.prefix, FETCH_TRACK_AUDIO_REQUESTED),
       index: index,
@@ -129,7 +145,7 @@ export class LineupActions {
     }
   }
 
-  fetchTrackAudioSucceeded(index, trackId) {
+  fetchTrackAudioSucceeded(index: number, trackId: ID) {
     return {
       type: addPrefix(this.prefix, FETCH_TRACK_AUDIO_SUCCEEDED),
       index: index,
@@ -137,7 +153,7 @@ export class LineupActions {
     }
   }
 
-  play(uid) {
+  play(uid?: UID) {
     return {
       type: addPrefix(this.prefix, PLAY),
       uid
@@ -150,7 +166,7 @@ export class LineupActions {
     }
   }
 
-  updateTrackMetadata(trackId, metadata) {
+  updateTrackMetadata(trackId: ID, metadata: TrackMetadata) {
     return {
       type: addPrefix(this.prefix, UPDATE_TRACK_METADATA),
       trackId,
@@ -158,7 +174,7 @@ export class LineupActions {
     }
   }
 
-  updateLineupOrder(orderedIds) {
+  updateLineupOrder(orderedIds: UID[]) {
     return {
       type: addPrefix(this.prefix, UPDATE_LINEUP_ORDER),
       orderedIds
@@ -166,7 +182,7 @@ export class LineupActions {
   }
 
   // Side-effect: Unsubscribes this lineup from cache entries it is subscribed to.
-  reset(source) {
+  reset(source?: string) {
     return {
       type: addPrefix(this.prefix, RESET),
       source
@@ -179,7 +195,7 @@ export class LineupActions {
     }
   }
 
-  add(entry, id) {
+  add(entry: unknown, id: ID) {
     return {
       type: addPrefix(this.prefix, ADD),
       entry,
@@ -187,7 +203,7 @@ export class LineupActions {
     }
   }
 
-  remove(kind, uid) {
+  remove(kind: string, uid: UID) {
     return {
       type: addPrefix(this.prefix, REMOVE),
       kind,
@@ -195,7 +211,7 @@ export class LineupActions {
     }
   }
 
-  setInView(inView) {
+  setInView(inView: boolean) {
     return {
       type: addPrefix(this.prefix, SET_IN_VIEW),
       inView
@@ -203,7 +219,7 @@ export class LineupActions {
   }
 
   // If limit is not provided, we use whatever is in the state
-  refreshInView(overwrite = false, payload, limit = null) {
+  refreshInView(overwrite = false, payload?: unknown, limit = null) {
     return {
       type: addPrefix(this.prefix, REFRESH_IN_VIEW),
       overwrite,
@@ -218,7 +234,7 @@ export class LineupActions {
     }
   }
 
-  setPage = page => {
+  setPage = (page: number) => {
     return {
       type: addPrefix(this.prefix, SET_PAGE),
       page


### PR DESCRIPTION
### Description

- Migrates lineup actions to ts to make it easier to import and use lineup actions
- Implements play/pause actions in lineup using new types
- Removes redundant play/pause implementations

### Dragons

We may want the ability to know when a track is played/paused from outside the lineup. Rather than keep the `playTrack` `pauseTrack` props, thinking we add`onPlay`, `onPause` callbacks at that point?