### PR TITLE
[AUD-1859] Fix lock screen media controls when chromecasting

### DIFF
--- a/packages/mobile/ios/AudiusReactNative/AppDelegate.m
+++ b/packages/mobile/ios/AudiusReactNative/AppDelegate.m
@@ -80,6 +80,8 @@
   GCKCastOptions* options = [[GCKCastOptions alloc] initWithDiscoveryCriteria:criteria];
   // Allow our app to control chromecast volume
   options.physicalVolumeButtonsWillControlDeviceVolume = YES;
+  // Prevent backgrounding from suspending sessions
+  options.suspendSessionsWhenBackgrounded = NO;
   [GCKCastContext setSharedInstanceWithOptions:options];
 
   return YES;

--- a/packages/mobile/src/components/audio/GoogleCast.tsx
+++ b/packages/mobile/src/components/audio/GoogleCast.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react'
 
 import { setIsCasting } from 'audius-client/src/common/store/cast/slice'
-import CastContext, {
+import {
   CastState,
   useCastState,
   useRemoteMediaClient,
@@ -26,7 +26,7 @@ export const useChromecast = () => {
   const streamPosition = useStreamPosition(0.5)
 
   const loadCast = useCallback(
-    (track, startTime = 0) => {
+    (track, startTime) => {
       if (client && track) {
         client.loadMedia({
           mediaInfo: {
@@ -73,7 +73,7 @@ export const useChromecast = () => {
   // Load media when the cast connects
   useEffect(() => {
     if (castState === CastState.CONNECTED) {
-      loadCast(track)
+      loadCast(track, global.progress.currentTime ?? 0)
     }
   }, [loadCast, track, castState])
 
@@ -103,9 +103,7 @@ export const useChromecast = () => {
     }
   }, [client, seek])
 
-  const openChromecastDialog = useCallback(() => {
-    CastContext.showCastDialog()
-  }, [])
-
-  return { isCasting: castState === CastState.CONNECTED, openChromecastDialog }
+  return {
+    isCasting: castState === CastState.CONNECTED
+  }
 }


### PR DESCRIPTION
### Description

* Fixes issue where chromecast session was suspended when app was backgrounded
* Starts the chromecast media at the correct time to prevent the scrubber from bouncing between 2 values. (There are still some instances where it occasionally gets off by like 1 second, but I think this is due to the latency of starting the session)

### Dragons

Removes unused `openChromecastDialog` function

### How Has This Been Tested?
iOS device (lock screen controls don't work on simulator)

### How will this change be monitored?

TestFlight QA
