### PR TITLE
[AUD-1616] Disallow identical track uploads in same session

### DIFF
--- a/packages/web/src/pages/upload-page/UploadPage.js
+++ b/packages/web/src/pages/upload-page/UploadPage.js
@@ -125,7 +125,9 @@ class Upload extends Component {
     // Disallow duplicate tracks:
     // Filter out any tracks that already exist in `state.tracks`
     // and any that exist multiple times in `selectedFiles`
-    const existing = new Set(this.state.tracks.map(({ file }) => `${file.name}-${file.lastModified}`))
+    const existing = new Set(
+      this.state.tracks.map(({ file }) => `${file.name}-${file.lastModified}`)
+    )
     selectedFiles = selectedFiles.filter(({ name, lastModified }) => {
       const id = `${name}-${lastModified}`
       if (existing.has(id)) return false

--- a/packages/web/src/pages/upload-page/UploadPage.js
+++ b/packages/web/src/pages/upload-page/UploadPage.js
@@ -122,6 +122,17 @@ class Upload extends Component {
   }
 
   onSelectTracks = async selectedFiles => {
+    // Disallow duplicate tracks:
+    // Filter out any tracks that already exist in `state.tracks`
+    // and any that exist multiple times in `selectedFiles`
+    const existing = new Set(this.state.tracks.map(({ file }) => `${file.name}-${file.lastModified}`))
+    selectedFiles = selectedFiles.filter(({ name, lastModified }) => {
+      const id = `${name}-${lastModified}`
+      if (existing.has(id)) return false
+      existing.add(id)
+      return true
+    })
+
     const processedFiles = processFiles(
       selectedFiles,
       false,
@@ -131,6 +142,7 @@ class Upload extends Component {
     if (tracks.length === processedFiles.length) {
       this.setState({ uploadTrackerror: null })
     }
+
     let uploadType = this.state.uploadType
     if (
       this.state.uploadType === UploadType.INDIVIDUAL_TRACK &&


### PR DESCRIPTION
### Description

- Selecting identical tracks (either in the same drag-and-drop session, or already selected and in the state) will skip duplicates

### Dragons

None

### How Has This Been Tested?

Tested locally

### How will this change be monitored?

Looking for error rate of MULTI_TRACK_UPLOAD decreasing
