### PR TITLE
Fix profile track-tab loadMore

### DIFF
--- a/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
+++ b/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
@@ -5,6 +5,7 @@ import {
   SquareSizes,
   WidthSizes
 } from 'audius-client/src/common/models/ImageSizes'
+import { UserMetadata } from 'audius-client/src/common/models/User'
 import { updateProfile } from 'audius-client/src/common/store/pages/profile/actions'
 import { Formik, FormikProps } from 'formik'
 import { View } from 'react-native'
@@ -124,7 +125,7 @@ export const EditProfileScreen = () => {
       if (profile_picture.file) {
         newProfile.updatedProfilePicture = cover_photo
       }
-      dispatchWeb(updateProfile(newProfile))
+      dispatchWeb(updateProfile(newProfile as UserMetadata))
     },
     [dispatchWeb, profile]
   )

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -17,9 +17,10 @@ export const TracksTab = () => {
 
   const loadMore = useCallback(
     (offset: number, limit: number) => {
+      if (!profile) return
       dispatchWeb(
         tracksActions.fetchLineupMetadatas(offset, limit, false, {
-          userId: profile?.user_id
+          userId: profile.user_id
         })
       )
     },

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -1,7 +1,10 @@
+import { useCallback } from 'react'
+
 import { tracksActions } from 'audius-client/src/common/store/pages/profile/lineups/tracks/actions'
 import { getProfileTracksLineup } from 'audius-client/src/common/store/pages/profile/selectors'
 
 import { Lineup } from 'app/components/lineup'
+import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
@@ -10,6 +13,18 @@ import { getProfile } from './selectors'
 export const TracksTab = () => {
   const { profile } = useSelectorWeb(getProfile)
   const lineup = useSelectorWeb(getProfileTracksLineup)
+  const dispatchWeb = useDispatchWeb()
+
+  const loadMore = useCallback(
+    (offset: number, limit: number) => {
+      dispatchWeb(
+        tracksActions.fetchLineupMetadatas(offset, limit, false, {
+          userId: profile?.user_id
+        })
+      )
+    },
+    [dispatchWeb, profile]
+  )
 
   if (!profile) return null
 
@@ -23,6 +38,8 @@ export const TracksTab = () => {
       listKey='profile-tracks'
       actions={tracksActions}
       lineup={lineup}
+      limit={profile.track_count}
+      loadMore={loadMore}
     />
   )
 }


### PR DESCRIPTION
### Description

Fixes issue where default loadMore wasn't including userId, leading to a load error for users with more than 12 tracks
- also patches type error