### PR TITLE
[AUD-1741] [AUD-1744] Fix Play button state on track/collection screen

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -5,7 +5,6 @@ import { getUserId } from 'audius-client/src/common/store/account/selectors'
 import { squashNewLines } from 'audius-client/src/common/utils/formatUtil'
 import { ImageStyle, Linking, TouchableOpacity, View } from 'react-native'
 import HyperLink from 'react-native-hyperlink'
-import { useSelector } from 'react-redux'
 
 import IconPause from 'app/assets/images/iconPause.svg'
 import IconPlay from 'app/assets/images/iconPlay.svg'
@@ -16,7 +15,6 @@ import Text from 'app/components/text'
 import UserBadges from 'app/components/user-badges'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
-import { getPlaying } from 'app/store/audio/selectors'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { make, track } from 'app/utils/analytics'
 
@@ -163,6 +161,7 @@ export const DetailsTile = ({
   hideRepostCount,
   hideShare,
   imageUrl,
+  isPlaying,
   onPressFavorites,
   onPressOverflow,
   onPressPlay,
@@ -183,7 +182,6 @@ export const DetailsTile = ({
   const styles = useStyles()
   const navigation = useNavigation()
 
-  const isPlaying = useSelector(getPlaying)
   const currentUserId = useSelectorWeb(getUserId)
 
   const isOwner = user?.user_id === currentUserId

--- a/packages/mobile/src/components/details-tile/types.ts
+++ b/packages/mobile/src/components/details-tile/types.ts
@@ -58,6 +58,9 @@ export type DetailsTileProps = {
   /** Url of the image */
   imageUrl?: string
 
+  /** Is the item playing */
+  isPlaying?: boolean
+
   /** Function to call when the favorites count is pressed */
   onPressFavorites?: GestureResponderHandler
 

--- a/packages/mobile/src/components/now-playing-drawer/AudioControls.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/AudioControls.tsx
@@ -148,7 +148,7 @@ export const AudioControls = ({ onNext, onPrevious }: AudioControlsProps) => {
   const renderPlayButton = () => {
     return (
       <AnimatedButton
-        isActive={isPlaying}
+        iconIndex={isPlaying ? 1 : 0}
         iconLightJSON={[IconPlay, IconPause]}
         iconDarkJSON={[IconPlay, IconPause]}
         onPress={onPressPlayButton}

--- a/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
@@ -161,7 +161,7 @@ export const PlayBar = ({
         iconLightJSON={[IconPlay, IconPause]}
         iconDarkJSON={[IconPlay, IconPause]}
         onPress={onPressPlayButton}
-        isActive={isPlaying}
+        iconIndex={isPlaying ? 1 : 0}
         style={styles.button}
         wrapperStyle={styles.playIcon}
       />

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -186,6 +186,7 @@ export const CollectionScreenDetailsTile = ({
       details={details}
       headerText={headerText}
       hideListenCount={true}
+      isPlaying={isPlaying && isQueued}
       renderBottomContent={renderTrackList}
       onPressPlay={handlePressPlay}
     />

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -384,6 +384,7 @@ export const TrackScreenDetailsTile = ({
       hideFavoriteCount={is_unlisted}
       hideListenCount={is_unlisted && !field_visibility?.play_count}
       hideRepostCount={is_unlisted}
+      isPlaying={isPlaying && queueTrack?.trackId === track_id}
       onPressFavorites={handlePressFavorites}
       onPressOverflow={handlePressOverflow}
       onPressPlay={handlePressPlay}


### PR DESCRIPTION
### Description

Fixes a bug where the play button would show playing even if the current track wasn't queued
Updates `PlayBar` and `AudioControls` play buttons to use `iconIndex`

### Dragons

N/A

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

Testflight qa
