### PR TITLE
[AUD-1692] Native bottom button performance round 2

### DIFF
--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBarButton.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBarButton.tsx
@@ -72,13 +72,22 @@ export const BottomTabBarButton = ({
   const handlePress = useCallback(() => {
     navigate(route, isFocused)
   }, [navigate, route, isFocused])
+
+  const handleLongPress = useCallback(() => {
+    if (isFocused) {
+      onLongPress()
+    } else {
+      handlePress()
+    }
+  }, [isFocused, handlePress, onLongPress])
+
   return (
     <AnimatedButtonProvider
       iconDarkJSON={icons.dark[route.name]}
       iconLightJSON={icons.light[route.name]}
       isActive={isFocused}
       isDarkMode={isDarkMode}
-      onLongPress={onLongPress}
+      onLongPress={handleLongPress}
       onPress={handlePress}
       style={styles.animatedButton}
       wrapperStyle={styles.iconWrapper}


### PR DESCRIPTION
### Description

* Adds `200ms` debounce to the state sync. Noticed that much of the button lag had to do with the volume of state sync actions happening on native. This was the case even when no components were rendering. Debouncing/batching the updates helped a lot here. Because of the partial state sync, we now have to aggregate the state to sync across debounce calls
* Adds a `50ms` delay to the navigation when pressing a bottom button. This allows the button highlight state and animation to feel much more snappy because it doesn't get blocked by the huge render of the incoming screen. The delay is nearly imperceptible, but does increase perceived performance IMO
* Allows long presses to trigger normal press handler on non active routes 

https://user-images.githubusercontent.com/19916043/158232418-f4843de6-1654-428d-a5a6-50b8ac1a96a1.mov


### Dragons

Both of these perf changes are not ideal and I'm open to feedback/tweaks here. 

The state sync debounce has the drawback that any UI action that gets "caught" in a debounce batch will look to the user as if there is a max 200ms delay. For example, changing screens and then opening a drawer could have a slight delay. I found that 200ms was a good compromise between reducing the volume of actions on screen changes / other state-intensive actions and not catching/delaying many UI actions

The navigation delay could make navigation feel slightly slower, but because of all the renders happening anyway I do think it's a net positive

Also there still seems to be some very rare cases of the animations getting stuck. It only happens when really spamming the bottom buttons. It seems like certain renders are skipped and the component isn't updated and I think this could still be fixed by setting keys correctly. Will look into this again

### How Has This Been Tested?

iOS simulator in dev and release configs

### How will this change be monitored?
Keep and eye on perf and continue fine tuning
