### PR TITLE
Remove logic to individually enable RN screens

### DIFF
--- a/packages/mobile/src/components/app-navigator/BottomTabNavigator.tsx
+++ b/packages/mobile/src/components/app-navigator/BottomTabNavigator.tsx
@@ -5,7 +5,7 @@ import { ParamListBase } from '@react-navigation/native'
 import { createStackNavigator } from '@react-navigation/stack'
 import { Animated, StyleSheet, View } from 'react-native'
 
-import BottomTabBar, { BottomTabBarProps } from 'app/components/bottom-tab-bar'
+import BottomTabBar from 'app/components/bottom-tab-bar'
 import NowPlayingDrawer from 'app/components/now-playing-drawer/NowPlayingDrawer'
 import { AudioScreen } from 'app/screens/audio-screen'
 import { EditProfileScreen } from 'app/screens/edit-profile-screen'
@@ -107,20 +107,13 @@ const ProfileStackScreen = createStackScreen<ProfileStackParamList>(Stack => (
 
 const Tab = createBottomTabNavigator()
 
-type BottomTabNavigatorProps = {
-  onBottomTabBarLayout: BottomTabBarProps['onLayout']
-}
-
 /**
  * The bottom tab navigator
  *
  * TODO: This navigator is only displayed when the user is authed, so we should
- * move drawers, modals, notifications in here. Need to wait until fully migrated to RN
- * because of the way the top level navigator is hidden to display the WebView
+ * move drawers, modals, notifications in here
  */
-export const BottomTabNavigator = ({
-  onBottomTabBarLayout
-}: BottomTabNavigatorProps) => {
+export const BottomTabNavigator = () => {
   // Set handlers for the NowPlayingDrawer and BottomTabBar
   // When the drawer is open, the bottom bar should hide (animated away).
   // When the drawer is closed, the bottom bar should reappear (animated in).
@@ -150,7 +143,6 @@ export const BottomTabNavigator = ({
             />
             <BottomTabBar
               {...props}
-              onLayout={onBottomTabBarLayout}
               display={bottomBarDisplay}
               translationAnim={bottomBarTranslationAnim}
             />

--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
@@ -16,7 +16,7 @@ import {
   getPathname,
   profilePage
 } from 'audius-client/src/utils/route'
-import { Animated, LayoutChangeEvent, StyleSheet } from 'react-native'
+import { Animated, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useSelector } from 'react-redux'
 
@@ -100,10 +100,6 @@ export type BottomTabBarProps = {
    */
   display: { isShowing: boolean }
   /**
-   * A function called when the compononent layout is complete
-   */
-  onLayout: (e: LayoutChangeEvent) => void
-  /**
    * Translation animation to move the bottom bar as drawers
    * are opened behind it
    */
@@ -114,8 +110,7 @@ const BottomTabBar = ({
   display,
   state,
   navigation,
-  translationAnim,
-  onLayout
+  translationAnim
 }: BottomTabBarProps & RNBottomTabBarProps) => {
   const pushRouteWeb = usePushRouteWeb()
   const bottomBarStyle = useTheme(styles.bottomBar, {
@@ -257,7 +252,6 @@ const BottomTabBar = ({
         style={bottomBarStyle}
         edges={['bottom']}
         pointerEvents='auto'
-        onLayout={onLayout}
       >
         {state.routes.map((route, index) => {
           const isFocused = state.index === index


### PR DESCRIPTION
### Description

This PR removes extra logic at the AppNavigator level to allow enabling certain RN screens individually. Since we decided to roll all the screens out at once, this is a little more performant

### Dragons

Wraps the BottomTabNavigator in a check for if the navigation is enabled, this prevents RN screens from rendering when they are supposed to be disabled. Shouldn't cause issues though

### How Has This Been Tested?

Manually on ios simulator

### How will this change be monitored?
Not deployed yet
