### PR TITLE
Add feature flag to disable sign up confirmation

### DIFF
--- a/packages/web/src/common/models/Analytics.ts
+++ b/packages/web/src/common/models/Analytics.ts
@@ -35,6 +35,7 @@ export enum Name {
   // Sign in
   SIGN_IN_OPEN = 'Sign In: Open',
   SIGN_IN_FINISH = 'Sign In: Finish',
+  SIGN_IN_WITH_INCOMPLETE_ACCOUNT = 'Sign In: Incomplete Account',
 
   // Settings
   SETTINGS_CHANGE_THEME = 'Settings: Change Theme',
@@ -293,6 +294,11 @@ type SignInOpen = {
 type SignInFinish = {
   eventName: Name.SIGN_IN_FINISH
   status: 'success' | 'invalid credentials'
+}
+
+type SignInWithIncompleteAccount = {
+  eventName: Name.SIGN_IN_WITH_INCOMPLETE_ACCOUNT
+  handle: string
 }
 
 // Settings
@@ -1047,6 +1053,7 @@ export type AllTrackingEvents =
   | CreateAccountOpenFinish
   | SignInOpen
   | SignInFinish
+  | SignInWithIncompleteAccount
   | SettingsChangeTheme
   | SettingsStartTwitterOauth
   | SettingsCompleteTwitterOauth

--- a/packages/web/src/common/services/remote-config/feature-flags.ts
+++ b/packages/web/src/common/services/remote-config/feature-flags.ts
@@ -18,7 +18,8 @@ export enum FeatureFlags {
   PREFER_HIGHER_PATCH_FOR_SECONDARIES = 'prefer_higher_patch_for_secondaries',
   REWARDS_NOTIFICATIONS_ENABLED = 'rewards_notifications_enabled',
   ENABLE_SPL_AUDIO = 'enable_spl_audio',
-  PLAYLIST_FOLDERS = 'playlist_folders'
+  PLAYLIST_FOLDERS = 'playlist_folders',
+  DISABLE_SIGN_UP_CONFIRMATION = 'disable_sign_up_confirmation'
 }
 
 /**
@@ -43,7 +44,8 @@ export const flagDefaults: { [key in FeatureFlags]: boolean } = {
   [FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES]: true,
   [FeatureFlags.REWARDS_NOTIFICATIONS_ENABLED]: false,
   [FeatureFlags.ENABLE_SPL_AUDIO]: false,
-  [FeatureFlags.PLAYLIST_FOLDERS]: false
+  [FeatureFlags.PLAYLIST_FOLDERS]: false,
+  [FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION]: false
 }
 
 export enum FeatureFlagCohortType {
@@ -87,5 +89,6 @@ export const flagCohortType: {
   [FeatureFlags.REWARDS_NOTIFICATIONS_ENABLED]:
     FeatureFlagCohortType.SESSION_ID,
   [FeatureFlags.ENABLE_SPL_AUDIO]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.PLAYLIST_FOLDERS]: FeatureFlagCohortType.USER_ID
+  [FeatureFlags.PLAYLIST_FOLDERS]: FeatureFlagCohortType.USER_ID,
+  [FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION]: FeatureFlagCohortType.SESSION_ID
 }

--- a/packages/web/src/pages/sign-on/store/sagas.js
+++ b/packages/web/src/pages/sign-on/store/sagas.js
@@ -14,7 +14,11 @@ import {
 } from 'redux-saga/effects'
 
 import { FavoriteSource, Name } from 'common/models/Analytics'
-import { IntKeys, StringKeys } from 'common/services/remote-config'
+import {
+  FeatureFlags,
+  IntKeys,
+  StringKeys
+} from 'common/services/remote-config'
 import * as accountActions from 'common/store/account/reducer'
 import { getAccountUser } from 'common/store/account/selectors'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
@@ -50,6 +54,8 @@ import mobileSagas from './mobileSagas'
 import { getRouteOnCompletion, getSignOn } from './selectors'
 import { FollowArtistsCategory, Pages } from './types'
 import { checkHandle } from './verifiedChecker'
+
+const { getFeatureEnabled, waitForRemoteConfig } = remoteConfigInstance
 
 const IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production'
 const IS_PRODUCTION = process.env.REACT_APP_ENVIRONMENT === 'production'
@@ -362,9 +368,18 @@ function* signUp() {
         // Set the has request browser permission to true as the signon provider will open it
         setHasRequestedBrowserPermission()
 
-        const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
-        if (!confirmed) {
-          throw new Error(`Could not confirm sign up for user id ${userId}`)
+        yield call(waitForRemoteConfig)
+
+        // Check feature flag to disable confirmation
+        if (!getFeatureEnabled(FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION)) {
+          const confirmed = yield call(
+            confirmTransaction,
+            blockHash,
+            blockNumber
+          )
+          if (!confirmed) {
+            throw new Error(`Could not confirm sign up for user id ${userId}`)
+          }
         }
       },
       function* () {

--- a/packages/web/src/pages/sign-on/store/sagas.js
+++ b/packages/web/src/pages/sign-on/store/sagas.js
@@ -471,6 +471,11 @@ function* signIn(action) {
         })
       )
       yield put(signOnActions.showToast(messages.incompleteAccount))
+
+      const trackEvent = make(Name.SIGN_IN_WITH_INCOMPLETE_ACCOUNT, {
+        handle: signInResponse.handle
+      })
+      yield put(trackEvent)
     } else if (signInResponse.error && signInResponse.phase === 'FIND_USER') {
       // Go to sign up flow because the account is incomplete
       yield put(


### PR DESCRIPTION
### Description

* Adds `DISABLE_SIGN_UP_CONFIRMATION` feature flag. Hoping this allows more users to successfully sign up while most discprovs are behind
* Adds `SIGN_IN_WITH_INCOMPLETE_ACCOUNT` event to track users who get into bad sign up state

### Dragons

This could potentially break many things. Since we aren't confirming, the user is potentially missing data until they get indexed. This especially causes problems when signing out immediately and trying to sign back in. We added analytics to determine if more users end up in this bad state

### How Has This Been Tested?

Tested social actions, creating playlists, etc while in an unindexed state and things seem to work pretty well

### How will this change be monitored?

New analytics event. Monitoring sign up success rate
