### PR TITLE
Bump libs to 1.2.94

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -79,12 +79,12 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.91",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.91.tgz",
-      "integrity": "sha512-sOt5+A2V4fLPRfmpGEVIwOCDfOinwNYGVmRocHwigHK9JWWidqK6j7uOGBuqA/tEVfGppXHV9Q2zFyDPUtouAA==",
+      "version": "1.2.94",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.94.tgz",
+      "integrity": "sha512-yKun8+XjlvXP08mD0DZ0/6xC/4XVd0kbqvHCg/WCJHbt6U/k5Q0HvLOYIosdZ6i5ympmienO+Z1i7LCZcO6A4Q==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
-        "@certusone/wormhole-sdk": "0.0.10",
+        "@certusone/wormhole-sdk": "0.1.1",
         "@ethersproject/solidity": "5.0.5",
         "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
         "@solana/spl-token": "0.1.6",
@@ -1405,9 +1405,9 @@
       }
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.0.10.tgz",
-      "integrity": "sha512-BGAi3qdgFjA3UO0XMefnn8aDBpQUj+eDcDfcN90sl26QqlC01YDVPz93FyLsNTTjM3X1WHNX0V66B6UzPDr6Vw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.1.1.tgz",
+      "integrity": "sha512-/FEOGOkDRVq5+aXNHb9W57WR03dI9ZvhFlc/qrrQhXJQYhkm4Y+i0L9NQN5J5TpZ/aZ3cX+E6Gw3nFsmbgCo/g==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.14.0",
         "@solana/spl-token": "^0.1.8",
@@ -1439,9 +1439,9 @@
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
         },
         "rxjs": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-          "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -1803,29 +1803,29 @@
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-      "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.0.tgz",
+      "integrity": "sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
         "bn.js": "^4.11.9"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
-      "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.0.tgz",
+      "integrity": "sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==",
       "requires": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/logger": "^5.6.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
-      "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.0.tgz",
+      "integrity": "sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.5.0"
+        "@ethersproject/bignumber": "^5.6.0"
       }
     },
     "@ethersproject/contracts": {
@@ -1907,18 +1907,18 @@
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
-      "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.0.tgz",
+      "integrity": "sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/bytes": "^5.6.0",
         "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
     },
     "@ethersproject/networks": {
       "version": "5.4.2",
@@ -2002,12 +2002,12 @@
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-      "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.0.tgz",
+      "integrity": "sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0",
         "hash.js": "1.1.7"
       }
     },
@@ -2037,13 +2037,13 @@
       }
     },
     "@ethersproject/strings": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
-      "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.0.tgz",
+      "integrity": "sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bytes": "^5.6.0",
+        "@ethersproject/constants": "^5.6.0",
+        "@ethersproject/logger": "^5.6.0"
       }
     },
     "@ethersproject/transactions": {
@@ -3997,9 +3997,9 @@
       },
       "dependencies": {
         "rxjs": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-          "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -4058,44 +4058,75 @@
       },
       "dependencies": {
         "@walletconnect/browser-utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.3.tgz",
-          "integrity": "sha512-QYpzoBgvEDBF2lu6L55d0jX1K9bfEy1UtPqAWCi6KBOgw1KQgfvHavephOXW+tQIAWYB5CROTxa4HTSVyYUEQA==",
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.5.tgz",
+          "integrity": "sha512-gm9ufi0n5cGBXoGWDtMVSqIJ0eXYW+ZFuTNVN0fm4oal26J7cPrOdFjzhv5zvx5fKztWQ21DNFZ+PRXBjXg04Q==",
           "requires": {
             "@walletconnect/safe-json": "1.0.0",
-            "@walletconnect/types": "^1.7.3",
+            "@walletconnect/types": "^1.7.5",
             "@walletconnect/window-getters": "1.0.0",
             "@walletconnect/window-metadata": "1.0.0",
             "detect-browser": "5.2.0"
           }
         },
         "@walletconnect/core": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.3.tgz",
