### PR TITLE
[AUD-1625] TrackScreen performance and DynamicImage fix

### DIFF
--- a/packages/mobile/src/WebAppManager.tsx
+++ b/packages/mobile/src/WebAppManager.tsx
@@ -11,8 +11,9 @@ type WebAppManagerProps = {
 }
 
 export const WebAppManager = ({ webApp, children }: WebAppManagerProps) => {
-  const commonState = useSelector((state: AppState) => state.common)
-  const isClientStoreEmpty = isEmpty(commonState)
+  const isClientStoreEmpty = useSelector((state: AppState) =>
+    isEmpty(state.common)
+  )
   return (
     <>
       {webApp}

--- a/packages/mobile/src/components/audio-breakdown-drawer/AudioBreakdownDrawer.tsx
+++ b/packages/mobile/src/components/audio-breakdown-drawer/AudioBreakdownDrawer.tsx
@@ -11,6 +11,7 @@ import {
   shortenSPLAddress
 } from 'audius-client/src/common/utils/wallet'
 import BN from 'bn.js'
+import { isEqual } from 'lodash'
 import {
   StyleSheet,
   TouchableWithoutFeedback,
@@ -181,10 +182,11 @@ const messages = {
 export const AudioBreakdownDrawer = () => {
   const styles = useThemedStyles(createStyles)
 
-  const accountBalance = (useSelectorWeb(getAccountBalance) ??
-    new BN('0')) as BNWei
+  const accountBalance = (useSelectorWeb(getAccountBalance, (a: BN, b: BN) =>
+    a.eq(b)
+  ) ?? new BN('0')) as BNWei
 
-  const associatedWallets = useSelectorWeb(getAssociatedWallets)
+  const associatedWallets = useSelectorWeb(getAssociatedWallets, isEqual)
   const {
     connectedEthWallets: ethWallets,
     connectedSolWallets: solWallets

--- a/packages/mobile/src/components/core/DynamicImage.tsx
+++ b/packages/mobile/src/components/core/DynamicImage.tsx
@@ -113,7 +113,7 @@ const ImageWithPlaceholder = ({
 }
 
 /**
- * A dynamic image that transitions between changes to the `image` prop.
+ * A dynamic image that transitions between changes to the `source` prop.
  */
 export const DynamicImage = memo(function DynamicImage({
   source,

--- a/packages/mobile/src/components/core/DynamicImage.tsx
+++ b/packages/mobile/src/components/core/DynamicImage.tsx
@@ -23,7 +23,6 @@ import {
   ViewStyle
 } from 'react-native'
 
-import transparentPlaceholderImg from 'app/assets/images/1x1-transparent.png'
 import { ImageSkeleton } from 'app/components/image-skeleton'
 import { StylesProp } from 'app/styles'
 
@@ -38,8 +37,6 @@ export type DynamicImageProps = {
   style?: StyleProp<ViewStyle>
   // Whether or not to immediately animate
   immediate?: boolean
-  // Whether or not to use the default placeholder
-  usePlaceholder?: boolean
   // overlays rendered above image
   children?: ReactNode
   // callback when image finishes loading
@@ -91,25 +88,16 @@ const isImageEqual = (
 }
 
 type ImageWithPlaceholderProps = {
-  usePlaceholder: boolean
   source?: ImageSourcePropType
   style: StyleProp<ImageStyle>
 }
 
-const ImageWithPlaceholder = ({
-  usePlaceholder,
-  source,
-  style
-}: ImageWithPlaceholderProps) => {
+const ImageWithPlaceholder = ({ source, style }: ImageWithPlaceholderProps) => {
   if (source) {
     return <Image source={source} style={style} />
   }
 
-  if (usePlaceholder) {
-    return <ImageSkeleton styles={{ root: style as ViewStyle }} />
-  }
-
-  return <Image source={transparentPlaceholderImg} style={style} />
+  return <ImageSkeleton styles={{ root: style as ViewStyle }} />
 }
 
 /**
@@ -120,7 +108,6 @@ export const DynamicImage = memo(function DynamicImage({
   style,
   styles: stylesProp,
   immediate,
-  usePlaceholder = true,
   children,
   onLoad
 }: DynamicImageProps) {
@@ -161,13 +148,13 @@ export const DynamicImage = memo(function DynamicImage({
     if (isFirstImageActive) {
       setIsFirstImageActive(false)
       setFirstImage(source)
-      animateTo(firstOpacity, 1, onLoad)
-      animateTo(secondOpacity, 0)
+      firstOpacity.setValue(1)
+      animateTo(secondOpacity, 0, onLoad)
     } else {
       setIsFirstImageActive(true)
       setSecondImage(source)
-      animateTo(firstOpacity, 0)
-      animateTo(secondOpacity, 1, onLoad)
+      secondOpacity.setValue(1)
+      animateTo(firstOpacity, 0, onLoad)
     }
   }, [
     animateTo,
@@ -202,7 +189,6 @@ export const DynamicImage = memo(function DynamicImage({
         <ImageWithPlaceholder
           source={firstImage}
           style={[{ width: firstSize, height: firstSize }, stylesProp?.image]}
-          usePlaceholder={usePlaceholder}
         />
       </Animated.View>
       <Animated.View
@@ -216,7 +202,6 @@ export const DynamicImage = memo(function DynamicImage({
         <ImageWithPlaceholder
           source={secondImage}
           style={[{ width: secondSize, height: secondSize }, stylesProp?.image]}
-          usePlaceholder={usePlaceholder}
         />
       </Animated.View>
       {children ? <View style={styles.children}>{children}</View> : null}

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 import { Name } from 'audius-client/src/common/models/Analytics'
 import { getUserId } from 'audius-client/src/common/store/account/selectors'
@@ -250,13 +250,13 @@ export const DetailsTile = ({
   const imageElement = coSign ? (
     <CoSign size={Size.LARGE}>
       <DynamicImage
-        source={{ uri: imageUrl }}
+        source={imageUrl ? { uri: imageUrl } : undefined}
         styles={{ image: styles.coverArt as ImageStyle }}
       />
     </CoSign>
   ) : (
     <DynamicImage
-      source={{ uri: imageUrl }}
+      source={imageUrl ? { uri: imageUrl } : undefined}
       styles={{ image: styles.coverArt as ImageStyle }}
     />
   )

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -248,7 +248,7 @@ export const DetailsTile = ({
   }
 
   const imageElement = coSign ? (
-    <CoSign size={Size.LARGE} style={styles.coverArt}>
+    <CoSign size={Size.LARGE}>
       <DynamicImage
         source={{ uri: imageUrl }}
         styles={{ image: styles.coverArt as ImageStyle }}

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 
 import { Name } from 'audius-client/src/common/models/Analytics'
 import { getUserId } from 'audius-client/src/common/store/account/selectors'

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -358,6 +358,7 @@ export const Lineup = ({
         return section.delineate ? <Delineator text={section.title} /> : null
       }}
       listKey={listKey}
+      scrollIndicatorInsets={{ right: Number.MIN_VALUE }}
     />
   )
 }

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -8,7 +8,7 @@ import {
   getFeedFilter
 } from 'audius-client/src/common/store/pages/feed/selectors'
 import { setVisibility } from 'audius-client/src/common/store/ui/modals/slice'
-import { isEqual } from 'lodash'
+import { isEqual, omit } from 'lodash'
 
 import { Screen } from 'app/components/core'
 import { Header } from 'app/components/header'
@@ -27,7 +27,10 @@ const messages = {
 
 export const FeedScreen = () => {
   const dispatchWeb = useDispatchWeb()
-  const feedLineup = useSelectorWeb(getFeedLineup, isEqual)
+  const feedLineup = useSelectorWeb(getFeedLineup, (a, b) => {
+    const omitUneeded = o => omit(o, ['inView'])
+    return isEqual(omitUneeded(a), omitUneeded(b))
+  })
   const feedFilter = useSelectorWeb(getFeedFilter)
   const [isRefreshing, setIsRefreshing] = useState(false)
 

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -1,3 +1,4 @@
+import { ID } from 'audius-client/src/common/models/Identifiers'
 import { LineupState } from 'audius-client/src/common/models/Lineup'
 import { Track } from 'audius-client/src/common/models/Track'
 import { User } from 'audius-client/src/common/models/User'
@@ -51,7 +52,7 @@ const createStyles = (themeColors: ThemeColors) =>
   })
 
 type TrackScreenMainContentProps = {
-  lineup: LineupState<Track>
+  lineup: LineupState<{ id: ID }>
   track: Track
   user: User
 }

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -9,7 +9,7 @@ import {
   getUser
 } from 'audius-client/src/common/store/pages/track/selectors'
 import { trackRemixesPage } from 'audius-client/src/utils/route'
-import { isEqual } from 'lodash'
+import { isEqual, omit } from 'lodash'
 import { StyleSheet, View } from 'react-native'
 
 import { Screen } from 'app/components/core'
@@ -114,9 +114,23 @@ const TrackScreenMainContent = ({
  */
 export const TrackScreen = () => {
   const { params } = useRoute<'Track'>()
-  const track = useSelectorWeb(state => getTrack(state, params))
-  const user = useSelectorWeb(state => getUser(state, { id: track?.owner_id }))
-  const lineup = useSelectorWeb(getMoreByArtistLineup, isEqual)
+  const track = useSelectorWeb(
+    state => getTrack(state, params),
+    (a, b) => {
+      const omitUneeded = o => omit(o, ['_stems', '_remix_parents'])
+      return isEqual(omitUneeded(a), omitUneeded(b))
+    }
+  )
+
+  const user = useSelectorWeb(
+    state => getUser(state, { id: track?.owner_id }),
+    isEqual
+  )
+
+  const lineup = useSelectorWeb(
+    getMoreByArtistLineup,
+    (a, b) => (!a.entries && !b.entries) || isEqual(a.entries, b.entries)
+  )
 
   if (!track || !user || !lineup) {
     console.warn(

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -117,6 +117,8 @@ export const TrackScreen = () => {
   const { params } = useRoute<'Track'>()
   const track = useSelectorWeb(
     state => getTrack(state, params),
+    // Omitting uneeded fields from the equality check because they are
+    // causing extra renders when added to the `track` object
     (a, b) => {
       const omitUneeded = o => omit(o, ['_stems', '_remix_parents'])
       return isEqual(omitUneeded(a), omitUneeded(b))
@@ -130,6 +132,8 @@ export const TrackScreen = () => {
 
   const lineup = useSelectorWeb(
     getMoreByArtistLineup,
+    // Checking for equality between the entries themselves, because
+    // lineup reset state changes cause extra renders
     (a, b) => (!a.entries && !b.entries) || isEqual(a.entries, b.entries)
   )
 


### PR DESCRIPTION
### Description

This PR:
  * Reduces rerenders related to loading the track screen
  * Fixes the scroll indicator on Lineup based pages
  * Fixes the flashing of images on Track/Collection screens

### Dragons

Added some pretty specific selector equality functions around track screen, if omitted data is needed in the future it will be important to update those

### How Has This Been Tested?
ios simulator

### How will this change be monitored?
when released
