### PR TITLE
Fix missing space in ios:update-signing-cert script

### DIFF
--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -17,7 +17,7 @@
     "ios:device:bounce": "react-native run-ios --scheme 'Bounce' --configuration Release --device",
     "ios:dev": "react-native run-ios --scheme 'Dev'",
     "ios:device:dev": "react-native run-ios --scheme 'Dev' --device",
-    "ios:update-signing-cert": "cd ios && fastlane match development -a co.audius.audiusmusic,co.audius.audiusmusic.bounce && cd..",
+    "ios:update-signing-cert": "cd ios && fastlane match development -a co.audius.audiusmusic,co.audius.audiusmusic.bounce && cd ..",
     "bundle:ios": "react-native bundle --entry-file='index.js' --bundle-output='./ios/main.jsbundle' --dev=false --platform='ios'",
     "build:ios": "xcodebuild -workspace ios/AudiusReactNative.xcworkspace -scheme AudiusReactNative -sdk iphoneos -configuration AppStoreDistribution archive -archivePath $PWD/build/AudiusReactNative.xcarchive",
     "build:ios:bounce": "xcodebuild -workspace ios/AudiusReactNative.xcworkspace -scheme Bounce -sdk iphoneos -configuration AppStoreDistribution archive -archivePath $PWD/build/AudiusReactNative.xcarchive",


### PR DESCRIPTION
### Description

Missing space in `cd..` causes last part of the command to fail
