### PR TITLE
[PAY-83] Remove step counts from rewards config

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -47,7 +47,6 @@ type RewardPanelProps = {
   panelButtonText: string
   progressLabel: string
   remainingLabel?: string
-  stepCount: number
   openModal: (modalType: ChallengeRewardsModalType) => void
   id: ChallengeRewardID
 }
@@ -60,8 +59,7 @@ const RewardPanel = ({
   openModal,
   progressLabel,
   remainingLabel,
-  icon,
-  stepCount
+  icon
 }: RewardPanelProps) => {
   const wm = useWithMobileStyle(styles.mobile)
   const userChallenges = useSelector(getOptimisticUserChallenges)
@@ -73,7 +71,9 @@ const RewardPanel = ({
     challenge?.state === 'completed' || challenge?.state === 'disbursed'
   const needsDisbursement = challenge && challenge.claimableAmount > 0
   const shouldShowProgressBar =
-    stepCount > 1 && challenge?.challenge_type !== 'aggregate'
+    challenge &&
+    challenge.max_steps > 1 &&
+    challenge.challenge_type !== 'aggregate'
 
   let progressLabelFilled: string
   if (shouldShowCompleted) {
@@ -83,14 +83,14 @@ const RewardPanel = ({
     progressLabelFilled = fillString(
       remainingLabel ?? '',
       (challenge?.max_steps - challenge?.current_step_count)?.toString() ?? '',
-      stepCount.toString()
+      challenge?.max_steps?.toString() ?? ''
     )
   } else {
     // Count up
     progressLabelFilled = fillString(
       progressLabel,
       challenge?.current_step_count?.toString() ?? '',
-      stepCount.toString()
+      challenge?.max_steps?.toString() ?? ''
     )
   }
 
@@ -115,7 +115,7 @@ const RewardPanel = ({
           <ProgressBar
             className={styles.rewardProgressBar}
             value={challenge?.current_step_count ?? 0}
-            max={stepCount}
+            max={challenge?.max_steps}
           />
         )}
       </div>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -203,7 +203,6 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const {
     fullDescription,
     progressLabel,
-    stepCount,
     modalButtonInfo,
     verifiedChallenge
   } = challengeRewardsConfig[modalType]
@@ -272,7 +271,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
           {fillString(
             progressLabel,
             currentStepCount.toString(),
-            stepCount.toString()
+            challenge?.max_steps?.toString() ?? ''
           )}
         </h3>
       )}
@@ -354,7 +353,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
                   <ProgressBar
                     className={wm(styles.progressBar)}
                     value={currentStepCount}
-                    max={stepCount}
+                    max={challenge?.max_steps}
                   />
                 </div>
               ) : null}
@@ -375,7 +374,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
               <ProgressBar
                 className={wm(styles.progressBar)}
                 value={currentStepCount}
-                max={stepCount}
+                max={challenge?.max_steps}
               />
             </div>
           )}

--- a/packages/web/src/pages/audio-rewards-page/config.tsx
+++ b/packages/web/src/pages/audio-rewards-page/config.tsx
@@ -64,7 +64,6 @@ type ChallengeRewardsInfo = {
   progressLabel: string
   remainingLabel?: string
   amount: number
-  stepCount: number
   panelButtonText: string
   modalButtonInfo: {
     incomplete: LinkButtonInfo | null
@@ -89,7 +88,6 @@ export const challengeRewardsConfig: Record<
     progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     amount: amounts.referrals,
-    stepCount: 5,
     panelButtonText: 'Invite your Friends',
     modalButtonInfo: {
       incomplete: null,
@@ -107,7 +105,6 @@ export const challengeRewardsConfig: Record<
     progressLabel: '%0/%1 Invites Accepted',
     remainingLabel: '%0/%1 Invites Remain',
     amount: amounts.referrals,
-    stepCount: 500,
     panelButtonText: 'Invite your Fans',
     modalButtonInfo: {
       incomplete: null,
@@ -124,7 +121,6 @@ export const challengeRewardsConfig: Record<
     fullDescription: () => `You earned $AUDIO for being invited`,
     progressLabel: '%0/%1 Invites',
     amount: amounts.referrals,
-    stepCount: 1,
     panelButtonText: 'More Info',
     modalButtonInfo: {
       incomplete: null,
@@ -142,7 +138,6 @@ export const challengeRewardsConfig: Record<
       'Get verified on Audius by linking your verified Twitter or Instagram account!',
     progressLabel: 'Not Linked',
     amount: amounts['connect-verified'],
-    stepCount: 1,
     panelButtonText: 'Link Verified Account',
     modalButtonInfo: {
       incomplete: linkButtonMap.verifyAccount,
@@ -160,7 +155,6 @@ export const challengeRewardsConfig: Record<
       'Sign in and listen to at least one track every day for 7 days',
     progressLabel: '%0/%1 Days',
     amount: amounts['listen-streak'],
-    stepCount: 7,
     panelButtonText: 'Trending on Audius',
     modalButtonInfo: {
       incomplete: linkButtonMap.trendingTracks,
@@ -177,7 +171,6 @@ export const challengeRewardsConfig: Record<
       'Install the Audius app for iPhone and Android and Sign in to your account!',
     progressLabel: 'Not Installed',
     amount: amounts['mobile-install'],
-    stepCount: 1,
     panelButtonText: 'Get the App',
     modalButtonInfo: {
       incomplete: null,
@@ -195,7 +188,6 @@ export const challengeRewardsConfig: Record<
       'Fill out the missing details on your Audius profile and start interacting with tracks and artists!',
     progressLabel: '%0/%1 Complete',
     amount: amounts['profile-completion'],
-    stepCount: 7,
     panelButtonText: 'More Info',
     modalButtonInfo: {
       incomplete: linkButtonMap.profile,
@@ -211,7 +203,6 @@ export const challengeRewardsConfig: Record<
     fullDescription: () => 'Upload 3 tracks to your profile',
     progressLabel: '%0/%1 Uploaded',
     amount: amounts['track-upload'],
-    stepCount: 3,
     panelButtonText: 'Upload Tracks',
     modalButtonInfo: {
       incomplete: linkButtonMap.trackUpload,


### PR DESCRIPTION
### Description

Remove config related to step counts. It was only being used in the rewards tile, and was causing discrepancies between what DNs were reporting and what the client showed.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

N/A

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Verified the rewards tiles look good on stage.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A
