### PR TITLE
[AUD-1669] Add tile press animation

### DIFF
--- a/packages/mobile/src/components/audio-rewards/RewardsBanner.tsx
+++ b/packages/mobile/src/components/audio-rewards/RewardsBanner.tsx
@@ -2,13 +2,12 @@ import { useCallback } from 'react'
 
 import { setTrendingRewardsModalType } from 'audius-client/src/common/store/pages/audio-rewards/slice'
 import { setVisibility } from 'audius-client/src/common/store/ui/modals/slice'
-import { Animated, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 
 import IconCrown from 'app/assets/images/iconCrown.svg'
 import { Tile } from 'app/components/core'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
-import { usePressScaleAnimation } from 'app/hooks/usePressScaleAnimation'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -70,8 +69,6 @@ export const RewardsBanner = (props: RewardsBannerProps) => {
     pageHeaderGradientColor2
   } = useThemeColors()
 
-  const { scale, handlePressIn, handlePressOut } = usePressScaleAnimation()
-
   const handlePress = useCallback(() => {
     dispatchWeb(setTrendingRewardsModalType({ modalType: type }))
     dispatchWeb(
@@ -80,32 +77,28 @@ export const RewardsBanner = (props: RewardsBannerProps) => {
   }, [dispatchWeb, type])
 
   return (
-    <Animated.View style={{ transform: [{ scale }] }}>
-      <Tile
-        as={LinearGradient}
-        colors={[pageHeaderGradientColor1, pageHeaderGradientColor2]}
-        start={{ x: 1, y: 1 }}
-        end={{ x: 0, y: 0 }}
-        styles={{
-          root: styles.root,
-          tile: styles.tile,
-          content: styles.tileContent
-        }}
-        onPress={handlePress}
-        onPressIn={handlePressIn}
-        onPressOut={handlePressOut}
-      >
-        <View style={styles.title}>
-          <IconCrown
-            style={styles.iconCrown}
-            fill={styles.iconCrown.fill}
-            height={styles.iconCrown.height}
-            width={styles.iconCrown.width}
-          />
-          <Text style={styles.titleText}>{messages.rewards}</Text>
-        </View>
-        <Text style={styles.descriptionText}>{messages[type]}</Text>
-      </Tile>
-    </Animated.View>
+    <Tile
+      as={LinearGradient}
+      colors={[pageHeaderGradientColor1, pageHeaderGradientColor2]}
+      start={{ x: 1, y: 1 }}
+      end={{ x: 0, y: 0 }}
+      styles={{
+        root: styles.root,
+        tile: styles.tile,
+        content: styles.tileContent
+      }}
+      onPress={handlePress}
+    >
+      <View style={styles.title}>
+        <IconCrown
+          style={styles.iconCrown}
+          fill={styles.iconCrown.fill}
+          height={styles.iconCrown.height}
+          width={styles.iconCrown.width}
+        />
+        <Text style={styles.titleText}>{messages.rewards}</Text>
+      </View>
+      <Text style={styles.descriptionText}>{messages[type]}</Text>
+    </Tile>
   )
 }

--- a/packages/mobile/src/components/core/Tile.tsx
+++ b/packages/mobile/src/components/core/Tile.tsx
@@ -39,6 +39,7 @@ type TileOwnProps<
   TileComponentType extends ComponentType = ComponentType
 > = TilePressableProps & {
   children: ReactNode
+  scaleTo?: number
   style?: StyleProp<ViewStyle>
   styles?: StylesProp<{
     // styles for root element
@@ -71,6 +72,7 @@ export const Tile = <
     onPressOut,
     style,
     styles: stylesProp,
+    scaleTo,
     ...other
   } = props
 
@@ -78,7 +80,7 @@ export const Tile = <
     scale,
     handlePressIn: handlePressInScale,
     handlePressOut: handlePressOutScale
-  } = usePressScaleAnimation()
+  } = usePressScaleAnimation(scaleTo)
 
   const handlePressIn = useCallback(
     (event: GestureResponderEvent) => {

--- a/packages/mobile/src/components/core/Tile.tsx
+++ b/packages/mobile/src/components/core/Tile.tsx
@@ -1,6 +1,8 @@
-import { ComponentProps, ComponentType, ReactNode } from 'react'
+import { ComponentProps, ComponentType, ReactNode, useCallback } from 'react'
 
 import {
+  Animated,
+  GestureResponderEvent,
   Pressable,
   PressableProps,
   StyleProp,
@@ -9,6 +11,7 @@ import {
 } from 'react-native'
 import { Shadow } from 'react-native-shadow-2'
 
+import { usePressScaleAnimation } from 'app/hooks/usePressScaleAnimation'
 import { StylesProp } from 'app/styles'
 import { makeStyles } from 'app/styles/makeStyles'
 
@@ -71,24 +74,52 @@ export const Tile = <
     ...other
   } = props
 
+  const {
+    scale,
+    handlePressIn: handlePressInScale,
+    handlePressOut: handlePressOutScale
+  } = usePressScaleAnimation()
+
+  const handlePressIn = useCallback(
+    (event: GestureResponderEvent) => {
+      onPressIn?.(event)
+      if (onPress) {
+        handlePressInScale()
+      }
+    },
+    [onPressIn, onPress, handlePressInScale]
+  )
+
+  const handlePressOut = useCallback(
+    (event: GestureResponderEvent) => {
+      onPressOut?.(event)
+      if (onPress) {
+        handlePressOutScale()
+      }
+    },
+    [onPressOut, onPress, handlePressOutScale]
+  )
+
   return (
-    <Shadow
-      offset={[0, 1]}
-      viewStyle={{ alignSelf: 'stretch' }}
-      distance={2}
-      startColor='rgba(133,129,153,0.11)'
-      containerViewStyle={[style, stylesProp?.root]}
-    >
-      <TileComponent style={[styles.tile, stylesProp?.tile]} {...other}>
-        <Pressable
-          style={[styles.content, stylesProp?.content]}
-          onPress={onPress}
-          onPressIn={onPressIn}
-          onPressOut={onPressOut}
-        >
-          {children}
-        </Pressable>
-      </TileComponent>
-    </Shadow>
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <Shadow
+        offset={[0, 1]}
+        viewStyle={{ alignSelf: 'stretch' }}
+        distance={2}
+        startColor='rgba(133,129,153,0.11)'
+        containerViewStyle={[style, stylesProp?.root]}
+      >
+        <TileComponent style={[styles.tile, stylesProp?.tile]} {...other}>
+          <Pressable
+            style={[styles.content, stylesProp?.content]}
+            onPress={onPress}
+            onPressIn={handlePressIn}
+            onPressOut={handlePressOut}
+          >
+            {children}
+          </Pressable>
+        </TileComponent>
+      </Shadow>
+    </Animated.View>
   )
 }


### PR DESCRIPTION
### Description

Adds press animation when tile is pressable.

### Dragons

This affects all tiles that are pressable. It seems like a fair assumption that any tile with onPress should have an animation, though.