-          "integrity": "sha512-sDKWrQccs96T2uMbyWbKxLOFjKFLyoLIxMtknNuZXGG6kw+NUee5GBu9tTZ7zfVuIh0te1YcpZPX7slXwNjY8g==",
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.5.tgz",
+          "integrity": "sha512-c4B8s9fZ/Ah2p460Hxo4e9pwLQVYT2+dVYAfqaxVzfYjhAokDEtO55Bdm1hujtRjQVqwTvCljKxBB+LgMp3k8w==",
           "requires": {
-            "@walletconnect/socket-transport": "^1.7.3",
-            "@walletconnect/types": "^1.7.3",
-            "@walletconnect/utils": "^1.7.3"
+            "@walletconnect/socket-transport": "^1.7.5",
+            "@walletconnect/types": "^1.7.5",
+            "@walletconnect/utils": "^1.7.5"
+          }
+        },
+        "@walletconnect/crypto": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.2.tgz",
+          "integrity": "sha512-+OlNtwieUqVcOpFTvLBvH+9J9pntEqH5evpINHfVxff1XIgwV55PpbdvkHu6r9Ib4WQDOFiD8OeeXs1vHw7xKQ==",
+          "requires": {
+            "@walletconnect/encoding": "^1.0.1",
+            "@walletconnect/environment": "^1.0.0",
+            "@walletconnect/randombytes": "^1.0.2",
+            "aes-js": "^3.1.2",
+            "hash.js": "^1.1.7"
+          }
+        },
+        "@walletconnect/encoding": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.1.tgz",
+          "integrity": "sha512-8opL2rs6N6E3tJfsqwS82aZQDL3gmupWUgmvuZ3CGU7z/InZs3R9jkzH8wmYtpbq0sFK3WkJkQRZFFk4BkrmFA==",
+          "requires": {
+            "is-typedarray": "1.0.0",
+            "typedarray-to-buffer": "3.1.5"
           }
         },
         "@walletconnect/iso-crypto": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.3.tgz",
-          "integrity": "sha512-T/mEoHMuYjft7SWiFTQa4Fng12U9Z7XQPUq9axJPgBY7a5dC4Bk3tJX8Ml7s7syLxc6inzCCMv/vaZGNskTgAw==",
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.5.tgz",
+          "integrity": "sha512-mJdRs2SqAPOLBBqLhU+ZnAh2c8TL2uDuL/ojV4aBzZ0ZHNT7X2zSOjAiixCb3vvH8GAt30OKmiRo3+ChI/9zvA==",
           "requires": {
-            "@walletconnect/crypto": "^1.0.1",
-            "@walletconnect/types": "^1.7.3",
-            "@walletconnect/utils": "^1.7.3"
+            "@walletconnect/crypto": "^1.0.2",
+            "@walletconnect/types": "^1.7.5",
+            "@walletconnect/utils": "^1.7.5"
+          }
+        },
+        "@walletconnect/randombytes": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.2.tgz",
+          "integrity": "sha512-ivgOtAyqQnN0rLQmOFPemsgYGysd/ooLfaDA/ACQ3cyqlca56t3rZc7pXfqJOIETx/wSyoF5XbwL+BqYodw27A==",
+          "requires": {
+            "@walletconnect/encoding": "^1.0.1",
+            "@walletconnect/environment": "^1.0.0",
+            "randombytes": "^2.1.0"
           }
         },
         "@walletconnect/socket-transport": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.3.tgz",
-          "integrity": "sha512-t0WlbgtnyOKHqKjceVBJI0c7wlsZIvZTsbYgQ3NN03uX8r5gv01FJxLvf/Uu5uip+LcjBZEz4TVwIO80As64nw==",
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.5.tgz",
+          "integrity": "sha512-4TYCxrNWb4f5a1NGsALXidr+/6dOiqgVfUQJ4fdP6R7ijL+7jtdiktguU9FIDq5wFXRE+ZdpCpwSAfOt60q/mQ==",
           "requires": {
-            "@walletconnect/types": "^1.7.3",
-            "@walletconnect/utils": "^1.7.3",
+            "@walletconnect/types": "^1.7.5",
+            "@walletconnect/utils": "^1.7.5",
             "ws": "7.5.3"
           },
           "dependencies": {
@@ -4107,19 +4138,19 @@
           }
         },
         "@walletconnect/types": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.3.tgz",
