### PR TITLE
[AUD-1774] Fix padding on TrendingRewards SegmentedControl

### DIFF
--- a/packages/mobile/src/components/core/SegmentedControl.tsx
+++ b/packages/mobile/src/components/core/SegmentedControl.tsx
@@ -101,7 +101,7 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
     width: '100%'
   },
   tabFullWidth: {
-    flex: 1,
+    flexGrow: 1,
     textAlign: 'center'
   }
 }))

--- a/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
+++ b/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
@@ -124,7 +124,7 @@ const createStyles = (themeColors: ThemeColors) =>
       fontSize: 13
     },
     trendingControl: {
-      paddingHorizontal: 28
+      marginHorizontal: 28
     },
     lastWeek: {
       textAlign: 'center',
@@ -228,6 +228,7 @@ export const TrendingRewardsDrawer = () => {
         <ScrollView showsVerticalScrollIndicator={false}>
           <View style={styles.trendingControl}>
             <SegmentedControl
+              fullWidth
               options={tabOptions}
               selected={modalType}
               onSelectOption={option =>


### PR DESCRIPTION
### Description

* Fixes padding on TrendingRewardsDrawer SegmentedControl
<img width="466" alt="Screen Shot 2022-03-28 at 10 49 41 AM" src="https://user-images.githubusercontent.com/19916043/160438328-91d93897-eef3-4713-b55c-15ad2aa9e236.png">

### Dragons

Affects other SegmentedControls, checked settings and everything looked good!

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
