### PR TITLE
[AUD-1723] Collectibles tab improvement

### DIFF
--- a/packages/mobile/src/screens/profile-screen/CollectiblesTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/CollectiblesTab.tsx
@@ -31,9 +31,14 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
     paddingVertical: spacing(6)
   },
   header: {
-    paddingHorizontal: spacing(6),
-    marginBottom: spacing(4)
+    paddingHorizontal: spacing(4),
+    marginTop: spacing(4),
+    marginBottom: spacing(2)
   },
+  headerContent: {
+    padding: spacing(4)
+  },
+
   title: {
     fontFamily: typography.fontByWeight.heavy,
     fontSize: 24,
@@ -93,34 +98,27 @@ export const CollectiblesTab = () => {
   const collectibles = [...collectibleList, ...solanaCollectibleList]
 
   return (
-    <View style={styles.root}>
-      <Tile styles={{ tile: styles.tile, content: styles.tileContent }}>
-        <FlatList
-          ref={ref}
-          listKey='profile-collectibles'
-          ListHeaderComponent={
-            <View style={styles.header}>
-              <GradientText accessibilityRole='header' style={styles.title}>
-                {messages.title}
-              </GradientText>
-              <Text style={styles.subtitle}>{messages.subtitle('you')}</Text>
-              <Pressable style={styles.shareButtonRoot}>
-                <IconShare
-                  fill={neutralLight4}
-                  style={styles.shareButtonIcon}
-                />
-                <Text style={styles.shareButtonText}>Share</Text>
-              </Pressable>
-            </View>
-          }
-          data={collectibles}
-          renderItem={({ item }) => (
-            <View style={styles.collectibleListItem}>
-              <CollectiblesCard collectible={item} />
-            </View>
-          )}
-        />
-      </Tile>
-    </View>
+    <FlatList
+      ref={ref}
+      listKey='profile-collectibles'
+      ListHeaderComponent={
+        <Tile styles={{ root: styles.header, content: styles.headerContent }}>
+          <GradientText accessibilityRole='header' style={styles.title}>
+            {messages.title}
+          </GradientText>
+          <Text style={styles.subtitle}>{messages.subtitle('you')}</Text>
+          <Pressable style={styles.shareButtonRoot}>
+            <IconShare fill={neutralLight4} style={styles.shareButtonIcon} />
+            <Text style={styles.shareButtonText}>Share</Text>
+          </Pressable>
+        </Tile>
+      }
+      data={collectibles}
+      renderItem={({ item }) => (
+        <View style={styles.collectibleListItem}>
+          <CollectiblesCard collectible={item} />
+        </View>
+      )}
+    />
   )
 }


### PR DESCRIPTION
### Description

* Performance seems good and didn't run into any crashes on accounts with large numbers of collectibles (FerrariJetpack, Mike Shinoda, etc)
* Removes the wrapping tile because the bottom edge was being rendered above the bottom bar at all times. Made the header it's own tile at the top. This changes the look slightly but I think it still makes sense:
<img width="477" alt="image" src="https://user-images.githubusercontent.com/19916043/162781203-14b0abf3-9b1b-4ed9-a842-468c7fe5d59b.png">


### Dragons
N/A

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
