### PR TITLE
Implement expanding/collapsing folders

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -10483,6 +10483,11 @@
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -26661,6 +26666,14 @@
       "version": "7.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-7.0.0-beta.5.tgz",
       "integrity": "sha512-zWXhOmidHs+OHYkoM7femawPkBpzy3XQA5+CbZA3xTdli4hyIUGqH+LQ8u7KQ5iPnArh+UbAiMwFKusXSEJFKw=="
+    },
+    "react-use-measure": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
+      "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
+      "requires": {
+        "debounce": "^1.2.1"
+      }
     },
     "react-with-direction": {
       "version": "1.3.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -83,6 +83,7 @@
     "react-twitter-auth": "0.0.13",
     "react-twitter-embed": "3.0.3",
     "react-use-gesture": "7.0.0-beta.5",
+    "react-use-measure": "^2.1.1",
     "redux": "4.0.5",
     "redux-devtools-extension": "2.13.8",
     "redux-saga": "1.1.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -83,7 +83,7 @@
     "react-twitter-auth": "0.0.13",
     "react-twitter-embed": "3.0.3",
     "react-use-gesture": "7.0.0-beta.5",
-    "react-use-measure": "^2.1.1",
+    "react-use-measure": "2.1.1",
     "redux": "4.0.5",
     "redux-devtools-extension": "2.13.8",
     "redux-saga": "1.1.3",

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.module.css
@@ -28,6 +28,14 @@
   margin-left: 10px;
 }
 
