### PR TITLE
Add commas to numbers

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawer.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { UserChallengeState } from 'audius-client/src/common/models/AudioRewards'
 import { ClaimStatus } from 'audius-client/src/common/store/pages/audio-rewards/slice'
+import { fillString } from 'audius-client/src/common/utils/fillString'
 import { formatNumberCommas } from 'audius-client/src/common/utils/formatUtil'
 import { StyleSheet, View, ImageSourcePropType } from 'react-native'
 
@@ -201,9 +202,11 @@ export const ChallengeRewardsDrawer = ({
   const statusText = hasCompleted
     ? messages.complete
     : isInProgress
-    ? `${formatNumberCommas(currentStep)}/${formatNumberCommas(
-        stepCount
-      )} ${progressLabel}`
+    ? fillString(
+        progressLabel,
+        formatNumberCommas(currentStep),
+        formatNumberCommas(stepCount)
+      )
     : messages.incomplete
 
   const claimedAmountText = `(${formatNumberCommas(claimedAmount)} ${

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawer.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { UserChallengeState } from 'audius-client/src/common/models/AudioRewards'
 import { ClaimStatus } from 'audius-client/src/common/store/pages/audio-rewards/slice'
+import { formatNumberCommas } from 'audius-client/src/common/utils/formatUtil'
 import { StyleSheet, View, ImageSourcePropType } from 'react-native'
 
 import IconCheck from 'app/assets/images/iconCheck.svg'
@@ -200,11 +201,17 @@ export const ChallengeRewardsDrawer = ({
   const statusText = hasCompleted
     ? messages.complete
     : isInProgress
-    ? `${currentStep}/${stepCount} ${progressLabel}`
+    ? `${formatNumberCommas(currentStep)}/${formatNumberCommas(
+        stepCount
+      )} ${progressLabel}`
     : messages.incomplete
 
-  const claimedAmountText = `(${claimedAmount} ${messages.claimedLabel})`
-  const claimableAmountText = `${claimableAmount} ${messages.claimableLabel}`
+  const claimedAmountText = `(${formatNumberCommas(claimedAmount)} ${
+    messages.claimedLabel
+  })`
+  const claimableAmountText = `${formatNumberCommas(claimableAmount)} ${
+    messages.claimableLabel
+  }`
 
   return (
     <AppDrawer
@@ -240,7 +247,7 @@ export const ChallengeRewardsDrawer = ({
                 {messages.reward}
               </Text>
               <GradientText style={styles.audioAmount}>
-                {`${amount}`}
+                {formatNumberCommas(amount)}
               </GradientText>
               <Text style={styles.audioLabel} weight='heavy'>
                 {messages.audio}

--- a/packages/mobile/src/screens/audio-screen/Panel.tsx
+++ b/packages/mobile/src/screens/audio-screen/Panel.tsx
@@ -1,5 +1,6 @@
 import { OptimisticUserChallenge } from 'audius-client/src/common/models/AudioRewards'
 import { fillString } from 'audius-client/src/common/utils/fillString'
+import { formatNumberCommas } from 'audius-client/src/common/utils/formatUtil'
 import { View, Image } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 
@@ -95,14 +96,14 @@ export const Panel = ({
         remainingLabel ?? '',
         (challenge?.max_steps - challenge?.current_step_count)?.toString() ??
           '',
-        stepCount.toString()
+        formatNumberCommas(stepCount.toString())
       )
     } else {
       // Count up
       progressLabelFilled = fillString(
         progressLabel,
         challenge?.current_step_count?.toString() ?? '',
-        stepCount.toString()
+        formatNumberCommas(stepCount.toString())
       )
     }
   }

--- a/packages/mobile/src/utils/challenges.tsx
+++ b/packages/mobile/src/utils/challenges.tsx
@@ -71,7 +71,7 @@ export const challenges = {
   referreralsVerifiedTitle: 'Invite your Fans',
   referralsVerifiedDescription:
     'Invite your fans! You’ll earn 1 $AUDIO for each friend who joins with your link (and they’ll get an $AUDIO too)',
-  referralsVerifiedShortDescription: 'Earn up to 5000 $AUDIO',
+  referralsVerifiedShortDescription: 'Earn up to 5,000 $AUDIO',
   referralsVerifiedProgressLabel: '%0/%1 Invites Accepted',
   referralsVerifiedRemainingLabel: '%0/%1 Invites Remain',
 

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -21,6 +21,7 @@ import {
   setChallengeRewardsModalType
 } from 'common/store/pages/audio-rewards/slice'
 import { fillString } from 'common/utils/fillString'
+import { formatNumberCommas } from 'common/utils/formatUtil'
 import { removeNullable } from 'common/utils/typeUtils'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useRemoteVar } from 'hooks/useRemoteConfig'
@@ -82,15 +83,17 @@ const RewardPanel = ({
     // Count down
     progressLabelFilled = fillString(
       remainingLabel ?? '',
-      (challenge?.max_steps - challenge?.current_step_count)?.toString() ?? '',
-      challenge?.max_steps?.toString() ?? ''
+      formatNumberCommas(
+        (challenge?.max_steps - challenge?.current_step_count)?.toString() ?? ''
+      ),
+      formatNumberCommas(challenge?.max_steps?.toString() ?? '')
     )
   } else {
     // Count up
     progressLabelFilled = fillString(
       progressLabel,
-      challenge?.current_step_count?.toString() ?? '',
-      challenge?.max_steps?.toString() ?? ''
+      formatNumberCommas(challenge?.current_step_count?.toString() ?? ''),
+      formatNumberCommas(challenge?.max_steps?.toString() ?? '')
     )
   }
 

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -33,6 +33,7 @@ import {
   claimChallengeReward
 } from 'common/store/pages/audio-rewards/slice'
 import { fillString } from 'common/utils/fillString'
+import { formatNumberCommas } from 'common/utils/formatUtil'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { show as showConfetti } from 'components/music-confetti/store/slice'
 import Toast from 'components/toast/Toast'
@@ -245,7 +246,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const progressReward = (
     <div className={wm(styles.progressReward)}>
       <h3>Reward</h3>
-      <h2>{challenge?.totalAmount}</h2>
+      <h2>{formatNumberCommas(challenge?.totalAmount || '')}</h2>
       <h4>$AUDIO</h4>
     </div>
   )
@@ -270,8 +271,8 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         <h3 className={styles.inProgress}>
           {fillString(
             progressLabel,
-            currentStepCount.toString(),
-            challenge?.max_steps?.toString() ?? ''
+            formatNumberCommas(currentStepCount.toString()),
+            formatNumberCommas(challenge?.max_steps?.toString() ?? '')
           )}
         </h3>
       )}
@@ -438,7 +439,9 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         ) : null}
         {audioClaimedSoFar > 0 && challenge?.state !== 'disbursed' ? (
           <div className={styles.claimRewardClaimedAmountLabel}>
-            {`(${audioClaimedSoFar} ${messages.claimedSoFar})`}
+            {`(${formatNumberCommas(audioClaimedSoFar)} ${
+              messages.claimedSoFar
+            })`}
           </div>
         ) : null}
       </div>

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -246,7 +246,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
   const progressReward = (
     <div className={wm(styles.progressReward)}>
       <h3>Reward</h3>
-      <h2>{formatNumberCommas(challenge?.totalAmount || '')}</h2>
+      <h2>{formatNumberCommas(challenge?.totalAmount ?? '')}</h2>
       <h4>$AUDIO</h4>
     </div>
   )

--- a/packages/web/src/pages/audio-rewards-page/config.tsx
+++ b/packages/web/src/pages/audio-rewards-page/config.tsx
@@ -8,6 +8,7 @@ import {
   OptimisticUserChallenge,
   TrendingRewardID
 } from 'common/models/AudioRewards'
+import { formatNumberCommas } from 'common/utils/formatUtil'
 import { Nullable } from 'common/utils/typeUtils'
 import {
   profilePage,
@@ -99,7 +100,8 @@ export const challengeRewardsConfig: Record<
     id: 'ref-v' as ChallengeRewardID,
     title: 'Invite your Fans',
     icon: <i className='emoji large incoming-envelope' />,
-    description: challenge => `Earn up to ${challenge?.totalAmount} $AUDIO`,
+    description: challenge =>
+      `Earn up to ${formatNumberCommas(challenge?.totalAmount ?? '')} $AUDIO`,
     fullDescription: challenge =>
       `Invite your fans! You’ll earn ${challenge?.amount} $AUDIO for each fan who joins with your link (and they’ll get an $AUDIO too)`,
     progressLabel: '%0/%1 Invites Accepted',


### PR DESCRIPTION
### Description

Adds commas to amount/step numbers in rewards page/modal

Also fixes bug with the progress text on mobile

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested manually on web desktop and iOS native

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
