### PR TITLE
[AUD-1781] Fix issue with feed not loading after sign in

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { Name, PlaybackSource } from 'audius-client/src/common/models/Analytics'
 import { ID, UID } from 'audius-client/src/common/models/Identifiers'
@@ -12,7 +12,6 @@ import {
   View
 } from 'react-native'
 import { useSelector } from 'react-redux'
-import { useEffectOnce } from 'react-use'
 
 import { SectionList } from 'app/components/core'
 import {
@@ -195,11 +194,11 @@ export const Lineup = ({
     limit
   ])
 
-  useEffectOnce(() => {
+  useEffect(() => {
     if (selfLoad) {
       handleLoadMore()
     }
-  })
+  }, [handleLoadMore, selfLoad])
 
   const togglePlay = useCallback(
     (uid: UID, id: ID, source: PlaybackSource) => {

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -9,12 +9,14 @@ import {
 } from 'audius-client/src/common/store/pages/feed/selectors'
 import { setVisibility } from 'audius-client/src/common/store/ui/modals/slice'
 import { isEqual, omit } from 'lodash'
+import { useSelector } from 'react-redux'
 
 import { Screen } from 'app/components/core'
 import { Header } from 'app/components/header'
 import { Lineup } from 'app/components/lineup'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { getIsSignedIn } from 'app/store/lifecycle/selectors'
 import { make, track } from 'app/utils/analytics'
 
 import { FeedFilterButton } from './FeedFilterButton'
@@ -31,6 +33,7 @@ export const FeedScreen = () => {
     const omitUneeded = o => omit(o, ['inView'])
     return isEqual(omitUneeded(a), omitUneeded(b))
   })
+  const signedIn = useSelector(getIsSignedIn)
   const feedFilter = useSelectorWeb(getFeedFilter)
   const [isRefreshing, setIsRefreshing] = useState(false)
 
@@ -72,7 +75,7 @@ export const FeedScreen = () => {
         loadMore={loadMore}
         refresh={handleRefresh}
         refreshing={isRefreshing}
-        selfLoad
+        selfLoad={!!signedIn}
         showsVerticalScrollIndicator={false}
       />
     </Screen>

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -78,6 +78,9 @@ export const RootScreen = () => {
   const onSignUp = useSelector(getOnSignUp)
   const isAccountAvailable = useSelector(getAccountAvailable)
 
+  // This check is overly complicated and should probably just check `signedIn`.
+  // However, this allows the feed screen to load initially so that when the
+  // splash screen disappears there is already content (skeletons) on the screen
   const isAuthed =
     !dappLoaded ||
     signedIn === null ||


### PR DESCRIPTION
### Description

* Fixes the issue with the feed not loading after sign in

This was due to the strange boolean logic we have to switch between `SignOnStack` and `MainStack`. `authed` is always true initially because the dapp has not yet loaded, which causes the feed screen to render while the splash screen is still visible. The feed lineup uses `selfLoad` which is fine when the account already exists in state, but when signing in the feed has already tried to load with no user and failed. Then no new fetch is performed on the lineup

We should probably improve the boolean logic there, could be as simple as checking `signedIn`. But trying that resulted in a flash of blank screen after the splash screen because the feed screen takes a second to render

The kinda hacky fix here is to set `selfLoad` based on `signedIn` so the feed renders initially but doesn't load until the user signs in

### Dragons

This should be pretty harmless because we require all users to sign in to see the feed

### How Has This Been Tested?

iOS sim. Ran through sign on, and sign up flows

### How will this change be monitored?

TestFlight QA
