### PR TITLE
Switch out scrollbar for new one in add playlist modal and nav bar to avoid jumpiness

### DIFF
--- a/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.module.css
+++ b/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.module.css
@@ -25,22 +25,6 @@
   padding: 0px 32px 24px;
 }
 
-.simpleBar {
-  flex: 1;
-  min-height: 0px;
-}
-
-.simpleBar :global(.simplebar-scrollbar) {
-  width: 6px;
-  right: 4px;
-  border-radius: 4px;
-  opacity: 0.5;
-}
-
-.simpleBar :global(.simplebar-scrollbar:before) {
-  width: 6px;
-}
-
 .list {
   cursor: pointer;
   user-select: none;

--- a/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
+++ b/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
@@ -1,9 +1,8 @@
 import React, { useContext, useMemo, useState } from 'react'
 
-import { Modal } from '@audius/stems'
+import { Modal, Scrollbar } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
-import SimpleBar from 'simplebar-react'
 
 import { ReactComponent as IconMultiselectAdd } from 'assets/img/iconMultiselectAdd.svg'
 import { useModalState } from 'common/hooks/useModalState'
@@ -125,7 +124,7 @@ const AddToPlaylistModal = () => {
         placeholder={messages.searchPlaceholder}
         shouldAutoFocus={false}
       />
-      <SimpleBar className={styles.simpleBar}>
+      <Scrollbar>
         <div className={styles.listContent}>
           <div className={cn(styles.listItem)} onClick={handleCreatePlaylist}>
             <IconMultiselectAdd className={styles.add} />
@@ -142,7 +141,7 @@ const AddToPlaylistModal = () => {
             ))}
           </div>
         </div>
-      </SimpleBar>
+      </Scrollbar>
     </Modal>
   )
 }

--- a/packages/web/src/components/nav/desktop/NavColumn.js
+++ b/packages/web/src/components/nav/desktop/NavColumn.js
@@ -1,11 +1,10 @@
 import React, { useCallback } from 'react'
 
+import { Scrollbar } from '@audius/stems'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
 import { withRouter, NavLink, useHistory } from 'react-router-dom'
-import SimpleBar from 'simplebar-react'
-import 'simplebar/dist/simplebar.min.css'
 
 import imageProfilePicEmpty from 'assets/img/imageProfilePicEmpty2X.png'
 import { Name, CreatePlaylistSource } from 'common/models/Analytics'
@@ -268,7 +267,7 @@ const NavColumn = ({
         isElectron={isElectron}
       />
       <div className={cn(styles.navContent, { [styles.show]: navLoaded })}>
-        <SimpleBar className={styles.scrollable}>
+        <Scrollbar className={styles.scrollable}>
           {account ? (
             <div className={styles.userHeader}>
               <div className={styles.accountWrapper}>
@@ -420,7 +419,7 @@ const NavColumn = ({
               </Droppable>
             </div>
           </div>
-        </SimpleBar>
+        </Scrollbar>
         <CreatePlaylistModal
           visible={showCreatePlaylistModal}
           onCreatePlaylist={onCreatePlaylist}

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -44,25 +44,6 @@ svg.logo path {
 
 .navColumn .scrollable {
   padding-top: 24px;
-  height: 100%;
-  min-height: 0;
-}
-
-.navColumn .scrollable :global(.simplebar-scrollbar) {
-  width: 6px;
-  right: 4px;
-  border-radius: 4px;
-  opacity: 0.5;
-}
-
-.navColumn .scrollable :global(.simplebar-scrollbar:before) {
-  width: 6px;
-}
-
-.navColumn .scrollable :global(.simplebar-content-wrapper) {
-  padding-right: 20px !important;
-  box-sizing: content-box !important;
-  width: var(--nav-width);
 }
 
 .navColumn .userHeader {


### PR DESCRIPTION
### Description
*Cannot be merged until corresponding [Stems PR](https://github.com/AudiusProject/stems/pull/107) is merged and Stem is bumped in this repo.*

Switch out old react-simplebar for near Scrollbar which uses react-perfect-scrollbar. Simplebar does not respond to content size changes well, which causes the scrollbar to look super glitchy when the content does change (I tried fixing it for a while with some props/CSS changes to no avail). React-perfect-scrollbar is able to do so smoothly and is generally more widely used than Simplebar.

I'm currently in the middle of switching out all instances of Simplebar but wanted to get these two out first.

Before:
![scrollbarbad](https://user-images.githubusercontent.com/36916764/159287537-bd198c89-8333-40c3-9c0f-3e18f8c73038.gif)

After:
![scrollbar](https://user-images.githubusercontent.com/36916764/159287579-e90ad36d-db1f-4ebd-bbda-5a4ded034446.gif)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in browser.

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
