### PR TITLE
Add drag auto scroll capability for custom scrollbar containers

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,7 @@
     "@craco/craco": "6.4.3",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",
     "@hcaptcha/react-hcaptcha": "0.3.6",
+    "@juggle/resize-observer": "^3.3.1",
     "@optimizely/optimizely-sdk": "4.0.0",
     "@project-serum/sol-wallet-adapter": "0.2.5",
     "@reduxjs/toolkit": "1.3.4",

--- a/packages/web/src/components/drag-autoscroller/DragAutoscroller.tsx
+++ b/packages/web/src/components/drag-autoscroller/DragAutoscroller.tsx
@@ -1,0 +1,96 @@
+import React, { useRef, useState } from 'react'
+
+import throttle from 'lodash/throttle'
+
+export type DragAutoscrollerProps = {
+  children: React.ReactNode
+  containerBoundaries: {
+    top: number
+    bottom: number
+    left: number
+    right: number
+  }
+  updateScrollTopPosition: (difference: number) => void
+  onChangeDragScrollingDirection: (
+    newDirection: 'up' | 'down' | undefined
+  ) => void
+}
+
+/** Helper component to be used inside a Stems Scrollbar component to allow
+ * the container to auto-scroll when items are being dragged.
+ */
+export const DragAutoscroller = ({
+  children,
+  containerBoundaries,
+  updateScrollTopPosition,
+  onChangeDragScrollingDirection
+}: DragAutoscrollerProps) => {
+  const [scrolling, setScrolling] = useState<undefined | 'up' | 'down'>()
+  const scrollingRef = useRef(scrolling)
+  scrollingRef.current = scrolling
+
+  const scroll = (direction: 'up' | 'down') => {
+    const difference = direction === 'up' ? -5 : 5
+    updateScrollTopPosition(difference)
+    if (scrollingRef.current != null) {
+      setTimeout(() => scroll(scrollingRef.current!), 20)
+    }
+  }
+
+  const throttledHandleDragHelper = throttle(
+    (clientX: number, clientY: number) => {
+      const isInRightLeftBounds =
+        clientX &&
+        clientX > containerBoundaries.left &&
+        clientX < containerBoundaries.right
+      if (
+        clientY &&
+        clientY <= containerBoundaries.top + 16 &&
+        isInRightLeftBounds
+      ) {
+        if (scrollingRef.current !== 'up') {
+          setScrolling('up')
+          onChangeDragScrollingDirection('up')
+          setTimeout(() => scroll('up'), 20)
+        }
+      } else if (
+        clientY &&
+        clientY >= containerBoundaries.bottom - 16 &&
+        isInRightLeftBounds
+      ) {
+        if (scrollingRef.current !== 'down') {
+          setScrolling('down')
+          onChangeDragScrollingDirection('down')
+          setTimeout(() => scroll('down'), 20)
+        }
+      } else if (scrollingRef.current != null) {
+        onChangeDragScrollingDirection(undefined)
+        setScrolling(undefined)
+      }
+    },
+    200
+  )
+
+  const handleDrag: React.DragEventHandler<HTMLDivElement> = e => {
+    const clientX = e.clientX
+    const clientY = e.clientY
+    throttledHandleDragHelper(clientX, clientY)
+  }
+
+  const handleDragEnd: React.DragEventHandler<HTMLDivElement> = () => {
+    setScrolling(undefined)
+    onChangeDragScrollingDirection(undefined)
+  }
+
+  return (
+    <div
+      // This gets called repeatedly during drag if dragged item comes from outside the container
+      onDragEnter={handleDrag}
+      // This gets called repeatedly during drag if dragged item is inside the container
+      onDrag={handleDrag}
+      onDragEnd={handleDragEnd}
+    >
+      {children}
+    </div>
+  )
+}

--- a/packages/web/src/components/drag-autoscroller/DragAutoscroller.tsx
+++ b/packages/web/src/components/drag-autoscroller/DragAutoscroller.tsx
@@ -2,6 +2,11 @@ import React, { useRef, useState } from 'react'
 
 import throttle from 'lodash/throttle'
 
