### PR TITLE
Fix local storage temp playlist bug

### DIFF
--- a/packages/web/src/store/playlist-library/helpers.test.js
+++ b/packages/web/src/store/playlist-library/helpers.test.js
@@ -10,7 +10,8 @@ import {
   reorderPlaylistLibrary,
   addPlaylistToFolder,
   extractTempPlaylistsFromLibrary,
-  replaceTempWithResolvedPlaylists
+  replaceTempWithResolvedPlaylists,
+  removePlaylistLibraryTempPlaylists
 } from './helpers'
 
 describe('findInPlaylistLibrary', () => {
@@ -473,6 +474,82 @@ describe('removePlaylistLibraryDuplicates', () => {
       ]
     }
     expect(result).toEqual(expectedResult)
+  })
+})
+
+describe('removePlaylistLibraryTempPlaylists', () => {
+  it('can remove temporary playlists', () => {
+    const library = {
+      contents: [
+        { type: 'temp_playlist', playlist_id: '33' },
+        { type: 'explore_playlist', playlist_id: 'Heavy Rotation' },
+        {
+          type: 'folder',
+          name: 'My folder',
+          id: 'uuid',
+          contents: [
+            { type: 'temp_playlist', playlist_id: '44' },
+            { type: 'playlist', playlist_id: 5 },
+            { type: 'playlist', playlist_id: 6 }
+          ]
+        },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 1 }
+      ]
+    }
+    const ret = removePlaylistLibraryTempPlaylists(library)
+    expect(ret).toEqual({
+      contents: [
+        { type: 'explore_playlist', playlist_id: 'Heavy Rotation' },
+        {
+          type: 'folder',
+          name: 'My folder',
+          id: 'uuid',
+          contents: [
+            { type: 'playlist', playlist_id: 5 },
+            { type: 'playlist', playlist_id: 6 }
+          ]
+        },
+        { type: 'playlist', playlist_id: 3 },
+        { type: 'playlist', playlist_id: 1 }
+      ]
+    })
+  })
+
+  it('does not remove non temp playlists', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'explore_playlist', playlist_id: 'Heavy Rotation' },
+        {
+          type: 'folder',
+          name: 'My folder',
+          id: 'uuid',
+          contents: [
+            { type: 'playlist', playlist_id: 10 },
+            { type: 'playlist', playlist_id: 11 }
+          ]
+        },
+        { type: 'playlist', playlist_id: 4 },
+        { type: 'playlist', playlist_id: 5 },
+        { type: 'playlist', playlist_id: 6 }
+      ]
+    }
+    const ret = removePlaylistLibraryTempPlaylists(library)
+    expect(ret).toEqual(library)
+  })
+
+  it('can deal with empty library', () => {
+    const library = {
+      contents: []
+    }
+    let ret = removePlaylistLibraryTempPlaylists(library)
+    expect(ret).toEqual(library)
+
+    library.contents = null
+    ret = removePlaylistLibraryTempPlaylists(library)
+    expect(ret).toEqual(library)
   })
 })
 

--- a/packages/web/src/store/playlist-library/helpers.ts
+++ b/packages/web/src/store/playlist-library/helpers.ts
@@ -312,6 +312,39 @@ export const addFolderToLibrary = (
 }
 
 /**
+ * Removes temp playlists from playlist library (without mutating)
+ * @param library
+ * @returns a copy of the library with all temp playlists removed
+ */
+export const removePlaylistLibraryTempPlaylists = (
+  library: PlaylistLibrary | PlaylistLibraryFolder
+) => {
+  if (!library.contents) return library
+  const newContents: (PlaylistLibraryFolder | PlaylistLibraryIdentifier)[] = []
+  for (const item of library.contents) {
+    switch (item.type) {
+      case 'folder': {
+        const folder = removePlaylistLibraryTempPlaylists(
+          item
+        ) as PlaylistLibraryFolder
+        newContents.push(folder)
+        break
+      }
+      case 'temp_playlist':
+        break
+      case 'explore_playlist':
+      case 'playlist':
+        newContents.push(item)
+        break
+    }
+  }
+  return {
+    ...library,
+    contents: newContents
+  }
+}
+
+/**
  * Removes duplicates in a playlist library
  * @param library
  * @param ids ids to keep track of as we recurse


### PR DESCRIPTION
### Description
Before:
1. Create a playlist
2. Quickly reorder the playlist or add it to a folder. This triggers a cache + local storage update with the new library order (which includes the temp playlist).
3. Refresh
4. Result: Temp playlist gets stuck in local storage, which prevents any user playlist library updates from being persisted because we wait for all temp playlists to be resolved before updating the user metadata

After:
Temp playlists never get put in local storage which prevents the corrupted state described above. 

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in browser using repro steps above

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
