### PR TITLE
Quick fix for update dot styles

### DIFF
--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -394,10 +394,6 @@ svg.logo path {
   justify-content: center;
 }
 
-.playlistUpdate {
-  height: 18px;
-}
-
 .playlistLinkContentContainer {
   display: flex;
   align-items: center;

--- a/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
@@ -126,7 +126,6 @@ export const PlaylistNavItem = ({
         isActive={() => url === getPathname()}
         activeClassName='active'
         className={cn(navColumnStyles.link, {
-          [navColumnStyles.playlistUpdate]: hasUpdate,
           [navColumnStyles.droppableLink]:
             isOwner &&
             dragging &&


### PR DESCRIPTION
### Description
Before:
<img width="227" alt="Screen Shot 2022-03-07 at 9 50 39 AM" src="https://user-images.githubusercontent.com/36916764/157079809-a3f255e2-b7a8-4e46-a0b6-82edf4ca17fe.png">

After:
<img width="218" alt="Screen Shot 2022-03-07 at 9 48 11 AM" src="https://user-images.githubusercontent.com/36916764/157079804-09913fe4-6f59-4eb5-9a19-a90e3a4e60c9.png">

Note the changes causing the "before" here hasn't been released yet so as long as this gets in before the next release we should be fine. 


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
