### PR TITLE
Increment build number by 2 to unblock apple

### DIFF
--- a/packages/mobile/ios/fastlane/Fastfile
+++ b/packages/mobile/ios/fastlane/Fastfile
@@ -109,7 +109,7 @@ platform :ios do
         initial_build_number: 1,
         version: versionNumber.to_s,
         live: false
-      ) + 1,
+      ) + 2,
     )
 
     # Build ios


### PR DESCRIPTION
### Description

We get rejected by AppStoreConnect for build 57 even though the CLI returns 56 as the latest version.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

🤷 

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

CI should pass