### PR TITLE
Fix settings-page when null-rendering

### DIFF
--- a/packages/web/src/components/data-entry/TabSlider.js
+++ b/packages/web/src/components/data-entry/TabSlider.js
@@ -31,11 +31,12 @@ const TabSlider = props => {
       selectedRefIdx = 0
     }
 
-    const { clientWidth: width, offsetLeft: left } = optionRefs.current[
-      selectedRefIdx
-    ].current
+    const optionRef = optionRefs.current[selectedRefIdx].current
 
-    setAnimatedProps({ to: { left: `${left}px`, width: `${width}px` } })
+    if (optionRef) {
+      const { clientWidth: width, offsetLeft: left } = optionRef
+      setAnimatedProps({ to: { left: `${left}px`, width: `${width}px` } })
+    }
   }, [
     props.options,
     selectedOption,

--- a/packages/web/src/pages/App.js
+++ b/packages/web/src/pages/App.js
@@ -159,6 +159,7 @@ import { DeactivateAccountPage } from './deactivate-account-page/DeactivateAccou
 import ExploreCollectionsPage from './explore-page/ExploreCollectionsPage'
 import FollowersPage from './followers-page/FollowersPage'
 import FollowingPage from './following-page/FollowingPage'
+import SettingsPage from './settings-page/SettingsPage'
 import { SubPage } from './settings-page/components/mobile/SettingsPage'
 import SmartCollectionPage from './smart-collection/SmartCollectionPage'
 
@@ -166,10 +167,6 @@ const MOBILE_BANNER_LOCAL_STORAGE_KEY = 'dismissMobileAppBanner'
 
 const SignOn = React.lazy(() => import('pages/sign-on/SignOn'))
 
-const SettingsPage = lazyWithPreload(
-  () => import('pages/settings-page/SettingsPage'),
-  0
-)
 const UploadPage = lazyWithPreload(
   () => import('pages/upload-page/UploadPage'),
   0

--- a/packages/web/src/services/Logging.ts
+++ b/packages/web/src/services/Logging.ts
@@ -1,5 +1,9 @@
 import { LoggingMessage, LOG_LEVEL } from './native-mobile-interface/logging'
 
+const processConsoleData = (data: any[]) => {
+  return data.map(dataItem => JSON.stringify(dataItem)).join(', ')
+}
+
 /**
  * Forwards logs to the mobile client if we're in mobile mode.
  */
@@ -10,14 +14,15 @@ export const setupMobileLogging = () => {
 
   const handleMessage = (
     level: LOG_LEVEL,
-    original: (message: string) => void
-  ) => (message: string) => {
-    const nativeMessage = new LoggingMessage(level, message)
+    original: (...data: any[]) => void
+  ) => (...data: any[]) => {
+    const nativeMessage = new LoggingMessage(level, processConsoleData(data))
     nativeMessage.send()
-    original(message)
+    original(...data)
   }
 
   window.console.log = handleMessage('LOG', window.console.log)
+  window.console.info = handleMessage('INFO', window.console.info)
   window.console.debug = handleMessage('DEBUG', window.console.debug)
   window.console.warn = handleMessage('WARNING', window.console.warn)
   window.console.error = handleMessage('ERROR', window.console.error)

--- a/packages/web/src/services/native-mobile-interface/logging.ts
+++ b/packages/web/src/services/native-mobile-interface/logging.ts
@@ -1,7 +1,7 @@
 import { NativeMobileMessage } from './helpers'
 import { MessageType } from './types'
 
-export type LOG_LEVEL = 'LOG' | 'WARNING' | 'DEBUG' | 'ERROR'
+export type LOG_LEVEL = 'LOG' | 'INFO' | 'WARNING' | 'DEBUG' | 'ERROR'
 export class LoggingMessage extends NativeMobileMessage {
   constructor(level: LOG_LEVEL, message: string) {
     super(MessageType.LOGGING, {


### PR DESCRIPTION
### Description

Fixes two issues when loading settings page using null-renderer:
 - React.lazy seems to not work
 - refs will sometimes not be attached and their values will be null.

### Dragons

We may have a future issue where we can't use react.lazy in places that we would like. The fix here will need to be build-time webpack code-mod to either use `React.lazy(....)` or `require(...).default` https://webpack.js.org/plugins/define-plugin/