### PR TITLE
Add playlists to folders functionality

### DIFF
--- a/packages/web/src/components/dragndrop/Droppable.js
+++ b/packages/web/src/components/dragndrop/Droppable.js
@@ -36,9 +36,13 @@ const Droppable = props => {
   }
 
   const drop = e => {
+    if (props.stopPropogationOnDrop) {
+      e.stopPropagation()
+    }
     const id = props.dragging.id
+    const kind = props.dragging.kind
     if (id) {
-      props.onDrop(id)
+      props.onDrop(id, kind)
     }
     setHovered(false)
   }
@@ -91,13 +95,15 @@ Droppable.propTypes = {
   acceptedKinds: PropTypes.arrayOf(PropTypes.string),
   disabled: PropTypes.bool,
   acceptOwner: PropTypes.bool,
-  children: PropTypes.any
+  children: PropTypes.any,
+  stopPropogationOnDrop: PropTypes.bool
 }
 
 Droppable.defaultProps = {
-  onDrop: id => {},
+  onDrop: (id, kind) => {},
   acceptedKinds: ['track', 'album', 'playlist', 'library-playlist'],
   disabled: false,
+  stopPropogationOnDrop: false,
   acceptOwner: true
 }
 

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -313,7 +313,8 @@ svg.logo path {
   width: calc(100% + 12px);
 }
 
-.navColumn .links a.link.disabledLink {
+.navColumn .links a.link.disabledLink,
+.navColumn .links button.link.disabledLink {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
@@ -52,7 +52,10 @@ export const PlaylistNavLink = ({
       key={droppableKey}
       className={styles.droppable}
       hoverClassName={styles.droppableHover}
-      onDrop={(id: ID | SmartCollectionVariant) => onReorder(id, playlistId)}
+      onDrop={(id: ID | SmartCollectionVariant) => {
+        onReorder(id, playlistId)
+      }}
+      stopPropogationOnDrop={true}
       acceptedKinds={['library-playlist']}
     >
       <Draggable

--- a/packages/web/src/store/playlist-library/helpers.test.js
+++ b/packages/web/src/store/playlist-library/helpers.test.js
@@ -7,7 +7,8 @@ import {
   removePlaylistFolderInLibrary,
   removePlaylistLibraryDuplicates,
   renamePlaylistFolderInLibrary,
-  reorderPlaylistLibrary
+  reorderPlaylistLibrary,
+  addPlaylistToFolder
 } from './helpers'
 
 describe('findInPlaylistLibrary', () => {
@@ -741,5 +742,133 @@ describe('removePlaylistFolderInLibrary', () => {
       'fake-uuid-not-in-library'
     )
     expect(result).toEqual({ ...library })
+  })
+})
+
+describe('addPlaylistToFolder', () => {
+  it('adds playlist to given folder', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        {
+          type: 'folder',
+          name: 'Foldero',
+          id: 'fake-uuid',
+          contents: [
+            { type: 'playlist', playlist_id: 3 },
+            { type: 'temp_playlist', playlist_id: 'asdf' }
+          ]
+        }
+      ]
+    }
+
+    const result = addPlaylistToFolder(library, 'Heavy Rotation', 'fake-uuid')
+    const expectedResult = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        {
+          type: 'folder',
+          name: 'Foldero',
+          id: 'fake-uuid',
+          contents: [
+            { type: 'explore_playlist', playlist_id: 'Heavy Rotation' },
+            { type: 'playlist', playlist_id: 3 },
+            { type: 'temp_playlist', playlist_id: 'asdf' }
+          ]
+        }
+      ]
+    }
+    expect(result).toEqual(expectedResult)
+  })
+
+  it('returns the original unchanged library if the playlist is already in the folder', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        {
+          type: 'folder',
+          name: 'Foldero',
+          id: 'fake-uuid',
+          contents: [
+            { type: 'playlist', playlist_id: 3 },
+            { type: 'temp_playlist', playlist_id: 'asdf' }
+          ]
+        }
+      ]
+    }
+
+    const result = addPlaylistToFolder(library, 'asdf', 'fake-uuid')
+    expect(result).toBe(library)
+  })
+
+  it('returns the original unchanged library if folder does not exist', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        {
+          type: 'folder',
+          name: 'Foldero',
+          id: 'fake-uuid',
+          contents: [
+            { type: 'playlist', playlist_id: 3 },
+            { type: 'temp_playlist', playlist_id: 'asdf' }
+          ]
+        }
+      ]
+    }
+
+    const result = addPlaylistToFolder(
+      library,
+      'Heavy Rotation',
+      'uuid-doesnt-exist'
+    )
+    expect(result).toBe(library)
+  })
+
+  it('returns the original unchanged library if the library has no contents', () => {
+    const library = {}
+
+    const result = addPlaylistToFolder(library, 'Heavy Rotation', 'fake-uuid')
+    expect(result).toBe(library)
+  })
+
+  it('moves the playlist into the folder if the playlist is already in the library but not in the folder', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        {
+          type: 'folder',
+          name: 'Foldero',
+          id: 'fake-uuid',
+          contents: [
+            { type: 'playlist', playlist_id: 3 },
+            { type: 'temp_playlist', playlist_id: 'asdf' }
+          ]
+        }
+      ]
+    }
+
+    const result = addPlaylistToFolder(library, 2, 'fake-uuid')
+    const expectedResult = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        {
+          type: 'folder',
+          name: 'Foldero',
+          id: 'fake-uuid',
+          contents: [
+            { type: 'playlist', playlist_id: 2 },
+            { type: 'playlist', playlist_id: 3 },
+            { type: 'temp_playlist', playlist_id: 'asdf' }
+          ]
+        }
+      ]
+    }
+    expect(result).toEqual(expectedResult)
   })
 })


### PR DESCRIPTION
### Description
UI / functionality for dragging a playlist (from library or tile) into a collapsed or expanded folder (general area)
Up next: Reordering playlists/folders incl. playlists within folders

![addplaylist](https://user-images.githubusercontent.com/36916764/157676453-1e019b41-62cb-4c66-b33f-6a0fde2898bb.gif)

### Dragons
Shouldn't affect anything in prod / outside of folders feature flag

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Unit tests + tested in browser 
*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
