### PR TITLE
[AUD-1761, AUD-1670] Add shadow offset and multiple shadows

### DIFF
--- a/packages/mobile/src/components/core/Tile/Tile.tsx
+++ b/packages/mobile/src/components/core/Tile/Tile.tsx
@@ -127,10 +127,10 @@ export const Tile = <
       />
       <TileShadow
         offset={[0, 2]}
-        distance={5}
-        startColor='rgba(133, 129, 153, 0.25)'
+        distance={7}
+        startColor='rgba(133, 129, 153, 0.1)'
         borderRadius={borderRadius}
-        inset={2}
+        inset={4}
       />
       <TileComponent style={[styles.tile, stylesProp?.tile]} {...other}>
         <Pressable

--- a/packages/mobile/src/components/core/Tile/Tile.tsx
+++ b/packages/mobile/src/components/core/Tile/Tile.tsx
@@ -9,24 +9,29 @@ import {
   View,
   ViewStyle
 } from 'react-native'
-import { Shadow } from 'react-native-shadow-2'
 
 import { usePressScaleAnimation } from 'app/hooks/usePressScaleAnimation'
 import { StylesProp } from 'app/styles'
 import { makeStyles } from 'app/styles/makeStyles'
 
-const useStyles = makeStyles(({ palette }) => ({
-  tile: {
-    flexDirection: 'row',
-    borderColor: palette.neutralLight8,
-    backgroundColor: palette.white,
-    borderWidth: 1,
-    borderRadius: 8
-  },
-  content: {
-    flex: 1
+import { TileShadow } from './TileShadow'
+
+const borderRadius = 8
+
+const useStyles = makeStyles(({ palette }) => {
+  return {
+    tile: {
+      flexDirection: 'row',
+      borderColor: palette.neutralLight8,
+      backgroundColor: palette.white,
+      borderWidth: 1,
+      borderRadius
+    },
+    content: {
+      flex: 1
+    }
   }
-}))
+})
 
 const defaultElement = View
 
@@ -103,25 +108,40 @@ export const Tile = <
   )
 
   return (
-    <Animated.View style={{ transform: [{ scale }] }}>
-      <Shadow
+    <Animated.View
+      style={[style, stylesProp?.root, { transform: [{ scale }] }]}
+    >
+      <TileShadow
+        offset={[0, 0]}
+        distance={1}
+        startColor='rgba(133, 129, 153, 0.1)'
+        borderRadius={borderRadius}
+        inset={0}
+      />
+      <TileShadow
         offset={[0, 1]}
-        viewStyle={{ alignSelf: 'stretch' }}
-        distance={2}
-        startColor='rgba(133,129,153,0.11)'
-        containerViewStyle={[style, stylesProp?.root]}
-      >
-        <TileComponent style={[styles.tile, stylesProp?.tile]} {...other}>
-          <Pressable
-            style={[styles.content, stylesProp?.content]}
-            onPress={onPress}
-            onPressIn={handlePressIn}
-            onPressOut={handlePressOut}
-          >
-            {children}
-          </Pressable>
-        </TileComponent>
-      </Shadow>
+        distance={0}
+        startColor='#e3e3e3'
+        borderRadius={borderRadius}
+        inset={0}
+      />
+      <TileShadow
+        offset={[0, 2]}
+        distance={5}
+        startColor='rgba(133, 129, 153, 0.25)'
+        borderRadius={borderRadius}
+        inset={2}
+      />
+      <TileComponent style={[styles.tile, stylesProp?.tile]} {...other}>
+        <Pressable
+          style={[styles.content, stylesProp?.content, { borderRadius: 4 }]}
+          onPress={onPress}
+          onPressIn={handlePressIn}
+          onPressOut={handlePressOut}
+        >
+          {children}
+        </Pressable>
+      </TileComponent>
     </Animated.View>
   )
 }

--- a/packages/mobile/src/components/core/Tile/TileShadow.tsx
+++ b/packages/mobile/src/components/core/Tile/TileShadow.tsx
@@ -1,0 +1,35 @@
+import { StyleSheet, View } from 'react-native'
+import { Shadow, ShadowProps } from 'react-native-shadow-2'
+
+import { makeStyles } from 'app/styles'
+
+type TileShadowProps = ShadowProps & {
+  borderRadius: number
+  inset: number
+}
+
+const useStyles = makeStyles((_, { borderRadius, inset }) => ({
+  view: {
+    flex: 1,
+    alignSelf: 'stretch',
+    borderRadius: borderRadius - inset
+  },
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    margin: inset
+  }
+}))
+
+export const TileShadow = (props: TileShadowProps) => {
+  const { borderRadius, inset, ...other } = props
+  const styles = useStyles({ borderRadius, inset })
+  return (
+    <Shadow
+      viewStyle={styles.view}
+      containerViewStyle={styles.container}
+      {...other}
+    >
+      <View />
+    </Shadow>
+  )
+}

--- a/packages/mobile/src/components/core/Tile/index.ts
+++ b/packages/mobile/src/components/core/Tile/index.ts
@@ -1,0 +1,1 @@
+export * from './Tile'


### PR DESCRIPTION
### Description

- Adds shadow inset to Tile
- Adds layered shadows to simulate multiple box-shadows

Before:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/8230000/159812595-3ec290e1-a94a-4583-8334-e1d6ea7f804d.png">

First attempt:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/8230000/159812554-af931092-86ed-44a2-85f2-2eb715d2cbc7.png">

Final:
<img width="390" alt="image" src="https://user-images.githubusercontent.com/8230000/159985744-a2423d2a-7119-42f9-818d-129c0b97a7cf.png">


### Dragons

- There may be a perf issue doing this, now that each tile renders 3x the shadows
- I followed our box-shadow specs for each shadow exactly, but it def looks funky, so we should modify things before merge