### PR TITLE
Allow editing playlists from the sidebar

### DIFF
--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.module.css
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.module.css
@@ -5,3 +5,9 @@
   overflow-y: visible !important;
   overflow-x: visible !important;
 }
+
+.spinner {
+  margin: 0 auto;
+  width: 100px;
+  height: 100px;
+}

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -398,9 +398,12 @@ svg.logo path {
   height: 18px;
 }
 
-.updateDotContainer {
+.playlistLinkContentContainer {
   display: flex;
   align-items: center;
+}
+
+.updateDotContainer {
   /* margin left = -(6px width + 4px margin-right on update dot element) so that list items stay aligned */
   margin-left: -10px;
 }

--- a/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useState } from 'react'
+
+import {
+  IconCaretRight,
+  IconFolder,
+  IconFolderOutline,
+  IconKebabHorizontal
+} from '@audius/stems'
+import cn from 'classnames'
+import { isEmpty } from 'lodash'
+
+import { ID } from 'common/models/Identifiers'
+import { PlaylistLibraryFolder } from 'common/models/PlaylistLibrary'
+import { SmartCollectionVariant } from 'common/models/SmartCollectionVariant'
+import Draggable from 'components/dragndrop/Draggable'
+import Droppable from 'components/dragndrop/Droppable'
+import IconButton from 'components/icon-button/IconButton'
+
+import navColumnStyles from './NavColumn.module.css'
+import styles from './PlaylistLibrary.module.css'
+
+type PlaylistFolderNavButtonProps = React.ComponentPropsWithoutRef<'button'> & {
+  onReorder: () => void
+}
+
+const FolderNavLink = ({
+  id,
+  name,
+  onReorder,
+  children,
+  className,
+  ...buttonProps
+}: PlaylistFolderNavButtonProps) => {
+  const [isDragging, setIsDragging] = useState(false)
+  const onDrag = useCallback(() => {
+    setIsDragging(true)
+  }, [setIsDragging])
+  const onDrop = useCallback(() => {
+    setIsDragging(false)
+  }, [setIsDragging])
+
+  return (
+    <Droppable
+      key={id}
+      className={styles.droppable}
+      hoverClassName={styles.droppableHover}
+      onDrop={(id: ID | SmartCollectionVariant) => onReorder()}
+      acceptedKinds={['library-playlist', 'playlist-folder']}
+    >
+      <Draggable
+        id={id}
+        text={name}
+        kind='playlist-folder'
+        onDrag={onDrag}
+        onDrop={onDrop}
+      >
+        <button
+          {...buttonProps}
+          draggable={false}
+          className={cn(className, styles.folderButton, styles.navLink, {
+            [styles.dragging]: isDragging
+          })}
+        >
+          {children}
+        </button>
+      </Draggable>
+    </Droppable>
+  )
+}
+
+export const PlaylistFolderNavItem = ({
+  folder,
+  hasUpdate = false,
+  dragging,
+  draggingKind,
+  onClickEdit
+}: {
+  folder: PlaylistLibraryFolder
+  hasUpdate: boolean
+  dragging: boolean
+  draggingKind: string
+  onClickEdit: (folderId: string) => void
+}) => {
+  const { id, name, contents } = folder
+  const isDroppableKind =
+    draggingKind === 'track' ||
+    draggingKind === 'playlist' ||
+    draggingKind === 'playlist-folder'
+  const [isHovering, setIsHovering] = useState(false)
+
+  return (
+    <Droppable
+      key={id}
+      className={navColumnStyles.droppable}
+      hoverClassName={navColumnStyles.droppableHover}
+      onDrop={() => {}}
+      acceptedKinds={['library-playlist']}
+    >
+      <FolderNavLink
+        onMouseEnter={() => {
+          setIsHovering(true)
+        }}
+        onMouseLeave={() => setIsHovering(false)}
+        id={id}
+        name={name}
+        onReorder={() => {}}
+        className={cn(navColumnStyles.link, {
+          [navColumnStyles.droppableLink]: dragging && isDroppableKind,
+          [navColumnStyles.disabledLink]:
+            dragging && !isDroppableKind && draggingKind !== 'library-playlist'
+        })}
+        onClick={() => {}}
+      >
+        <div className={styles.folderButtonContentContainer}>
+          {isEmpty(contents) ? (
+            <IconFolderOutline
+              width={12}
+              height={12}
+              className={styles.iconFolder}
+            />
+          ) : (
+            <IconFolder
+              width={12}
+              height={12}
+              className={cn(styles.iconFolder, {
+                [styles.iconFolderUpdated]: hasUpdate
+              })}
+            />
+          )}
+          <div className={styles.folderNameContainer}>
+            <span>{name}</span>
+          </div>
+          <IconCaretRight height={11} width={11} className={styles.iconCaret} />
+          <IconButton
+            className={cn(styles.iconKebabHorizontal, {
+              [styles.hidden]: !isHovering || dragging
+            })}
+            icon={<IconKebabHorizontal height={11} width={11} />}
+            onClick={e => {
+              e.preventDefault()
+              e.stopPropagation()
+              onClickEdit(id)
+            }}
+          />
+        </div>
+      </FolderNavLink>
+
+      {/* Loop over contents and render playlist list */}
+    </Droppable>
+  )
+}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
@@ -36,7 +36,7 @@
 .iconKebabHorizontal {
   color: var(--nav-column-link);
   opacity: 100;
-  transition: all 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
 }
 
 .iconKebabHorizontal:hover,

