### PR TITLE
[AUD-1800] Remove pull-to-refresh on track screen

### DIFF
--- a/packages/mobile/src/components/core/FlatList.tsx
+++ b/packages/mobile/src/components/core/FlatList.tsx
@@ -22,10 +22,11 @@ const CollapsibleFlatList = ({
   sceneName,
   ...other
 }: CollapsibleFlatListProps) => {
+  const { onRefresh } = other
   const scrollPropsAndRef = useCollapsibleScene(sceneName)
   return (
     <View>
-      <PullToRefresh />
+      {onRefresh ? <PullToRefresh /> : null}
       <Animated.FlatList {...other} {...scrollPropsAndRef} />
     </View>
   )
@@ -54,12 +55,14 @@ const AnimatedFlatList = forwardRef<RNFlatList, FlatListProps>(
 
     return (
       <View>
-        <PullToRefresh
-          isRefreshing={isRefreshing}
-          onRefresh={handleRefresh}
-          scrollAnim={scrollAnim}
-          isRefreshDisabled={isRefreshDisabled}
-        />
+        {handleRefresh ? (
+          <PullToRefresh
+            isRefreshing={isRefreshing}
+            onRefresh={handleRefresh}
+            scrollAnim={scrollAnim}
+            isRefreshDisabled={isRefreshDisabled}
+          />
+        ) : null}
         <Animated.FlatList
           scrollToOverflowEnabled
           ref={ref || scrollRef}

--- a/packages/mobile/src/components/core/PullToRefresh.tsx
+++ b/packages/mobile/src/components/core/PullToRefresh.tsx
@@ -100,9 +100,9 @@ export const useOverflowHandlers = ({
   const onScroll = attachToScroll(scrollAnim)
 
   return {
-    isRefreshing: isRefreshing || isDebouncing,
+    isRefreshing: onRefresh ? isRefreshing || isDebouncing : undefined,
     isRefreshDisabled: isMomentumScroll,
-    handleRefresh,
+    handleRefresh: onRefresh ? handleRefresh : undefined,
     scrollAnim,
     onScroll,
     onScrollBeginDrag,

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -40,10 +40,8 @@ const useCollapsibleSectionListScene = (sceneName: string) => {
   }
 }
 
-const CollapsibleSectionList = ({
-  sceneName,
-  ...other
-}: CollapsibleSectionListProps) => {
+const CollapsibleSectionList = (props: CollapsibleSectionListProps) => {
+  const { sceneName, ...other } = props
   const { refreshing, onRefresh, scrollY: collapsibleScrollAnim } = useContext(
     CollapsibleTabNavigatorContext
   )
@@ -53,15 +51,17 @@ const CollapsibleSectionList = ({
 
   return (
     <View>
-      <Portal hostName='PullToRefreshPortalHost'>
-        <PullToRefresh
-          isRefreshing={refreshing}
-          onRefresh={onRefresh}
-          scrollAnim={collapsibleScrollAnim}
-          topOffset={40}
-          color={staticWhite}
-        />
-      </Portal>
+      {onRefresh ? (
+        <Portal hostName='PullToRefreshPortalHost'>
+          <PullToRefresh
+            isRefreshing={refreshing}
+            onRefresh={onRefresh}
+            scrollAnim={collapsibleScrollAnim}
+            topOffset={40}
+            color={staticWhite}
+          />
+        </Portal>
+      ) : null}
       <Animated.SectionList {...other} {...scrollPropsAndRef} />
     </View>
   )
@@ -69,9 +69,10 @@ const CollapsibleSectionList = ({
 
 const AnimatedSectionList = forwardRef<RNSectionList, SectionListProps>(
   function AnimatedSectionList(
-    { refreshing, onRefresh, ...other },
+    props,
     ref: MutableRefObject<RNSectionList<any, DefaultSectionT> | null>
   ) {
+    const { refreshing, onRefresh, ...other } = props
     const scrollResponder = ref.current?.getScrollResponder()
     const {
       isRefreshing,
@@ -89,12 +90,14 @@ const AnimatedSectionList = forwardRef<RNSectionList, SectionListProps>(
 
     return (
       <View>
-        <PullToRefresh
-          isRefreshing={isRefreshing}
-          onRefresh={handleRefresh}
-          scrollAnim={scrollAnim}
-          isRefreshDisabled={isRefreshDisabled}
-        />
+        {handleRefresh ? (
+          <PullToRefresh
+            isRefreshing={isRefreshing}
+            onRefresh={handleRefresh}
+            scrollAnim={scrollAnim}
+            isRefreshDisabled={isRefreshDisabled}
+          />
+        ) : null}
         <Animated.SectionList
           scrollToOverflowEnabled
           ref={ref}


### PR DESCRIPTION
### Description

Removes pull-to-refresh on track screen. Also goes the extra step and removes refresh indicator for any section-list that doesn't explicitly pass down an `onRefresh` function. Curious if the way it was implemented is best!