### PR TITLE
[AUD-1768] Update artist info in now playing drawer to center icons

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
@@ -22,6 +22,14 @@ const createStyles = (themeColors: ThemeColors) =>
       marginBottom: 4,
       textAlign: 'center'
     },
+    infoContainer: {
+      flexDirection: 'row'
+    },
+    artistInfo: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      maxWidth: '95%'
+    },
     artist: {
       color: themeColors.secondary,
       fontSize: 18
@@ -52,8 +60,12 @@ export const TrackInfo = ({
             </Text>
           </Pressable>
           <Pressable onPress={onPressArtist}>
-            <Text numberOfLines={1} style={styles.artist} weight='medium'>
-              {user.name}
+            <View style={styles.infoContainer}>
+              <View style={styles.artistInfo}>
+                <Text numberOfLines={1} style={styles.artist} weight='medium'>
+                  {user.name}
+                </Text>
+              </View>
               <UserBadges
                 user={{
                   balance: user.balance,
@@ -64,7 +76,7 @@ export const TrackInfo = ({
                 badgeSize={12}
                 hideName
               />
-            </Text>
+            </View>
           </Pressable>
         </>
       )}


### PR DESCRIPTION
### Description

[AUD-1768]
Small fix to center the icons

Needed to use a View to actually center them and then needed another to make sure that they didn't go off the side when the artist name was really long

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/a
