### PR TITLE
[AUD-1775] Improve search results loading state

### DIFF
--- a/packages/mobile/src/screens/search-results-screen/SearchFocusContext.tsx
+++ b/packages/mobile/src/screens/search-results-screen/SearchFocusContext.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+export const SearchFocusContext = createContext({
+  isFocused: true
+})

--- a/packages/mobile/src/screens/search-results-screen/SearchResultsScreen.tsx
+++ b/packages/mobile/src/screens/search-results-screen/SearchResultsScreen.tsx
@@ -1,3 +1,7 @@
+import { useMemo } from 'react'
+
+import { useIsFocused } from '@react-navigation/native'
+
 import IconAlbum from 'app/assets/images/iconAlbum.svg'
 import IconNote from 'app/assets/images/iconNote.svg'
 import IconPlaylists from 'app/assets/images/iconPlaylists.svg'
@@ -9,6 +13,7 @@ import {
   tabScreen
 } from 'app/components/top-tab-bar/TopTabNavigator'
 
+import { SearchFocusContext } from './SearchFocusContext'
 import { AlbumsTab } from './tabs/AlbumsTab'
 import { PlaylistsTab } from './tabs/PlaylistsTab'
 import { ProfilesTab } from './tabs/ProfilesTab'
@@ -19,6 +24,9 @@ const messages = {
 }
 
 export const SearchResultsScreen = () => {
+  const isFocused = useIsFocused()
+  const focusContext = useMemo(() => ({ isFocused }), [isFocused])
+
   const profilesScreen = tabScreen({
     name: 'Profiles',
     Icon: IconUser,
@@ -46,12 +54,14 @@ export const SearchResultsScreen = () => {
   return (
     <Screen topbarRight={null}>
       <Header text={messages.header} />
-      <TabNavigator initialScreenName='Profiles'>
-        {profilesScreen}
-        {tracksScreen}
-        {albumsScreen}
-        {playlistsScreen}
-      </TabNavigator>
+      <SearchFocusContext.Provider value={focusContext}>
+        <TabNavigator initialScreenName='Profiles'>
+          {profilesScreen}
+          {tracksScreen}
+          {albumsScreen}
+          {playlistsScreen}
+        </TabNavigator>
+      </SearchFocusContext.Provider>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/search-results-screen/TagSearchScreen.tsx
+++ b/packages/mobile/src/screens/search-results-screen/TagSearchScreen.tsx
@@ -1,4 +1,6 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
+
+import { useIsFocused } from '@react-navigation/native'
 
 import IconNote from 'app/assets/images/iconNote.svg'
 import IconUser from 'app/assets/images/iconUser.svg'
@@ -9,6 +11,7 @@ import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useRoute } from 'app/hooks/useRoute'
 import { MessageType } from 'app/message'
 
+import { SearchFocusContext } from './SearchFocusContext'
 import { ProfilesTab } from './tabs/ProfilesTab'
 import { TracksTab } from './tabs/TracksTab'
 
@@ -21,6 +24,8 @@ const messages = {
  * but only displays matching tracks & profiles.
  */
 export const TagSearchScreen = () => {
+  const isFocused = useIsFocused()
+  const focusContext = useMemo(() => ({ isFocused }), [isFocused])
   const dispatchWeb = useDispatchWeb()
   const { params } = useRoute<'TagSearch'>()
   const { query } = params
@@ -47,10 +52,12 @@ export const TagSearchScreen = () => {
   return (
     <Screen topbarRight={null}>
       <Header text={messages.header} />
-      <TabNavigator initialScreenName='Tracks'>
-        {tracksScreen}
-        {profilesScreen}
-      </TabNavigator>
+      <SearchFocusContext.Provider value={focusContext}>
+        <TabNavigator initialScreenName='Tracks'>
+          {tracksScreen}
+          {profilesScreen}
+        </TabNavigator>
+      </SearchFocusContext.Provider>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/search-results-screen/tabs/SearchResultsTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/SearchResultsTab.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, useContext, useEffect, useState } from 'react'
 
 import Status from 'audius-client/src/common/models/Status'
 import { getSearchStatus } from 'audius-client/src/common/store/pages/search-results/selectors'
@@ -8,6 +8,7 @@ import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
 
 import { EmptyResults } from '../EmptyResults'
+import { SearchFocusContext } from '../SearchFocusContext'
 
 const useStyles = makeStyles(({ spacing }) => ({
   spinner: {
@@ -21,14 +22,35 @@ const useStyles = makeStyles(({ spacing }) => ({
 type SearchResultsTabProps = {
   children: ReactNode
   noResults?: boolean
+  status?: Status
 }
 
 export const SearchResultsTab = (props: SearchResultsTabProps) => {
-  const { children, noResults } = props
+  const { children, noResults, status } = props
+  const { isFocused } = useContext(SearchFocusContext)
   const styles = useStyles()
-  const status = useSelectorWeb(getSearchStatus)
+  const searchStatus = useSelectorWeb(getSearchStatus)
+  const [isRefreshing, setIsRefreshing] = useState(true)
 
-  if (status === Status.LOADING) {
+  useEffect(() => {
+    if (!isFocused) {
+      // Prevents a large rerender in the middle of a stack navigation.
+      // Note: having to manage status with navigation focus may not be needed
+      // when move common store into native.
+      setTimeout(() => {
+        setIsRefreshing(true)
+      }, 1000)
+    }
+    if (searchStatus === Status.LOADING) {
+      setIsRefreshing(false)
+    }
+  }, [isFocused, searchStatus])
+
+  if (
+    isRefreshing ||
+    searchStatus === Status.LOADING ||
+    status === Status.LOADING
+  ) {
     return <LoadingSpinner style={styles.spinner} />
   }
 

--- a/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
@@ -11,7 +11,10 @@ export const TracksTab = () => {
   const lineup = useSelectorWeb(getSearchTracksLineup, isEqual)
 
   return (
-    <SearchResultsTab noResults={lineup?.entries.length === 0}>
+    <SearchResultsTab
+      noResults={lineup?.entries.length === 0}
+      status={lineup?.status}
+    >
       <Lineup actions={tracksActions} lineup={lineup} />
     </SearchResultsTab>
   )

--- a/packages/mobile/src/screens/search-screen/SearchBar.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchBar.tsx
@@ -43,14 +43,16 @@ export const SearchBar = () => {
   )
 
   const handleSubmit = useCallback(() => {
-    const route = getTagSearchRoute(query)
-    navigation.push({
-      native: {
-        screen: 'TagSearch',
-        params: { query }
-      },
-      web: { route, fromPage: 'search' }
-    })
+    if (query.startsWith('#')) {
+      const route = getTagSearchRoute(query)
+      navigation.push({
+        native: {
+          screen: 'TagSearch',
+          params: { query }
+        },
+        web: { route, fromPage: 'search' }
+      })
+    }
   }, [query, navigation])
 
   const onClear = useCallback(() => {


### PR DESCRIPTION
### Description

Fixes a few loading issue with search results:

- Fixes case where "no results" briefly shows up in between the loading component and the results list.
- Fixes case where popping back to search results shows old list, then loading component, then list again. For now we are following what prod mobile does, which is show a loading component on pop-back.
- Fixes case where search-results tracks have a secondary loading status (inside tracks.status) that is slightly different from searchStatus that was not being referenced, resulting in extra flash of "no-results" every time.