--- a/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
@@ -1,0 +1,182 @@
+import React, { useCallback, useState } from 'react'
+
+import { IconKebabHorizontal } from '@audius/stems'
+import cn from 'classnames'
+import { NavLink, NavLinkProps } from 'react-router-dom'
+
+import { ID } from 'common/models/Identifiers'
+import { SmartCollectionVariant } from 'common/models/SmartCollectionVariant'
+import { AccountCollection } from 'common/store/account/reducer'
+import Draggable from 'components/dragndrop/Draggable'
+import Droppable from 'components/dragndrop/Droppable'
+import IconButton from 'components/icon-button/IconButton'
+import Tooltip from 'components/tooltip/Tooltip'
+import UpdateDot from 'components/update-dot/UpdateDot'
+import { getPathname } from 'utils/route'
+
+import navColumnStyles from './NavColumn.module.css'
+import styles from './PlaylistLibrary.module.css'
+
+const messages = { recentlyUpdatedTooltip: 'Recently Updated' }
+
+type PlaylistNavLinkProps = NavLinkProps & {
+  droppableKey: ID | SmartCollectionVariant
+  playlistId: ID | SmartCollectionVariant
+  name: string
+  onReorder: (
+    draggingId: ID | SmartCollectionVariant,
+    droppingId: ID | SmartCollectionVariant
+  ) => void
+  link?: string
+}
+
+export const PlaylistNavLink = ({
+  droppableKey,
+  playlistId,
+  name,
+  link,
+  onReorder,
+  children,
+  className,
+  ...navLinkProps
+}: PlaylistNavLinkProps) => {
+  const [isDragging, setIsDragging] = useState(false)
+  const onDrag = useCallback(() => {
+    setIsDragging(true)
+  }, [setIsDragging])
+  const onDrop = useCallback(() => {
+    setIsDragging(false)
+  }, [setIsDragging])
+  return (
+    <Droppable
+      key={droppableKey}
+      className={styles.droppable}
+      hoverClassName={styles.droppableHover}
+      onDrop={(id: ID | SmartCollectionVariant) => onReorder(id, playlistId)}
+      acceptedKinds={['library-playlist']}
+    >
+      <Draggable
+        id={playlistId}
+        text={name}
+        link={link}
+        kind='library-playlist'
+        onDrag={onDrag}
+        onDrop={onDrop}
+      >
+        <NavLink
+          {...navLinkProps}
+          draggable={false}
+          className={cn(className, styles.navLink, {
+            [styles.dragging]: isDragging
+          })}
+        >
+          {children}
+        </NavLink>
+      </Draggable>
+    </Droppable>
+  )
+}
+
+type PlaylistNavItemProps = {
+  playlist: AccountCollection
+  url: string
+  addTrack: (trackId: ID) => void
+  isOwner: boolean
+  onReorder: (
+    draggingId: ID | SmartCollectionVariant,
+    droppingId: ID | SmartCollectionVariant
+  ) => void
+  hasUpdate?: boolean
+  dragging: boolean
+  draggingKind: string
+  onClickPlaylist: (id: ID, hasUpdate: boolean) => void
+  onClickEdit?: (id: ID) => void
+}
+export const PlaylistNavItem = ({
+  playlist,
+  hasUpdate = false,
+  url,
+  addTrack,
+  isOwner,
+  onReorder,
+  dragging,
+  draggingKind,
+  onClickPlaylist,
+  onClickEdit
+}: PlaylistNavItemProps) => {
+  const { id, name } = playlist
+  const [isHovering, setIsHovering] = useState(false)
+
+  return (
+    <Droppable
+      key={id}
+      className={navColumnStyles.droppable}
+      hoverClassName={navColumnStyles.droppableHover}
+      onDrop={addTrack}
+      acceptedKinds={['track']}
+      disabled={!isOwner}
+    >
+      <PlaylistNavLink
+        droppableKey={id}
+        playlistId={id}
+        name={name}
+        link={url}
+        to={url}
+        onReorder={onReorder}
+        isActive={() => url === getPathname()}
+        activeClassName='active'
+        className={cn(navColumnStyles.link, {
+          [navColumnStyles.playlistUpdate]: hasUpdate,
+          [navColumnStyles.droppableLink]:
+            isOwner &&
+            dragging &&
+            (draggingKind === 'track' || draggingKind === 'playlist'),
+          [navColumnStyles.disabledLink]:
+            dragging &&
+            ((draggingKind !== 'track' &&
+              draggingKind !== 'playlist' &&
+              draggingKind !== 'library-playlist') ||
+              !isOwner)
+        })}
+        onClick={() => onClickPlaylist(id, hasUpdate)}
+        onMouseEnter={() => {
+          setIsHovering(true)
+        }}
+        onMouseLeave={() => setIsHovering(false)}
+      >
+        <div className={navColumnStyles.playlistLinkContentContainer}>
+          {!hasUpdate ? null : (
+            <div className={navColumnStyles.updateDotContainer}>
+              <Tooltip
+                className={navColumnStyles.updateDotTooltip}
+                shouldWrapContent={true}
+                shouldDismissOnClick={false}
+                mount={null}
+                mouseEnterDelay={0.1}
+                text={messages.recentlyUpdatedTooltip}
+              >
+                <div>
+                  <UpdateDot />
+                </div>
+              </Tooltip>
+            </div>
+          )}
+          <span>{name}</span>
+          {!isOwner || !onClickEdit ? null : (
+            <IconButton
+              className={cn(styles.iconKebabHorizontal, {
+                [styles.hidden]: !isHovering || dragging
+              })}
+              icon={<IconKebabHorizontal height={11} width={11} />}
+              onClick={e => {
+                e.preventDefault()
+                e.stopPropagation()
+                onClickEdit(id)
+              }}
+            />
+          )}
+        </div>
+      </PlaylistNavLink>
+    </Droppable>
+  )
+}


### PR DESCRIPTION
### Description
Allow editing playlists from sidebar (desktop)

See designs [here](https://www.figma.com/proto/u8UHdkD60030aqsRkItWUV/Playlist-Folders?page-id=101%3A141&node-id=748%3A4421&viewport=282%2C48%2C0.08&scaling=min-zoom&starting-point-node-id=748%3A4421&show-proto-sidebar=1)

![editplaylistfromsidebar](https://user-images.githubusercontent.com/36916764/156046848-6a30990e-ca22-4080-95c0-dea70e48c04d.gif)

This addition is guarded under the `playlist_folders` feature flag

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*
Make sure this doesn't break any existing playlist UI/functionality

### How Has This Been Tested?
Tested in browser

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?
Adding Amplitude events in one PR after reaching feature completion

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
