### PR TITLE
[AUD-1858] Move isPlayingUid logic back into TrackTile and CollectionTile and fix Collectiontile play-pause logic

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -6,8 +6,7 @@ import { useSelector } from 'react-redux'
 
 import { LineupTileProps } from 'app/components/lineup-tile/types'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
-import { AppState } from 'app/store'
-import { getPlaying, getPlayingUid } from 'app/store/audio/selectors'
+import { getPlaying } from 'app/store/audio/selectors'
 
 import { LineupTileActionButtons } from './LineupTileActionButtons'
 import {
@@ -30,6 +29,7 @@ export const LineupTile = ({
   id,
   imageUrl,
   index,
+  isPlayingUid,
   isTrending,
   isUnlisted,
   onLoad,
@@ -55,10 +55,6 @@ export const LineupTile = ({
     save_count
   } = item
   const { _artist_pick, name, user_id } = user
-
-  const isPlayingUid = useSelector(
-    (state: AppState) => getPlayingUid(state) === uid
-  )
   const isPlaying = useSelector(getPlaying)
   const currentUserId = useSelectorWeb(getUserId)
 
@@ -82,11 +78,8 @@ export const LineupTile = ({
   }, [onLoad, isLoaded, index, opacity])
 
   const handlePress = useCallback(() => {
-    onPress?.({
-      isPlayingUid,
-      isPlaying
-    })
-  }, [isPlayingUid, isPlaying, onPress])
+    onPress?.({ isPlaying })
+  }, [isPlaying, onPress])
 
   return (
     <LineupTileRoot onPress={handlePress}>

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -27,12 +27,15 @@ import { requestOpen as requestOpenShareModal } from 'audius-client/src/common/s
 import { RepostType } from 'audius-client/src/common/store/user-list/reposts/types'
 import { open as openOverflowMenu } from 'common/store/ui/mobile-overflow-menu/slice'
 import { isEqual } from 'lodash'
+import { useSelector } from 'react-redux'
 
 import { LineupItemProps } from 'app/components/lineup-tile/types'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { useTrackCoverArt } from 'app/hooks/useTrackCoverArt'
+import { AppState } from 'app/store'
+import { getPlayingUid } from 'app/store/audio/selectors'
 
 import { LineupTile } from './LineupTile'
 
@@ -78,6 +81,9 @@ const TrackTileComponent = ({
   const dispatchWeb = useDispatchWeb()
   const navigation = useNavigation()
   const currentUserId = useSelectorWeb(getUserId)
+  const isPlayingUid = useSelector(
+    (state: AppState) => getPlayingUid(state) === lineupTileProps.uid
+  )
 
   const {
     _cover_art_sizes,
@@ -103,7 +109,7 @@ const TrackTileComponent = ({
   })
 
   const handlePress = useCallback(
-    ({ isPlaying, isPlayingUid }) => {
+    ({ isPlaying }) => {
       togglePlay({
         uid: lineupTileProps.uid,
         id: track_id,
@@ -112,7 +118,7 @@ const TrackTileComponent = ({
         isPlayingUid
       })
     },
-    [togglePlay, lineupTileProps.uid, track_id]
+    [togglePlay, lineupTileProps.uid, track_id, isPlayingUid]
   )
 
   const handlePressTitle = useCallback(() => {
@@ -199,6 +205,7 @@ const TrackTileComponent = ({
   return (
     <LineupTile
       {...lineupTileProps}
+      isPlayingUid={isPlayingUid}
       duration={duration}
       favoriteType={FavoriteType.TRACK}
       repostType={RepostType.TRACK}

--- a/packages/mobile/src/components/lineup-tile/types.ts
+++ b/packages/mobile/src/components/lineup-tile/types.ts
@@ -66,11 +66,14 @@ export type LineupTileProps = Omit<LineupItemProps, 'togglePlay'> & {
   /** Url of the image */
   imageUrl?: string
 
+  /** Does the tile uid match the playing uid */
+  isPlayingUid: boolean
+
   /** The item (track or collection) */
   item: Track | Collection
 
   /** Function to call when tile is pressed */
-  onPress?: (args: { isPlaying: boolean; isPlayingUid: boolean }) => void
+  onPress?: (args: { isPlaying: boolean }) => void
 
   /** Function to call when the overflow menu button is pressed */
   onPressOverflow?: GestureResponderHandler

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -232,7 +232,7 @@ export const Lineup = ({
               source: source || PlaybackSource.TRACK_TILE
             })
           )
-        } else if (isPlayingUid && isPlaying) {
+        } else {
           dispatchWeb(actions.pause())
           track(
             make({


### PR DESCRIPTION
### Description
[AUD-1858]

### Dragons

There may be unintended regression added to certain flows with the TrackTile. Please keep an eye out for that

### How Has This Been Tested?

Manually tested. Play-pause for collection tile works and the title switched to primary color

### How will this change be monitored?

N/A