+.iconCaret {
+  transition: transform 0.15s ease;
+}
+
+.iconCaretDown {
+  transform: rotate(90deg);
+}
+
 .iconKebabHorizontal {
   color: var(--nav-column-link);
   opacity: 100;
@@ -77,4 +85,9 @@
 .top {
   padding-top: 4px;
   margin-top: -4px;
+}
+
+.folderContentsContainer {
+  padding-top: 8px;
+  padding-left: 8px;
 }

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import cn from 'classnames'
 import { isEmpty } from 'lodash'
@@ -8,6 +8,10 @@ import { useModalState } from 'common/hooks/useModalState'
 import { Name } from 'common/models/Analytics'
 import { SmartCollection } from 'common/models/Collection'
 import { ID } from 'common/models/Identifiers'
+import {
+  PlaylistLibrary as PlaylistLibraryType,
+  PlaylistLibraryFolder
+} from 'common/models/PlaylistLibrary'
 import { SmartCollectionVariant } from 'common/models/SmartCollectionVariant'
 import { FeatureFlags } from 'common/services/remote-config'
 import { AccountCollection } from 'common/store/account/reducer'
@@ -40,6 +44,54 @@ import { PlaylistNavItem, PlaylistNavLink } from './PlaylistNavItem'
 
 type PlaylistLibraryProps = {
   onClickNavLinkWithAccount: () => void
+}
+
+type LibraryContentsLevelProps = {
+  contents: PlaylistLibraryType['contents']
+  playlists: { [id: number]: AccountCollection }
+  renderPlaylist: (playlist: AccountCollection) => void
+  renderExplorePlaylist: (playlist: SmartCollection) => void
+  renderFolder: (folder: PlaylistLibraryFolder) => void
+}
+
+// Function component for rendering a single level of the playlist library. Playlist library consists of up to two content levels (root + inside a folder)
+const LibraryContentsLevel = ({
+  contents,
+  playlists,
+  renderPlaylist,
+  renderExplorePlaylist,
+  renderFolder
+}: LibraryContentsLevelProps) => {
+  console.log(contents, 'contents')
+  return (
+    <>
+      {contents.map(content => {
+        switch (content.type) {
+          case 'explore_playlist': {
+            const playlist = SMART_COLLECTION_MAP[content.playlist_id]
+            if (!playlist) return null
+            return renderExplorePlaylist(playlist)
+          }
+          case 'playlist': {
+            const playlist = playlists[content.playlist_id]
+            return renderPlaylist(playlist)
+          }
+          case 'temp_playlist': {
+            try {
+              const playlist = playlists[parseInt(content.playlist_id)]
+              return renderPlaylist(playlist)
+            } catch (e) {
+              console.debug(e)
+              break
+            }
+          }
+          case 'folder':
+            return renderFolder(content)
+        }
+        return null
+      })}
+    </>
+  )
 }
 
 const PlaylistLibrary = ({
@@ -116,7 +168,7 @@ const PlaylistLibrary = ({
     )
   }
 
-  const onClick = useCallback(
+  const onClickPlaylist = useCallback(
     (playlistId: ID, hasUpdate: boolean) => {
       onClickNavLinkWithAccount()
       record(
@@ -128,7 +180,6 @@ const PlaylistLibrary = ({
     },
     [record, onClickNavLinkWithAccount]
   )
-
   const renderPlaylist = (playlist: AccountCollection) => {
     if (!account || !playlist) return null
     const { id, name } = playlist
@@ -147,7 +198,7 @@ const PlaylistLibrary = ({
         onReorder={onReorder}
         dragging={dragging}
         draggingKind={draggingKind}
-        onClickPlaylist={onClick}
+        onClickPlaylist={onClickPlaylist}
         onClickEdit={
           isOwner && isPlaylistFoldersEnabled
             ? handleClickEditPlaylist
@@ -157,10 +208,54 @@ const PlaylistLibrary = ({
     )
   }
 
+  const renderFolder = (folder: PlaylistLibraryFolder) => {
+    return (
+      <PlaylistFolderNavItem
+        key={folder.id}
+        folder={folder}
+        hasUpdate={false}
+        dragging={dragging}
+        draggingKind={draggingKind}
+        onClickEdit={handleClickEditFolder}
+      >
+        {isEmpty(folder.contents) ? null : (
+          <div className={styles.folderContentsContainer}>
+            <LibraryContentsLevel
+              playlists={playlists}
+              contents={folder.contents}
+              renderPlaylist={renderPlaylist}
+              renderExplorePlaylist={renderExplorePlaylist}
+              renderFolder={renderFolder}
+            />
+          </div>
+        )}
+      </PlaylistFolderNavItem>
+    )
+  }
+
+  const playlistsNotInLibrary = useMemo(() => {
+    const result = { ...playlists }
+    if (library && playlists) {
+      library.contents.forEach(content => {
+        if (content.type === 'temp_playlist') {
+          const playlist = playlists[parseInt(content.playlist_id)]
+          if (playlist) {
+            delete result[parseInt(content.playlist_id)]
+          }
+        } else if (content.type === 'playlist') {
+          const playlist = playlists[content.playlist_id]
+          if (playlist) {
+            delete result[content.playlist_id]
+          }
+        }
+      })
+    }
+    return result
+  }, [library, playlists])
+
   // Iterate over playlist library and render out available explore/smart
   // playlists and ordered playlists. Remaining playlists that are unordered
   // are rendered aftewards by sort order.
-  const playlistsNotInLibrary = { ...playlists }
   return (
     <>
       <Droppable
@@ -170,53 +265,19 @@ const PlaylistLibrary = ({
         onDrop={(id: ID | SmartCollectionVariant) => onReorder(id, -1)}
         acceptedKinds={['library-playlist']}
       />
-      {account &&
-        playlists &&
-        library &&
-        library.contents.map(content => {
-          switch (content.type) {
-            case 'explore_playlist': {
-              const playlist = SMART_COLLECTION_MAP[content.playlist_id]
-              if (!playlist) return null
-              return renderExplorePlaylist(playlist)
-            }
-            case 'playlist': {
-              const playlist = playlists[content.playlist_id]
-              if (playlist) {
-                delete playlistsNotInLibrary[content.playlist_id]
-              }
-              return renderPlaylist(playlist)
-            }
-            case 'temp_playlist': {
-              try {
-                const playlist = playlists[parseInt(content.playlist_id)]
-                if (playlist) {
-                  delete playlistsNotInLibrary[parseInt(content.playlist_id)]
-                }
-                return renderPlaylist(playlist)
-              } catch (e) {
-                console.debug(e)
-                break
-              }
-            }
-            case 'folder':
-              return (
-                <PlaylistFolderNavItem
-                  key={content.id}
-                  folder={content}
-                  hasUpdate={false}
-                  dragging={dragging}
-                  draggingKind={draggingKind}
-                  onClickEdit={handleClickEditFolder}
-                />
-              )
-          }
-          return null
-        })}
+      {account && playlists && library ? (
+        <LibraryContentsLevel
+          playlists={playlists}
+          contents={library.contents || []}
+          renderPlaylist={renderPlaylist}
+          renderExplorePlaylist={renderExplorePlaylist}
+          renderFolder={renderFolder}
+        />
+      ) : null}
       {Object.values(playlistsNotInLibrary).map(playlist => {
         return renderPlaylist(playlist)
       })}
-      {library && isEmpty(library.contents) ? (
+      {isEmpty(library?.contents) ? (
         <div className={cn(navColumnStyles.link, navColumnStyles.disabled)}>
           Create your first playlist!
         </div>

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -62,7 +62,6 @@ const LibraryContentsLevel = ({
   renderExplorePlaylist,
   renderFolder
 }: LibraryContentsLevelProps) => {
-  console.log(contents, 'contents')
   return (
     <>
       {contents.map(content => {

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -50,8 +50,8 @@ type LibraryContentsLevelProps = {
   renderExplorePlaylist: (playlistId: SmartCollectionVariant) => void
   renderFolder: (folder: PlaylistLibraryFolder) => void
 }
-
-// Function component for rendering a single level of the playlist library. Playlist library consists of up to two content levels (root + inside a folder)
+/** Function component for rendering a single level of the playlist library.
+ * Playlist library consists of up to two content levels (root + inside a folder) */
 const LibraryContentsLevel = ({
   contents,
   renderPlaylist,
@@ -69,17 +69,13 @@ const LibraryContentsLevel = ({
             return renderPlaylist(content.playlist_id)
           }
           case 'temp_playlist': {
-            try {
-              return renderPlaylist(parseInt(content.playlist_id))
-            } catch (e) {
-              console.debug(e)
-              break
-            }
+            return renderPlaylist(parseInt(content.playlist_id))
           }
           case 'folder':
             return renderFolder(content)
+          default:
+            return null
         }
-        return null
       })}
     </>
   )
@@ -173,7 +169,7 @@ const PlaylistLibrary = ({
     },
     [record, onClickNavLinkWithAccount]
   )
-  const renderPlaylist = (playlistId: number) => {
+  const renderPlaylist = (playlistId: ID) => {
     const playlist = playlists[playlistId]
     if (!account || !playlist) return null
     const { id, name } = playlist
@@ -226,11 +222,14 @@ const PlaylistLibrary = ({
     )
   }
 
+  /** We want to ensure that all playlists attached to the user's account show up in the library UI, even
+  /* if the user's library itself does not contain some of the playlists (for example, if a write failed).
+  /* This computes those playlists that are attached to the user's account but are not in the user library. */
   const playlistsNotInLibrary = useMemo(() => {
     const result = { ...playlists }
-    function helpComputePlaylistsNotInLibrary(
+    const helpComputePlaylistsNotInLibrary = (
       libraryContentsLevel: PlaylistLibraryType['contents']
-    ) {
+    ) => {
       libraryContentsLevel.forEach(content => {
         if (content.type === 'temp_playlist' || content.type === 'playlist') {
           const playlist = playlists[Number(content.playlist_id)]
@@ -249,9 +248,9 @@ const PlaylistLibrary = ({
     return result
   }, [library, playlists])
 
-  // Iterate over playlist library and render out available explore/smart
-  // playlists and ordered playlists. Remaining playlists that are unordered
-  // are rendered aftewards by sort order.
+  /** Iterate over playlist library and render out available explore/smart
+  /* playlists and ordered playlists. Remaining playlists that are unordered
+  /* are rendered afterwards by sort order. */
   return (
     <>
       <Droppable


### PR DESCRIPTION
### Description
-Show/hide playlist folder contents
![expand](https://user-images.githubusercontent.com/36916764/157159884-ffeff44f-bca5-4b5b-af09-bf5338712c07.gif)


### Dragons
I refactored the playlist library component a bit to enable the library contents nesting - need to make sure this doesn't break anything. I tested things pretty thoroughly on staging (no playlists/folders, playlists with updates, playlists/folders with long names, etc) but wasn't quite sure how to test the `playlistsNotInLibrary` functionality (will comment in PR).

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in browser using fake data for folder contents

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
