### PR TITLE
[AUD-1684]: ProfileScreen performance

### DIFF
--- a/packages/mobile/src/components/app-navigator/BottomTabNavigator.tsx
+++ b/packages/mobile/src/components/app-navigator/BottomTabNavigator.tsx
@@ -87,7 +87,11 @@ const FavoritesStackScreen = createStackScreen<FavoritesStackParamList>(
 
 const ProfileStackScreen = createStackScreen<ProfileStackParamList>(Stack => (
   <>
-    <Stack.Screen name='ProfileStack' component={ProfileScreen} />
+    <Stack.Screen
+      name='ProfileStack'
+      component={ProfileScreen}
+      initialParams={{ handle: 'accountUser' }}
+    />
     <Stack.Screen name='EditProfile' component={EditProfileScreen} />
     <Stack.Screen name='SettingsScreen' component={SettingsScreen} />
     <Stack.Screen name='AboutScreen' component={AboutScreen} />

--- a/packages/mobile/src/components/app-navigator/TopTabNavigator.tsx
+++ b/packages/mobile/src/components/app-navigator/TopTabNavigator.tsx
@@ -1,6 +1,9 @@
 import { ComponentType, ReactNode } from 'react'
 
-import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs'
+import {
+  createMaterialTopTabNavigator,
+  MaterialTopTabNavigationOptions
+} from '@react-navigation/material-top-tabs'
 import { SvgProps } from 'react-native-svg'
 
 import { TopTabBar } from 'app/components/top-tab-bar'
@@ -17,11 +20,13 @@ const useStyles = makeStyles(({ palette }) => ({
 type TabNavigatorProps = {
   initialScreenName?: string
   children: ReactNode
+  screenOptions?: MaterialTopTabNavigationOptions
 }
 
 export const TabNavigator = ({
   initialScreenName,
-  children
+  children,
+  screenOptions
 }: TabNavigatorProps) => {
   const styles = useStyles()
   return (
@@ -31,7 +36,8 @@ export const TabNavigator = ({
       screenOptions={{
         tabBarStyle: styles.root,
         tabBarLabelStyle: styles.label,
-        tabBarIndicatorStyle: styles.indicator
+        tabBarIndicatorStyle: styles.indicator,
+        ...screenOptions
       }}
     >
       {children}
@@ -48,10 +54,11 @@ type ScreenConfig = {
 
 type TabScreenConfig = ScreenConfig & {
   key?: string
+  initialParams?: Record<string, unknown>
 }
 
 export const tabScreen = (config: TabScreenConfig) => {
-  const { key, name, label, Icon, component } = config
+  const { key, name, label, Icon, component, initialParams } = config
   return (
     <Tab.Screen
       key={key}
@@ -61,6 +68,7 @@ export const tabScreen = (config: TabScreenConfig) => {
         tabBarLabel: label ?? name,
         tabBarIcon: ({ color }) => <Icon fill={color} />
       }}
+      initialParams={initialParams}
     />
   )
 }

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -122,7 +122,8 @@ export const Lineup = ({
   listKey,
   selfLoad,
   includeLineupStatus,
-  ...scrollViewProps
+  limit = Infinity,
+  ...sectionListProps
 }: LineupProps) => {
   const dispatchWeb = useDispatchWeb()
   const ref = useRef<SectionList>(null)
@@ -158,6 +159,7 @@ export const Lineup = ({
       lineupLength < countOrDefault &&
       // Page item count doesn't exceed current offset
       (page === 0 || pageItemCount <= offset) &&
+      entries.length < limit &&
       (includeLineupStatus ? status !== Status.LOADING : true)
 
     if (shouldLoadMore) {
@@ -183,7 +185,8 @@ export const Lineup = ({
     loadMore,
     dispatchWeb,
     pageItemCount,
-    includeLineupStatus
+    includeLineupStatus,
+    limit
   ])
 
   useEffectOnce(() => {
@@ -277,10 +280,11 @@ export const Lineup = ({
 
     const getSkeletonCount = () => {
       const shouldCalculateSkeletons =
+        items.length < limit &&
         // Lineup has more items to load
         hasMore &&
-        // Data is loading
-        isMetadataLoading &&
+        // Data is loading or about to start
+        (items.length === 0 || isMetadataLoading) &&
         // There are fewer items than the max count
         items.length < countOrDefault
 
@@ -321,10 +325,14 @@ export const Lineup = ({
       ]
     }
 
+    const data = [...items, ...skeletonItems]
+
+    if (data.length === 0) return []
+
     return [
       {
         delineate: false,
-        data: [...items, ...skeletonItems]
+        data: data
       }
     ]
   }, [
@@ -336,12 +344,13 @@ export const Lineup = ({
     pageItemCount,
     leadingElementId,
     showLeadingElementArtistPick,
-    start
+    start,
+    limit
   ])
 
   return (
     <SectionList
-      {...scrollViewProps}
+      {...sectionListProps}
       ref={ref}
       ListHeaderComponent={header}
       ListFooterComponent={<View style={{ height: 160 }} />}

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -121,6 +121,7 @@ export const Lineup = ({
   variant = LineupVariant.MAIN,
   listKey,
   selfLoad,
+  includeLineupStatus,
   ...scrollViewProps
 }: LineupProps) => {
   const dispatchWeb = useDispatchWeb()
@@ -157,7 +158,7 @@ export const Lineup = ({
       lineupLength < countOrDefault &&
       // Page item count doesn't exceed current offset
       (page === 0 || pageItemCount <= offset) &&
-      status !== Status.LOADING
+      (includeLineupStatus ? status !== Status.LOADING : true)
 
     if (shouldLoadMore) {
       const itemLoadCount = itemCounts.initial + page * itemCounts.loadMore
@@ -181,7 +182,8 @@ export const Lineup = ({
     countOrDefault,
     loadMore,
     dispatchWeb,
-    pageItemCount
+    pageItemCount,
+    includeLineupStatus
   ])
 
   useEffectOnce(() => {

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -111,4 +111,10 @@ export type LineupProps = {
    * another VirtualizedList.
    */
   listKey?: string
+
+  /**
+   * When `true` don't load more while lineup status is `LOADING`.
+   * This helps prevent collisions with any in-flight loading from web-app
+   */
+  includeLineupStatus?: boolean
 } & Pick<ScrollViewProps, 'showsVerticalScrollIndicator'>

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -3,7 +3,7 @@ import Kind from 'audius-client/src/common/models/Kind'
 import { Lineup as LineupData } from 'audius-client/src/common/models/Lineup'
 import { LineupActions } from 'audius-client/src/common/store/lineup/actions'
 import { Maybe } from 'audius-client/src/common/utils/typeUtils'
-import { ScrollViewProps, SectionListProps } from 'react-native'
+import { SectionListProps } from 'react-native'
 
 export enum LineupVariant {
   MAIN = 'main',
@@ -67,7 +67,7 @@ export type LineupProps = {
    * A header to display at the top of the lineup,
    * will scroll with the rest of the content
    */
-  header?: SectionListProps<any>['ListHeaderComponent']
+  header?: SectionListProps<unknown>['ListHeaderComponent']
 
   /**
    * Function called on refresh
@@ -117,4 +117,7 @@ export type LineupProps = {
    * This helps prevent collisions with any in-flight loading from web-app
    */
   includeLineupStatus?: boolean
-} & Pick<ScrollViewProps, 'showsVerticalScrollIndicator'>
+} & Pick<
+  SectionListProps<unknown>,
+  'showsVerticalScrollIndicator' | 'ListEmptyComponent'
+>

--- a/packages/mobile/src/components/user/ProfilePicture.tsx
+++ b/packages/mobile/src/components/user/ProfilePicture.tsx
@@ -18,11 +18,11 @@ const useStyles = makeStyles(({ palette }) => ({
   }
 }))
 
-type ProfilePhotoProps = Partial<DynamicImageProps> & {
+export type ProfilePictureProps = Partial<DynamicImageProps> & {
   profile: User
 }
 
-export const ProfilePhoto = (props: ProfilePhotoProps) => {
+export const ProfilePicture = (props: ProfilePictureProps) => {
   const { styles: stylesProp, profile, ...other } = props
   const styles = useStyles()
 

--- a/packages/mobile/src/hooks/selectors.ts
+++ b/packages/mobile/src/hooks/selectors.ts
@@ -1,4 +1,3 @@
-import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
 import { getProfileUser } from 'audius-client/src/common/store/pages/profile/selectors'
 import { isEqual } from 'lodash'
 
@@ -6,8 +5,4 @@ import { useSelectorWeb } from './useSelectorWeb'
 
 export const useProfile = (params?: { handle?: string }) => {
   return useSelectorWeb(state => getProfileUser(state, params), isEqual)
-}
-
-export const useAccountUser = () => {
-  return useSelectorWeb(getAccountUser, isEqual)
 }

--- a/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
@@ -1,27 +1,19 @@
-import { useMemo } from 'react'
+import { getProfileAlbums } from 'audius-client/src/common/store/pages/profile/selectors'
 
 import { CollectionList } from 'app/components/collection-list/CollectionList'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { useEmptyProfileText } from './EmptyProfileTile'
-import { useProfileAlbums } from './selectors'
 
 export const AlbumsTab = () => {
-  const { profile, albums } = useProfileAlbums()
+  const albums = useSelectorWeb(getProfileAlbums)
 
-  const userAlbums = useMemo(() => {
-    if (profile && albums) {
-      return albums.map(album => ({ ...album, user: profile }))
-    }
-  }, [profile, albums])
-
-  const emptyListText = useEmptyProfileText(profile, 'albums')
-
-  if (!userAlbums) return null
+  const emptyListText = useEmptyProfileText('albums')
 
   return (
     <CollectionList
       listKey='profile-albums'
-      collection={userAlbums}
+      collection={albums}
       emptyListText={emptyListText}
       disableTopTabScroll
       fromPage='profile'

--- a/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
+++ b/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useCallback } from 'react'
 
 import { FollowSource } from 'audius-client/src/common/models/Analytics'
-import { User } from 'audius-client/src/common/models/User'
 import {
   followUser,
   unfollowUser
@@ -15,13 +14,14 @@ import IconFollow from 'app/assets/images/iconFollow.svg'
 import IconFollowing from 'app/assets/images/iconFollowing.svg'
 import IconClose from 'app/assets/images/iconRemove.svg'
 import { Button, IconButton, Text } from 'app/components/core'
-import { ProfilePhoto } from 'app/components/user'
+import { ProfilePicture } from 'app/components/user'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
 import { track, make } from 'app/utils/analytics'
 
 import { EventNames } from '../../../types/analytics'
+import { useSelectProfile } from '../selectors'
 
 import { ArtistLink } from './ArtistLink'
 
@@ -66,16 +66,15 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
 }))
 
 type ArtistRecommendationsProps = {
-  profile: User
   onClose: () => void
 }
 
 const getRelatedArtistIds = makeGetRelatedArtists()
 
 export const ArtistRecommendations = (props: ArtistRecommendationsProps) => {
+  const { onClose } = props
   const styles = useStyles()
-  const { profile, onClose } = props
-  const { user_id, name } = profile
+  const { user_id, name } = useSelectProfile(['user_id', 'name'])
 
   const dispatchWeb = useDispatchWeb()
 
@@ -133,7 +132,7 @@ export const ArtistRecommendations = (props: ArtistRecommendationsProps) => {
       </View>
       <View style={styles.suggestedArtistsPhotos}>
         {suggestedArtists.map(artist => (
-          <ProfilePhoto
+          <ProfilePicture
             key={artist.user_id}
             profile={artist}
             style={styles.suggestedArtistPhoto}

--- a/packages/mobile/src/screens/profile-screen/CoverPhoto.tsx
+++ b/packages/mobile/src/screens/profile-screen/CoverPhoto.tsx
@@ -1,11 +1,12 @@
 import { WidthSizes } from 'audius-client/src/common/models/ImageSizes'
-import { User } from 'audius-client/src/common/models/User'
 
 import BadgeArtist from 'app/assets/images/badgeArtist.svg'
 import imageCoverPhotoBlank from 'app/assets/images/imageCoverPhotoBlank.jpg'
 import { DynamicImage } from 'app/components/core'
 import { useUserCoverPhoto } from 'app/hooks/useUserCoverPhoto'
 import { makeStyles } from 'app/styles/makeStyles'
+
+import { useSelectProfile } from './selectors'
 
 const useStyles = makeStyles(({ spacing }) => ({
   artistBadge: {
@@ -21,13 +22,13 @@ const useStyles = makeStyles(({ spacing }) => ({
   }
 }))
 
-type CoverPhotoProps = {
-  profile: User
-}
-
-export const CoverPhoto = ({ profile }: CoverPhotoProps) => {
+export const CoverPhoto = () => {
   const styles = useStyles()
-  const { user_id, _cover_photo_sizes, track_count } = profile
+  const { user_id, _cover_photo_sizes, track_count } = useSelectProfile([
+    'user_id',
+    '_cover_photo_sizes',
+    'track_count'
+  ])
 
   const coverPhoto = useUserCoverPhoto(
     user_id,

--- a/packages/mobile/src/screens/profile-screen/EmptyProfileTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/EmptyProfileTile.tsx
@@ -1,9 +1,9 @@
-import { User } from 'audius-client/src/common/models/User'
+import { getUserId } from 'audius-client/src/common/store/account/selectors'
 
 import { EmptyTile } from 'app/components/core'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
-import { getIsOwner, useSelectProfile } from './selectors'
+import { useSelectProfile } from './selectors'
 
 const messages = {
   you: 'You',
@@ -17,9 +17,11 @@ const messages = {
 
 type Tab = 'tracks' | 'albums' | 'playlists' | 'reposts'
 
-export const useEmptyProfileText = (profileUser: User, tab: Tab) => {
-  const { name } = useSelectProfile(['name'])
-  const isOwner = useSelectorWeb(getIsOwner)
+export const useEmptyProfileText = (tab: Tab) => {
+  const { user_id, name } = useSelectProfile(['user_id', 'name'])
+  const accountId = useSelectorWeb(getUserId)
+
+  const isOwner = user_id === accountId
 
   const youAction = `${messages.you} ${messages.haveNot}`
   const nameAction = `${name} ${messages.hasNot}`
@@ -32,8 +34,7 @@ type EmptyProfileTileProps = {
 
 export const EmptyProfileTile = (props: EmptyProfileTileProps) => {
   const { tab } = props
-  const profile = useSelectProfile(['user_id', 'name'])
-  const emptyText = useEmptyProfileText(profile, tab)
+  const emptyText = useEmptyProfileText(tab)
 
   return <EmptyTile message={emptyText} />
 }

--- a/packages/mobile/src/screens/profile-screen/EmptyProfileTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/EmptyProfileTile.tsx
@@ -1,8 +1,9 @@
 import { User } from 'audius-client/src/common/models/User'
-import { Nullable } from 'audius-client/src/common/utils/typeUtils'
 
 import { EmptyTile } from 'app/components/core'
-import { useAccountUser } from 'app/hooks/selectors'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+
+import { getIsOwner, useSelectProfile } from './selectors'
 
 const messages = {
   you: 'You',
@@ -16,24 +17,22 @@ const messages = {
 
 type Tab = 'tracks' | 'albums' | 'playlists' | 'reposts'
 
-export const useEmptyProfileText = (profile: Nullable<User>, tab: Tab) => {
-  const accountUser = useAccountUser()
+export const useEmptyProfileText = (profileUser: User, tab: Tab) => {
+  const { name } = useSelectProfile(['name'])
+  const isOwner = useSelectorWeb(getIsOwner)
 
-  if (!profile) return ''
-  const { user_id, name } = profile
-  const isOwner = user_id === accountUser?.user_id
   const youAction = `${messages.you} ${messages.haveNot}`
   const nameAction = `${name} ${messages.hasNot}`
   return `${isOwner ? youAction : nameAction} ${messages[tab]}`
 }
 
 type EmptyProfileTileProps = {
-  profile: User
   tab: Tab
 }
 
 export const EmptyProfileTile = (props: EmptyProfileTileProps) => {
-  const { tab, profile } = props
+  const { tab } = props
+  const profile = useSelectProfile(['user_id', 'name'])
   const emptyText = useEmptyProfileText(profile, tab)
 
   return <EmptyTile message={emptyText} />

--- a/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
+++ b/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { User } from 'audius-client/src/common/models/User'
 import {
   Pressable,
   View,
@@ -14,6 +13,7 @@ import { Hyperlink } from 'app/components/core'
 import { makeStyles } from 'app/styles/makeStyles'
 
 import { Sites } from './Sites'
+import { useSelectProfile } from './selectors'
 import { squashNewLines } from './utils'
 
 const messages = {
@@ -39,12 +39,12 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   }
 }))
 
-type ExpandableBioProps = {
-  profile: User
-}
-
-export const ExpandableBio = ({ profile }: ExpandableBioProps) => {
-  const { bio, website, donation } = profile
+export const ExpandableBio = () => {
+  const { bio, website, donation } = useSelectProfile([
+    'bio',
+    'website',
+    'donation'
+  ])
   const styles = useStyles()
   const [fullBioHeight, setFullBioHeight] = useState(0)
   const hasSites = Boolean(website || donation)
@@ -95,7 +95,7 @@ export const ExpandableBio = ({ profile }: ExpandableBioProps) => {
             </Text>
           </Hyperlink>
         ) : null}
-        {hasSites && isExpanded ? <Sites profile={profile} /> : null}
+        {hasSites && isExpanded ? <Sites /> : null}
       </View>
       {shouldShowMore ? (
         <Pressable style={styles.expandButton} onPress={handleToggleExpanded}>

--- a/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
@@ -1,27 +1,19 @@
-import { useMemo } from 'react'
+import { getProfilePlaylists } from 'audius-client/src/common/store/pages/profile/selectors'
 
 import { CollectionList } from 'app/components/collection-list'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { useEmptyProfileText } from './EmptyProfileTile'
-import { useProfilePlaylists } from './selectors'
 
 export const PlaylistsTab = () => {
-  const { profile, playlists } = useProfilePlaylists()
+  const playlists = useSelectorWeb(getProfilePlaylists)
 
-  const userPlaylists = useMemo(() => {
-    if (profile && playlists) {
-      return playlists.map(album => ({ ...album, user: profile }))
-    }
-  }, [profile, playlists])
-
-  const emptyListText = useEmptyProfileText(profile, 'playlists')
-
-  if (!userPlaylists) return null
+  const emptyListText = useEmptyProfileText('playlists')
 
   return (
     <CollectionList
       listKey='profile-playlists'
-      collection={userPlaylists}
+      collection={playlists}
       emptyListText={emptyListText}
       disableTopTabScroll
       fromPage='profile'

--- a/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileBadge.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-import { User } from 'audius-client/src/common/models/User'
 import { setVisibility } from 'audius-client/src/common/store/ui/modals/slice'
 import { View, Text } from 'react-native'
 
@@ -13,6 +12,8 @@ import { MODAL_NAME } from 'app/components/audio-rewards/TiersExplainerDrawer'
 import { Tile } from 'app/components/core'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { makeStyles } from 'app/styles/makeStyles'
+
+import { useSelectProfile } from './selectors'
 
 const messages = {
   tier: 'tier'
@@ -46,11 +47,8 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   }
 }))
 
-type ProfileBadgeProps = {
-  profile: User
-}
-
-export const ProfileBadge = ({ profile }: ProfileBadgeProps) => {
+export const ProfileBadge = () => {
+  const profile = useSelectProfile(['balance', 'associated_wallets_balance'])
   const styles = useStyles()
   const tier = getUserAudioTier(profile)
   const tierRank = getAudioTierRank(tier)

--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -1,13 +1,13 @@
 import { FollowSource } from 'audius-client/src/common/models/Analytics'
-import { User } from 'audius-client/src/common/models/User'
 import { View, Text } from 'react-native'
 
 import { FollowButton } from 'app/components/user'
-import { useAccountUser } from 'app/hooks/selectors'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
 
 import { EditProfileButton } from './EditProfileButton'
 import { SubscribeButton } from './SubscribeButton'
+import { getIsOwner, useSelectProfile } from './selectors'
 
 const useStyles = makeStyles(({ typography, palette, spacing }) => ({
   username: {
@@ -62,26 +62,38 @@ const messages = {
 }
 
 type ProfileInfoProps = {
-  profile: User
   onFollow: () => void
 }
 
 export const ProfileInfo = (props: ProfileInfoProps) => {
-  const { profile, onFollow } = props
+  const { onFollow } = props
   const styles = useStyles()
-  const { does_current_user_follow, does_follow_current_user } = profile
-  const accountUser = useAccountUser()
-  const isOwner = accountUser?.user_id === profile.user_id
+  const profile = useSelectProfile([
+    'user_id',
+    'name',
+    'handle',
+    'does_current_user_follow',
+    'does_follow_current_user'
+  ])
+
+  const {
+    name,
+    handle,
+    does_current_user_follow,
+    does_follow_current_user
+  } = profile
+
+  const isOwner = useSelectorWeb(getIsOwner)
 
   return (
     <View style={styles.info}>
       <View>
         <Text accessibilityRole='header' style={styles.username}>
-          {profile.name}
+          {name}
         </Text>
         <View style={styles.handleInfo}>
           <View style={styles.handle}>
-            <Text style={styles.handleText}>@{profile.handle}</Text>
+            <Text style={styles.handleText}>@{handle}</Text>
           </View>
           {does_follow_current_user ? (
             <View style={styles.followsYou}>

--- a/packages/mobile/src/screens/profile-screen/ProfileMetrics.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileMetrics.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-import { User } from 'audius-client/src/common/models/User'
 import { setFollowers } from 'audius-client/src/common/store/user-list/followers/actions'
 import { setFollowing } from 'audius-client/src/common/store/user-list/following/actions'
 import { Pressable, Text, View } from 'react-native'
@@ -9,6 +8,8 @@ import { ProfileStackParamList } from 'app/components/app-navigator/types'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles/makeStyles'
+
+import { useSelectProfile } from './selectors'
 
 const messages = {
   tracks: 'tracks',
@@ -43,13 +44,19 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
   }
 }))
 
-type ProfileMetricsProps = {
-  profile: User
-}
-
-export const ProfileMetrics = ({ profile }: ProfileMetricsProps) => {
+export const ProfileMetrics = () => {
   const styles = useStyles()
-  const { user_id, track_count, follower_count, followee_count } = profile
+  const {
+    user_id,
+    track_count,
+    follower_count,
+    followee_count
+  } = useSelectProfile([
+    'user_id',
+    'track_count',
+    'follower_count',
+    'followee_count'
+  ])
 
   const navigation = useNavigation<ProfileStackParamList>()
   const dispatchWeb = useDispatchWeb()

--- a/packages/mobile/src/screens/profile-screen/ProfilePicture.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfilePicture.tsx
@@ -1,0 +1,11 @@
+import {
+  ProfilePicture as ProfilePictureBase,
+  ProfilePictureProps
+} from 'app/components/user'
+
+import { useSelectProfile } from './selectors'
+
+export const ProfilePicture = (props: Partial<ProfilePictureProps>) => {
+  const profile = useSelectProfile(['user_id', '_profile_picture_sizes'])
+  return <ProfilePictureBase profile={profile} {...props} />
+}

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -11,11 +11,8 @@ import IconSettings from 'app/assets/images/iconSettings.svg'
 import { TopBarIconButton } from 'app/components/app-navigator/TopBarIconButton'
 import { ProfileStackParamList } from 'app/components/app-navigator/types'
 import { Screen, VirtualizedScrollView } from 'app/components/core'
-import { ProfilePhoto } from 'app/components/user'
-import { useAccountUser, useProfile } from 'app/hooks/selectors'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { useRoute } from 'app/hooks/useRoute'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles/makeStyles'
 import { useThemeColors } from 'app/utils/theme'
@@ -25,9 +22,11 @@ import { CoverPhoto } from './CoverPhoto'
 import { ExpandableBio } from './ExpandableBio'
 import { ProfileInfo } from './ProfileInfo'
 import { ProfileMetrics } from './ProfileMetrics'
+import { ProfilePicture } from './ProfilePicture'
 import { ProfileSocials } from './ProfileSocials'
 import { ProfileTabNavigator } from './ProfileTabNavigator'
 import { UploadTrackButton } from './UploadTrackButton'
+import { getIsOwner, useSelectProfileRoot } from './selectors'
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
   header: {
@@ -60,15 +59,15 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 
 export const ProfileScreen = () => {
   const styles = useStyles()
-  const accountUser = useAccountUser()
-  const { handle } = accountUser
-  const { params = { handle } } = useRoute<'Profile'>()
-  const profile = useProfile(params)
+  const profile = useSelectProfileRoot(['does_current_user_follow'])
+  const isOwner = useSelectorWeb(getIsOwner)
   const dispatchWeb = useDispatchWeb()
   const status = useSelectorWeb(getProfileStatus)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [hasUserFollowed, setHasUserFollowed] = useToggle(false)
   const { accentOrange } = useThemeColors()
+
+  console.log('rerender profile')
 
   const navigation = useNavigation<ProfileStackParamList>()
 
@@ -112,8 +111,6 @@ export const ProfileScreen = () => {
     }
   }, [status])
 
-  const isOwner = accountUser?.user_id === profile?.user_id
-
   const topbarLeft = isOwner ? (
     <View style={styles.topBarIcons}>
       <TopBarIconButton icon={IconSettings} onPress={handleNavigateSettings} />
@@ -134,23 +131,20 @@ export const ProfileScreen = () => {
           onRefresh={handleRefresh}
           refreshing={isRefreshing}
         >
-          <CoverPhoto profile={profile} />
-          <ProfilePhoto style={styles.profilePicture} profile={profile} />
+          <CoverPhoto />
+          <ProfilePicture style={styles.profilePicture} />
           <View style={styles.header}>
-            <ProfileInfo profile={profile} onFollow={handleFollow} />
-            <ProfileMetrics profile={profile} />
-            <ProfileSocials profile={profile} />
-            <ExpandableBio profile={profile} />
+            <ProfileInfo onFollow={handleFollow} />
+            <ProfileMetrics />
+            <ProfileSocials />
+            <ExpandableBio />
             {!hasUserFollowed ? null : (
-              <ArtistRecommendations
-                profile={profile}
-                onClose={handleCloseArtistRecs}
-              />
+              <ArtistRecommendations onClose={handleCloseArtistRecs} />
             )}
             {!isOwner ? null : <UploadTrackButton />}
           </View>
           <View style={styles.navigator}>
-            <ProfileTabNavigator profile={profile} />
+            <ProfileTabNavigator />
           </View>
         </VirtualizedScrollView>
       )}

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import Status from 'audius-client/src/common/models/Status'
+import { getUserId } from 'audius-client/src/common/store/account/selectors'
 import { fetchProfile } from 'audius-client/src/common/store/pages/profile/actions'
 import { getProfileStatus } from 'audius-client/src/common/store/pages/profile/selectors'
 import { LayoutAnimation, View } from 'react-native'
@@ -26,7 +27,7 @@ import { ProfilePicture } from './ProfilePicture'
 import { ProfileSocials } from './ProfileSocials'
 import { ProfileTabNavigator } from './ProfileTabNavigator'
 import { UploadTrackButton } from './UploadTrackButton'
-import { getIsOwner, useSelectProfileRoot } from './selectors'
+import { useSelectProfileRoot } from './selectors'
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
   header: {
@@ -59,15 +60,13 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 
 export const ProfileScreen = () => {
   const styles = useStyles()
-  const profile = useSelectProfileRoot(['does_current_user_follow'])
-  const isOwner = useSelectorWeb(getIsOwner)
+  const profile = useSelectProfileRoot(['user_id', 'does_current_user_follow'])
+  const accountId = useSelectorWeb(getUserId)
   const dispatchWeb = useDispatchWeb()
   const status = useSelectorWeb(getProfileStatus)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [hasUserFollowed, setHasUserFollowed] = useToggle(false)
   const { accentOrange } = useThemeColors()
-
-  console.log('rerender profile')
 
   const navigation = useNavigation<ProfileStackParamList>()
 
@@ -110,6 +109,8 @@ export const ProfileScreen = () => {
       setIsRefreshing(false)
     }
   }, [status])
+
+  const isOwner = profile?.user_id === accountId
 
   const topbarLeft = isOwner ? (
     <View style={styles.topBarIcons}>

--- a/packages/mobile/src/screens/profile-screen/ProfileSocials.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileSocials.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-import { User } from 'audius-client/src/common/models/User'
 import { View } from 'react-native'
 
 import IconInstagram from 'app/assets/images/iconInstagram.svg'
@@ -12,6 +11,7 @@ import { EventNames } from 'app/types/analytics'
 import { make, track } from 'app/utils/analytics'
 
 import { ProfileBadge } from './ProfileBadge'
+import { useSelectProfile } from './selectors'
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
   socials: {
@@ -27,12 +27,19 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
   }
 }))
 
-type ProfileSocialsProps = {
-  profile: User
-}
+export const ProfileSocials = () => {
+  const {
+    handle,
+    twitter_handle,
+    instagram_handle,
+    tiktok_handle
+  } = useSelectProfile([
+    'handle',
+    'twitter_handle',
+    'instagram_handle',
+    'tiktok_handle'
+  ])
 
-export const ProfileSocials = ({ profile }: ProfileSocialsProps) => {
-  const { handle, twitter_handle, instagram_handle, tiktok_handle } = profile
   const styles = useStyles()
   const sanitizedHandle = handle.replace('@', '')
 
@@ -83,7 +90,7 @@ export const ProfileSocials = ({ profile }: ProfileSocialsProps) => {
 
   return (
     <View style={styles.socials}>
-      <ProfileBadge profile={profile} />
+      <ProfileBadge />
       {twitter_handle ? (
         <IconButton
           icon={IconTwitterBird}

--- a/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
@@ -1,5 +1,3 @@
-import { User } from 'audius-client/src/common/models/User'
-
 import IconAlbum from 'app/assets/images/iconAlbum.svg'
 import IconCollectibles from 'app/assets/images/iconCollectibles.svg'
 import IconNote from 'app/assets/images/iconNote.svg'
@@ -15,16 +13,15 @@ import { CollectiblesTab } from './CollectiblesTab'
 import { PlaylistsTab } from './PlaylistsTab'
 import { RepostsTab } from './RepostsTab'
 import { TracksTab } from './TracksTab'
+import { useSelectProfile } from './selectors'
 import { useShouldShowCollectiblesTab } from './utils'
 
-type ProfileTabNavigatiorProps = {
-  profile: User
-}
+export const ProfileTabNavigator = () => {
+  const { track_count } = useSelectProfile(['track_count'])
 
-export const ProfileTabNavigator = ({ profile }: ProfileTabNavigatiorProps) => {
-  const isArtist = profile.track_count > 0
+  const isArtist = track_count > 0
 
-  const showCollectiblesTab = useShouldShowCollectiblesTab(profile)
+  const showCollectiblesTab = useShouldShowCollectiblesTab()
 
   const trackScreen = tabScreen({
     name: 'Tracks',

--- a/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
@@ -17,7 +17,9 @@ import { useSelectProfile } from './selectors'
 import { useShouldShowCollectiblesTab } from './utils'
 
 export const ProfileTabNavigator = () => {
-  const { track_count } = useSelectProfile(['track_count'])
+  const { user_id, track_count } = useSelectProfile(['user_id', 'track_count'])
+
+  const initialParams = { id: user_id }
 
   const isArtist = track_count > 0
 
@@ -26,36 +28,45 @@ export const ProfileTabNavigator = () => {
   const trackScreen = tabScreen({
     name: 'Tracks',
     Icon: IconNote,
-    component: TracksTab
+    component: TracksTab,
+    initialParams
   })
 
   const albumsScreen = tabScreen({
     name: 'Albums',
     Icon: IconAlbum,
-    component: AlbumsTab
+    component: AlbumsTab,
+    initialParams
   })
 
   const playlistsScreen = tabScreen({
     name: 'Playlists',
     Icon: IconPlaylists,
-    component: PlaylistsTab
+    component: PlaylistsTab,
+    initialParams
   })
 
   const repostsScreen = tabScreen({
     name: 'Reposts',
     Icon: IconRepost,
-    component: RepostsTab
+    component: RepostsTab,
+    initialParams
   })
 
   const collectiblesScreen = tabScreen({
     name: 'Collectibles',
     Icon: IconCollectibles,
-    component: CollectiblesTab
+    component: CollectiblesTab,
+    initialParams
   })
+
+  const screenOptions = {
+    lazy: true
+  }
 
   if (isArtist) {
     return (
-      <TabNavigator>
+      <TabNavigator screenOptions={screenOptions}>
         {trackScreen}
         {albumsScreen}
         {playlistsScreen}
@@ -66,7 +77,7 @@ export const ProfileTabNavigator = () => {
   }
 
   return (
-    <TabNavigator>
+    <TabNavigator screenOptions={screenOptions}>
       {repostsScreen}
       {playlistsScreen}
       {showCollectiblesTab ? collectiblesScreen : null}

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -13,7 +13,7 @@ export const RepostsTab = () => {
   if (!profile) return null
 
   if (profile.repost_count === 0) {
-    return <EmptyProfileTile profile={profile} tab='reposts' />
+    return <EmptyProfileTile tab='reposts' />
   }
 
   return (

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -1,20 +1,21 @@
+import { makeGetLineupMetadatas } from 'audius-client/src/common/store/lineup/selectors'
 import { feedActions } from 'audius-client/src/common/store/pages/profile/lineups/feed/actions'
+import { getProfileFeedLineup } from 'audius-client/src/common/store/pages/profile/selectors'
+import { isEqual } from 'lodash'
 
 import { Lineup } from 'app/components/lineup'
-import { useProfile } from 'app/hooks/selectors'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
-import { useProfileFeedLineup } from './selectors'
+import { useSelectProfile } from './selectors'
+
+const getUserFeedMetadatas = makeGetLineupMetadatas(getProfileFeedLineup)
 
 export const RepostsTab = () => {
-  const profile = useProfile()
-  const lineup = useProfileFeedLineup()
+  const lineup = useSelectorWeb(getUserFeedMetadatas, isEqual)
+  const { repost_count } = useSelectProfile(['repost_count'])
 
-  if (!profile) return null
-
-  if (profile.repost_count === 0) {
-    return <EmptyProfileTile tab='reposts' />
-  }
+  console.log('rerender reposts', repost_count)
 
   return (
     <Lineup
@@ -22,7 +23,9 @@ export const RepostsTab = () => {
       actions={feedActions}
       lineup={lineup}
       selfLoad
+      limit={repost_count}
       disableTopTabScroll
+      ListEmptyComponent={<EmptyProfileTile tab='reposts' />}
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/Sites.tsx
+++ b/packages/mobile/src/screens/profile-screen/Sites.tsx
@@ -1,4 +1,3 @@
-import { User } from 'audius-client/src/common/models/User'
 import { View, Text } from 'react-native'
 
 import IconDonate from 'app/assets/images/iconDonate.svg'
@@ -6,6 +5,8 @@ import IconLink from 'app/assets/images/iconLink.svg'
 import { Link } from 'app/components/core'
 import { makeStyles } from 'app/styles/makeStyles'
 import { useThemeColors } from 'app/utils/theme'
+
+import { useSelectProfile } from './selectors'
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   sites: {
@@ -27,14 +28,10 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   }
 }))
 
-type SitesProps = {
-  profile: User
-}
-
-export const Sites = ({ profile }: SitesProps) => {
+export const Sites = () => {
   const styles = useStyles()
   const { neutral } = useThemeColors()
-  const { website, donation } = profile
+  const { website, donation } = useSelectProfile(['website', 'donation'])
 
   const iconProps = {
     height: 20,

--- a/packages/mobile/src/screens/profile-screen/SubscribeButton.tsx
+++ b/packages/mobile/src/screens/profile-screen/SubscribeButton.tsx
@@ -9,7 +9,7 @@ import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
 
-import { getProfile } from './selectors'
+import { getIsSubscribed } from './selectors'
 
 const messages = {
   subscribe: 'subscribe',
@@ -33,7 +33,7 @@ export const SubscribeButton = (props: SubscribeButtonProps) => {
   const styles = useStyles()
   const { profile } = props
   const { user_id } = profile
-  const { isSubscribed } = useSelectorWeb(getProfile)
+  const isSubscribed = useSelectorWeb(getIsSubscribed)
   const dispatchWeb = useDispatchWeb()
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -1,17 +1,20 @@
 import { useCallback } from 'react'
 
 import { tracksActions } from 'audius-client/src/common/store/pages/profile/lineups/tracks/actions'
+import { getProfileTracksLineup } from 'audius-client/src/common/store/pages/profile/selectors'
+import { isEqual } from 'lodash'
 
 import { Lineup } from 'app/components/lineup'
 import { useProfile } from 'app/hooks/selectors'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
-import { useProfileTracksLineup } from './selectors'
 
 export const TracksTab = () => {
   const profile = useProfile()
-  const lineup = useProfileTracksLineup()
+  const lineup = useSelectorWeb(getProfileTracksLineup, isEqual)
+
   const dispatchWeb = useDispatchWeb()
 
   const loadMore = useCallback(
@@ -29,7 +32,7 @@ export const TracksTab = () => {
   if (!profile) return null
 
   if (profile.track_count === 0) {
-    return <EmptyProfileTile profile={profile} tab='tracks' />
+    return <EmptyProfileTile tab='tracks' />
   }
 
   return (

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -5,45 +5,42 @@ import { getProfileTracksLineup } from 'audius-client/src/common/store/pages/pro
 import { isEqual } from 'lodash'
 
 import { Lineup } from 'app/components/lineup'
-import { useProfile } from 'app/hooks/selectors'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
+import { useSelectProfile } from './selectors'
 
 export const TracksTab = () => {
-  const profile = useProfile()
   const lineup = useSelectorWeb(getProfileTracksLineup, isEqual)
-
   const dispatchWeb = useDispatchWeb()
+  const { user_id, track_count, _artist_pick } = useSelectProfile([
+    'user_id',
+    'track_count',
+    '_artist_pick'
+  ])
 
   const loadMore = useCallback(
     (offset: number, limit: number) => {
-      if (!profile) return
       dispatchWeb(
         tracksActions.fetchLineupMetadatas(offset, limit, false, {
-          userId: profile.user_id
+          userId: user_id
         })
       )
     },
-    [dispatchWeb, profile]
+    [dispatchWeb, user_id]
   )
-
-  if (!profile) return null
-
-  if (profile.track_count === 0) {
-    return <EmptyProfileTile tab='tracks' />
-  }
 
   return (
     <Lineup
-      leadingElementId={profile._artist_pick}
+      leadingElementId={_artist_pick}
       listKey='profile-tracks'
       actions={tracksActions}
       lineup={lineup}
-      limit={profile.track_count}
+      limit={track_count}
       loadMore={loadMore}
       disableTopTabScroll
+      ListEmptyComponent={<EmptyProfileTile tab='tracks' />}
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -1,14 +1,56 @@
+import { User } from 'audius-client/src/common/models/User'
+import {
+  getAccountUser,
+  getUserId
+} from 'audius-client/src/common/store/account/selectors'
 import { makeGetLineupMetadatas } from 'audius-client/src/common/store/lineup/selectors'
 import {
   getProfileFeedLineup,
   getProfileTracksLineup,
+  getProfileUser,
+  getProfileUserId,
   makeGetProfile
 } from 'audius-client/src/common/store/pages/profile/selectors'
 import { isEqual } from 'lodash'
+import { createSelector } from 'reselect'
 
+import { useRoute } from 'app/hooks/useRoute'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
+/*
+ * Selects profile user and ensures rerenders occur only for changes specified in deps
+ */
+export const useSelectProfileRoot = (deps: Array<keyof User>) => {
+  const accountUserHandle = useSelectorWeb(
+    state => getAccountUser(state)?.handle
+  )
+  const { params = { handle: accountUserHandle } } = useRoute<'Profile'>()
+  const profile = useSelectorWeb(
+    state => getProfileUser(state, params),
+    (a, b) => deps.every(arg => isEqual(a?.[arg], b?.[arg]))
+  )
+  return profile
+}
+
+/*
+ * Assumes existance of user for convenience. To only be used for inner
+ * components that wouldn't render if user wasn't present
+ */
+export const useSelectProfile = (deps: Array<keyof User>) => {
+  return useSelectProfileRoot(deps) as User
+}
+
 export const getProfile = makeGetProfile()
+
+export const getIsSubscribed = createSelector(
+  [getProfile],
+  profile => profile.isSubscribed
+)
+
+export const getIsOwner = createSelector(
+  [getProfileUserId, getUserId],
+  (profileUserId, accountUserId) => profileUserId === accountUserId
+)
 
 export const useProfileTracksLineup = () => {
   return useSelectorWeb(getProfileTracksLineup, isEqual)

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -3,10 +3,7 @@ import {
   getAccountUser,
   getUserId
 } from 'audius-client/src/common/store/account/selectors'
-import { makeGetLineupMetadatas } from 'audius-client/src/common/store/lineup/selectors'
 import {
-  getProfileFeedLineup,
-  getProfileTracksLineup,
   getProfileUser,
   getProfileUserId,
   makeGetProfile
@@ -21,12 +18,13 @@ import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
  * Selects profile user and ensures rerenders occur only for changes specified in deps
  */
 export const useSelectProfileRoot = (deps: Array<keyof User>) => {
-  const accountUserHandle = useSelectorWeb(
-    state => getAccountUser(state)?.handle
-  )
-  const { params = { handle: accountUserHandle } } = useRoute<'Profile'>()
+  const { params } = useRoute<'Profile'>()
+  const { handle } = params
+  const isAccountUser = handle === 'accountUser'
+
   const profile = useSelectorWeb(
-    state => getProfileUser(state, params),
+    state =>
+      isAccountUser ? getAccountUser(state) : getProfileUser(state, params),
     (a, b) => deps.every(arg => isEqual(a?.[arg], b?.[arg]))
   )
   return profile
@@ -51,17 +49,3 @@ export const getIsOwner = createSelector(
   [getProfileUserId, getUserId],
   (profileUserId, accountUserId) => profileUserId === accountUserId
 )
-
-export const useProfileTracksLineup = () => {
-  return useSelectorWeb(getProfileTracksLineup, isEqual)
-}
-
-export const useProfileAlbums = () => useSelectorWeb(getProfile, isEqual)
-
-export const useProfilePlaylists = () => useSelectorWeb(getProfile, isEqual)
-
-const getUserFeedMetadatas = makeGetLineupMetadatas(getProfileFeedLineup)
-
-export const useProfileFeedLineup = () => {
-  return useSelectorWeb(getUserFeedMetadatas, isEqual)
-}

--- a/packages/mobile/src/screens/profile-screen/utils.ts
+++ b/packages/mobile/src/screens/profile-screen/utils.ts
@@ -1,17 +1,16 @@
 import { useMemo } from 'react'
 
 import { ID } from 'audius-client/src/common/models/Identifiers'
-import { User } from 'audius-client/src/common/models/User'
 import { Nullable } from 'audius-client/src/common/utils/typeUtils'
 import {
   badgeTiers,
   makeGetTierAndVerifiedForUser
 } from 'audius-client/src/components/user-badges/utils'
 
-import { useAccountUser } from 'app/hooks/selectors'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { MIN_COLLECTIBLES_TIER } from './constants'
+import { getIsOwner, useSelectProfile } from './selectors'
 
 /**
  * Wraps our reselect tier selector in useMemo and useSelector
@@ -39,15 +38,21 @@ export const useSelectTierInfo = (userId: ID) => {
  * If the user is viewing their own profile, the collectibles don't
  * need to be ordered
  */
-export const useShouldShowCollectiblesTab = (profile: User) => {
+export const useShouldShowCollectiblesTab = () => {
   const {
     user_id,
     has_collectibles,
     collectibleList,
     solanaCollectibleList,
     collectibles
-  } = profile
-  const accountUser = useAccountUser()
+  } = useSelectProfile([
+    'user_id',
+    'has_collectibles',
+    'collectibleList',
+    'solanaCollectibleList',
+    'collectibles'
+  ])
+  const isOwner = useSelectorWeb(getIsOwner)
   const { tierNumber } = useSelectTierInfo(user_id)
 
   const hasCollectiblesTierRequirement =
@@ -66,11 +71,10 @@ export const useShouldShowCollectiblesTab = (profile: User) => {
   const neverSetCollectiblesOrder = !collectibles
   const hasVisibleCollectibles =
     hasCollectibles && (neverSetCollectiblesOrder || hasCollectiblesOrder)
-  const isUserOnTheirProfile = accountUser?.user_id === user_id
 
   if (hasVisibleCollectibles) return true
 
-  if (hasCollectibles && isUserOnTheirProfile) return true
+  if (hasCollectibles && isOwner) return true
 
   return false
 }

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsRow.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsRow.tsx
@@ -4,7 +4,7 @@ import { getAccountUser } from 'audius-client/src/common/store/account/selectors
 import { Text, View } from 'react-native'
 
 import { ProfileStackParamList } from 'app/components/app-navigator/types'
-import { ProfilePhoto } from 'app/components/user'
+import { ProfilePicture } from 'app/components/user'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
@@ -43,7 +43,7 @@ export const AccountSettingsRow = () => {
   return (
     <SettingsRow style={styles.root} onPress={handlePress}>
       <View style={styles.content}>
-        <ProfilePhoto profile={accountUser} style={styles.profilePicture} />
+        <ProfilePicture profile={accountUser} style={styles.profilePicture} />
         <View style={styles.info}>
           <Text style={styles.name}>{name}</Text>
           <Text style={styles.handle}>@{handle}</Text>

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
@@ -12,7 +12,7 @@ import IconMail from 'app/assets/images/iconMail.svg'
 import IconSignOut from 'app/assets/images/iconSignOut.svg'
 import IconVerified from 'app/assets/images/iconVerified.svg'
 import { Screen } from 'app/components/core'
-import { ProfilePhoto } from 'app/components/user'
+import { ProfilePicture } from 'app/components/user'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
@@ -73,7 +73,7 @@ export const AccountSettingsScreen = () => {
     <Screen title={messages.title} topbarRight={null} variant='secondary'>
       <ScrollView>
         <View style={styles.header}>
-          <ProfilePhoto profile={accountUser} style={styles.profilePhoto} />
+          <ProfilePicture profile={accountUser} style={styles.profilePhoto} />
           <Text style={styles.name}>{name}</Text>
           <Text style={styles.handle}>@{handle}</Text>
         </View>

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -135,6 +135,7 @@ export const TrackScreen = () => {
         }
         lineup={lineup}
         start={1}
+        includeLineupStatus
       />
     </Screen>
   )

--- a/packages/mobile/src/screens/user-list-screen/UserChip.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserChip.tsx
@@ -6,7 +6,7 @@ import { User } from 'audius-client/src/common/models/User'
 import { Nullable } from 'audius-client/src/common/utils/typeUtils'
 import { View, Text, Pressable } from 'react-native'
 
-import { ProfilePhoto, FollowButton } from 'app/components/user'
+import { ProfilePicture, FollowButton } from 'app/components/user'
 import { UserBadges } from 'app/components/user-badges'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
@@ -52,7 +52,7 @@ export const UserChip = (props: UserChipProps) => {
   return (
     <View style={styles.root}>
       <Pressable style={styles.details} onPress={handlePress}>
-        <ProfilePhoto profile={user} style={styles.photo} />
+        <ProfilePicture profile={user} style={styles.photo} />
         <View>
           <Text style={styles.name} numberOfLines={1}>
             {name}


### PR DESCRIPTION
### Description

Uses new selector equality and selectors to drastically minimize profile rerenders and push them as far down the render tree as possible.

Experimenting with `lazy: true` for profile tabs. This helps with navigation animation by quieting down other tabs.

A few improvements to Lineup
 - Show skeleton on initial mount, which improves perceieved perf as the lineups don't suddenly show skeletons
 - Check the `limit` prop before rendering skeletons or loading more. this allows us to immediately show `ListEmptyComponent`, which is useful for our EmptyProfileTiles

A bit of a hack adding `initalParams: {handle: "accountUser"}}` which is a way to immediately tell account profile tab to render with account user data