### PR TITLE
[AUD-1779] Improve track tile click animation fluidity

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -203,6 +203,9 @@ export const Lineup = ({
 
   const togglePlay = useCallback(
     (uid: UID, id: ID, source: PlaybackSource) => {
+      // setImmediate prevents this cpu-intensive callback from firing until
+      // the lineup-tile press animation finishes. This may not be needed when
+      // we remove the web-view.
       setImmediate(() => {
         if (uid !== playingUid || (uid === playingUid && !playing)) {
           dispatchWeb(actions.play(uid))

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -203,25 +203,27 @@ export const Lineup = ({
 
   const togglePlay = useCallback(
     (uid: UID, id: ID, source: PlaybackSource) => {
-      if (uid !== playingUid || (uid === playingUid && !playing)) {
-        dispatchWeb(actions.play(uid))
-        track(
-          make({
-            eventName: Name.PLAYBACK_PLAY,
-            id: `${id}`,
-            source: source || PlaybackSource.TRACK_TILE
-          })
-        )
-      } else if (uid === playingUid && playing) {
-        dispatchWeb(actions.pause())
-        track(
-          make({
-            eventName: Name.PLAYBACK_PAUSE,
-            id: `${id}`,
-            source: source || PlaybackSource.TRACK_TILE
-          })
-        )
-      }
+      setImmediate(() => {
+        if (uid !== playingUid || (uid === playingUid && !playing)) {
+          dispatchWeb(actions.play(uid))
+          track(
+            make({
+              eventName: Name.PLAYBACK_PLAY,
+              id: `${id}`,
+              source: source || PlaybackSource.TRACK_TILE
+            })
+          )
+        } else if (uid === playingUid && playing) {
+          dispatchWeb(actions.pause())
+          track(
+            make({
+              eventName: Name.PLAYBACK_PAUSE,
+              id: `${id}`,
+              source: source || PlaybackSource.TRACK_TILE
+            })
+          )
+        }
+      })
     },
     [actions, dispatchWeb, playing, playingUid]
   )


### PR DESCRIPTION
### Description

Improves track tile click animation by delaying the cpu intensive tasks (queueing) until after the animation finishes

### Dragons

- Obviously this slightly slows down play/pause responsiveness. In testing it seems okay, but something to watch out for.
- I also considered adding the `setImmediate` to all tile `onPress` actions since that would ensure all animations are smooth. Curious what folks think about that idea and its tradeoffs

