### PR TITLE
[AUD-1857] Fix issue with scrolling to bottom of Lineup

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -130,7 +130,7 @@ export const Lineup = ({
 }: LineupProps) => {
   const dispatchWeb = useDispatchWeb()
   const ref = useRef<RNSectionList>(null)
-  const [isAtBottom, setIsAtBottom] = useState(false)
+  const [isPastLoadThreshold, setIsPastLoadThreshold] = useState(false)
   useScrollToTop(() => {
     ref.current?.scrollToLocation({
       sectionIndex: 0,
@@ -191,13 +191,13 @@ export const Lineup = ({
     limit
   ])
 
-  // When scrolled to the very bottom of the lineup and the lineup is not loading,
+  // When scrolled past the end threshold of the lineup and the lineup is not loading,
   // trigger another load
   useEffect(() => {
-    if (isAtBottom && lineup.status !== Status.LOADING) {
+    if (isPastLoadThreshold && lineup.status !== Status.LOADING) {
       handleLoadMore()
     }
-  }, [isAtBottom, lineup.status, handleLoadMore])
+  }, [isPastLoadThreshold, lineup.status, handleLoadMore])
 
   useEffect(() => {
     if (selfLoad && lineup.entries.length === 0) {
@@ -382,16 +382,16 @@ export const Lineup = ({
         layoutMeasurement.height + contentOffset.y >=
         contentSize.height - LOAD_MORE_THRESHOLD * layoutMeasurement.height
       ) {
-        if (!isAtBottom) {
-          setIsAtBottom(true)
+        if (!isPastLoadThreshold) {
+          setIsPastLoadThreshold(true)
         }
       } else {
-        if (isAtBottom) {
-          setIsAtBottom(false)
+        if (isPastLoadThreshold) {
+          setIsPastLoadThreshold(false)
         }
       }
     },
-    [isAtBottom]
+    [isPastLoadThreshold]
   )
 
   return (

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -378,7 +378,10 @@ export const Lineup = ({
   const handleScroll = useCallback(
     ({ nativeEvent }) => {
       const { layoutMeasurement, contentOffset, contentSize } = nativeEvent
-      if (layoutMeasurement.height + contentOffset.y >= contentSize.height) {
+      if (
+        layoutMeasurement.height + contentOffset.y >=
+        contentSize.height - LOAD_MORE_THRESHOLD * layoutMeasurement.height
+      ) {
         if (!isAtBottom) {
           setIsAtBottom(true)
         }

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Name, PlaybackSource } from 'audius-client/src/common/models/Analytics'
 import { ID, UID } from 'audius-client/src/common/models/Identifiers'
@@ -130,6 +130,7 @@ export const Lineup = ({
 }: LineupProps) => {
   const dispatchWeb = useDispatchWeb()
   const ref = useRef<RNSectionList>(null)
+  const [isAtBottom, setIsAtBottom] = useState(false)
   useScrollToTop(() => {
     ref.current?.scrollToLocation({
       sectionIndex: 0,
@@ -189,6 +190,14 @@ export const Lineup = ({
     includeLineupStatus,
     limit
   ])
+
+  // When scrolled to the very bottom of the lineup and the lineup is not loading,
+  // trigger another load
+  useEffect(() => {
+    if (isAtBottom && lineup.status !== Status.LOADING) {
+      handleLoadMore()
+    }
+  }, [isAtBottom, lineup.status, handleLoadMore])
 
   useEffect(() => {
     if (selfLoad && lineup.entries.length === 0) {
@@ -366,10 +375,27 @@ export const Lineup = ({
     limit
   ])
 
+  const handleScroll = useCallback(
+    ({ nativeEvent }) => {
+      const { layoutMeasurement, contentOffset, contentSize } = nativeEvent
+      if (layoutMeasurement.height + contentOffset.y >= contentSize.height) {
+        if (!isAtBottom) {
+          setIsAtBottom(true)
+        }
+      } else {
+        if (isAtBottom) {
+          setIsAtBottom(false)
+        }
+      }
+    },
+    [isAtBottom]
+  )
+
   return (
     <SectionList
       {...listProps}
       ref={ref}
+      onScroll={handleScroll}
       ListHeaderComponent={header}
       ListFooterComponent={<View style={{ height: 16 }} />}
       onEndReached={handleLoadMore}


### PR DESCRIPTION
### Description

The Lineup had an issue where when the end threshold was reached while metadata was still loading, no new load would be triggered because the check against offset was happening during the load.

This fixes the issue by separately keeping track of if the threshold has been reached and then triggering a fetch when the lineup load finishes

A more ideal solution could be to remove the check against offset completely, allowing for free scrolling. But this results in duplicate/unordered lineup items so would need to be a bigger feature.

### Dragons

Touches lineup loading, potentially dangerous.

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
