### PR TITLE
[AUD-1894] Remix Lineup fixes

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -99,6 +99,7 @@ const styles = StyleSheet.create({
 
 type Section = {
   delineate: boolean
+  hasLeadingElement?: boolean
   title?: string
   data: Array<LineupItem | LoadingLineupItem>
 }
@@ -113,6 +114,7 @@ export const Lineup = ({
   disableTopTabScroll,
   isTrending,
   leadingElementId,
+  leadingElementDelineator,
   lineup,
   loadMore,
   header,
@@ -348,7 +350,7 @@ export const Lineup = ({
 
       return [
         { delineate: false, data: [artistPick] },
-        { delineate: true, data: restEntries }
+        { delineate: true, data: restEntries, hasLeadingElement: true }
       ]
     }
 
@@ -403,17 +405,20 @@ export const Lineup = ({
       ListFooterComponent={<View style={{ height: 16 }} />}
       onEndReached={handleLoadMore}
       onEndReachedThreshold={LOAD_MORE_THRESHOLD}
-      // TODO: Either style the refreshing indicator or
-      // roll our own
       onRefresh={refresh}
       refreshing={refreshing}
       sections={sections}
       stickySectionHeadersEnabled={false}
-      // TODO: figure out why this is causing duplicate ids
-      // keyExtractor={(item, index) => String(item.id + index)}
+      keyExtractor={(item, index) => `${item.id}  ${index}`}
       renderItem={renderItem}
       renderSectionHeader={({ section }) => {
-        return section.delineate ? <Delineator text={section.title} /> : null
+        if (section.delineate) {
+          if (section.hasLeadingElement && leadingElementDelineator) {
+            return leadingElementDelineator
+          }
+          return <Delineator text={section.title} />
+        }
+        return null
       }}
       listKey={listKey}
       scrollIndicatorInsets={{ right: Number.MIN_VALUE }}

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -112,12 +112,13 @@ export const Lineup = ({
   count,
   delineate,
   disableTopTabScroll,
+  fetchPayload,
+  header,
   isTrending,
   leadingElementId,
   leadingElementDelineator,
   lineup,
   loadMore,
-  header,
   rankIconCount = 0,
   refresh,
   refreshing,
@@ -178,19 +179,22 @@ export const Lineup = ({
       if (loadMore) {
         loadMore(offset, limit, page === 0)
       } else {
-        dispatchWeb(actions.fetchLineupMetadatas(offset, limit, page === 0))
+        dispatchWeb(
+          actions.fetchLineupMetadatas(offset, limit, page === 0, fetchPayload)
+        )
       }
     }
   }, [
-    lineup,
     actions,
-    itemCounts,
     countOrDefault,
-    loadMore,
     dispatchWeb,
-    pageItemCount,
+    fetchPayload,
     includeLineupStatus,
-    limit
+    itemCounts,
+    limit,
+    lineup,
+    loadMore,
+    pageItemCount
   ])
 
   // When scrolled past the end threshold of the lineup and the lineup is not loading,

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -1,3 +1,5 @@
+import { ReactElement } from 'react'
+
 import { ID, UID } from 'audius-client/src/common/models/Identifiers'
 import Kind from 'audius-client/src/common/models/Kind'
 import { Lineup as LineupData } from 'audius-client/src/common/models/Lineup'
@@ -49,6 +51,11 @@ export type LineupProps = {
    * The leadingElementId is displayed at the top of the lineup
    */
   leadingElementId?: ID
+
+  /**
+   * A custom delineator to show after the leading element
+   */
+  leadingElementDelineator?: ReactElement
 
   /** The number of tracks to fetch in each request */
   limit?: number

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -43,6 +43,17 @@ export type LineupProps = {
    */
   disableTopTabScroll?: boolean
 
+  /**
+   * Optional payload to pass to the fetch action
+   */
+  fetchPayload?: any
+
+  /**
+   * A header to display at the top of the lineup,
+   * will scroll with the rest of the content
+   */
+  header?: SectionListProps<unknown>['ListHeaderComponent']
+
   /** Are we in a trending lineup? Allows tiles to specialize their rendering */
   isTrending?: boolean
 
@@ -69,12 +80,6 @@ export type LineupProps = {
    * Function called to load more entries
    */
   loadMore?: (offset: number, limit: number, overwrite: boolean) => void
-
-  /**
-   * A header to display at the top of the lineup,
-   * will scroll with the rest of the content
-   */
-  header?: SectionListProps<unknown>['ListHeaderComponent']
 
   /**
    * Function called on refresh

--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -81,6 +81,7 @@ export const TrackRemixesScreen = () => {
       <Header text={messages.header} />
       <Lineup
         lineup={lineup}
+        fetchPayload={{ trackId: track?.track_id }}
         header={
           track && user ? (
             <View style={styles.header}>

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { ID } from 'audius-client/src/common/models/Identifiers'
 import { LineupState } from 'audius-client/src/common/models/Lineup'
 import { Track } from 'audius-client/src/common/models/Track'
@@ -6,21 +8,22 @@ import { makeGetLineupMetadatas } from 'audius-client/src/common/store/lineup/se
 import { tracksActions } from 'audius-client/src/common/store/pages/track/lineup/actions'
 import {
   getLineup,
+  getRemixParentTrack,
   getTrack,
   getUser
 } from 'audius-client/src/common/store/pages/track/selectors'
+import { Nullable } from 'audius-client/src/common/utils/typeUtils'
 import { trackRemixesPage } from 'audius-client/src/utils/route'
 import { isEqual, omit } from 'lodash'
-import { StyleSheet, View } from 'react-native'
+import { Text, View } from 'react-native'
 
-import { Screen } from 'app/components/core'
+import IconArrow from 'app/assets/images/iconArrow.svg'
+import { Button, Screen } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
-import Text from 'app/components/text'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
-import { useThemedStyles } from 'app/hooks/useThemedStyles'
-import { ThemeColors } from 'app/utils/theme'
+import { makeStyles } from 'app/styles'
 
 import { TrackScreenDetailsTile } from './TrackScreenDetailsTile'
 import { TrackScreenRemixes } from './TrackScreenRemixes'
@@ -33,26 +36,33 @@ const messages = {
   viewOtherRemixes: 'View Other Remixes'
 }
 
-const createStyles = (themeColors: ThemeColors) =>
-  StyleSheet.create({
-    root: {
-      padding: 12
-    },
-    headerContainer: {
-      marginBottom: 24
-    },
-    lineupHeader: {
-      width: '100%',
-      textAlign: 'center',
-      color: themeColors.neutralLight3,
-      fontSize: 14,
-      marginTop: 36,
-      textTransform: 'uppercase'
-    }
-  })
+const useStyles = makeStyles(({ palette, spacing, typography }) => ({
+  root: {
+    padding: spacing(3),
+    paddingBottom: 0
+  },
+  headerContainer: {
+    marginBottom: spacing(6)
+  },
+  lineupHeader: {
+    width: '100%',
+    textAlign: 'center',
+    ...typography.h3,
+    color: palette.neutralLight3,
+    textTransform: 'uppercase'
+  },
+  buttonContainer: {
+    padding: spacing(6)
+  },
+  button: {
+    backgroundColor: palette.secondary
+  }
+}))
 
 type TrackScreenMainContentProps = {
   lineup: LineupState<{ id: ID }>
+  lineupHeader: ReactNode
+  remixParentTrack: Nullable<Track & { user: User }>
   track: Track
   user: User
 }
@@ -62,26 +72,16 @@ type TrackScreenMainContentProps = {
  */
 const TrackScreenMainContent = ({
   lineup,
+  lineupHeader,
   track,
   user
 }: TrackScreenMainContentProps) => {
-  const styles = useThemedStyles(createStyles)
   const navigation = useNavigation()
+  const styles = useStyles()
 
-  const remixParentTrackId = track.remix_of?.tracks?.[0]?.parent_track_id
   const remixTrackIds = track._remixes?.map(({ track_id }) => track_id) ?? null
-  const showMoreByArtistTitle =
-    (remixParentTrackId && lineup.entries.length > 2) ||
-    (!remixParentTrackId && lineup.entries.length > 1)
 
-  const moreByArtistTitle = showMoreByArtistTitle && (
-    <Text
-      style={styles.lineupHeader}
-      weight='bold'
-    >{`${messages.moreBy} ${user?.name}`}</Text>
-  )
-
-  const goToAllRemixes = () => {
+  const handlePressGoToRemixes = () => {
     navigation.push({
       native: { screen: 'TrackRemixes', params: { id: track.track_id } },
       web: { route: trackRemixesPage(track.permalink) }
@@ -103,11 +103,11 @@ const TrackScreenMainContent = ({
         remixTrackIds.length > 0 && (
           <TrackScreenRemixes
             trackIds={remixTrackIds}
-            goToAllRemixes={goToAllRemixes}
+            onPressGoToRemixes={handlePressGoToRemixes}
             count={track._remixes_count ?? null}
           />
         )}
-      {moreByArtistTitle}
+      {lineupHeader}
     </View>
   )
 }
@@ -116,7 +116,11 @@ const TrackScreenMainContent = ({
  * `TrackScreen` displays a single track and a Lineup of more tracks by the artist
  */
 export const TrackScreen = () => {
+  const navigation = useNavigation()
   const { params } = useRoute<'Track'>()
+
+  const styles = useStyles()
+
   const track = useSelectorWeb(
     state => getTrack(state, params),
     // Omitting uneeded fields from the equality check because they are
@@ -138,6 +142,7 @@ export const TrackScreen = () => {
     // lineup reset state changes cause extra renders
     (a, b) => (!a.entries && !b.entries) || isEqual(a.entries, b.entries)
   )
+  const remixParentTrack = useSelectorWeb(getRemixParentTrack)
 
   if (!track || !user || !lineup) {
     console.warn(
@@ -146,13 +151,74 @@ export const TrackScreen = () => {
     return null
   }
 
+  const handlePressGoToRemixes = () => {
+    if (!remixParentTrack) {
+      return
+    }
+    navigation.push({
+      native: {
+        screen: 'TrackRemixes',
+        params: { id: remixParentTrack.track_id }
+      },
+      web: { route: trackRemixesPage(remixParentTrack.permalink) }
+    })
+  }
+
+  const remixParentTrackId = track.remix_of?.tracks?.[0]?.parent_track_id
+  const showMoreByArtistTitle =
+    (remixParentTrackId && lineup.entries.length > 2) ||
+    (!remixParentTrackId && lineup.entries.length > 1)
+
+  const hasValidRemixParent =
+    !!remixParentTrackId &&
+    !!remixParentTrack &&
+    remixParentTrack.is_delete === false &&
+    !remixParentTrack.user?.is_deactivated
+
+  const moreByArtistTitle = showMoreByArtistTitle && (
+    <Text
+      style={styles.lineupHeader}
+    >{`${messages.moreBy} ${user?.name}`}</Text>
+  )
+
+  const originalTrackTitle = (
+    <Text style={styles.lineupHeader}>{messages.originalTrack}</Text>
+  )
+
   return (
     <Screen>
       <Lineup
         actions={tracksActions}
         count={6}
         header={
-          <TrackScreenMainContent track={track} user={user} lineup={lineup} />
+          <TrackScreenMainContent
+            lineup={lineup}
+            remixParentTrack={remixParentTrack}
+            track={track}
+            user={user}
+            lineupHeader={
+              hasValidRemixParent ? originalTrackTitle : moreByArtistTitle
+            }
+          />
+        }
+        leadingElementId={remixParentTrack?.track_id}
+        leadingElementDelineator={
+          <>
+            <View style={styles.buttonContainer}>
+              <Button
+                title={messages.viewOtherRemixes}
+                icon={IconArrow}
+                variant='primary'
+                size='small'
+                onPress={handlePressGoToRemixes}
+                fullWidth
+                styles={{
+                  root: styles.button
+                }}
+              />
+            </View>
+            {moreByArtistTitle}
+          </>
         }
         lineup={lineup}
         start={1}

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -175,11 +175,11 @@ export const TrackScreen = () => {
     remixParentTrack.is_delete === false &&
     !remixParentTrack.user?.is_deactivated
 
-  const moreByArtistTitle = showMoreByArtistTitle && (
+  const moreByArtistTitle = showMoreByArtistTitle ? (
     <Text
       style={styles.lineupHeader}
     >{`${messages.moreBy} ${user?.name}`}</Text>
-  )
+  ) : null
 
   const originalTrackTitle = (
     <Text style={styles.lineupHeader}>{messages.originalTrack}</Text>

--- a/packages/mobile/src/screens/track-screen/TrackScreenRemixes.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenRemixes.tsx
@@ -17,7 +17,7 @@ const messages = {
 
 type TrackScreenRemixesProps = {
   trackIds: ID[]
-  goToAllRemixes: () => void
+  onPressGoToRemixes: () => void
   count: number | null
 }
 
@@ -62,7 +62,7 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
 
 export const TrackScreenRemixes = ({
   trackIds,
-  goToAllRemixes,
+  onPressGoToRemixes,
   count
 }: TrackScreenRemixesProps) => {
   const styles = useStyles()
@@ -83,7 +83,7 @@ export const TrackScreenRemixes = ({
         icon={IconArrow}
         variant='primary'
         size='medium'
-        onPress={goToAllRemixes}
+        onPress={onPressGoToRemixes}
         styles={{
           root: styles.button
         }}

--- a/packages/web/src/common/store/pages/track/lineup/reducer.js
+++ b/packages/web/src/common/store/pages/track/lineup/reducer.js
@@ -4,7 +4,8 @@ import { PREFIX } from 'common/store/pages/track/lineup/actions'
 
 const initialState = {
   ...initialLineupState,
-  prefix: PREFIX
+  prefix: PREFIX,
+  maxEntries: 6
 }
 
 const actionsMap = {


### PR DESCRIPTION
### Description

* Adds "Remix of" UI
<img width="482" alt="Screen Shot 2022-04-13 at 11 51 43 AM" src="https://user-images.githubusercontent.com/19916043/163270072-c0eaa477-d125-41ce-9ae7-4b54c0f57e4d.png">
* Fixes issue with Remixes screen lineup loading
* Fixes issue with track screen with no other tracks by artist lineup loading

### Dragons

Shuffled some things around on track screen, added a max of 6 on the track screen Lineup (this was only enforced at the component level for some reason)

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
