### PR TITLE
Fix album draggable bug

### DIFF
--- a/packages/web/src/components/card/mobile/Card.tsx
+++ b/packages/web/src/components/card/mobile/Card.tsx
@@ -58,6 +58,7 @@ type CardProps = {
   secondaryText: string | React.ReactNode
   isUser?: boolean
   trackCount?: number
+  isPlaylist?: boolean
   // Socials
   reposts?: number
   favorites?: number
@@ -140,7 +141,8 @@ Card.defaultProps = {
   primaryText: '',
   secondaryText: '',
   onClick: () => {},
-  className: ''
+  className: '',
+  isPlaylist: true
 }
 
 export default Card

--- a/packages/web/src/components/lineup/CardLineup.tsx
+++ b/packages/web/src/components/lineup/CardLineup.tsx
@@ -37,7 +37,7 @@ const DesktopCardContainer = ({
             <Draggable
               key={`draggable-${card.props.playlistId}`}
               text={card.props.primaryText}
-              kind={card.props.isAlbum ? 'album' : 'playlist'}
+              kind={card.props.isPlaylist ? 'playlist' : 'album'}
               id={card.props.playlistId}
               link={card.props.link}
             >

--- a/packages/web/src/pages/explore-page/components/mobile/CollectionsPage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/CollectionsPage.tsx
@@ -48,6 +48,7 @@ const ExplorePage = ({
         trackCount={playlist.playlist_contents.track_ids.length}
         reposts={playlist.repost_count}
         favorites={playlist.save_count}
+        isPlaylist={!playlist.is_album}
         onClickReposts={() => onClickReposts(playlist.playlist_id)}
         onClickFavorites={() => onClickFavorites(playlist.playlist_id)}
         onClick={() =>


### PR DESCRIPTION
### Description
Before:
Could drag album tile to playlist library, which would be a no op
Could not drag album tile to "Favorites" list

After:
Can only drag album tile to "Favorites" list

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in browser
*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
