### PR TITLE
[AUD-1826] Fix now playing drawer scrubber positioning and remove swipe when now playing drawer is open

### DIFF
--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -132,13 +132,15 @@ export const Slider = memo(
     // The position of the drag-handle
     const [handlePosition, setHandlePosition] = useState(0)
 
-    useEffect(() => {
+    const getRailPageX = () => {
       if (railRef.current) {
         railRef.current.measure((x, y, width, height, pageX, pageY) => {
           setRailPageX(pageX)
         })
       }
-    }, [railRef])
+    }
+
+    useEffect(getRailPageX, [railRef])
 
     const currentAnimation = useRef<Animated.CompositeAnimation>()
     const play = useCallback(
@@ -283,6 +285,7 @@ export const Slider = memo(
           onLayout={e => {
             const { width } = e.nativeEvent.layout
             setRailWidth(width)
+            getRailPageX()
           }}
           style={styles.rail}
           onTouchStart={onPressRail}

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import {
   ParamListBase,
   RouteProp,
@@ -14,6 +16,7 @@ import { RepostType } from 'audius-client/src/common/store/user-list/reposts/typ
 import { MessageType } from 'audius-client/src/services/native-mobile-interface/types'
 
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { useDrawer } from 'app/hooks/useDrawer'
 import { CollectionScreen } from 'app/screens/collection-screen/CollectionScreen'
 import { ProfileScreen } from 'app/screens/profile-screen'
 import {
@@ -98,6 +101,11 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
   const screenOptions = useAppScreenOptions()
   const navigation = useNavigation()
   const drawerNavigation = navigation.getParent()?.getParent()
+  const { isOpen: isNowPlayingDrawerOpen } = useDrawer('NowPlaying')
+
+  useEffect(() => {
+    drawerNavigation?.setOptions({ swipeEnabled: !isNowPlayingDrawerOpen })
+  }, [drawerNavigation, isNowPlayingDrawerOpen])
 
   return (
     <Stack.Navigator


### PR DESCRIPTION
### Description
[AUD-1826]

* Added function to get pageX for rail on layout change (Originally the drawer was close so the pageX was 0 causing the offset)
* Disabled swipe for notifications when now playing drawer is open

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A