+const SCROLL_TIMEOUT_DURATION_MS = 20
+const SCROLL_STEP_PX = 5
+const DRAG_HANDLER_THROTTLE_DURATION_MS = 200
+const DISTANCE_FROM_EDGE_AUTOSCROLL_THRESHOLD_PX = 16
+
 export type DragAutoscrollerProps = {
   children: React.ReactNode
   containerBoundaries: {
@@ -30,10 +35,13 @@ export const DragAutoscroller = ({
   scrollingRef.current = scrolling
 
   const scroll = (direction: 'up' | 'down') => {
-    const difference = direction === 'up' ? -5 : 5
+    const difference = direction === 'up' ? -SCROLL_STEP_PX : SCROLL_STEP_PX
     updateScrollTopPosition(difference)
     if (scrollingRef.current != null) {
-      setTimeout(() => scroll(scrollingRef.current!), 20)
+      setTimeout(
+        () => scroll(scrollingRef.current!),
+        SCROLL_TIMEOUT_DURATION_MS
+      )
     }
   }
 
@@ -45,30 +53,34 @@ export const DragAutoscroller = ({
         clientX < containerBoundaries.right
       if (
         clientY &&
-        clientY <= containerBoundaries.top + 16 &&
+        clientY <=
+          containerBoundaries.top +
+            DISTANCE_FROM_EDGE_AUTOSCROLL_THRESHOLD_PX &&
         isInRightLeftBounds
       ) {
         if (scrollingRef.current !== 'up') {
           setScrolling('up')
           onChangeDragScrollingDirection('up')
-          setTimeout(() => scroll('up'), 20)
+          setTimeout(() => scroll('up'), SCROLL_TIMEOUT_DURATION_MS)
         }
       } else if (
         clientY &&
-        clientY >= containerBoundaries.bottom - 16 &&
+        clientY >=
+          containerBoundaries.bottom -
+            DISTANCE_FROM_EDGE_AUTOSCROLL_THRESHOLD_PX &&
         isInRightLeftBounds
       ) {
         if (scrollingRef.current !== 'down') {
           setScrolling('down')
           onChangeDragScrollingDirection('down')
-          setTimeout(() => scroll('down'), 20)
+          setTimeout(() => scroll('down'), SCROLL_TIMEOUT_DURATION_MS)
         }
       } else if (scrollingRef.current != null) {
         onChangeDragScrollingDirection(undefined)
         setScrolling(undefined)
       }
     },
-    200
+    DRAG_HANDLER_THROTTLE_DURATION_MS
   )
 
   const handleDrag: React.DragEventHandler<HTMLDivElement> = e => {

--- a/packages/web/src/components/nav/desktop/NavColumn.js
+++ b/packages/web/src/components/nav/desktop/NavColumn.js
@@ -1,25 +1,26 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 
 import { Scrollbar } from '@audius/stems'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
-import { withRouter, NavLink, useHistory } from 'react-router-dom'
+import { NavLink, useHistory, withRouter } from 'react-router-dom'
+import useMeasure from 'react-use-measure'
 
 import imageProfilePicEmpty from 'assets/img/imageProfilePicEmpty2X.png'
-import { Name, CreatePlaylistSource } from 'common/models/Analytics'
+import { CreatePlaylistSource, Name } from 'common/models/Analytics'
 import { SquareSizes } from 'common/models/ImageSizes'
 import Status from 'common/models/Status'
 import { FeatureFlags } from 'common/services/remote-config'
 import {
-  getAccountUser,
   getAccountStatus,
+  getAccountUser,
   getPlaylistLibrary
 } from 'common/store/account/selectors'
 import { getDominantColorsByTrack } from 'common/store/average-color/slice'
 import {
-  createPlaylist,
-  addTrackToPlaylist
+  addTrackToPlaylist,
+  createPlaylist
 } from 'common/store/cache/collections/actions'
 import {
   toggleNotificationPanel,
@@ -42,6 +43,7 @@ import {
   getIsOpen
 } from 'common/store/ui/createPlaylistModal/selectors'
 import CreatePlaylistModal from 'components/create-playlist/CreatePlaylistModal'
+import { DragAutoscroller } from 'components/drag-autoscroller/DragAutoscroller'
 import Droppable from 'components/dragndrop/Droppable'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import CurrentlyPlaying from 'components/nav/desktop/CurrentlyPlaying'
@@ -61,16 +63,16 @@ import { make, useRecord } from 'store/analytics/actions'
 import { getIsDragging } from 'store/dragndrop/selectors'
 import { update as updatePlaylistLibrary } from 'store/playlist-library/slice'
 import {
-  FEED_PAGE,
-  TRENDING_PAGE,
-  SAVED_PAGE,
-  HISTORY_PAGE,
   DASHBOARD_PAGE,
-  UPLOAD_PAGE,
+  EXPLORE_PAGE,
+  FEED_PAGE,
   fullTrackPage,
-  profilePage,
+  HISTORY_PAGE,
   playlistPage,
-  EXPLORE_PAGE
+  profilePage,
+  SAVED_PAGE,
+  TRENDING_PAGE,
+  UPLOAD_PAGE
 } from 'utils/route'
 
 import NavAudio from './NavAudio'
@@ -115,6 +117,15 @@ const NavColumn = ({
   const record = useRecord()
   const { location } = useHistory()
   const { pathname } = location
+  const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure()
+  const scrollbarRef = useRef(null)
+  const [dragScrollingDirection, setDragScrollingDirection] = useState(
+    undefined
+  )
+  const handleChangeDragScrollingDirection = useCallback(newDirection => {
+    setDragScrollingDirection(newDirection)
+  }, [])
+
   const goToSignUp = useCallback(
     source => {
       routeToSignup()
@@ -196,6 +207,13 @@ const NavColumn = ({
     [account, goToSignUp, showActionRequiresAccount, updatePlaylistLastViewedAt]
   )
 
+  const updateScrollTopPosition = useCallback(difference => {
+    if (scrollbarRef != null && scrollbarRef.current !== null) {
+      scrollbarRef.current.scrollTop =
+        scrollbarRef.current.scrollTop + difference
+    }
+  }, [])
+
   /** @param {bool} full whether or not to get the full page link */
   const getTrackPageLink = useCallback(
     (full = false) => {
@@ -266,159 +284,181 @@ const NavColumn = ({
         goToRoute={goToRoute}
         isElectron={isElectron}
       />
-      <div className={cn(styles.navContent, { [styles.show]: navLoaded })}>
-        <Scrollbar className={styles.scrollable}>
-          {account ? (
-            <div className={styles.userHeader}>
-              <div className={styles.accountWrapper}>
-                <DynamicImage
-                  wrapperClassName={styles.wrapperPhoto}
-                  className={styles.dynamicPhoto}
-                  onClick={goToProfile}
-                  image={profileImage}
-                />
-                <div className={styles.userInfoWrapper}>
-                  <div className={styles.name} onClick={goToProfile}>
-                    {name}
-                    <UserBadges
-                      userId={account.user_id}
-                      badgeSize={12}
-                      className={styles.badge}
-                    />
+      <div
+        ref={navBodyContainerMeasureRef}
+        className={cn(styles.navContent, {
+          [styles.show]: navLoaded,
+          [styles.dragScrollingUp]: dragScrollingDirection === 'up',
+          [styles.dragScrollingDown]: dragScrollingDirection === 'down'
+        })}
+      >
+        <Scrollbar
+          containerRef={el => {
+            scrollbarRef.current = el
+          }}
+          className={styles.scrollable}
+        >
+          <DragAutoscroller
+            containerBoundaries={navBodyContainerBoundaries}
+            updateScrollTopPosition={updateScrollTopPosition}
+            onChangeDragScrollingDirection={handleChangeDragScrollingDirection}
+          >
+            {account ? (
+              <div className={styles.userHeader}>
+                <div className={styles.accountWrapper}>
+                  <DynamicImage
+                    wrapperClassName={styles.wrapperPhoto}
+                    className={styles.dynamicPhoto}
+                    onClick={goToProfile}
+                    image={profileImage}
+                  />
+                  <div className={styles.userInfoWrapper}>
+                    <div className={styles.name} onClick={goToProfile}>
+                      {name}
+                      <UserBadges
+                        userId={account.user_id}
+                        badgeSize={12}
+                        className={styles.badge}
+                      />
+                    </div>
+                    <div className={styles.handleContainer}>
+                      <span
+                        className={styles.handle}
+                        onClick={goToProfile}
+                      >{`@${handle}`}</span>
+                    </div>
                   </div>
-                  <div className={styles.handleContainer}>
-                    <span
-                      className={styles.handle}
-                      onClick={goToProfile}
-                    >{`@${handle}`}</span>
+                </div>
+                <NavAudio />
+              </div>
+            ) : (
+              <div className={styles.userHeader}>
+                <div className={styles.accountWrapper}>
+                  <div
+                    className={styles.photo}
+                    style={{ backgroundImage: `url(${imageProfilePicEmpty})` }}
+                    onClick={onClickNavProfile}
+                  />
+                  <div className={styles.userInfoWrapper}>
+                    <div className={styles.haveAccount}>Have an Account?</div>
+                    <div className={styles.logIn} onClick={onClickNavProfile}>
+                      Sign In
+                    </div>
                   </div>
                 </div>
               </div>
-              <NavAudio />
-            </div>
-          ) : (
-            <div className={styles.userHeader}>
-              <div className={styles.accountWrapper}>
-                <div
-                  className={styles.photo}
-                  style={{ backgroundImage: `url(${imageProfilePicEmpty})` }}
-                  onClick={onClickNavProfile}
-                />
-                <div className={styles.userInfoWrapper}>
-                  <div className={styles.haveAccount}>Have an Account?</div>
-                  <div className={styles.logIn} onClick={onClickNavProfile}>
-                    Sign In
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
+            )}
 
-          <div className={styles.links}>
-            <div className={styles.linkGroup}>
-              <div className={styles.groupHeader}>Discover</div>
-              <NavLink
-                to={FEED_PAGE}
-                activeClassName='active'
-                className={cn(styles.link, {
-                  [styles.disabledLink]: !account || dragging
-                })}
-                onClick={onClickNavLinkWithAccount}
-              >
-                Feed
-              </NavLink>
-              <NavLink
-                to={TRENDING_PAGE}
-                activeClassName='active'
-                className={cn(styles.link, { [styles.disabledLink]: dragging })}
-              >
-                Trending
-              </NavLink>
-              <NavLink
-                to={EXPLORE_PAGE}
-                exact
-                activeClassName='active'
-                className={cn(styles.link, { [styles.disabledLink]: dragging })}
-              >
-                Explore
-              </NavLink>
-            </div>
-            <div className={styles.linkGroup}>
-              <div className={styles.groupHeader}>Library</div>
-              <Droppable
-                className={styles.droppable}
-                hoverClassName={styles.droppableHover}
-                acceptedKinds={['track', 'album']}
-                acceptOwner={false}
-                onDrop={kind === 'album' ? saveCollection : saveTrack}
-              >
+            <div className={styles.links}>
+              <div className={styles.linkGroup}>
+                <div className={styles.groupHeader}>Discover</div>
                 <NavLink
-                  to={SAVED_PAGE}
+                  to={FEED_PAGE}
                   activeClassName='active'
                   className={cn(styles.link, {
-                    [styles.disabledLink]:
-                      !account ||
-                      (dragging && kind === 'playlist') ||
-                      draggingIsOwner,
-                    [styles.droppableLink]:
-                      dragging &&
-                      !draggingIsOwner &&
-                      (kind === 'track' || kind === 'album')
+                    [styles.disabledLink]: !account || dragging
                   })}
                   onClick={onClickNavLinkWithAccount}
                 >
-                  Favorites
+                  Feed
                 </NavLink>
-              </Droppable>
-              <NavLink
-                to={HISTORY_PAGE}
-                activeClassName='active'
-                className={cn(styles.link, {
-                  [styles.disabledLink]: !account || dragging
-                })}
-                onClick={onClickNavLinkWithAccount}
-              >
-                History
-              </NavLink>
-            </div>
-            <div className={styles.linkGroup}>
-              <Droppable
-                className={styles.droppableGroup}
-                hoverClassName={styles.droppableGroupHover}
-                onDrop={saveCollection}
-                acceptedKinds={['playlist']}
-              >
-                <div
-                  className={cn(styles.groupHeader, {
-                    [styles.droppableLink]: dragging && kind === 'playlist'
+                <NavLink
+                  to={TRENDING_PAGE}
+                  activeClassName='active'
+                  className={cn(styles.link, {
+                    [styles.disabledLink]: dragging
                   })}
                 >
-                  Playlists
-                  <div className={styles.newPlaylist}>
-                    <Tooltip
-                      text={
-                        isPlaylistFoldersEnabled
-                          ? messages.newPlaylistOrFolderTooltip
-                          : messages.newPlaylistTooltip
-                      }
-                      mount='parent'
-                    >
-                      <span>
-                        <Pill
-                          text='New'
-                          icon='save'
-                          onClick={openCreatePlaylist}
-                        />
-                      </span>
-                    </Tooltip>
+                  Trending
+                </NavLink>
+                <NavLink
+                  to={EXPLORE_PAGE}
+                  exact
+                  activeClassName='active'
+                  className={cn(styles.link, {
+                    [styles.disabledLink]: dragging
+                  })}
+                >
+                  Explore
+                </NavLink>
+              </div>
+              <div className={styles.linkGroup}>
+                <div className={styles.groupHeader}>Library</div>
+                <Droppable
+                  className={styles.droppable}
+                  hoverClassName={styles.droppableHover}
+                  acceptedKinds={['track', 'album']}
+                  acceptOwner={false}
+                  onDrop={kind === 'album' ? saveCollection : saveTrack}
+                >
+                  <NavLink
+                    to={SAVED_PAGE}
+                    activeClassName='active'
+                    className={cn(styles.link, {
+                      [styles.disabledLink]:
+                        !account ||
+                        (dragging && kind === 'playlist') ||
+                        draggingIsOwner,
+                      [styles.droppableLink]:
+                        dragging &&
+                        !draggingIsOwner &&
+                        (kind === 'track' || kind === 'album')
+                    })}
+                    onClick={onClickNavLinkWithAccount}
+                  >
+                    Favorites
+                  </NavLink>
+                </Droppable>
+                <NavLink
+                  to={HISTORY_PAGE}
+                  activeClassName='active'
+                  className={cn(styles.link, {
+                    [styles.disabledLink]: !account || dragging
+                  })}
+                  onClick={onClickNavLinkWithAccount}
+                >
+                  History
+                </NavLink>
+              </div>
+              <div className={styles.linkGroup}>
+                <Droppable
+                  className={styles.droppableGroup}
+                  hoverClassName={styles.droppableGroupHover}
+                  onDrop={saveCollection}
+                  acceptedKinds={['playlist']}
+                >
+                  <div
+                    className={cn(styles.groupHeader, {
+                      [styles.droppableLink]: dragging && kind === 'playlist'
+                    })}
+                  >
+                    Playlists
+                    <div className={styles.newPlaylist}>
+                      <Tooltip
+                        text={
+                          isPlaylistFoldersEnabled
+                            ? messages.newPlaylistOrFolderTooltip
+                            : messages.newPlaylistTooltip
+                        }
+                        mount='parent'
+                      >
+                        <span>
+                          <Pill
+                            text='New'
+                            icon='save'
+                            onClick={openCreatePlaylist}
+                          />
+                        </span>
+                      </Tooltip>
+                    </div>
                   </div>
-                </div>
-                <PlaylistLibrary
-                  onClickNavLinkWithAccount={onClickNavLinkWithAccount}
-                />
-              </Droppable>
+                  <PlaylistLibrary
+                    onClickNavLinkWithAccount={onClickNavLinkWithAccount}
+                  />
+                </Droppable>
+              </div>
             </div>
-          </div>
+          </DragAutoscroller>
         </Scrollbar>
         <CreatePlaylistModal
           visible={showCreatePlaylistModal}

--- a/packages/web/src/components/nav/desktop/NavColumn.js
+++ b/packages/web/src/components/nav/desktop/NavColumn.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react'
 
 import { Scrollbar } from '@audius/stems'
+import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -117,7 +118,9 @@ const NavColumn = ({
   const record = useRecord()
   const { location } = useHistory()
   const { pathname } = location
-  const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure()
+  const [navBodyContainerMeasureRef, navBodyContainerBoundaries] = useMeasure({
+    polyfill: ResizeObserver
+  })
   const scrollbarRef = useRef(null)
   const [dragScrollingDirection, setDragScrollingDirection] = useState(
     undefined

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -35,11 +35,11 @@
 }
 
 .navContent.dragScrollingUp {
-  box-shadow: inset 0px 18px 16px -21px var(--neutral-dark-3);
+  box-shadow: inset 0px 8px 5px -5px var(--tile-shadow-3);
 }
 
 .navContent.dragScrollingDown {
-  box-shadow: inset 0px -18px 16px -21px var(--neutral-dark-3);
+  box-shadow: inset 0px -8px 5px -5px var(--tile-shadow-3);
 }
 
 .navContent.show {

--- a/packages/web/src/components/nav/desktop/NavColumn.module.css
+++ b/packages/web/src/components/nav/desktop/NavColumn.module.css
@@ -30,8 +30,16 @@
   flex-direction: column;
   width: 100%;
   overflow: hidden;
-  transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.3s ease-in-out, box-shadow 0.2s ease;
   flex-grow: 1;
+}
+
+.navContent.dragScrollingUp {
+  box-shadow: inset 0px 18px 16px -21px var(--neutral-dark-3);
+}
+
+.navContent.dragScrollingDown {
+  box-shadow: inset 0px -18px 16px -21px var(--neutral-dark-3);
 }
 
 .navContent.show {

--- a/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
@@ -95,7 +95,9 @@ export const PlaylistFolderNavItem = ({
   const [isHovering, setIsHovering] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
   const record = useRecord()
-  const [ref, bounds] = useMeasure()
+  const [ref, bounds] = useMeasure({
+    polyfill: ResizeObserver
+  })
   const contentsStyle = useSpring({
     height: isExpanded ? bounds.height : 0,
     opacity: isExpanded ? 100 : 0,

--- a/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
@@ -6,6 +6,7 @@ import {
   IconFolderOutline,
   IconKebabHorizontal
 } from '@audius/stems'
+import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
 import { useSpring, animated } from 'react-spring'
 import useMeasure from 'react-use-measure'


### PR DESCRIPTION
### Description
![autoscroll](https://user-images.githubusercontent.com/36916764/160175451-d685f135-87df-4863-8b13-9528b1c4ac9e.gif)

Sadly the new scrollbar component doesn't play well with native drag and drop scrolling - see https://github.com/mdbootstrap/perfect-scrollbar/issues/100 and https://stackoverflow.com/questions/55482184/auto-scroll-while-dragging-an-item-with-perfect-scrollbar-and-sortablejs.

This means that when you drag something to the top or bottom of the nav container, it doesn't scroll automatically like it used to.
This PR adds back that functionality manually (+ a shadow indicator when you're drag-scrolling up or down).

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in browser
*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
