### PR TITLE
catch invisible characters in AUDIUS_REMOTE_DEV_HOST

### DIFF
--- a/packages/web/scripts/configureLocalEnv.js
+++ b/packages/web/scripts/configureLocalEnv.js
@@ -17,7 +17,7 @@ if (process.argv[2] && process.argv[2] === '--remote-host') {
   }
   if (HOST.trim() != HOST) {
     throw new Error(
-      `Invisible characters detected in $AUDIUS_REMOTE_DEV_HOST: '${AUDIUS_REMOTE_DEV_HOST}'`
+      `Invisible characters detected in $AUDIUS_REMOTE_DEV_HOST: '${HOST}'`
     )
   }
 }

--- a/packages/web/scripts/configureLocalEnv.js
+++ b/packages/web/scripts/configureLocalEnv.js
@@ -15,6 +15,11 @@ if (process.argv[2] && process.argv[2] === '--remote-host') {
       'Misconfigured local env. Ensure AUDIUS_REMOTE_DEV_HOST envvar has been exported.'
     )
   }
+  if (HOST.trim() != HOST) {
+    throw new Error(
+      `Invisible characters detected in $AUDIUS_REMOTE_DEV_HOST: '${AUDIUS_REMOTE_DEV_HOST}'`
+    )
+  }
 }
 
 try {


### PR DESCRIPTION
### Description

### Dragons

If this code breaks, it will break right when launching the audius-client.

### How Has This Been Tested?

```
$ export AUDIUS_REMOTE_DEV_HOST=$(ssh box whichip)
Connection to 104.198.141.182 closed.
$ node ./scripts/configureLocalEnv.js --remote-host
/Users/joaquin/repos/audius-client/packages/web/scripts/configureLocalEnv.js:19
    throw new Error(
    ^

'rror: Invisible characters detected in $AUDIUS_REMOTE_DEV_HOST: '104.198.141.182
    at Object.<anonymous> (/Users/joaquin/repos/audius-client/packages/web/scripts/configureLocalEnv.js:19:11)
    at Module._compile (node:internal/modules/cjs/loader:1099:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47

Node.js v17.8.0
$ ssh box whichip
104.198.141.182
Connection to 104.198.141.182 closed.
$ export AUDIUS_REMOTE_DEV_HOST=104.198.141.182
$ node ./scripts/configureLocalEnv.js --remote-host
Configured .env.dev.local
```

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
