### PR TITLE
[AUD-1824] Improve track-tile skeleton transition

### DIFF
--- a/packages/mobile/src/components/core/DynamicImage.tsx
+++ b/packages/mobile/src/components/core/DynamicImage.tsx
@@ -104,8 +104,8 @@ export const DynamicImage = memo(function DynamicImage({
   const [firstImage, setFirstImage] = useState<string>()
   const [secondImage, setSecondImage] = useState<string>()
 
-  const firstOpacity = useRef(new Animated.Value(0)).current
-  const secondOpacity = useRef(new Animated.Value(0)).current
+  const firstOpacity = useRef(new Animated.Value(0.5)).current
+  const secondOpacity = useRef(new Animated.Value(0.5)).current
 
   const [isFirstImageActive, setIsFirstImageActive] = useState(true)
 

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -61,7 +61,7 @@ export const LineupTile = ({
 
   const [artworkLoaded, setArtworkLoaded] = useState(false)
 
-  const opacity = useRef(new Animated.Value(0)).current
+  const opacity = useRef(new Animated.Value(0.5)).current
 
   const isOwner = user_id === currentUserId
   const isLoaded = artworkLoaded


### PR DESCRIPTION
### Description

Improves the transition handoff from track-tile skeleton to track-tile content by starting the content fade-in at 50%, which is a similar color to the skeleton gray color. Happy to continue adjusting if it seems like it could be better!


https://user-images.githubusercontent.com/8230000/162079739-bb37081a-f8ac-451f-906b-5f368b81c531.mov

With the dynamic image opacity change:

https://user-images.githubusercontent.com/8230000/162080902-7ceebc81-8406-4c2d-8121-2569d00d228c.mov


