### PR TITLE
[AUD-1733] Fix NowPlaying close

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -57,8 +57,8 @@ const styles = StyleSheet.create({
     marginBottom: 16
   },
   scrubberContainer: {
-    marginLeft: 60,
-    marginRight: 60
+    marginLeft: 40,
+    marginRight: 40
   }
 })
 

--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -238,7 +238,7 @@ const NowPlayingDrawer = ({
             />
             <Logo opacityAnim={playBarOpacityAnim} />
             <View style={styles.titleBarContainer}>
-              <TitleBar onClose={handleDrawerClose} />
+              <TitleBar onClose={handleDrawerCloseFromSwipe} />
             </View>
             <View style={styles.artworkContainer}>
               <Artwork track={track} />

--- a/packages/mobile/src/components/scrubber/Scrubber.tsx
+++ b/packages/mobile/src/components/scrubber/Scrubber.tsx
@@ -38,8 +38,7 @@ const createStyles = (themeColors: ThemeColors) =>
     timestamp: {
       color: themeColors.neutral,
       fontSize: 12,
-      flexShrink: 1,
-      width: 25
+      flexShrink: 1
     }
   })
 
@@ -151,7 +150,7 @@ export const Scrubber = ({
 
   return (
     <View style={styles.root}>
-      <Text style={styles.timestamp} weight='regular'>
+      <Text style={styles.timestamp} weight='regular' numberOfLines={1}>
         {dragSeconds || timestampStart}
       </Text>
       <Slider
@@ -162,7 +161,7 @@ export const Scrubber = ({
         onDrag={onDrag}
         duration={duration}
       />
-      <Text style={styles.timestamp} weight='regular'>
+      <Text style={styles.timestamp} weight='regular' numberOfLines={1}>
         {timestampEnd}
       </Text>
     </View>


### PR DESCRIPTION
### Description

Fixes a bug where clicking the caret in the NowPlayingDrawer didn't close it correctly
Fixes a bug where the scrubber timestamp would overflow

Broken:
<img width="481" alt="Scrubber timestamp overflow" src="https://user-images.githubusercontent.com/19916043/159534280-6ddfb74b-ecc1-4e1b-aa6c-fa21f48a1298.png">

### Dragons
Slight styling tweaks to scrubber

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

Testflight qa
