### PR TITLE
Upgrade libs to 1.2.105, adds constants patch

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -84,9 +84,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.104",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.104.tgz",
-      "integrity": "sha512-XBev3OSLGJK4ASuOPZCgTuH2/DyaOL1UZdzR4dRT8SSD3Pff7paE57D40Ys+g0p5favLKnauWl/VEbd1CFU9xQ==",
+      "version": "1.2.105",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.105.tgz",
+      "integrity": "sha512-NsAUPquQQALnZHS8paQvYJXuqGfvO1f4CIdFepZh3vfLbQiAqSGiOAgwFYrL1bEFneo54+xs7J6kipYdAqxoHA==",
       "requires": {
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.1.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "version": "1.1.5",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.104",
+    "@audius/libs": "1.2.105",
     "@audius/stems": "0.3.28",
     "@craco/craco": "6.4.3",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",

--- a/packages/web/src/services/LocalStorage.ts
+++ b/packages/web/src/services/LocalStorage.ts
@@ -1,7 +1,10 @@
-import { CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY } from '@audius/libs/src/constants'
-import { DISCOVERY_PROVIDER_TIMESTAMP } from '@audius/libs/src/services/discoveryProvider/constants'
-
 import { User } from 'common/models/User'
+
+// TODO: the following should come from @audius/libs/constants when we build
+// it with esm. Importing with common-js breaks the app since it tries
+// to import all of libs, which we try to do async later on.
+const CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY = '@audius/libs:found-user'
+const DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-node-timestamp'
 
 const AUDIUS_ACCOUNT_KEY = '@audius/account'
 const AUDIUS_ACCOUNT_USER_KEY = '@audius/audius-user'

--- a/packages/web/src/types/libs/libs.d.ts
+++ b/packages/web/src/types/libs/libs.d.ts
@@ -1,3 +1,1 @@
 declare module '@audius/libs'
-declare module '@audius/libs/src/constants'
-declare module '@audius/libs/src/services/discoveryProvider/constants'


### PR DESCRIPTION
### Description

Upgrades libs to latest, and includes fixes for constants that were imported directly from libs/src, which isn't supported anymore.