### PR TITLE
[AUD-1852] Fix opacity interpolation for the mobile tracking bar

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/TrackingBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/TrackingBar.tsx
@@ -49,8 +49,8 @@ export const TrackingBar = ({
             // the now playing drawer is opened so that the drawer may
             // animate in corner radius without showing at the same time
             // as the tracker.
-            inputRange: [0, 0.95 * NOW_PLAYING_HEIGHT, NOW_PLAYING_HEIGHT],
-            outputRange: [0, 0, 1]
+            inputRange: [0, 0.9 * NOW_PLAYING_HEIGHT, NOW_PLAYING_HEIGHT],
+            outputRange: [0, 0, 2]
           })
         }
       ]}


### PR DESCRIPTION
### Description

[AUD-1852]
Fixed the interpolation for the TrackingBar opacity. A bit hacky, but the effect looks good

### Dragons

N/A

### How Has This Been Tested?

Manually Tested

![Simulator Screen Shot - iPhone 13 - 2022-04-07 at 12 44 27](https://user-images.githubusercontent.com/23732287/162255247-a9b39d34-b465-4a69-badb-480fb5627b27.png)
![Simulator Screen Shot - iPhone 13 - 2022-04-07 at 12 47 12](https://user-images.githubusercontent.com/23732287/162255324-0cc43317-c9bc-42f2-bc1e-b1706111ee5b.png)

### How will this change be monitored?

N/A
