### PR TITLE
[AUD-1807] Fix Chromecast permissions

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -24,9 +24,9 @@ import {
 } from 'common/store/ui/mobile-overflow-menu/types'
 import { requestOpen as requestOpenShareModal } from 'common/store/ui/share-modal/slice'
 import { View, StyleSheet } from 'react-native'
+import { CastButton } from 'react-native-google-cast'
 
 import IconAirplay from 'app/assets/images/iconAirplay.svg'
-import IconChromecast from 'app/assets/images/iconChromecast.svg'
 import IconKebabHorizontal from 'app/assets/images/iconKebabHorizontal.svg'
 import IconShare from 'app/assets/images/iconShare.svg'
 import { useAirplay } from 'app/components/audio/Airplay'
@@ -35,8 +35,6 @@ import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { useThemedStyles } from 'app/hooks/useThemedStyles'
 import { ThemeColors, useThemeColors } from 'app/utils/theme'
-
-import { useChromecast } from '../audio/GoogleCast'
 
 import { FavoriteButton } from './FavoriteButton'
 import { RepostButton } from './RepostButton'
@@ -143,7 +141,6 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   }, [track, currentUserId, dispatchWeb])
 
   const { openAirplayDialog } = useAirplay()
-  const { openChromecastDialog } = useChromecast()
 
   const renderCastButton = () => {
     if (castMethod === 'airplay') {
@@ -157,11 +154,12 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
       )
     }
     return (
-      <IconButton
-        onPress={openChromecastDialog}
-        icon={IconChromecast}
-        fill={isCasting ? primary : neutral}
-        styles={{ icon: styles.icon, root: styles.button }}
+      <CastButton
+        style={{
+          ...styles.button,
+          ...styles.icon,
+          tintColor: isCasting ? primary : neutral
+        }}
       />
     )
   }


### PR DESCRIPTION
### Description

* Uses the provided `CastButton` to trigger the cast dialog so that network permissions are properly obtained
![image](https://user-images.githubusercontent.com/19916043/162299006-652d2d0c-fd67-41e7-ba8d-b3e6ec915045.png)
![image](https://user-images.githubusercontent.com/19916043/162299094-617f0a80-e9aa-4b75-8e2c-f1e336fe4e26.png)
![image](https://user-images.githubusercontent.com/19916043/162299159-2a4b66cd-be44-4fe1-b7c8-c7e2e8b5e869.png)
![image](https://user-images.githubusercontent.com/19916043/162299220-a25dae67-6d88-447f-ba48-3d81e4d5f342.png)

### Dragons

There isn't a good way to render the provided `CastButton` in the background and trigger it. So we are kinda tied to the icon and animations provided out of the box. However, with styling the button looks pretty similar to the rest of the UI

### How Has This Been Tested?

iOS device in release config

### How will this change be monitored?

TestFlight QA