### PR TITLE
[AUD-1638] Partial web -> mobile state syncing

### DIFF
--- a/packages/mobile/src/WebAppManager.tsx
+++ b/packages/mobile/src/WebAppManager.tsx
@@ -11,8 +11,8 @@ type WebAppManagerProps = {
 }
 
 export const WebAppManager = ({ webApp, children }: WebAppManagerProps) => {
-  const clientStore = useSelector((state: AppState) => state.clientStore)
-  const isClientStoreEmpty = isEmpty(clientStore)
+  const commonState = useSelector((state: AppState) => state.common)
+  const isClientStoreEmpty = isEmpty(commonState)
   return (
     <>
       {webApp}

--- a/packages/mobile/src/hooks/useSelectorWeb.ts
+++ b/packages/mobile/src/hooks/useSelectorWeb.ts
@@ -8,7 +8,7 @@ export const useSelectorWeb = <ReturnValue>(
   equalityFn?: (left: ReturnValue, right: ReturnValue) => boolean
 ) => {
   return useSelector(
-    (state: { clientStore: CommonState }) => selector(state.clientStore),
+    (state: { common: CommonState }) => selector(state.common),
     equalityFn
   )
 }

--- a/packages/mobile/src/message/handleMessage.ts
+++ b/packages/mobile/src/message/handleMessage.ts
@@ -8,7 +8,7 @@ import { messageHandlers as analytics } from './handlers/analytics'
 import { messageHandlers as android } from './handlers/android'
 import { messageHandlers as audio } from './handlers/audio'
 import { messageHandlers as cast } from './handlers/cast'
-import { messageHandlers as clientStore } from './handlers/clientStore'
+import { messageHandlers as commonState } from './handlers/commonState'
 import { messageHandlers as download } from './handlers/download'
 import { messageHandlers as haptics } from './handlers/haptics'
 import { messageHandlers as lifecycle } from './handlers/lifecycle'
@@ -29,7 +29,7 @@ const messageHandlers: Partial<MessageHandlers> = {
   ...(isIos ? {} : android),
   ...audio,
   ...cast,
-  ...clientStore,
+  ...commonState,
   ...download,
   ...haptics,
   ...lifecycle,

--- a/packages/mobile/src/message/handlers/commonState.ts
+++ b/packages/mobile/src/message/handlers/commonState.ts
@@ -1,9 +1,9 @@
-import { receive } from 'app/store/clientStore/slice'
+import { receive } from 'app/store/common/slice'
 
 import { MessageType, MessageHandlers } from '../types'
 
 export const messageHandlers: Partial<MessageHandlers> = {
-  [MessageType.SYNC_CLIENT_STORE]: ({ message, dispatch }) => {
+  [MessageType.SYNC_COMMON_STATE]: ({ message, dispatch }) => {
     dispatch(receive(message.state))
   }
 }

--- a/packages/mobile/src/message/types.ts
+++ b/packages/mobile/src/message/types.ts
@@ -128,7 +128,7 @@ export enum MessageType {
   // Theme
   THEME_CHANGE = 'theme-change',
 
-  SYNC_CLIENT_STORE = 'sync-client-store',
+  SYNC_COMMON_STATE = 'sync-common-state',
 
   // hCaptcha
   UPDATE_HCAPTCHA_SCORE = 'update-hcaptcha-score'

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -31,10 +31,13 @@ export const FeedScreen = () => {
   const feedFilter = useSelectorWeb(getFeedFilter)
   const [isRefreshing, setIsRefreshing] = useState(false)
 
-  const loadMore = (offset: number, limit: number, overwrite: boolean) => {
-    dispatchWeb(feedActions.fetchLineupMetadatas(offset, limit, overwrite))
-    track(make({ eventName: Name.FEED_PAGINATE, offset, limit }))
-  }
+  const loadMore = useCallback(
+    (offset: number, limit: number, overwrite: boolean) => {
+      dispatchWeb(feedActions.fetchLineupMetadatas(offset, limit, overwrite))
+      track(make({ eventName: Name.FEED_PAGINATE, offset, limit }))
+    },
+    [dispatchWeb]
+  )
 
   useEffect(() => {
     if (!feedLineup.isMetadataLoading) {
@@ -42,10 +45,10 @@ export const FeedScreen = () => {
     }
   }, [feedLineup])
 
-  const refresh = () => {
+  const refresh = useCallback(() => {
     setIsRefreshing(true)
     dispatchWeb(feedActions.refreshInView(true))
-  }
+  }, [dispatchWeb])
 
   const handleFilterButtonPress = useCallback(() => {
     dispatchWeb(setVisibility({ modal: 'FeedFilter', visible: true }))

--- a/packages/mobile/src/store/clientStore/slice.ts
+++ b/packages/mobile/src/store/clientStore/slice.ts
@@ -9,7 +9,10 @@ const slice = createSlice({
   initialState,
   reducers: {
     receive: (state, action) => {
-      return action.payload
+      return {
+        ...state,
+        ...action.payload
+      }
     }
   }
 })

--- a/packages/mobile/src/store/common/slice.ts
+++ b/packages/mobile/src/store/common/slice.ts
@@ -5,7 +5,7 @@ const initialState: any = {}
 // Slice
 
 const slice = createSlice({
-  name: 'CLIENT_STORE',
+  name: 'COMMON',
   initialState,
   reducers: {
     receive: (state, action) => {

--- a/packages/mobile/src/store/index.ts
+++ b/packages/mobile/src/store/index.ts
@@ -7,7 +7,7 @@ import { composeWithDevTools } from 'redux-devtools-extension'
 import createSagaMiddleware from 'redux-saga'
 
 import audio, { AudioState } from './audio/reducer'
-import clientStore from './clientStore/slice'
+import common from './common/slice'
 import downloads, { DownloadState } from './download/slice'
 import drawers, { DrawersState } from './drawers/slice'
 import googleCast, { GoogleCastState } from './googleCast/reducer'
@@ -22,7 +22,7 @@ import web, { WebState } from './web/reducer'
 
 export type AppState = {
   audio: AudioState
-  clientStore: CommonState
+  common: CommonState
   drawers: DrawersState
   downloads: DownloadState
   googleCast: GoogleCastState
@@ -39,7 +39,7 @@ export type AppState = {
 const createRootReducer = () =>
   combineReducers({
     audio,
-    clientStore,
+    common,
     drawers,
     downloads,
     googleCast,

--- a/packages/web/src/services/native-mobile-interface/types.ts
+++ b/packages/web/src/services/native-mobile-interface/types.ts
@@ -126,7 +126,7 @@ export enum MessageType {
   // Theme
   THEME_CHANGE = 'theme-change',
 
-  SYNC_CLIENT_STORE = 'sync-client-store',
+  SYNC_COMMON_STATE = 'sync-common-state',
 
   // hCaptcha
   UPDATE_HCAPTCHA_SCORE = 'update-hcaptcha-score'


### PR DESCRIPTION
### Description

After getting some conflicting signals, I was finally able to confirm that the expensive part of the state syncing operation is sending large amounts of data over the message bridge. Here is an average case of the times in ms for each leg of the trip:

![image](https://user-images.githubusercontent.com/19916043/156494788-262dafd0-c01c-4e79-ac9b-b1bb1f056c78.png)

Sending only the changed top-level entries of the state over the bridge, the `Web -> Mobile` time was decreased by ~75%. This specific case was for an update in the `pages` slice

![image](https://user-images.githubusercontent.com/19916043/156494956-bb907cf5-dd2c-42e8-98a7-2d335bdd84a7.png)

We could probably further improve this by flattening the redux state, but that might get into diminishing returns

Also includes:
  * Rename `clientStore` to `commonState` for clarity
  * Added some useCallbacks to prevent rerenders on FeedScreen

### Dragons

Using reference equality on the web layer to determine which slices have changed, so theoretically the mobile state should never get out of sync. But something to be aware of if we do run into something weird

### How Has This Been Tested?

Tested on ios simulator and device

### How will this change be monitored?
Not deployed yet
