### PR TITLE
[AUD-1896] Fix text on remixes lineup

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -96,7 +96,7 @@ export const TrackRemixesScreen = () => {
                 <Pressable onPress={handlePressTrack}>
                   <Text style={[styles.text, styles.link]}>{track.title}</Text>
                 </Pressable>
-                <Text style={styles.text}>{messages.of}&nbsp;</Text>
+                <Text style={styles.text}>&nbsp;{messages.by}&nbsp;</Text>
                 <Pressable style={styles.user} onPress={handlePressArtistName}>
                   <Text style={[styles.text, styles.link]}>{user.name}</Text>
                   {user ? (


### PR DESCRIPTION
### Description

* Fixes issues with the text at the top of the Track Remixes lineup
<img width="480" alt="image" src="https://user-images.githubusercontent.com/19916043/163079132-416a2539-ebec-4143-a77a-781444d984fa.png">


### Dragons

N/A

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight
