### PR TITLE
Show folder update UI and get rid of playlist updates feature flag

### DIFF
--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -241,7 +241,9 @@ const PlaylistLibrary = ({
       <PlaylistFolderNavItem
         key={folder.id}
         folder={folder}
-        hasUpdate={false}
+        hasUpdate={folder.contents.some(c => {
+          c.type !== 'folder' && updates.includes(Number(c.playlist_id))
+        })}
         dragging={dragging}
         draggingKind={draggingKind}
         onClickEdit={handleClickEditFolder}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -22,7 +22,7 @@ import { addTrackToPlaylist } from 'common/store/cache/collections/actions'
 import { getPlaylistUpdates } from 'common/store/notifications/selectors'
 import Droppable from 'components/dragndrop/Droppable'
 import { ToastContext } from 'components/toast/ToastContext'
-import { useArePlaylistUpdatesEnabled, useFlag } from 'hooks/useRemoteConfig'
+import { useFlag } from 'hooks/useRemoteConfig'
 import { SMART_COLLECTION_MAP } from 'pages/smart-collection/smartCollections'
 import { make, useRecord } from 'store/analytics/actions'
 import { setFolderId as setEditFolderModalFolderId } from 'store/application/ui/editFolderModal/slice'
@@ -99,9 +99,6 @@ const PlaylistLibrary = ({
   const updates = useSelector(getPlaylistUpdates)
   const { dragging, kind: draggingKind } = useSelector(getIsDragging)
   const dispatch = useDispatch()
-  const {
-    isEnabled: arePlaylistUpdatesEnabled
-  } = useArePlaylistUpdatesEnabled()
   const { isEnabled: isPlaylistFoldersEnabled } = useFlag(
     FeatureFlags.PLAYLIST_FOLDERS
   )
@@ -219,7 +216,7 @@ const PlaylistLibrary = ({
       <PlaylistNavItem
         key={id}
         playlist={playlist}
-        hasUpdate={Boolean(arePlaylistUpdatesEnabled) && hasUpdate}
+        hasUpdate={hasUpdate}
         url={url}
         addTrack={addTrack}
         isOwner={isOwner}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -97,6 +97,7 @@ const PlaylistLibrary = ({
   const playlists = useSelector(getAccountNavigationPlaylists)
   const library = useSelector(getPlaylistLibrary)
   const updates = useSelector(getPlaylistUpdates)
+  const updatesSet = new Set(updates)
   const { dragging, kind: draggingKind } = useSelector(getIsDragging)
   const dispatch = useDispatch()
   const { isEnabled: isPlaylistFoldersEnabled } = useFlag(
@@ -211,7 +212,7 @@ const PlaylistLibrary = ({
     const url = playlistPage(playlist.user.handle, name, id)
     const addTrack = (trackId: ID) => dispatch(addTrackToPlaylist(trackId, id))
     const isOwner = playlist.user.handle === account.handle
-    const hasUpdate = updates.includes(id)
+    const hasUpdate = updatesSet.has(id)
     return (
       <PlaylistNavItem
         key={id}
@@ -238,9 +239,9 @@ const PlaylistLibrary = ({
       <PlaylistFolderNavItem
         key={folder.id}
         folder={folder}
-        hasUpdate={folder.contents.some(c => {
-          c.type !== 'folder' && updates.includes(Number(c.playlist_id))
-        })}
+        hasUpdate={folder.contents.some(
+          c => c.type !== 'folder' && updatesSet.has(Number(c.playlist_id))
+        )}
         dragging={dragging}
         draggingKind={draggingKind}
         onClickEdit={handleClickEditFolder}

--- a/packages/web/src/hooks/useRemoteConfig.ts
+++ b/packages/web/src/hooks/useRemoteConfig.ts
@@ -1,11 +1,6 @@
 import { createUseFeatureFlagHook } from 'common/hooks/useFeatureFlag'
 import { createUseRemoteVarHook } from 'common/hooks/useRemoteVar'
-import { FeatureFlags } from 'common/services/remote-config'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 
 export const useFlag = createUseFeatureFlagHook(remoteConfigInstance)
 export const useRemoteVar = createUseRemoteVarHook(remoteConfigInstance)
-
-export const useArePlaylistUpdatesEnabled = () => {
-  return useFlag(FeatureFlags.PLAYLIST_UPDATES_ENABLED)
-}

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -27,7 +27,6 @@ import MobilePageContainer from 'components/mobile-page-container/MobilePageCont
 import { useMainPageHeader } from 'components/nav/store/context'
 import TrackList from 'components/track/mobile/TrackList'
 import { TrackItemAction } from 'components/track/mobile/TrackListItem'
-import { useArePlaylistUpdatesEnabled } from 'hooks/useRemoteConfig'
 import useTabs from 'hooks/useTabs/useTabs'
 import { make, useRecord } from 'store/analytics/actions'
 import { albumPage, TRENDING_PAGE, playlistPage } from 'utils/route'
@@ -268,9 +267,6 @@ const PlaylistCardLineup = ({
   playlistUpdates: number[]
   updatePlaylistLastViewedAt: (playlistId: number) => void
 }) => {
-  const {
-    isEnabled: arePlaylistUpdatesEnabled
-  } = useArePlaylistUpdatesEnabled()
   const record = useRecord()
 
   const filteredPlaylists = getFilteredPlaylists(playlists || [])
@@ -303,7 +299,7 @@ const PlaylistCardLineup = ({
             })
           )
         }}
-        updateDot={!!arePlaylistUpdatesEnabled && hasUpdate}
+        updateDot={hasUpdate}
       />
     )
   })


### PR DESCRIPTION
### Description
-Remove playlist updates feature flag
-Show purple folder if one of its playlists has an update
![updatelist](https://user-images.githubusercontent.com/36916764/158306190-80205f22-5f85-4fd4-9701-b1649ff338de.gif)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in browser

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
