### PR TITLE
[AUD-1632] ProfileScreen performance

### DIFF
--- a/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
+++ b/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
@@ -1,7 +1,6 @@
-import { getProfileUser } from 'audius-client/src/common/store/pages/profile/selectors'
 import { Text, View } from 'react-native'
 
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { useProfile } from 'app/hooks/selectors'
 import { makeStyles } from 'app/styles'
 
 import { AppDrawer } from '../drawer/AppDrawer'
@@ -68,7 +67,8 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
 export const TiersExplainerDrawer = () => {
   const styles = useStyles()
 
-  const profile = useSelectorWeb(getProfileUser)
+  const profile = useProfile()
+
   if (!profile) return null
 
   const tier = getUserAudioTier(profile)

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -220,6 +220,7 @@ export const Lineup = ({
     index: number
     item: LineupItem | LoadingLineupItem
   }) => {
+    if (!item) return null
     if ('_loading' in item) {
       if (item._loading) {
         return (

--- a/packages/mobile/src/hooks/selectors.ts
+++ b/packages/mobile/src/hooks/selectors.ts
@@ -1,0 +1,19 @@
+import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
+import { getProfileUser } from 'audius-client/src/common/store/pages/profile/selectors'
+import { isEmpty } from 'lodash'
+
+import { useSelectorWeb } from './useSelectorWeb'
+
+export const useProfile = () => {
+  return useSelectorWeb(
+    getProfileUser,
+    (a, b) =>
+      a?.user_id === b?.user_id &&
+      isEmpty(a?._cover_photo_sizes) === isEmpty(b?._cover_photo_sizes) &&
+      isEmpty(a?._profile_picture_sizes) === isEmpty(b?._profile_picture_sizes)
+  )
+}
+
+export const useAccountUser = () => {
+  return useSelectorWeb(getAccountUser, (a, b) => a?.user_id === b?.user_id)
+}

--- a/packages/mobile/src/hooks/selectors.ts
+++ b/packages/mobile/src/hooks/selectors.ts
@@ -1,19 +1,13 @@
 import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
 import { getProfileUser } from 'audius-client/src/common/store/pages/profile/selectors'
-import { isEmpty } from 'lodash'
+import { isEqual } from 'lodash'
 
 import { useSelectorWeb } from './useSelectorWeb'
 
 export const useProfile = () => {
-  return useSelectorWeb(
-    getProfileUser,
-    (a, b) =>
-      a?.user_id === b?.user_id &&
-      isEmpty(a?._cover_photo_sizes) === isEmpty(b?._cover_photo_sizes) &&
-      isEmpty(a?._profile_picture_sizes) === isEmpty(b?._profile_picture_sizes)
-  )
+  return useSelectorWeb(getProfileUser, isEqual)
 }
 
 export const useAccountUser = () => {
-  return useSelectorWeb(getAccountUser, (a, b) => a?.user_id === b?.user_id)
+  return useSelectorWeb(getAccountUser, isEqual)
 }

--- a/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
@@ -1,14 +1,12 @@
 import { useMemo } from 'react'
 
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
-
-import { CollectionList } from '../../components/collection-list/CollectionList'
+import { CollectionList } from 'app/components/collection-list/CollectionList'
 
 import { useEmptyProfileText } from './EmptyProfileTile'
-import { getProfile } from './selectors'
+import { useProfileAlbums } from './selectors'
 
 export const AlbumsTab = () => {
-  const { profile, albums } = useSelectorWeb(getProfile)
+  const { profile, albums } = useProfileAlbums()
 
   const userAlbums = useMemo(() => {
     if (profile && albums) {

--- a/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
+++ b/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback } from 'react'
 
 import { FollowSource } from 'audius-client/src/common/models/Analytics'
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import {
   followUser,
   unfollowUser
@@ -66,7 +66,7 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
 }))
 
 type ArtistRecommendationsProps = {
-  profile: ProfileUser
+  profile: User
   onClose: () => void
 }
 
@@ -90,8 +90,9 @@ export const ArtistRecommendations = (props: ArtistRecommendationsProps) => {
     )
   })
 
-  const suggestedArtists = useSelectorWeb(state =>
-    getRelatedArtistIds(state, { id: user_id })
+  const suggestedArtists = useSelectorWeb(
+    state => getRelatedArtistIds(state, { id: user_id }),
+    (a, b) => a.length === b.length
   )
 
   const isFollowingAllArtists = suggestedArtists.every(

--- a/packages/mobile/src/screens/profile-screen/CoverPhoto.tsx
+++ b/packages/mobile/src/screens/profile-screen/CoverPhoto.tsx
@@ -1,5 +1,5 @@
 import { WidthSizes } from 'audius-client/src/common/models/ImageSizes'
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 
 import BadgeArtist from 'app/assets/images/badgeArtist.svg'
 import { DynamicImage } from 'app/components/core'
@@ -21,7 +21,7 @@ const useStyles = makeStyles(({ spacing }) => ({
 }))
 
 type CoverPhotoProps = {
-  profile: ProfileUser
+  profile: User
 }
 
 export const CoverPhoto = ({ profile }: CoverPhotoProps) => {

--- a/packages/mobile/src/screens/profile-screen/EmptyProfileTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/EmptyProfileTile.tsx
@@ -1,9 +1,8 @@
 import { User } from 'audius-client/src/common/models/User'
-import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
 import { Nullable } from 'audius-client/src/common/utils/typeUtils'
 
 import { EmptyTile } from 'app/components/core'
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { useAccountUser } from 'app/hooks/selectors'
 
 const messages = {
   you: 'You',
@@ -18,7 +17,7 @@ const messages = {
 type Tab = 'tracks' | 'albums' | 'playlists' | 'reposts'
 
 export const useEmptyProfileText = (profile: Nullable<User>, tab: Tab) => {
-  const accountUser = useSelectorWeb(getAccountUser)
+  const accountUser = useAccountUser()
 
   if (!profile) return ''
   const { user_id, name } = profile

--- a/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
+++ b/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import {
   Pressable,
   View,
@@ -40,7 +40,7 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
 }))
 
 type ExpandableBioProps = {
-  profile: ProfileUser
+  profile: User
 }
 
 export const ExpandableBio = ({ profile }: ExpandableBioProps) => {

--- a/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
@@ -1,14 +1,12 @@
 import { useMemo } from 'react'
 
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
-
-import { CollectionList } from '../../components/collection-list/CollectionList'
+import { CollectionList } from 'app/components/collection-list'
 
 import { useEmptyProfileText } from './EmptyProfileTile'
-import { getProfile } from './selectors'
+import { useProfilePlaylists } from './selectors'
 
 export const PlaylistsTab = () => {
-  const { profile, playlists } = useSelectorWeb(getProfile)
+  const { profile, playlists } = useProfilePlaylists()
 
   const userPlaylists = useMemo(() => {
     if (profile && playlists) {

--- a/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import { setVisibility } from 'audius-client/src/common/store/ui/modals/slice'
 import { View, Text } from 'react-native'
 
@@ -47,7 +47,7 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
 }))
 
 type ProfileBadgeProps = {
-  profile: ProfileUser
+  profile: User
 }
 
 export const ProfileBadge = ({ profile }: ProfileBadgeProps) => {

--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -1,9 +1,8 @@
-import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import { View, Text } from 'react-native'
 
 import { FollowButton } from 'app/components/user'
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { useAccountUser } from 'app/hooks/selectors'
 import { makeStyles } from 'app/styles'
 
 import { EditProfileButton } from './EditProfileButton'
@@ -51,7 +50,7 @@ const messages = {
 }
 
 type ProfileInfoProps = {
-  profile: ProfileUser
+  profile: User
   onFollow: () => void
 }
 
@@ -59,7 +58,7 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
   const { profile, onFollow } = props
   const styles = useStyles()
   const { does_current_user_follow, does_follow_current_user } = profile
-  const accountUser = useSelectorWeb(getAccountUser)
+  const accountUser = useAccountUser()
   const isOwner = accountUser?.user_id === profile.user_id
 
   return (

--- a/packages/mobile/src/screens/profile-screen/ProfileMetrics.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileMetrics.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import { setFollowers } from 'audius-client/src/common/store/user-list/followers/actions'
 import { setFollowing } from 'audius-client/src/common/store/user-list/following/actions'
 import { Pressable, Text, View } from 'react-native'
@@ -43,7 +43,7 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
 }))
 
 type ProfileMetricsProps = {
-  profile: ProfileUser
+  profile: User
 }
 
 export const ProfileMetrics = ({ profile }: ProfileMetricsProps) => {

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
 import { LayoutAnimation, View } from 'react-native'
 import { useToggle } from 'react-use'
 
@@ -9,8 +8,8 @@ import IconSettings from 'app/assets/images/iconSettings.svg'
 import { TopBarIconButton } from 'app/components/app-navigator/TopBarIconButton'
 import { Screen, VirtualizedScrollView } from 'app/components/core'
 import { ProfilePhoto } from 'app/components/user'
+import { useAccountUser, useProfile } from 'app/hooks/selectors'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles/makeStyles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -22,7 +21,6 @@ import { ProfileMetrics } from './ProfileMetrics'
 import { ProfileSocials } from './ProfileSocials'
 import { ProfileTabNavigator } from './ProfileTabNavigator'
 import { UploadTrackButton } from './UploadTrackButton'
-import { getProfile } from './selectors'
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
   header: {
@@ -50,26 +48,27 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 
 export const ProfileScreen = () => {
   const styles = useStyles()
-  const { profile } = useSelectorWeb(getProfile)
-  const accountUser = useSelectorWeb(getAccountUser)
+  const profile = useProfile()
+  const accountUser = useAccountUser()
+
   const [hasUserFollowed, setHasUserFollowed] = useToggle(false)
   const { accentOrange } = useThemeColors()
 
   const navigation = useNavigation()
 
-  const handleNavigateSettings = () => {
+  const handleNavigateSettings = useCallback(() => {
     navigation.push({
       native: { screen: 'SettingsScreen', params: undefined },
       web: { route: '/settings' }
     })
-  }
+  }, [navigation])
 
-  const handleNavigateAudio = () => {
+  const handleNavigateAudio = useCallback(() => {
     navigation.push({
       native: { screen: 'AudioScreen', params: undefined },
       web: { route: '/audio ' }
     })
-  }
+  }, [navigation])
 
   const handleFollow = useCallback(() => {
     if (!profile?.does_current_user_follow) {

--- a/packages/mobile/src/screens/profile-screen/ProfileSocials.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileSocials.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import { View } from 'react-native'
 
 import IconInstagram from 'app/assets/images/iconInstagram.svg'
@@ -28,7 +28,7 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 }))
 
 type ProfileSocialsProps = {
-  profile: ProfileUser
+  profile: User
 }
 
 export const ProfileSocials = ({ profile }: ProfileSocialsProps) => {

--- a/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
@@ -1,4 +1,4 @@
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 
 import IconAlbum from 'app/assets/images/iconAlbum.svg'
 import IconCollectibles from 'app/assets/images/iconCollectibles.svg'
@@ -18,7 +18,7 @@ import { TracksTab } from './TracksTab'
 import { useShouldShowCollectiblesTab } from './utils'
 
 type ProfileTabNavigatiorProps = {
-  profile: ProfileUser
+  profile: User
 }
 
 export const ProfileTabNavigator = ({ profile }: ProfileTabNavigatiorProps) => {

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -1,18 +1,14 @@
-import { makeGetLineupMetadatas } from 'audius-client/src/common/store/lineup/selectors'
 import { feedActions } from 'audius-client/src/common/store/pages/profile/lineups/feed/actions'
-import { getProfileFeedLineup } from 'audius-client/src/common/store/pages/profile/selectors'
 
 import { Lineup } from 'app/components/lineup'
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { useProfile } from 'app/hooks/selectors'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
-import { getProfile } from './selectors'
-
-const getUserFeedMetadatas = makeGetLineupMetadatas(getProfileFeedLineup)
+import { useProfileFeedLineup } from './selectors'
 
 export const RepostsTab = () => {
-  const { profile } = useSelectorWeb(getProfile)
-  const lineup = useSelectorWeb(getUserFeedMetadatas)
+  const profile = useProfile()
+  const lineup = useProfileFeedLineup()
 
   if (!profile) return null
 

--- a/packages/mobile/src/screens/profile-screen/Sites.tsx
+++ b/packages/mobile/src/screens/profile-screen/Sites.tsx
@@ -1,4 +1,4 @@
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import { View, Text } from 'react-native'
 
 import IconDonate from 'app/assets/images/iconDonate.svg'
@@ -6,10 +6,6 @@ import IconLink from 'app/assets/images/iconLink.svg'
 import { Link } from 'app/components/core'
 import { makeStyles } from 'app/styles/makeStyles'
 import { useThemeColors } from 'app/utils/theme'
-
-type SitesProps = {
-  profile: ProfileUser
-}
 
 const useStyles = makeStyles(({ spacing, palette }) => ({
   sites: {
@@ -27,6 +23,10 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
     color: palette.neutral
   }
 }))
+
+type SitesProps = {
+  profile: User
+}
 
 export const Sites = ({ profile }: SitesProps) => {
   const styles = useStyles()

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -1,18 +1,17 @@
 import { useCallback } from 'react'
 
 import { tracksActions } from 'audius-client/src/common/store/pages/profile/lineups/tracks/actions'
-import { getProfileTracksLineup } from 'audius-client/src/common/store/pages/profile/selectors'
 
 import { Lineup } from 'app/components/lineup'
+import { useProfile } from 'app/hooks/selectors'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
-import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
-import { getProfile } from './selectors'
+import { useProfileTracksLineup } from './selectors'
 
 export const TracksTab = () => {
-  const { profile } = useSelectorWeb(getProfile)
-  const lineup = useSelectorWeb(getProfileTracksLineup)
+  const profile = useProfile()
+  const lineup = useProfileTracksLineup()
   const dispatchWeb = useDispatchWeb()
 
   const loadMore = useCallback(

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -1,58 +1,25 @@
-import { Collection } from 'audius-client/src/common/models/Collection'
 import { makeGetLineupMetadatas } from 'audius-client/src/common/store/lineup/selectors'
 import {
   getProfileFeedLineup,
   getProfileTracksLineup,
   makeGetProfile
 } from 'audius-client/src/common/store/pages/profile/selectors'
-import { Nullable } from 'audius-client/src/common/utils/typeUtils'
-import { isEmpty } from 'lodash'
+import { isEqual } from 'lodash'
 
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 export const getProfile = makeGetProfile()
 
 export const useProfileTracksLineup = () => {
-  return useSelectorWeb(getProfileTracksLineup, (a, b) => {
-    return a.entries.length === b.entries.length
-  })
+  return useSelectorWeb(getProfileTracksLineup, isEqual)
 }
 
-const hasCoverArt = (collection: Collection) =>
-  !isEmpty(collection._cover_art_sizes)
+export const useProfileAlbums = () => useSelectorWeb(getProfile, isEqual)
 
-const areCollectionsEqual = (
-  a?: Nullable<Collection[]>,
-  b?: Nullable<Collection[]>
-) => {
-  return Boolean(
-    a &&
-      b &&
-      a.length === b.length &&
-      a.filter(hasCoverArt).length === b.filter(hasCoverArt).length
-  )
-}
-
-export const useProfileAlbums = () =>
-  useSelectorWeb(getProfile, (a, b) => {
-    return (
-      a.profile?.user_id === b.profile?.user_id &&
-      areCollectionsEqual(a?.albums, b?.albums)
-    )
-  })
-
-export const useProfilePlaylists = () =>
-  useSelectorWeb(getProfile, (a, b) => {
-    return (
-      a.profile?.user_id === b.profile?.user_id &&
-      areCollectionsEqual(a?.playlists, b?.playlists)
-    )
-  })
+export const useProfilePlaylists = () => useSelectorWeb(getProfile, isEqual)
 
 const getUserFeedMetadatas = makeGetLineupMetadatas(getProfileFeedLineup)
 
 export const useProfileFeedLineup = () => {
-  return useSelectorWeb(getUserFeedMetadatas, (a, b) => {
-    return a.entries.length === b.entries.length
-  })
+  return useSelectorWeb(getUserFeedMetadatas, isEqual)
 }

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -1,3 +1,58 @@
-import { makeGetProfile } from 'audius-client/src/common/store/pages/profile/selectors'
+import { Collection } from 'audius-client/src/common/models/Collection'
+import { makeGetLineupMetadatas } from 'audius-client/src/common/store/lineup/selectors'
+import {
+  getProfileFeedLineup,
+  getProfileTracksLineup,
+  makeGetProfile
+} from 'audius-client/src/common/store/pages/profile/selectors'
+import { Nullable } from 'audius-client/src/common/utils/typeUtils'
+import { isEmpty } from 'lodash'
+
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 export const getProfile = makeGetProfile()
+
+export const useProfileTracksLineup = () => {
+  return useSelectorWeb(getProfileTracksLineup, (a, b) => {
+    return a.entries.length === b.entries.length
+  })
+}
+
+const hasCoverArt = (collection: Collection) =>
+  !isEmpty(collection._cover_art_sizes)
+
+const areCollectionsEqual = (
+  a?: Nullable<Collection[]>,
+  b?: Nullable<Collection[]>
+) => {
+  return Boolean(
+    a &&
+      b &&
+      a.length === b.length &&
+      a.filter(hasCoverArt).length === b.filter(hasCoverArt).length
+  )
+}
+
+export const useProfileAlbums = () =>
+  useSelectorWeb(getProfile, (a, b) => {
+    return (
+      a.profile?.user_id === b.profile?.user_id &&
+      areCollectionsEqual(a?.albums, b?.albums)
+    )
+  })
+
+export const useProfilePlaylists = () =>
+  useSelectorWeb(getProfile, (a, b) => {
+    return (
+      a.profile?.user_id === b.profile?.user_id &&
+      areCollectionsEqual(a?.playlists, b?.playlists)
+    )
+  })
+
+const getUserFeedMetadatas = makeGetLineupMetadatas(getProfileFeedLineup)
+
+export const useProfileFeedLineup = () => {
+  return useSelectorWeb(getUserFeedMetadatas, (a, b) => {
+    return a.entries.length === b.entries.length
+  })
+}

--- a/packages/mobile/src/screens/profile-screen/utils.ts
+++ b/packages/mobile/src/screens/profile-screen/utils.ts
@@ -1,14 +1,14 @@
 import { useMemo } from 'react'
 
 import { ID } from 'audius-client/src/common/models/Identifiers'
-import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
-import { ProfileUser } from 'audius-client/src/common/store/pages/profile/types'
+import { User } from 'audius-client/src/common/models/User'
 import { Nullable } from 'audius-client/src/common/utils/typeUtils'
 import {
   badgeTiers,
   makeGetTierAndVerifiedForUser
 } from 'audius-client/src/components/user-badges/utils'
 
+import { useAccountUser } from 'app/hooks/selectors'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { MIN_COLLECTIBLES_TIER } from './constants'
@@ -39,7 +39,7 @@ export const useSelectTierInfo = (userId: ID) => {
  * If the user is viewing their own profile, the collectibles don't
  * need to be ordered
  */
-export const useShouldShowCollectiblesTab = (profile: ProfileUser) => {
+export const useShouldShowCollectiblesTab = (profile: User) => {
   const {
     user_id,
     has_collectibles,
@@ -47,7 +47,7 @@ export const useShouldShowCollectiblesTab = (profile: ProfileUser) => {
     solanaCollectibleList,
     collectibles
   } = profile
-  const accountUser = useSelectorWeb(getAccountUser)
+  const accountUser = useAccountUser()
   const { tierNumber } = useSelectTierInfo(user_id)
 
   const hasCollectiblesTierRequirement =

--- a/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
+++ b/packages/mobile/src/screens/trending-screen/TrendingLineup.tsx
@@ -15,7 +15,6 @@ import {
   getDiscoverTrendingMonthLineup,
   getDiscoverTrendingWeekLineup
 } from 'audius-client/src/common/store/pages/trending/selectors'
-import { isEqual } from 'lodash'
 
 import { Lineup } from 'app/components/lineup'
 import { LineupProps } from 'app/components/lineup/types'
@@ -55,7 +54,10 @@ type TrendingLineupProps = BaseLineupProps & {
 
 export const TrendingLineup = (props: TrendingLineupProps) => {
   const { timeRange, ...other } = props
-  const trendingLineup = useSelectorWeb(selectorsMap[timeRange], isEqual)
+  const trendingLineup = useSelectorWeb(
+    selectorsMap[timeRange],
+    (a, b) => a.entries.length === b.entries.length
+  )
   const [isRefreshing, setIsRefreshing] = useState(false)
   const navigation = useNavigation()
   const dispatchWeb = useDispatchWeb()


### PR DESCRIPTION
### Description

Cuts down profile page rerenders from 60 (at the root) to 3 for the entire profile stack
- Uses hook selector hybrids to share equality functions, but open to defining whatever pattern we want.

### Dragons

There are assumptions made with the selectors that prevent potential re-renders that are necessary for some subcomponents to function (ie expecting nested profile data that gets added in a separate re-render)

### How Has This Been Tested?

Ran through various profiles to ensure things look the same

### How will this change be monitored?

If there seems to be data missing on the profile page, we will look into existing selectors as one of the first points of triage
