### PR TITLE
Create playlist folder functionality

### DIFF
--- a/packages/web/src/common/models/PlaylistLibrary.ts
+++ b/packages/web/src/common/models/PlaylistLibrary.ts
@@ -22,6 +22,7 @@ export type PlaylistLibraryIdentifier =
   | TempPlaylistIdentifier
 
 export type PlaylistLibraryFolder = {
+  id: string
   type: 'folder'
   name: string
   contents: (PlaylistLibraryFolder | PlaylistLibraryIdentifier)[]

--- a/packages/web/src/common/store/ui/createPlaylistModal/actions.ts
+++ b/packages/web/src/common/store/ui/createPlaylistModal/actions.ts
@@ -2,5 +2,9 @@ import { ID } from 'common/models/Identifiers'
 export const OPEN = 'APPLICATION/UI/CREATE_PLAYLIST_MODAL/OPEN'
 export const CLOSE = 'APPLICATION/UI/CREATE_PLAYLIST_MODAL/CLOSE'
 
-export const open = (collectionId?: ID) => ({ type: OPEN, collectionId })
+export const open = (collectionId?: ID, hideFolderTab = false) => ({
+  type: OPEN,
+  collectionId,
+  hideFolderTab
+})
 export const close = () => ({ type: CLOSE })

--- a/packages/web/src/common/store/ui/createPlaylistModal/reducer.ts
+++ b/packages/web/src/common/store/ui/createPlaylistModal/reducer.ts
@@ -5,22 +5,28 @@ import { CreatePlaylistModalState } from './types'
 
 const initialState = {
   isOpen: false,
-  collectionId: null
+  collectionId: null,
+  hideFolderTab: false
 }
 
 const actionsMap = {
-  [OPEN](state: CreatePlaylistModalState, action: { collectionId: ID }) {
+  [OPEN](
+    state: CreatePlaylistModalState,
+    action: { collectionId: ID; hideFolderTab: boolean }
+  ) {
     return {
       ...state,
       isOpen: true,
-      collectionId: action.collectionId
+      collectionId: action.collectionId,
+      hideFolderTab: action.hideFolderTab
     }
   },
   [CLOSE](state: CreatePlaylistModalState) {
     return {
       ...state,
       isOpen: false,
-      collectionId: null
+      collectionId: null,
+      hideFolderTab: false
     }
   }
 }

--- a/packages/web/src/common/store/ui/createPlaylistModal/selectors.ts
+++ b/packages/web/src/common/store/ui/createPlaylistModal/selectors.ts
@@ -7,6 +7,8 @@ export const getBaseState = (state: CommonState) => state.ui.createPlaylistModal
 
 export const getIsOpen = (state: CommonState) => getBaseState(state).isOpen
 export const getId = (state: CommonState) => getBaseState(state).collectionId
+export const getHideFolderTab = (state: CommonState) =>
+  getBaseState(state).hideFolderTab
 
 export const getMetadata = (state: CommonState) => {
   const id = getId(state)

--- a/packages/web/src/common/store/ui/createPlaylistModal/types.ts
+++ b/packages/web/src/common/store/ui/createPlaylistModal/types.ts
@@ -3,4 +3,5 @@ import { ID } from 'common/models/Identifiers'
 export type CreatePlaylistModalState = {
   isOpen: boolean
   collectionId: ID | null
+  hideFolderTab: boolean
 }

--- a/packages/web/src/components/create-playlist/CreatePlaylistModal.tsx
+++ b/packages/web/src/components/create-playlist/CreatePlaylistModal.tsx
@@ -16,7 +16,7 @@ import zIndex from 'utils/zIndex'
 
 import styles from './CreatePlaylistModal.module.css'
 import FolderForm from './FolderForm'
-import PlaylistForm from './PlaylistForm'
+import PlaylistForm, { PlaylistFormFields } from './PlaylistForm'
 
 const messages = {
   createPlaylistTabTitle: 'Create Playlist',
@@ -28,13 +28,17 @@ const INITIAL_TAB = 'create-playlist' as TabName
 
 type CreatePlaylistModalProps = {
   visible?: boolean
+  hideFolderTab?: boolean
   onCancel: () => void
-  onCreatePlaylist: () => void
+  onCreatePlaylist: (metadata: PlaylistFormFields) => void
+  onCreateFolder: (name: string) => void
 }
 
 const CreatePlaylistModal = ({
   visible = true,
+  hideFolderTab = false,
   onCancel,
+  onCreateFolder,
   onCreatePlaylist
 }: CreatePlaylistModalProps) => {
   const { isEnabled: isPlaylistFoldersEnabled } = useFlag(
@@ -103,7 +107,7 @@ const CreatePlaylistModal = ({
         />
       </ModalHeader>
       <ModalContent>
-        {!isPlaylistFoldersEnabled ? null : (
+        {!isPlaylistFoldersEnabled || hideFolderTab ? null : (
           <div className={styles.segmentedControlContainer}>
             <SegmentedControl
               options={tabOptions}
@@ -119,7 +123,7 @@ const CreatePlaylistModal = ({
             onSave={onCreatePlaylist}
           />
         ) : (
-          <FolderForm onSubmit={() => {}} />
+          <FolderForm onSubmit={onCreateFolder} />
         )}
       </ModalContent>
     </Modal>

--- a/packages/web/src/components/create-playlist/PlaylistForm.tsx
+++ b/packages/web/src/components/create-playlist/PlaylistForm.tsx
@@ -22,7 +22,7 @@ const messages = {
   createPlaylistButtonText: 'Create Playlist'
 }
 
-type PlaylistFormFields = Partial<Collection> & {
+export type PlaylistFormFields = Partial<Collection> & {
   artwork: {
     file: Blob
     url: string

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -249,7 +249,7 @@ svg.logo path {
   overflow: hidden;
   list-style: none;
   margin: 0;
-  padding: 0px;
+  padding: 0;
 }
 .navColumn .links .linkGroup {
   margin: 0px 16px 25px;
@@ -288,9 +288,21 @@ svg.logo path {
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: middle;
+  border: 0;
+  background: none;
+  text-align: inherit;
 }
 
-.navColumn .links a.link {
+.navColumn .links .link:hover {
+  cursor: pointer;
+}
+
+.navColumn .links button.link {
+  line-height: unset;
+}
+
+.navColumn .links a.link,
+.navColumn .links button.link {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
@@ -300,6 +312,7 @@ svg.logo path {
 
 .navColumn .links a.link.disabledLink {
   opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .navColumn .links a.link.droppableLink {

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -401,10 +401,10 @@ svg.logo path {
 .updateDotContainer {
   display: flex;
   align-items: center;
-  position: absolute;
-  left: 30px;
+  /* margin left = -(6px width + 4px margin-right on update dot element) so that list items stay aligned */
+  margin-left: -10px;
 }
 
 .updateDotTooltip :global(.ant-tooltip-arrow) {
-  left: 33px;
+  left: 24px;
 }

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -261,7 +261,7 @@ svg.logo path {
   font-size: var(--font-l);
   font-weight: var(--font-heavy);
   line-height: 22px;
-  padding-bottom: 8px;
+  padding-bottom: 2px;
   padding-left: 16px;
   color: var(--nav-column-group-header);
 
@@ -273,14 +273,14 @@ svg.logo path {
 .navColumn .links .link {
   font-size: var(--font-s);
   font-weight: var(--font-medium);
-  line-height: 8px;
   position: relative;
   display: table;
   min-width: 100px;
 
   /* negative margin so the link hover chip shows up. */
   margin-left: -16px;
-  padding: 6px 0 6px 40px;
+  /* left padding is visibly (32px + -16px margin =) 16px to match the left padding of .groupHeader */
+  padding: 6px 0 6px 32px;
   color: var(--nav-column-link);
   transition: color 0.07s ease-in-out;
 
@@ -295,10 +295,6 @@ svg.logo path {
 
 .navColumn .links .link:hover {
   cursor: pointer;
-}
-
-.navColumn .links button.link {
-  line-height: unset;
 }
 
 .navColumn .links a.link,

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
@@ -2,6 +2,41 @@
   transition: opacity 1s ease-in-out;
 }
 
+.folderButtonContentContainer {
+  height: 100%;
+  line-height: unset;
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+}
+
+.folderNameContainer {
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.iconFolder path {
+  align-self: flex-end;
+  fill: none;
+  stroke-width: 1px;
+  stroke: var(--nav-column-link);
+}
+
+.iconFolder {
+  flex-shrink: 0;
+  margin-right: 8px;
+}
+
+.iconCaret {
+  flex-shrink: 0;
+  margin-left: 10px;
+}
+
+.iconFolder.iconFolderUpdated {
+  color: var(--secondary);
+}
+
 .dragging {
   opacity: 0.5;
 }

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -46,12 +46,7 @@ type PlaylistNavLinkProps = NavLinkProps & {
   link?: string
 }
 
-type PlaylistFolderNavButtonProps = React.DetailedHTMLProps<
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  HTMLButtonElement
-> & {
-  name: string
-  id: string
+type PlaylistFolderNavButtonProps = React.ComponentPropsWithoutRef<'button'> & {
   onReorder: () => void
 }
 
@@ -117,6 +112,7 @@ const FolderNavLink = ({
   const onDrop = useCallback(() => {
     setIsDragging(false)
   }, [setIsDragging])
+
   return (
     <Droppable
       key={id}
@@ -158,6 +154,11 @@ const PlaylistFolderNavItem = ({
   draggingKind: string
 }) => {
   const { id, name, contents } = folder
+  const isDroppableKind =
+    draggingKind === 'track' ||
+    draggingKind === 'playlist' ||
+    draggingKind === 'playlist-folder'
+
   return (
     <Droppable
       key={id}
@@ -171,17 +172,9 @@ const PlaylistFolderNavItem = ({
         name={name}
         onReorder={() => {}}
         className={cn(navColumnStyles.link, {
-          [navColumnStyles.droppableLink]:
-            dragging &&
-            (draggingKind === 'track' ||
-              draggingKind === 'playlist' ||
-              draggingKind === 'playlist-folder'),
+          [navColumnStyles.droppableLink]: dragging && isDroppableKind,
           [navColumnStyles.disabledLink]:
-            dragging &&
-            draggingKind !== 'track' &&
-            draggingKind !== 'playlist' &&
-            draggingKind !== 'library-playlist' &&
-            draggingKind !== 'playlist-folder'
+            dragging && !isDroppableKind && draggingKind !== 'library-playlist'
         })}
         onClick={() => {}}
       >

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useState } from 'react'
 
+import { IconCaretRight, IconFolder } from '@audius/stems'
 import cn from 'classnames'
+import { isEmpty } from 'lodash'
 import { useDispatch } from 'react-redux'
 import { NavLink, NavLinkProps } from 'react-router-dom'
 
 import { Name } from 'common/models/Analytics'
 import { SmartCollection } from 'common/models/Collection'
 import { ID } from 'common/models/Identifiers'
+import { PlaylistLibraryFolder } from 'common/models/PlaylistLibrary'
 import { SmartCollectionVariant } from 'common/models/SmartCollectionVariant'
 import { AccountCollection } from 'common/store/account/reducer'
 import {
@@ -32,7 +35,7 @@ import { playlistPage, getPathname } from 'utils/route'
 import navColumnStyles from './NavColumn.module.css'
 import styles from './PlaylistLibrary.module.css'
 
-type DraggableNavLinkProps = NavLinkProps & {
+type PlaylistNavLinkProps = NavLinkProps & {
   droppableKey: ID | SmartCollectionVariant
   playlistId: ID | SmartCollectionVariant
   name: string
@@ -43,7 +46,16 @@ type DraggableNavLinkProps = NavLinkProps & {
   link?: string
 }
 
-const DraggableNavLink = ({
+type PlaylistFolderNavButtonProps = React.DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> & {
+  name: string
+  id: string
+  onReorder: () => void
+}
+
+const PlaylistNavLink = ({
   droppableKey,
   playlistId,
   name,
@@ -52,7 +64,7 @@ const DraggableNavLink = ({
   children,
   className,
   ...navLinkProps
-}: DraggableNavLinkProps) => {
+}: PlaylistNavLinkProps) => {
   const [isDragging, setIsDragging] = useState(false)
   const onDrag = useCallback(() => {
     setIsDragging(true)
@@ -86,6 +98,110 @@ const DraggableNavLink = ({
           {children}
         </NavLink>
       </Draggable>
+    </Droppable>
+  )
+}
+
+const FolderNavLink = ({
+  id,
+  name,
+  onReorder,
+  children,
+  className,
+  ...buttonProps
+}: PlaylistFolderNavButtonProps) => {
+  const [isDragging, setIsDragging] = useState(false)
+  const onDrag = useCallback(() => {
+    setIsDragging(true)
+  }, [setIsDragging])
+  const onDrop = useCallback(() => {
+    setIsDragging(false)
+  }, [setIsDragging])
+  return (
+    <Droppable
+      key={id}
+      className={styles.droppable}
+      hoverClassName={styles.droppableHover}
+      onDrop={(id: ID | SmartCollectionVariant) => onReorder()}
+      acceptedKinds={['library-playlist', 'playlist-folder']}
+    >
+      <Draggable
+        id={id}
+        text={name}
+        kind='playlist-folder'
+        onDrag={onDrag}
+        onDrop={onDrop}
+      >
+        <button
+          {...buttonProps}
+          draggable={false}
+          className={cn(className, styles.navLink, {
+            [styles.dragging]: isDragging
+          })}
+        >
+          {children}
+        </button>
+      </Draggable>
+    </Droppable>
+  )
+}
+
+const PlaylistFolderNavItem = ({
+  folder,
+  hasUpdate = false,
+  dragging,
+  draggingKind
+}: {
+  folder: PlaylistLibraryFolder
+  hasUpdate: boolean
+  dragging: boolean
+  draggingKind: string
+}) => {
+  const { id, name, contents } = folder
+  return (
+    <Droppable
+      key={id}
+      className={navColumnStyles.droppable}
+      hoverClassName={navColumnStyles.droppableHover}
+      onDrop={() => {}}
+      acceptedKinds={['library-playlist']}
+    >
+      <FolderNavLink
+        id={id}
+        name={name}
+        onReorder={() => {}}
+        className={cn(navColumnStyles.link, {
+          [navColumnStyles.droppableLink]:
+            dragging &&
+            (draggingKind === 'track' ||
+              draggingKind === 'playlist' ||
+              draggingKind === 'playlist-folder'),
+          [navColumnStyles.disabledLink]:
+            dragging &&
+            draggingKind !== 'track' &&
+            draggingKind !== 'playlist' &&
+            draggingKind !== 'library-playlist' &&
+            draggingKind !== 'playlist-folder'
+        })}
+        onClick={() => {}}
+      >
+        <div className={styles.folderButtonContentContainer}>
+          <IconFolder
+            width={12}
+            height={12}
+            className={cn(styles.iconFolder, {
+              [styles.iconFolderEmpty]: isEmpty(contents),
+              [styles.iconFolderUpdated]: hasUpdate
+            })}
+          />
+          <div className={styles.folderNameContainer}>
+            <span>{name}</span>
+          </div>
+          <IconCaretRight height={11} width={11} className={styles.iconCaret} />
+        </div>
+      </FolderNavLink>
+
+      {/* Loop over contents and render playlist list */}
     </Droppable>
   )
 }
@@ -124,7 +240,7 @@ const PlaylistLibrary = ({
     const name = playlist.playlist_name
     const url = playlist.link
     return (
-      <DraggableNavLink
+      <PlaylistNavLink
         playlistId={name as SmartCollectionVariant}
         droppableKey={name as SmartCollectionVariant}
         name={name}
@@ -139,7 +255,7 @@ const PlaylistLibrary = ({
         })}
       >
         {name}
-      </DraggableNavLink>
+      </PlaylistNavLink>
     )
   }
 
@@ -172,7 +288,7 @@ const PlaylistLibrary = ({
         acceptedKinds={['track']}
         disabled={!isOwner}
       >
-        <DraggableNavLink
+        <PlaylistNavLink
           droppableKey={id}
           playlistId={id}
           name={name}
@@ -215,7 +331,7 @@ const PlaylistLibrary = ({
           ) : (
             <span>{name}</span>
           )}
-        </DraggableNavLink>
+        </PlaylistNavLink>
       </Droppable>
     )
   }
@@ -236,25 +352,25 @@ const PlaylistLibrary = ({
       {account &&
         playlists &&
         library &&
-        library.contents.map(identifier => {
-          switch (identifier.type) {
+        library.contents.map(content => {
+          switch (content.type) {
             case 'explore_playlist': {
-              const playlist = SMART_COLLECTION_MAP[identifier.playlist_id]
+              const playlist = SMART_COLLECTION_MAP[content.playlist_id]
               if (!playlist) return null
               return renderExplorePlaylist(playlist)
             }
             case 'playlist': {
-              const playlist = playlists[identifier.playlist_id]
+              const playlist = playlists[content.playlist_id]
               if (playlist) {
-                delete playlistsNotInLibrary[identifier.playlist_id]
+                delete playlistsNotInLibrary[content.playlist_id]
               }
               return renderPlaylist(playlist)
             }
             case 'temp_playlist': {
               try {
-                const playlist = playlists[parseInt(identifier.playlist_id)]
+                const playlist = playlists[parseInt(content.playlist_id)]
                 if (playlist) {
-                  delete playlistsNotInLibrary[parseInt(identifier.playlist_id)]
+                  delete playlistsNotInLibrary[parseInt(content.playlist_id)]
                 }
                 return renderPlaylist(playlist)
               } catch (e) {
@@ -263,15 +379,21 @@ const PlaylistLibrary = ({
               }
             }
             case 'folder':
-              // TODO support folders!
-              break
+              return (
+                <PlaylistFolderNavItem
+                  folder={content}
+                  hasUpdate={false}
+                  dragging={dragging}
+                  draggingKind={draggingKind}
+                />
+              )
           }
           return null
         })}
       {Object.values(playlistsNotInLibrary).map(playlist => {
         return renderPlaylist(playlist)
       })}
-      {playlists && Object.keys(playlists).length === 0 ? (
+      {library && isEmpty(library.contents) ? (
         <div className={cn(navColumnStyles.link, navColumnStyles.disabled)}>
           Create your first playlist!
         </div>

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -1058,7 +1058,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     fetchFollowUsers: (followGroup: any, limit: number, offset: number) =>
       dispatch(profileActions.fetchFollowUsers(followGroup, limit, offset)),
 
-    openCreatePlaylistModal: () => dispatch(createPlaylistModalActions.open()),
+    openCreatePlaylistModal: () =>
+      dispatch(createPlaylistModalActions.open(undefined, true)),
     setNotificationSubscription: (userId: ID, isSubscribed: boolean) =>
       dispatch(
         profileActions.setNotificationSubscription(userId, isSubscribed, true)

--- a/packages/web/src/pages/saved-page/components/mobile/NewPlaylistButton.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/NewPlaylistButton.tsx
@@ -51,7 +51,7 @@ function mapStateToProps(state: AppState) {
 
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
-    open: () => dispatch(createPlaylistActions.open())
+    open: () => dispatch(createPlaylistActions.open(undefined, true))
   }
 }
 

--- a/packages/web/src/store/playlist-library/helpers.ts
+++ b/packages/web/src/store/playlist-library/helpers.ts
@@ -122,13 +122,13 @@ export const removeFromPlaylistLibrary = (
 
 export const constructPlaylistFolder = (
   name: string,
-  contents?: (PlaylistLibraryFolder | PlaylistLibraryIdentifier)[]
+  contents: (PlaylistLibraryFolder | PlaylistLibraryIdentifier)[] = []
 ): PlaylistLibraryFolder => {
   return {
     id: uuid(),
     type: 'folder',
     name,
-    contents: contents || []
+    contents: contents
   }
 }
 

--- a/packages/web/src/store/playlist-library/helpers.ts
+++ b/packages/web/src/store/playlist-library/helpers.ts
@@ -5,6 +5,7 @@ import {
   PlaylistLibraryIdentifier
 } from 'common/models/PlaylistLibrary'
 import { SmartCollectionVariant } from 'common/models/SmartCollectionVariant'
+import { uuid } from 'common/utils/uid'
 
 /**
  * Finds an item by id in the playlist library
@@ -90,6 +91,7 @@ export const removeFromPlaylistLibrary = (
         const res = removeFromPlaylistLibrary(item, playlistId)
         removed = res.removed
         newItem = {
+          id: item.id,
           type: item.type,
           name: item.name,
           contents: res.library.contents
@@ -115,6 +117,34 @@ export const removeFromPlaylistLibrary = (
       contents: newContents
     },
     removed
+  }
+}
+
+export const constructPlaylistFolder = (
+  name: string,
+  contents?: (PlaylistLibraryFolder | PlaylistLibraryIdentifier)[]
+): PlaylistLibraryFolder => {
+  return {
+    id: uuid(),
+    type: 'folder',
+    name,
+    contents: contents || []
+  }
+}
+
+/**
+ * Adds new folder to a playlist library and returns the result.
+ * Does not mutate.
+ * @param library
+ * @param folder
+ */
+export const addFolderToLibrary = (
+  library: PlaylistLibrary | null,
+  folder: PlaylistLibraryFolder
+): PlaylistLibrary => {
+  return {
+    ...(library || {}),
+    contents: [...(library?.contents || []), folder]
   }
 }
 


### PR DESCRIPTION
### Description
-Functionality for creating playlist folder (note - drag/drop not implemented but some starter code is in there)
-Hide folder tab if the modal isn't opened from the desktop sidebar 

Note these changes are reliant [on schema changes](https://github.com/AudiusProject/audius-protocol/pull/2610). 

[Designs
](https://www.figma.com/file/u8UHdkD60030aqsRkItWUV/Playlist-Folders?node-id=101%3A141)

![folders](https://user-images.githubusercontent.com/36916764/155570111-de4040a0-0c15-4d98-8909-63773b0f8c08.gif)


### Dragons
-Product should be unchanged if the feature flag `playlist_folders` is not on
*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
-Try creating playlist folder in browser

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
