### PR TITLE
[AUD-1603] Fix overflow menu nav, close now-playing drawer on navigate

### DIFF
--- a/packages/mobile/src/components/overflow-menu-drawer/CollectionOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/CollectionOverflowMenuDrawer.tsx
@@ -31,7 +31,7 @@ import {
 } from 'audius-client/src/utils/route'
 
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
-import { usePushRouteWeb } from 'app/hooks/usePushRouteWeb'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 type Props = {
@@ -40,7 +40,7 @@ type Props = {
 
 const CollectionOverflowMenuDrawer = ({ render }: Props) => {
   const dispatchWeb = useDispatchWeb()
-  const pushRouteWeb = usePushRouteWeb()
+  const navigation = useNavigation()
   const { id: modalId } = useSelectorWeb(getMobileOverflowModal)
   const id = modalId as ID
 
@@ -73,11 +73,24 @@ const CollectionOverflowMenuDrawer = ({ render }: Props) => {
       dispatchWeb(unsaveCollection(id, FavoriteSource.OVERFLOW)),
     [OverflowAction.SHARE]: () =>
       dispatchWeb(shareCollection(id, ShareSource.OVERFLOW)),
-    [OverflowAction.VIEW_ALBUM_PAGE]: () =>
-      pushRouteWeb(
-        (is_album ? albumPage : playlistPage)(handle, playlist_name, id)
-      ),
-    [OverflowAction.VIEW_ARTIST_PAGE]: () => pushRouteWeb(profilePage(handle)),
+    [OverflowAction.VIEW_ALBUM_PAGE]: () => {
+      navigation.navigate({
+        native: { screen: 'Collection', params: { id } },
+        web: {
+          route: (is_album ? albumPage : playlistPage)(
+            handle,
+            playlist_name,
+            id
+          )
+        }
+      })
+    },
+    [OverflowAction.VIEW_ARTIST_PAGE]: () => {
+      navigation.navigate({
+        native: { screen: 'Profile', params: { handle } },
+        web: { route: profilePage(handle) }
+      })
+    },
     [OverflowAction.EDIT_PLAYLIST]: () => dispatchWeb(openEditPlaylist(id)),
     [OverflowAction.DELETE_PLAYLIST]: () => dispatchWeb(openDeletePlaylist(id)),
     [OverflowAction.PUBLISH_PLAYLIST]: () =>

--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -30,7 +30,8 @@ import {
 import { profilePage } from 'audius-client/src/utils/route'
 
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
-import { usePushRouteWeb } from 'app/hooks/usePushRouteWeb'
+import { useDrawer } from 'app/hooks/useDrawer'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 type Props = {
@@ -38,8 +39,9 @@ type Props = {
 }
 
 const TrackOverflowMenuDrawer = ({ render }: Props) => {
+  const { onClose: closeNowPlayingDrawer } = useDrawer('NowPlaying')
+  const navigation = useNavigation()
   const dispatchWeb = useDispatchWeb()
-  const pushRouteWeb = usePushRouteWeb()
   const { id: modalId } = useSelectorWeb(getMobileOverflowModal)
   const id = modalId as ID
 
@@ -72,11 +74,20 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
       dispatchWeb(shareTrack(id, ShareSource.OVERFLOW)),
     [OverflowAction.ADD_TO_PLAYLIST]: () =>
       dispatchWeb(openAddToPlaylistModal(id, title)),
-    [OverflowAction.VIEW_TRACK_PAGE]: () =>
-      permalink === undefined
-        ? console.error(`Permalink missing for track ${id}`)
-        : pushRouteWeb(permalink),
-    [OverflowAction.VIEW_ARTIST_PAGE]: () => pushRouteWeb(profilePage(handle)),
+    [OverflowAction.VIEW_TRACK_PAGE]: () => {
+      closeNowPlayingDrawer()
+      navigation.navigate({
+        native: { screen: 'Track', params: { id } },
+        web: { route: permalink }
+      })
+    },
+    [OverflowAction.VIEW_ARTIST_PAGE]: () => {
+      closeNowPlayingDrawer()
+      navigation.navigate({
+        native: { screen: 'Profile', params: { handle } },
+        web: { route: profilePage(handle) }
+      })
+    },
     [OverflowAction.FOLLOW_ARTIST]: () =>
       dispatchWeb(followUser(owner_id, FollowSource.OVERFLOW)),
     [OverflowAction.UNFOLLOW_ARTIST]: () =>


### PR DESCRIPTION
### Description

Fixes two issues:
1. Overflow menu `View Track/Collection Page` and `View Artist Page` were not hooked up with native navigation
2. When clicking overflow menu items that trigger navigation, the NowPlayingDrawer would not close

### Dragons

It is def a bit interesting the way this pr implements this fix. Curious of folks thoughts