### PR TITLE
[AUD-1855] Improve drawer performance

### DIFF
--- a/packages/web/src/store/configureStore.ts
+++ b/packages/web/src/store/configureStore.ts
@@ -1,15 +1,13 @@
 import * as Sentry from '@sentry/browser'
 import { routerMiddleware, push as pushRoute } from 'connected-react-router'
-import { debounce, isEmpty, pick, pickBy } from 'lodash'
+import { isEmpty, pick, pickBy } from 'lodash'
 import { createStore, applyMiddleware, Action, Store } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction'
 import createSagaMiddleware from 'redux-saga'
 import createSentryMiddleware from 'redux-sentry-middleware'
 
-import { CommonState } from 'common/store'
 import { Level } from 'common/store/errors/level'
 import { reportToSentry } from 'common/store/errors/reportToSentry'
-import { Nullable } from 'common/utils/typeUtils'
 import { postMessage } from 'services/native-mobile-interface/helpers'
 import { MessageType } from 'services/native-mobile-interface/types'
 import { track as amplitudeTrack } from 'store/analytics/providers/amplitude'
@@ -123,22 +121,6 @@ const middlewares = applyMiddleware(
 // the common store from web -> mobile
 const commonStateKeys = Object.keys(commonStoreReducers)
 
-let aggregateStateToSync: Nullable<Partial<CommonState>> = null
-
-const debouncedPostMessage = debounce(
-  () => {
-    if (!isEmpty(aggregateStateToSync)) {
-      postMessage({
-        type: MessageType.SYNC_COMMON_STATE,
-        state: aggregateStateToSync
-      })
-      aggregateStateToSync = null
-    }
-  },
-  200,
-  { leading: true }
-)
-
 const syncCommonStateToNativeMobile = (store: Store) => {
   if (NATIVE_MOBILE) {
     let previousState: RootState
@@ -165,14 +147,12 @@ const syncCommonStateToNativeMobile = (store: Store) => {
           value !== previousState[key as keyof RootState]
       )
 
-      // Aggregate state to sync across debounces
-      aggregateStateToSync = aggregateStateToSync
-        ? { ...aggregateStateToSync, ...stateToSync }
-        : stateToSync
-
-      previousState = state
-
-      debouncedPostMessage()
+      if (!isEmpty(stateToSync)) {
+        postMessage({
+          type: MessageType.SYNC_COMMON_STATE,
+          state: stateToSync
+        })
+      }
     })
   }
 }


### PR DESCRIPTION
### Description

* Removes the debounce from the state sync. This was added to help with lag when navigating between screens via the bottom tabs, but other performance improvements have made it unnecessary
* Still seems to be a slight delay with the Share drawer sometimes, but there is not much rendering going on so if anything it's probably some small latency with the message bridge. Think it should be ok for now

### Dragons

Could potentially be a lot of rerenders again in places that I didn't check

### How Has This Been Tested?

iOS sim in dev and release configs

### How will this change be monitored?

TestFlight QA
