### PR TITLE
Allow TrackTile click in the action button section

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileActionButtons.tsx
@@ -99,12 +99,7 @@ export const LineupTileActionButtons = ({
   )
 
   return (
-    <View
-      style={styles.bottomButtons}
-      // Capture touches to prevent from triggering play
-      onStartShouldSetResponder={() => true}
-      onTouchEnd={e => e.stopPropagation()}
-    >
+    <View style={styles.bottomButtons}>
       <View style={styles.leftButtons}>
         {!isUnlisted && (
           <>


### PR DESCRIPTION
### Description
Remove gesture responder capture to allow track tile to be clicked in the bottom part

### Dragons

Not sure if there was a reason we didn't allow this initially, or if any unintended issues arise from this change

### How Has This Been Tested?

Manually tested, click play works and the buttons still work 

### How will this change be monitored?

N/A
