### PR TITLE
[AUD-1886] Fix search results refresh

### DIFF
--- a/packages/mobile/src/screens/search-results-screen/tabs/SearchResultsTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/SearchResultsTab.tsx
@@ -49,7 +49,7 @@ export const SearchResultsTab = (props: SearchResultsTabProps) => {
   if (
     isRefreshing ||
     searchStatus === Status.LOADING ||
-    status === Status.LOADING
+    (status === Status.LOADING && noResults)
   ) {
     return <LoadingSpinner style={styles.spinner} />
   }


### PR DESCRIPTION
### Description

Fixes case where loadMore would cause loading-indicator to render. We only want to show loading-indicator when we are loadingMore and there are no current lineup items.