### PR TITLE
[AUD-1686] Button style fixes in native

### DIFF
--- a/packages/mobile/src/components/core/Button.tsx
+++ b/packages/mobile/src/components/core/Button.tsx
@@ -28,10 +28,10 @@ const useStyles = makeStyles(
           borderWidth: 0
         },
         text: {
-          color: palette.white
+          color: palette.staticWhite
         },
         icon: {
-          color: palette.white
+          color: palette.staticWhite
         }
       },
       secondary: {
@@ -144,8 +144,8 @@ const useStyles = makeStyles(
 
     const baseStyles = {
       root: {
+        ...flexRowCentered(),
         justifyContent: 'center',
-        alignItems: 'center',
         alignSelf: 'center',
         borderRadius: 4
       },


### PR DESCRIPTION
### Description

* Fixes an issue with full width button contents not being centered
* Fixes the color of the text on buttons in dark mode
<img width="504" alt="image" src="https://user-images.githubusercontent.com/19916043/158456362-e7011811-43be-42e1-ba24-ca3a948cc29e.png">


### Dragons
Potentially all buttons affected

### How Has This Been Tested?
Tested on iOS simulator. Did a sweep and all the buttons look good

### How will this change be monitored?
n/a
