### PR TITLE
[AUD-1845]  Configure deep linking

### DIFF
--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -1,10 +1,14 @@
 import { ReactNode, useContext } from 'react'
 
 import {
+  getStateFromPath,
   LinkingOptions,
   NavigationContainer as RNNavigationContainer
 } from '@react-navigation/native'
+import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
 
+import { usePushRouteWeb } from 'app/hooks/usePushRouteWeb'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { RootScreenParamList } from 'app/screens/root-screen/RootScreen'
 
 import { ThemeContext } from '../theme/ThemeContext'
@@ -14,84 +18,97 @@ import { navigationThemes } from './navigationThemes'
 type Props = {
   children: ReactNode
 }
-
-const linking: LinkingOptions<RootScreenParamList> = {
-  prefixes: ['https://audius.co'],
-  // configuration for matching screens with paths
-  config: {
-    screens: {
-      App: {
-        initialRouteName: 'feed',
-        screens: {
-          feed: {
-            screens: {
-              FeedStack: 'feed',
-              Track: '*/*',
-              Profile: '*'
-            }
-          },
-          trending: {
-            screens: {
-              TrendingStack: {
-                screens: {
-                  ThisWeek: 'trending/thisWeek',
-                  ThisMonth: 'trending/thisMonth',
-                  ThisYear: 'trending/thisYear'
-                }
-              }
-            }
-          },
-          explore: {
-            screens: {
-              ExploreStack: {
-                screens: {
-                  forYou: 'explore/forYou',
-                  moods: 'explore/moods',
-                  playlists: 'explore/playlists',
-                  artists: 'explore/artists'
-                }
-              }
-            }
-          },
-          favorites: {
-            screens: {
-              FavoritesStack: {
-                screens: {
-                  tracks: 'favorites/tracks',
-                  albums: 'favorites/albums',
-                  playlists: 'favorites/playlists'
-                }
-              }
-            }
-          },
-          profile: {
-            screens: {
-              ProfileStack: {
-                screens: {
-                  Tracks: '*/tracks',
-                  Albums: '*/albums',
-                  Playlists: '*/playlists',
-                  Reposts: '*/reposts',
-                  Collectibles: '*/collectibles/*'
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 /**
  * NavigationContainer contains the react-navigation context
  * and configures linking
  */
 const NavigationContainer = ({ children }: Props) => {
   const { theme, isSystemDarkMode } = useContext(ThemeContext)
+  const pushRouteWeb = usePushRouteWeb()
+  const account = useSelectorWeb(getAccountUser)
 
   const navigationTheme =
     theme === 'auto' ? (isSystemDarkMode ? 'dark' : 'default') : theme
+
+  const linking: LinkingOptions<RootScreenParamList> = {
+    prefixes: ['https://audius.co', 'https://staging.audius.co'],
+    // configuration for matching screens with paths
+    config: {
+      screens: {
+        App: {
+          screens: {
+            MainStack: {
+              initialRouteName: 'feed',
+              screens: {
+                feed: {
+                  initialRouteName: 'Feed',
+                  screens: {
+                    Feed: '/feed',
+                    Collection: '*/playlist/*',
+                    Track: '*/*',
+                    Profile: ':handle'
+                  }
+                },
+                trending: {
+                  initialRouteName: 'Trending',
+                  screens: {
+                    Trending: 'trending'
+                  }
+                },
+                explore: {
+                  initialRouteName: 'Explore',
+                  screens: {
+                    Explore: 'explore',
+                    TrendingPlaylists: 'explore/playlists',
+                    TrendingUnderground: 'explore/underground',
+                    LetThemDJ: 'explore/let-them-dj',
+                    TopAlbums: 'explore/top-albums',
+                    UnderTheRadar: 'explore/under-the-radar',
+                    BestNewReleases: 'explore/best-new-releases',
+                    Remixables: 'explore/remixables',
+                    MostLoved: 'explore/most-loved',
+                    FeelingLucky: 'explore/feeling-lucky',
+                    HeavyRotation: 'explore/heavy-rotation',
+                    ChillPlaylists: 'explore/chill',
+                    IntensePlaylists: 'explore/intense',
+                    IntimatePlaylists: 'explore/intimate',
+                    ProvokingPlaylists: 'explore/provoking',
+                    UpbeatPlaylists: 'explore/upbeat'
+                  }
+                },
+                favorites: {
+                  screens: {
+                    Favorites: 'favorites'
+                  }
+                },
+                profile: {
+                  screens: {
+                    UserProfile: 'profile'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    getStateFromPath: (path, options) => {
+      // Strip the trending query param because `/trending` will
+      // always go to ThisWeek
+      if (path.match(/^\/trending/)) {
+        path = '/trending'
+      }
+
+      pushRouteWeb(path, undefined, false)
+
+      // Check if the path is the current user and set path as `/profile`
+      if (path.replace('/', '') === account?.handle) {
+        path = '/profile'
+      }
+
+      return getStateFromPath(path, options)
+    }
+  }
 
   return (
     <RNNavigationContainer

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -50,7 +50,16 @@ const NavigationContainer = ({ children }: Props) => {
                     // don't load properly on web. So for now deep linking
                     // to profile tabs (other than for your own account) isn't
                     // implemented
-                    Profile: ':handle'
+                    Profile: {
+                      path: ':handle',
+                      screens: {
+                        Tracks: 'tracks',
+                        Albums: 'albums',
+                        Playlists: 'playlists',
+                        Reposts: 'reposts',
+                        Collectibles: 'collectibles'
+                      }
+                    } as any // Nested navigator typing with own params is broken, see: https://github.com/react-navigation/react-navigation/issues/9897
                   }
                 },
                 trending: {
@@ -88,12 +97,13 @@ const NavigationContainer = ({ children }: Props) => {
                 profile: {
                   screens: {
                     UserProfile: {
+                      path: 'profile',
                       screens: {
-                        Tracks: 'profile',
-                        Albums: 'profile/albums',
-                        Playlists: 'profile/playlists',
-                        Reposts: 'profile/reposts',
-                        Collectibles: 'profile/collectibles'
+                        Tracks: 'tracks',
+                        Albums: 'albums',
+                        Playlists: 'playlists',
+                        Reposts: 'reposts',
+                        Collectibles: 'collectibles'
                       }
                     }
                   }
@@ -118,22 +128,16 @@ const NavigationContainer = ({ children }: Props) => {
         path = path.replace(`/${account?.handle}`, '/profile')
       } else {
         // If the path has two parts
-        if (path.match(/^\/.+\/.+$/)) {
-          // If the path matches a profile tab
+        if (path.match(/^\/[^/]+\/[^/]+$/)) {
+          // If the path doesn't match a profile tab, it's a track
           if (
-            path.match(/^\/.+\/(tracks|albums|playlists|reposts|collectibles)$/)
+            !path.match(
+              /^\/[^/]+\/(tracks|albums|playlists|reposts|collectibles)$/
+            )
           ) {
-            // Strip the profile tab because the urls don't load properly on web
-            path = path.match(/^\/(.+)\//)?.[1] ?? ''
-          } else {
-            // Otherwise it's a track
             path = '/track'
           }
         }
-      }
-
-      if (path.match(/^\/profile\/tracks/)) {
-        path = '/profile'
       }
 
       return getStateFromPath(path, options)

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -43,9 +43,13 @@ const NavigationContainer = ({ children }: Props) => {
                 feed: {
                   initialRouteName: 'Feed',
                   screens: {
-                    Feed: '/feed',
+                    Feed: 'feed',
                     Collection: '*/playlist/*',
-                    Track: '*/*',
+                    Track: 'track',
+                    // Unfortunately routes like username/playlists
+                    // don't load properly on web. So for now deep linking
+                    // to profile tabs (other than for your own account) isn't
+                    // implemented
                     Profile: ':handle'
                   }
                 },
@@ -83,7 +87,15 @@ const NavigationContainer = ({ children }: Props) => {
                 },
                 profile: {
                   screens: {
-                    UserProfile: 'profile'
+                    UserProfile: {
+                      screens: {
+                        Tracks: 'profile',
+                        Albums: 'profile/albums',
+                        Playlists: 'profile/playlists',
+                        Reposts: 'profile/reposts',
+                        Collectibles: 'profile/collectibles'
+                      }
+                    }
                   }
                 }
               }
@@ -101,8 +113,26 @@ const NavigationContainer = ({ children }: Props) => {
 
       pushRouteWeb(path, undefined, false)
 
-      // Check if the path is the current user and set path as `/profile`
-      if (path.replace('/', '') === account?.handle) {
+      if (path.match(`^/${account?.handle}(/|$)`)) {
+        // If the path is the current user and set path as `/profile`
+        path = path.replace(`/${account?.handle}`, '/profile')
+      } else {
+        // If the path has two parts
+        if (path.match(/^\/.+\/.+$/)) {
+          // If the path matches a profile tab
+          if (
+            path.match(/^\/.+\/(tracks|albums|playlists|reposts|collectibles)$/)
+          ) {
+            // Strip the profile tab because the urls don't load properly on web
+            path = path.match(/^\/(.+)\//)?.[1] ?? ''
+          } else {
+            // Otherwise it's a track
+            path = '/track'
+          }
+        }
+      }
+
+      if (path.match(/^\/profile\/tracks/)) {
         path = '/profile'
       }
 

--- a/packages/mobile/src/components/web/WebApp.tsx
+++ b/packages/mobile/src/components/web/WebApp.tsx
@@ -349,7 +349,7 @@ const WebApp = ({
     const login = urlParams.login
     const warning = urlParams.warning
     const email = urlParams.email
-    return { login, warning, email }
+    return login || warning || email ? { login, warning, email } : null
   }, [])
 
   const getSearchParams = (searchString: string) => {

--- a/packages/mobile/src/screens/app-screen/ExploreTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/ExploreTabScreen.tsx
@@ -27,7 +27,7 @@ import { AppTabScreenParamList } from './AppTabScreen'
 import { createAppTabScreenStack } from './createAppTabScreenStack'
 
 export type ExploreTabScreenParamList = AppTabScreenParamList & {
-  ExploreStack: undefined
+  Explore: undefined
   // Smart Collection Screens
   UnderTheRadar: undefined
   MostLoved: undefined
@@ -69,7 +69,7 @@ export const ExploreTabScreen = createAppTabScreenStack<
   ExploreTabScreenParamList
 >(Stack => (
   <>
-    <Stack.Screen name='ExploreStack' component={ExploreScreen} />
+    <Stack.Screen name='Explore' component={ExploreScreen} />
     <Stack.Screen name='LetThemDJ' component={LetThemDJScreen} />
     <Stack.Screen name='TopAlbums' component={TopAlbumsScreen} />
     <Stack.Screen

--- a/packages/mobile/src/screens/app-screen/FavoritesTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/FavoritesTabScreen.tsx
@@ -5,7 +5,7 @@ import { AppTabScreenParamList } from './AppTabScreen'
 import { createAppTabScreenStack } from './createAppTabScreenStack'
 
 export type FavoritesTabScreenParamList = AppTabScreenParamList & {
-  FavoritesStack: undefined
+  Favorites: undefined
   CreatePlaylist: undefined
 }
 

--- a/packages/mobile/src/screens/app-screen/FeedTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/FeedTabScreen.tsx
@@ -4,7 +4,7 @@ import { AppTabScreenParamList } from './AppTabScreen'
 import { createAppTabScreenStack } from './createAppTabScreenStack'
 
 export type FeedTabScreenParamList = AppTabScreenParamList & {
-  FeedStack: undefined
+  Feed: undefined
 }
 
 export const FeedTabScreen = createAppTabScreenStack<FeedTabScreenParamList>(

--- a/packages/mobile/src/screens/app-screen/ProfileTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/ProfileTabScreen.tsx
@@ -15,7 +15,7 @@ import { AppTabScreenParamList } from './AppTabScreen'
 import { createAppTabScreenStack } from './createAppTabScreenStack'
 
 export type ProfileTabScreenParamList = AppTabScreenParamList & {
-  ProfileStack: undefined
+  UserProfile: undefined
   EditProfile: undefined
   SettingsScreen: undefined
   AboutScreen: undefined

--- a/packages/mobile/src/screens/app-screen/TrendingTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/TrendingTabScreen.tsx
@@ -4,7 +4,7 @@ import { AppTabScreenParamList } from './AppTabScreen'
 import { createAppTabScreenStack } from './createAppTabScreenStack'
 
 export type TrendingTabScreenParamList = AppTabScreenParamList & {
-  TrendingStack: undefined
+  Trending: undefined
 }
 
 export const TrendingTabScreen = createAppTabScreenStack<

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -21,7 +21,9 @@ import { NotificationsScreen } from '../notifications-screen/NotificationsScreen
 
 export type RootScreenParamList = {
   signOn: undefined
-  App: NavigatorScreenParams<AppScreenParamList>
+  App: NavigatorScreenParams<{
+    MainStack: NavigatorScreenParams<AppScreenParamList>
+  }>
 }
 
 const Drawer = createDrawerNavigator()


### PR DESCRIPTION
### Description

* Configures mapping so deep links go to correct screens

### Dragons

* Need to run in release configuration to test links when the app is not already running. 
* Came across some logic for handling recovery params, not sure if we already have this implemented in the new app. Will need to double check on this

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
