### PR TITLE
Fix more styling issues in the nav column 😩

### DIFF
--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -280,7 +280,7 @@ svg.logo path {
   /* negative margin so the link hover chip shows up. */
   margin-left: -16px;
   /* left padding is visibly (32px + -16px margin =) 16px to match the left padding of .groupHeader */
-  padding: 6px 0 6px 32px;
+  padding: 5px 0 5px 32px;
   color: var(--nav-column-link);
   transition: color 0.07s ease-in-out;
 
@@ -304,6 +304,13 @@ svg.logo path {
   white-space: nowrap;
   width: 100%;
   display: inline-block;
+}
+
+.navColumn .links a.link.editable,
+.navColumn .links button.link.editable {
+  /** Add 12px to the width so that we can free up some space for the horizontal kebab (which only appears on hover). This won't cause
+  overflow because there is already a -16px margin on nav link buttons. */
+  width: calc(100% + 12px);
 }
 
 .navColumn .links a.link.disabledLink {
@@ -392,11 +399,6 @@ svg.logo path {
 .profileCompletionContainer {
   display: flex;
   justify-content: center;
-}
-
-.playlistLinkContentContainer {
-  display: flex;
-  align-items: center;
 }
 
 .updateDotContainer {

--- a/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
@@ -112,6 +112,7 @@ export const PlaylistFolderNavItem = ({
         onClick={() => {}}
       >
         <div className={styles.libraryLinkContentContainer}>
+          {isEmpty(contents) ? (
             <IconFolderOutline
               width={12}
               height={12}

--- a/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
@@ -57,7 +57,7 @@ const FolderNavLink = ({
         <button
           {...buttonProps}
           draggable={false}
-          className={cn(className, styles.folderButton, styles.navLink, {
+          className={cn(className, styles.navLink, {
             [styles.dragging]: isDragging
           })}
         >
@@ -104,15 +104,14 @@ export const PlaylistFolderNavItem = ({
         id={id}
         name={name}
         onReorder={() => {}}
-        className={cn(navColumnStyles.link, {
+        className={cn(navColumnStyles.link, navColumnStyles.editable, {
           [navColumnStyles.droppableLink]: dragging && isDroppableKind,
           [navColumnStyles.disabledLink]:
             dragging && !isDroppableKind && draggingKind !== 'library-playlist'
         })}
         onClick={() => {}}
       >
-        <div className={styles.folderButtonContentContainer}>
-          {isEmpty(contents) ? (
+        <div className={styles.libraryLinkContentContainer}>
             <IconFolderOutline
               width={12}
               height={12}
@@ -127,7 +126,7 @@ export const PlaylistFolderNavItem = ({
               })}
             />
           )}
-          <div className={styles.folderNameContainer}>
+          <div className={styles.libraryLinkTextContainer}>
             <span>{name}</span>
           </div>
           <IconCaretRight height={11} width={11} className={styles.iconCaret} />

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
@@ -2,13 +2,7 @@
   transition: opacity 1s ease-in-out;
 }
 
-.folderButton {
-  /** Add 12px to the width so that we can free up some space for the horizontal kebab (which only appears on hover). This won't cause
-  overflow because there is already a -16px margin on nav link buttons. */
-  width: calc(100% + 12px);
-}
-
-.folderButtonContentContainer {
+.libraryLinkContentContainer {
   height: 100%;
   line-height: normal;
   display: inline-flex;
@@ -16,10 +10,11 @@
   align-items: center;
 }
 
-.folderNameContainer {
+.libraryLinkTextContainer {
   overflow-x: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  flex-shrink: 1;
 }
 
 .iconFolder {

--- a/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
@@ -130,6 +130,7 @@ export const PlaylistNavItem = ({
             isOwner &&
             dragging &&
             (draggingKind === 'track' || draggingKind === 'playlist'),
+          [navColumnStyles.editable]: isOwner && onClickEdit != null,
           [navColumnStyles.disabledLink]:
             dragging &&
             ((draggingKind !== 'track' &&
@@ -143,7 +144,7 @@ export const PlaylistNavItem = ({
         }}
         onMouseLeave={() => setIsHovering(false)}
       >
-        <div className={navColumnStyles.playlistLinkContentContainer}>
+        <div className={styles.libraryLinkContentContainer}>
           {!hasUpdate ? null : (
             <div className={navColumnStyles.updateDotContainer}>
               <Tooltip
@@ -160,7 +161,9 @@ export const PlaylistNavItem = ({
               </Tooltip>
             </div>
           )}
-          <span>{name}</span>
+          <div className={styles.libraryLinkTextContainer}>
+            <span>{name}</span>
+          </div>
           {!isOwner || !onClickEdit ? null : (
             <IconButton
               className={cn(styles.iconKebabHorizontal, {


### PR DESCRIPTION
### Description
-Fix regression I caused where long playlist names were clipped instead of ellipsis-ed (not in prod yet)
-Fix spacing in between playlist links (too big before) to match [these designs](https://www.figma.com/file/u8UHdkD60030aqsRkItWUV/Playlist-Folders?node-id=101%3A141) 
-Consolidate some styles

<img width="236" alt="Screen Shot 2022-03-07 at 7 21 28 PM" src="https://user-images.githubusercontent.com/36916764/157153499-c7907c43-14e6-48d8-b285-10d63e7da955.png">

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested in browser with long and short playlist/folder names, playlist folder flag on/off, playlist updates/not

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
