### PR TITLE
Separate send and confirm send

### DIFF
--- a/packages/web/src/store/token-dashboard/sagas.ts
+++ b/packages/web/src/store/token-dashboard/sagas.ts
@@ -22,7 +22,6 @@ import {
   pressSend,
   setModalState,
   setModalVisibility as setSendAUDIOModalVisibility,
-  inputSendData,
   confirmSend,
   setDiscordCode,
   setIsConnectingWallet,
@@ -69,7 +68,7 @@ import { confirmTransaction } from 'store/confirmer/sagas'
 
 const CONNECT_WALLET_CONFIRMATION_UID = 'CONNECT_WALLET'
 
-function* send() {
+function* pressSendAsync() {
   // Set modal state to input
   const inputStage: ModalState = {
     stage: 'SEND',
@@ -81,11 +80,9 @@ function* send() {
     put(setSendAUDIOModalVisibility({ isVisible: true })),
     put(setModalState({ modalState: inputStage }))
   ])
+}
 
-  // Await input + confirmation
-  yield take(inputSendData.type)
-  yield take(confirmSend.type)
-
+function* confirmSendAsync() {
   // Send the txn, update local balance
   const sendData: ReturnType<typeof getSendData> = yield select(getSendData)
   if (!sendData) return
@@ -792,7 +789,11 @@ function* preloadProviders() {
 }
 
 function* watchPressSend() {
-  yield takeLatest(pressSend.type, send)
+  yield takeLatest(pressSend.type, pressSendAsync)
+}
+
+function* watchConfirmSend() {
+  yield takeLatest(confirmSend.type, confirmSendAsync)
 }
 
 function* watchGetAssociatedWallets() {
@@ -814,6 +815,7 @@ function* watchRemoveWallet() {
 const sagas = () => {
   return [
     watchPressSend,
+    watchConfirmSend,
     watchForDiscordCode,
     watchGetAssociatedWallets,
     watchConnectNewWallet,


### PR DESCRIPTION
### Description
Send and confirm send are tied together, but we want them separate in order to be able to interject the SocialProof modal.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally confirmed relay works w/o SocialProof. Will confirm on staging with.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
