### PR TITLE
[AUD-1648] RN Scroll To Top

### DIFF
--- a/packages/mobile/src/components/animated-button/AnimatedButtonProvider.tsx
+++ b/packages/mobile/src/components/animated-button/AnimatedButtonProvider.tsx
@@ -10,6 +10,7 @@ import { useColor } from 'app/utils/theme'
 export type BaseAnimatedButtonProps = {
   iconIndex?: number
   onPress?: GestureResponderHandler
+  onLongPress?: GestureResponderHandler
   isActive?: boolean
   isDisabled?: boolean
   showUnderlay?: boolean
@@ -27,6 +28,7 @@ const AnimatedButton = ({
   iconIndex: externalIconIndex,
   iconJSON,
   onPress,
+  onLongPress,
   isActive,
   isDisabled = false,
   showUnderlay = false,
@@ -81,25 +83,23 @@ const AnimatedButton = ({
     externalIconIndex
   ])
 
-  const handleClick = useCallback(() => {
-    if (isDisabled) {
-      return
-    }
-
+  const handlePress = useCallback(() => {
     if (hasMultipleStates || !isActive) {
       setIsPlaying(true)
       animationRef.current?.play()
     }
 
     onPress?.()
-  }, [
-    isDisabled,
-    onPress,
-    isActive,
-    setIsPlaying,
-    hasMultipleStates,
-    animationRef
-  ])
+  }, [onPress, isActive, setIsPlaying, hasMultipleStates, animationRef])
+
+  const handleLongPress = useCallback(() => {
+    if (onLongPress) {
+      onLongPress()
+      return
+    }
+
+    handlePress()
+  }, [onLongPress, handlePress])
 
   // For multi state buttons, when `isActive` flips, trigger
   // the animation to run
@@ -138,8 +138,9 @@ const AnimatedButton = ({
 
   return (
     <TouchableHighlight
-      onPress={handleClick}
-      onLongPress={handleClick}
+      disabled={isDisabled}
+      onPress={handlePress}
+      onLongPress={handleLongPress}
       hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}
       style={style}
       underlayColor={showUnderlay ? underlayColor : null}

--- a/packages/mobile/src/components/animated-button/AnimatedButtonProvider.tsx
+++ b/packages/mobile/src/components/animated-button/AnimatedButtonProvider.tsx
@@ -95,10 +95,9 @@ const AnimatedButton = ({
   const handleLongPress = useCallback(() => {
     if (onLongPress) {
       onLongPress()
-      return
+    } else {
+      handlePress()
     }
-
-    handlePress()
   }, [onLongPress, handlePress])
 
   // For multi state buttons, when `isActive` flips, trigger

--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect } from 'react'
 
 import { BottomTabBarProps as RNBottomTabBarProps } from '@react-navigation/bottom-tabs'
+import { BottomTabNavigationEventMap } from '@react-navigation/bottom-tabs/lib/typescript/src/types'
+import { NavigationHelpers, ParamListBase } from '@react-navigation/native'
 import { getUserHandle } from 'audius-client/src/common/store/account/selectors'
 import { setTab } from 'audius-client/src/common/store/pages/explore/slice'
 import { Tabs } from 'audius-client/src/common/store/pages/explore/types'
@@ -63,7 +65,7 @@ const springToValue = (
   }).start(finished)
 }
 
-export type BottomTabBarProps = {
+export type BottomTabBarProps = RNBottomTabBarProps & {
   /**
    * Display properties on the bottom bar to control whether
    * the bottom bar is showing
@@ -74,6 +76,15 @@ export type BottomTabBarProps = {
    * are opened behind it
    */
   translationAnim: Animated.Value
+
+  navigation: NavigationHelpers<
+    ParamListBase,
+    BottomTabNavigationEventMap & {
+      scrollToTop: {
+        data: undefined
+      }
+    }
+  >
 }
 
 export const BottomTabBar = ({
@@ -184,6 +195,12 @@ export const BottomTabBar = ({
     [navigation, pushRouteWeb, handle, openSignOn, resetExploreTab, scrollToTop]
   )
 
+  const handleLongPress = () => {
+    navigation.emit({
+      type: 'scrollToTop'
+    })
+  }
+
   return (
     <Animated.View
       style={[
@@ -212,6 +229,7 @@ export const BottomTabBar = ({
               isFocused={isFocused}
               isDarkMode={isDarkMode}
               navigate={navigate}
+              onLongPress={handleLongPress}
             />
           )
         })}

--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
@@ -190,6 +190,10 @@ export const BottomTabBar = ({
 
       if (!isFocused && !event.defaultPrevented) {
         navigation.navigate(route.name)
+      } else if (isFocused) {
+        navigation.emit({
+          type: 'scrollToTop'
+        })
       }
     },
     [navigation, pushRouteWeb, handle, openSignOn, resetExploreTab, scrollToTop]

--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBarButton.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBarButton.tsx
@@ -12,6 +12,7 @@ import IconProfileDark from 'app/assets/animations/iconProfileDark.json'
 import IconProfileLight from 'app/assets/animations/iconProfileLight.json'
 import IconTrendingDark from 'app/assets/animations/iconTrendingDark.json'
 import IconTrendingLight from 'app/assets/animations/iconTrendingLight.json'
+import { GestureResponderHandler } from 'app/types/gesture'
 
 import AnimatedBottomButton from './buttons/AnimatedBottomButton'
 
@@ -38,6 +39,7 @@ type BottomTabBarButtonProps = {
   isDarkMode: boolean
   route: NavigationRoute
   navigate: (route: NavigationRoute, isFocused: boolean) => void
+  onLongPress: GestureResponderHandler
 }
 
 export const BottomTabBarButton = ({
@@ -45,7 +47,8 @@ export const BottomTabBarButton = ({
   isFocused,
   isDarkMode,
   route,
-  navigate
+  navigate,
+  onLongPress
 }: BottomTabBarButtonProps) => {
   const handlePress = useCallback(() => {
     navigate(route, isFocused)
@@ -56,6 +59,7 @@ export const BottomTabBarButton = ({
       isActive={isFocused}
       isDarkMode={isDarkMode}
       onPress={handlePress}
+      onLongPress={onLongPress}
       iconLightJSON={icons.light[route.name]}
       iconDarkJSON={icons.dark[route.name]}
     />

--- a/packages/mobile/src/components/core/CardList.tsx
+++ b/packages/mobile/src/components/core/CardList.tsx
@@ -1,15 +1,26 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 
 import { FlatList, FlatListProps, ListRenderItem, View } from 'react-native'
+
+import { useScrollToTop } from 'app/hooks/useScrollToTop'
 
 import { EmptyTile } from './EmptyTile'
 
 export type CardListProps<ItemT> = FlatListProps<ItemT> & {
   emptyListText?: string
+  disableTopTabScroll?: boolean
 }
 
 export const CardList = <ItemT,>(props: CardListProps<ItemT>) => {
-  const { renderItem, emptyListText, ...other } = props
+  const { renderItem, emptyListText, disableTopTabScroll, ...other } = props
+
+  const ref = useRef<FlatList>(null)
+  useScrollToTop(() => {
+    ref.current?.scrollToOffset({
+      offset: 0,
+      animated: true
+    })
+  }, disableTopTabScroll)
 
   const handleRenderItem: ListRenderItem<ItemT> = useCallback(
     info => {
@@ -28,6 +39,7 @@ export const CardList = <ItemT,>(props: CardListProps<ItemT>) => {
 
   return (
     <FlatList
+      ref={ref}
       renderItem={handleRenderItem}
       numColumns={2}
       ListEmptyComponent={

--- a/packages/mobile/src/components/core/VirtualizedScrollView.tsx
+++ b/packages/mobile/src/components/core/VirtualizedScrollView.tsx
@@ -1,6 +1,8 @@
-import { ReactElement } from 'react'
+import { ReactElement, useRef } from 'react'
 
 import { StyleProp, ViewStyle, FlatList } from 'react-native'
+
+import { useScrollToTop } from 'app/hooks/useScrollToTop'
 
 type VirtualizedScrollViewProps = {
   children: ReactElement | ReactElement[]
@@ -14,8 +16,17 @@ type VirtualizedScrollViewProps = {
 export const VirtualizedScrollView = (props: VirtualizedScrollViewProps) => {
   const { children, listKey, style } = props
   const listHeader = Array.isArray(children) ? <>{children}</> : children
+  const ref = useRef<FlatList>(null)
+  useScrollToTop(() => {
+    ref.current?.scrollToOffset({
+      offset: 0,
+      animated: true
+    })
+  })
+
   return (
     <FlatList
+      ref={ref}
       listKey={listKey}
       style={style}
       ListHeaderComponent={listHeader}

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 
 import { Name, PlaybackSource } from 'audius-client/src/common/models/Analytics'
 import { ID, UID } from 'audius-client/src/common/models/Identifiers'
@@ -14,6 +14,7 @@ import {
   LineupTileSkeleton
 } from 'app/components/lineup-tile'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { useScrollToTop } from 'app/hooks/useScrollToTop'
 import { getPlaying, getPlayingUid } from 'app/store/audio/selectors'
 import { make, track } from 'app/utils/analytics'
 
@@ -105,6 +106,7 @@ export const Lineup = ({
   actions,
   count,
   delineate,
+  disableTopTabScroll,
   isTrending,
   leadingElementId,
   lineup,
@@ -121,6 +123,14 @@ export const Lineup = ({
   ...scrollViewProps
 }: LineupProps) => {
   const dispatchWeb = useDispatchWeb()
+  const ref = useRef<SectionList>(null)
+  useScrollToTop(() => {
+    ref.current?.scrollToLocation({
+      sectionIndex: 0,
+      itemIndex: 0,
+      animated: true
+    })
+  }, disableTopTabScroll)
 
   const playing = useSelector(getPlaying)
   const playingUid = useSelector(getPlayingUid)
@@ -328,6 +338,7 @@ export const Lineup = ({
   return (
     <SectionList
       {...scrollViewProps}
+      ref={ref}
       ListHeaderComponent={header}
       ListFooterComponent={<View style={{ height: 160 }} />}
       onEndReached={handleLoadMore}

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -36,6 +36,11 @@ export type LineupProps = {
    */
   delineate?: boolean
 
+  /**
+   * Do not scroll to top of lineup when containing tab navigator tab is pressed
+   */
+  disableTopTabScroll?: boolean
+
   /** Are we in a trending lineup? Allows tiles to specialize their rendering */
   isTrending?: boolean
 

--- a/packages/mobile/src/hooks/useScrollToTop.ts
+++ b/packages/mobile/src/hooks/useScrollToTop.ts
@@ -1,0 +1,59 @@
+import { useCallback } from 'react'
+
+import {
+  NavigationProp,
+  useFocusEffect,
+  useNavigation
+} from '@react-navigation/native'
+
+/**
+ * A hook that listens for `scrollToTop` event on all parent navigators
+ * When the nearest navigator is type `tab`, Listens to `tabPress` event
+ *
+ * react-navigation exports `useScrollToTop` but it doesn't support nested navigators
+ * see: https://github.com/react-navigation/react-navigation/issues/8586
+ */
+export const useScrollToTop = (
+  scrollToTop: () => void,
+  disableTopTabScroll = false
+) => {
+  const navigation = useNavigation()
+
+  useFocusEffect(
+    useCallback(() => {
+      const parents = getParentNavigators(navigation)
+
+      const removeListeners = parents.map(p =>
+        p.addListener('scrollToTop' as any, () => {
+          scrollToTop()
+        })
+      )
+
+      const removeTabListener =
+        navigation.getState().type === 'tab' && !disableTopTabScroll
+          ? navigation.addListener('tabPress' as any, () => {
+              scrollToTop()
+            })
+          : null
+
+      return () => {
+        removeListeners.forEach(r => r())
+        removeTabListener?.()
+      }
+    }, [navigation, scrollToTop, disableTopTabScroll])
+  )
+}
+
+/**
+ * Get array of all parent navigators
+ */
+const getParentNavigators = (
+  navigation: NavigationProp<any>,
+  parents: NavigationProp<any>[] = []
+): NavigationProp<any>[] => {
+  const parent = navigation.getParent()
+  if (!parent) {
+    return [navigation, ...parents]
+  }
+  return getParentNavigators(parent, [navigation, ...parents])
+}

--- a/packages/mobile/src/hooks/useScrollToTop.ts
+++ b/packages/mobile/src/hooks/useScrollToTop.ts
@@ -8,7 +8,7 @@ import {
 
 /**
  * A hook that listens for `scrollToTop` event on all parent navigators
- * When the nearest navigator is type `tab`, Listens to `tabPress` event
+ * When the nearest navigator is type `tab`, listens to `tabPress` event
  *
  * react-navigation exports `useScrollToTop` but it doesn't support nested navigators
  * see: https://github.com/react-navigation/react-navigation/issues/8586
@@ -51,12 +51,12 @@ export const useScrollToTop = (
  * Get array of all parent navigators
  */
 const getParentNavigators = (
-  navigation: NavigationProp<any>,
+  navigation?: NavigationProp<any>,
   parents: NavigationProp<any>[] = []
 ): NavigationProp<any>[] => {
-  const parent = navigation.getParent()
-  if (!parent) {
-    return [navigation, ...parents]
+  if (!navigation) {
+    return parents
   }
+  const parent = navigation.getParent()
   return getParentNavigators(parent, [navigation, ...parents])
 }

--- a/packages/mobile/src/hooks/useScrollToTop.ts
+++ b/packages/mobile/src/hooks/useScrollToTop.ts
@@ -29,16 +29,19 @@ export const useScrollToTop = (
         })
       )
 
-      const removeTabListener =
-        navigation.getState().type === 'tab' && !disableTopTabScroll
-          ? navigation.addListener('tabPress' as any, () => {
-              scrollToTop()
-            })
-          : null
+      const removeTabListeners = (navigation.getState().type === 'tab' &&
+      !disableTopTabScroll
+        ? ['tabPress', 'tabLongPress']
+        : []
+      ).map(e =>
+        navigation.addListener(e as any, () => {
+          scrollToTop()
+        })
+      )
 
       return () => {
         removeListeners.forEach(r => r())
-        removeTabListener?.()
+        removeTabListeners.forEach(r => r())
       }
     }, [navigation, scrollToTop, disableTopTabScroll])
   )

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/ForYouTab.tsx
@@ -1,5 +1,8 @@
+import { useRef } from 'react'
+
 import { ScrollView, StyleSheet, View } from 'react-native'
 
+import { useScrollToTop } from 'app/hooks/useScrollToTop'
 import { useThemedStyles } from 'app/hooks/useThemedStyles'
 import { ThemeColors } from 'app/utils/theme'
 
@@ -60,12 +63,20 @@ const tiles = [
 export const ForYouTab = () => {
   const styles = useThemedStyles(createStyles)
 
+  const ref = useRef<ScrollView>(null)
+  useScrollToTop(() => {
+    ref.current?.scrollTo({
+      y: 0,
+      animated: true
+    })
+  })
+
   return (
-    <ScrollView style={styles.tabContainer}>
+    <ScrollView style={styles.tabContainer} ref={ref}>
       <TabInfo header={messages.infoHeader} text={messages.infoText} />
       <View style={styles.contentContainer}>
         {tiles.map(tile => (
-          <ColorTile style={styles.tile} key={tile.variant} {...tile} />
+          <ColorTile style={styles.tile} key={tile.title} {...tile} />
         ))}
       </View>
     </ScrollView>

--- a/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
@@ -23,6 +23,7 @@ export const AlbumsTab = () => {
       listKey='profile-albums'
       collection={userAlbums}
       emptyListText={emptyListText}
+      disableTopTabScroll
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/CollectiblesTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/CollectiblesTab.tsx
@@ -1,7 +1,10 @@
+import { useRef } from 'react'
+
 import { View, Pressable, Text, FlatList } from 'react-native'
 
 import IconShare from 'app/assets/images/iconShare.svg'
 import { Tile, GradientText } from 'app/components/core'
+import { useScrollToTop } from 'app/hooks/useScrollToTop'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
@@ -74,6 +77,14 @@ export const CollectiblesTab = () => {
   const { neutralLight4 } = useThemeColors()
   const { profile } = useSelectorWeb(getProfile)
 
+  const ref = useRef<FlatList>(null)
+  useScrollToTop(() => {
+    ref.current?.scrollToOffset({
+      offset: 0,
+      animated: true
+    })
+  }, true)
+
   if (!profile) return null
 
   const { collectibleList = [], solanaCollectibleList = [] } = profile
@@ -84,6 +95,7 @@ export const CollectiblesTab = () => {
     <View style={styles.root}>
       <Tile styles={{ tile: styles.tile, content: styles.tileContent }}>
         <FlatList
+          ref={ref}
           listKey='profile-collectibles'
           ListHeaderComponent={
             <View style={styles.header}>

--- a/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
@@ -23,6 +23,7 @@ export const PlaylistsTab = () => {
       listKey='profile-playlists'
       collection={userPlaylists}
       emptyListText={emptyListText}
+      disableTopTabScroll
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -22,6 +22,7 @@ export const RepostsTab = () => {
       actions={feedActions}
       lineup={lineup}
       selfLoad
+      disableTopTabScroll
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -40,6 +40,7 @@ export const TracksTab = () => {
       lineup={lineup}
       limit={profile.track_count}
       loadMore={loadMore}
+      disableTopTabScroll
     />
   )
 }


### PR DESCRIPTION
### Description

* Adds custom `useScrollToTop` hook that supports nested tab navigators (unlike the one provided by react-navigation)
* Triggers scroll to top on long tab press and focused tab press
* Does not scroll to top on profile tab page tab press

https://user-images.githubusercontent.com/19916043/157122124-7c97c617-bc55-478e-acab-e483c3d11f7e.mov

### Dragons

Attaching listeners to a few events, they get cleaned up but could have slight performance/memory impact

### How Has This Been Tested?

iOS simulator

### How will this change be monitored?

Not released yet
