### PR TITLE
Silently disable play button on track screen until the lineup loads

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -95,6 +95,7 @@ const TrackScreenMainContent = ({
           track={track}
           user={user}
           uid={lineup?.entries?.[0]?.uid}
+          isLineupLoading={lineup.isMetadataLoading}
         />
       </View>
 

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -68,6 +68,7 @@ type TrackScreenDetailsTileProps = {
   track: Track
   user: User
   uid: UID
+  isLineupLoading: boolean
 }
 
 const useStyles = makeStyles(({ palette, spacing, typography }) => ({
@@ -121,7 +122,8 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
 export const TrackScreenDetailsTile = ({
   track,
   user,
-  uid
+  uid,
+  isLineupLoading
 }: TrackScreenDetailsTileProps) => {
   const styles = useStyles()
   const navigation = useNavigation()
@@ -196,6 +198,8 @@ export const TrackScreenDetailsTile = ({
   ].filter(({ isHidden, value }) => !isHidden && !!value)
 
   const handlePressPlay = useCallback(() => {
+    if (isLineupLoading) return
+
     const trackPlay = () =>
       record(
         make({
@@ -225,7 +229,15 @@ export const TrackScreenDetailsTile = ({
       dispatchWeb(tracksActions.play(uid))
       trackPlay()
     }
-  }, [track_id, uid, dispatchWeb, isPlaying, playingUid, queueTrack])
+  }, [
+    track_id,
+    uid,
+    dispatchWeb,
+    isPlaying,
+    playingUid,
+    queueTrack,
+    isLineupLoading
+  ])
 
   const handlePressFavorites = useCallback(() => {
     dispatchWeb(setFavorite(track_id, FavoriteType.TRACK))


### PR DESCRIPTION
### Description
Silently disabling the play button until the 'more by this artist' lineup loads to avoid the weird play-pause behavior

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A