-          "integrity": "sha512-EtFM7LxjrbCoCJvRZf3wydPitwlB0s4S9sj9yXe13j7mMgf9ruS5Ixa/sCfDKskZdGvkhFis9+Nw+gO++A/klg=="
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.5.tgz",
+          "integrity": "sha512-0HvZzxD93et4DdrYgAvclI1BqclkZS7iPWRtbGg3r+PQhRPbOkNypzBy6XH6wflbmr+WBGdmyJvynHsdhcCqUA=="
         },
         "@walletconnect/utils": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.3.tgz",
-          "integrity": "sha512-WVZqCBgoIer3fUUVEQm0TYZrDBEOSlKJ91EgA27I41TJGer7OE7pEjJhaNgwWTIwsfJJkjNWp+4wa78Qf/e5vg==",
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.5.tgz",
+          "integrity": "sha512-U954rIIA/g/Cmdqy+n3hMY1DDMmXxGs8w/QmrK9b/H5nkQ3e4QicOyynq5g/JTTesN5HZdDTFiyX9r0GSKa+iA==",
           "requires": {
-            "@walletconnect/browser-utils": "^1.7.3",
-            "@walletconnect/encoding": "^1.0.0",
+            "@walletconnect/browser-utils": "^1.7.5",
+            "@walletconnect/encoding": "^1.0.1",
             "@walletconnect/jsonrpc-utils": "^1.0.0",
-            "@walletconnect/types": "^1.7.3",
+            "@walletconnect/types": "^1.7.5",
             "bn.js": "4.11.8",
             "js-sha3": "0.8.0",
             "query-string": "6.13.5"
@@ -4141,9 +4172,9 @@
           }
         },
         "rxjs": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-          "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -4172,9 +4203,9 @@
       },
       "dependencies": {
         "@walletconnect/types": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.3.tgz",
-          "integrity": "sha512-EtFM7LxjrbCoCJvRZf3wydPitwlB0s4S9sj9yXe13j7mMgf9ruS5Ixa/sCfDKskZdGvkhFis9+Nw+gO++A/klg=="
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.5.tgz",
+          "integrity": "sha512-0HvZzxD93et4DdrYgAvclI1BqclkZS7iPWRtbGg3r+PQhRPbOkNypzBy6XH6wflbmr+WBGdmyJvynHsdhcCqUA=="
         }
       }
     },
@@ -4189,9 +4220,9 @@
       },
       "dependencies": {
         "rxjs": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-          "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -4212,9 +4243,9 @@
       },
       "dependencies": {
         "rxjs": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-          "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -4306,9 +4337,9 @@
       },
       "dependencies": {
         "rxjs": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
-          "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -18425,14 +18456,14 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.179",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
-          "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w=="
+          "version": "4.14.180",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+          "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g=="
         },
         "@types/node": {
-          "version": "12.20.46",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.46.tgz",
-          "integrity": "sha512-cPjLXj8d6anFPzFvOPxS3fvly3Shm5nTfl6g8X5smexixbuGUf7hfr21J5tX9JW+UPStp/5P5R8qrKL5IyVJ+A=="
+          "version": "12.20.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.47.tgz",
+          "integrity": "sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -24842,9 +24873,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "17.0.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-          "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
+          "version": "17.0.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+          "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
         }
       }
     },
@@ -28347,7 +28378,7 @@
       }
     },
     "simplebar-react-legacy": {
-      "version": "npm:simplebar-react-legacy@1.2.3",
+      "version": "npm:simplebar-react@1.2.3",
       "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
       "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
       "requires": {
@@ -30808,12 +30839,17 @@
         "yallist": "^3.1.1"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+        },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.6"
           }
         }
       }
@@ -31919,9 +31955,9 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
     "utf-8-validate": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.8.tgz",
-      "integrity": "sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
+      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
       "requires": {
         "node-gyp-build": "^4.3.0"
       }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "version": "1.1.3",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.91",
+    "@audius/libs": "1.2.94",
     "@audius/stems": "0.3.27",
     "@craco/craco": "6.4.3",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",


### PR DESCRIPTION
### Description

Bump libs to 1.2.94. This will include consuming a new route called /async_processing_status instead of /track_content_status

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
