### PR TITLE
[AUD-1760] Fix alignment issues with "Follows you"

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -15,19 +15,25 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
     color: palette.neutral
   },
   handleInfo: {
+    marginTop: -6,
     flexDirection: 'row',
     alignItems: 'center',
-    alignContent: 'center'
+    alignContent: 'center',
+    flexWrap: 'wrap',
+    maxWidth: 200
   },
   handle: {
+    flexShrink: 0,
     marginRight: spacing(2),
     textAlignVertical: 'bottom'
   },
   handleText: {
+    marginTop: 6,
     ...typography.h4,
     color: palette.neutralLight4
   },
   followsYou: {
+    marginTop: -6,
     borderRadius: 4,
     overflow: 'hidden',
     borderColor: palette.neutralLight4,


### PR DESCRIPTION
### Description

Centers the vertical alignment of the "Follows You" badge
Wraps the badge to the next line for longer handles

<img width="471" alt="Screen Shot 2022-03-23 at 11 42 48 AM" src="https://user-images.githubusercontent.com/19916043/159751974-7e472442-7f51-404d-be5e-d31052d49335.png">
<img width="475" alt="Screen Shot 2022-03-23 at 11 42 23 AM" src="https://user-images.githubusercontent.com/19916043/159751977-0f194747-eaa2-4344-be09-349bb7c920e7.png">


### Dragons

N/A

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
