### PR TITLE
[AUD-1812] Prevent unnecessary store syncs

### DIFF
--- a/packages/web/src/common/store/notifications/reducer.ts
+++ b/packages/web/src/common/store/notifications/reducer.ts
@@ -187,6 +187,13 @@ const actionsMap: any = {
     state: NotificationState,
     action: actions.SetPlaylistUpdates
   ) {
+    if (
+      action.playlistUpdates.length === 0 &&
+      state.playlistUpdates.length === 0
+    ) {
+      return state
+    }
+
     return {
       ...state,
       playlistUpdates: action.playlistUpdates || []

--- a/packages/web/src/common/store/pages/audio-rewards/slice.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/slice.ts
@@ -97,12 +97,14 @@ const slice = createSlice({
       if (userChallenges === null) {
         state.userChallenges = {}
       } else {
-        state.userChallenges = userChallenges.reduce(
+        state.userChallenges = userChallenges.reduce<
+          Partial<Record<ChallengeRewardID, UserChallenge>>
+        >(
           (acc, challenge) => ({
             ...acc,
             [challenge.challenge_id]: challenge
           }),
-          {} as Partial<Record<ChallengeRewardID, UserChallenge>>
+          {}
         )
       }
       state.loading = false

--- a/packages/web/src/common/store/pages/audio-rewards/slice.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/slice.ts
@@ -97,18 +97,13 @@ const slice = createSlice({
       if (userChallenges === null) {
         state.userChallenges = {}
       } else {
-        state.userChallenges = userChallenges.reduce((acc, challenge) => {
-          // TODO: AUD-1536
-          // Remove this custom override logic when we have identified the proper fix
-          if (
-            challenge.challenge_id === 'listen-streak' &&
-            challenge.is_complete
-          ) {
-            challenge.current_step_count = challenge.max_steps
-          }
-          acc[challenge.challenge_id] = challenge
-          return acc
-        }, {} as Partial<Record<ChallengeRewardID, UserChallenge>>)
+        state.userChallenges = userChallenges.reduce(
+          (acc, challenge) => ({
+            ...acc,
+            [challenge.challenge_id]: challenge
+          }),
+          {} as Partial<Record<ChallengeRewardID, UserChallenge>>
+        )
       }
       state.loading = false
     },
@@ -119,7 +114,9 @@ const slice = createSlice({
       state,
       action: PayloadAction<UndisbursedUserChallenge[]>
     ) => {
-      state.undisbursedChallenges = action.payload
+      if (state.undisbursedChallenges.length > 0 || action.payload.length > 0) {
+        state.undisbursedChallenges = action.payload
+      }
     },
     setUserChallengesDisbursed: (
       state,


### PR DESCRIPTION
### Description

* Updates some reducers to not update state when not necessary. This allows the equality checks to be more accurate when determining when to sync state to the mobile layer
* Removes a todo and special case for `listen-streak` challenge types. See: https://linear.app/audius/issue/AUD-1536/fix-challenge-overrides-for-completed-challenges

### Dragons

Touches rewards reducers which could be dangerous

### How Has This Been Tested?

iOS sim, checked that empty sync actions were reduced

### How will this change be monitored?

TestFlight QA
