### PR TITLE
[AUD-1671] Prevent Drawer from popping to top of screen

### DIFF
--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -322,7 +322,7 @@ export const Drawer: DrawerComponent = ({
 }: DrawerProps) => {
   const styles = useThemedStyles(createStyles(zIndex, shouldAnimateShadow))
 
-  const [drawerHeight, setDrawerHeight] = useState(FULL_DRAWER_HEIGHT)
+  const [drawerHeight, setDrawerHeight] = useState(0)
   // isBackgroundVisible will be true until the close animation finishes
   const [isBackgroundVisible, setIsBackgroundVisible] = useState(false)
 


### PR DESCRIPTION
### Description

BIG PR

* Fixes a bug where the drawer would pop to the top of the screen. This usually happened when lots of other processing was going on and the `onLayout` callback wasn't called immediately

### Dragons

Affects drawers, but the actual height should always get set and therefore this shouldn't be dangerous

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
