### PR TITLE
[AUD-1770] Use latest react-native-linear-gradient

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - React-Core
   - boost (1.76.0)
   - BVLinearGradient (2.5.6):
-    - React
+    - React-Core
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.66.3)
@@ -803,7 +803,7 @@ SPEC CHECKSUMS:
   Amplitude: ef9ed339ddd33c9183edf63fa4bbaa86cf873321
   amplitude-react-native: c7d779d1e2ec4062c833207df7588cc2a9146325
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
+  BVLinearGradient: 48f1964a78bddfae412d1aac5f386c2949fe0306
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: de148e8310b8b878db304ceea2fec13f2c02e3a0

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -6300,7 +6300,7 @@
       "version": "file:../web",
       "requires": {
         "@audius/libs": "1.2.91",
-        "@audius/stems": "0.3.26",
+        "@audius/stems": "0.3.27",
         "@craco/craco": "6.4.3",
         "@fingerprintjs/fingerprintjs-pro": "3.5.6",
         "@hcaptcha/react-hcaptcha": "0.3.6",
@@ -49044,9 +49044,8 @@
       "integrity": "sha512-eRKm4wlsmZHmsWFyv77kYc2F+ZyEVqe0m7mqhsMzWk6TQT4FBDtEDxmRDDFq+ivCu/1QD+EPhmYcAIpeGr7Ekg=="
     },
     "react-native-linear-gradient": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/react-native-linear-gradient/-/react-native-linear-gradient-2.5.6.tgz",
-      "integrity": "sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg=="
+      "version": "github:react-native-linear-gradient/react-native-linear-gradient#9aece37cdf7d33ed52a1747b36e9e84f3c7a49ef",
+      "from": "github:react-native-linear-gradient/react-native-linear-gradient#9aece37cdf7d33ed52a1747b36e9e84f3c7a49ef"
     },
     "react-native-markdown-display": {
       "version": "7.0.0-alpha.2",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -84,7 +84,7 @@
     "react-native-haptic-feedback": "1.11.0",
     "react-native-hyperlink": "0.0.19",
     "react-native-image-picker": "4.7.3",
-    "react-native-linear-gradient": "2.5.6",
+    "react-native-linear-gradient": "github:react-native-linear-gradient/react-native-linear-gradient.git#9aece37cdf7d33ed52a1747b36e9e84f3c7a49ef",
     "react-native-markdown-display": "7.0.0-alpha.2",
     "react-native-modal": "11.5.4",
     "react-native-music-control": "1.4.0",


### PR DESCRIPTION
### Description

Upgrades to use @rickyrombo fixes for react-native-linear-gradient

Before:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/8230000/160188983-cf860ff3-1953-4aac-a8f8-b5a8e3f7a0f5.png">


After: 
<img width="422" alt="image" src="https://user-images.githubusercontent.com/8230000/160187853-4e51fbe9-7984-4064-80a4-1752d58cfbcd.png">


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
