### PR TITLE
[AUD-1902] Fix scroll to end of lineup on profile page

### DIFF
--- a/packages/mobile/src/components/core/FlatList.tsx
+++ b/packages/mobile/src/components/core/FlatList.tsx
@@ -19,16 +19,22 @@ type CollapsibleFlatListProps = {
   sceneName: string
 } & RNFlatListProps<any>
 
-const CollapsibleFlatList = ({
-  sceneName,
-  ...other
-}: CollapsibleFlatListProps) => {
+const CollapsibleFlatList = (props: CollapsibleFlatListProps) => {
+  const { sceneName, ...other } = props
   const { onRefresh } = other
   const scrollPropsAndRef = useCollapsibleScene(sceneName)
   return (
     <View>
       {onRefresh ? <PullToRefresh /> : null}
-      <Animated.FlatList {...other} {...scrollPropsAndRef} />
+      <Animated.FlatList
+        {...other}
+        {...scrollPropsAndRef}
+        // @ts-ignore `forkEvent` is not defined on the type but it exists
+        onScroll={Animated.forkEvent(
+          scrollPropsAndRef.onScroll,
+          props.onScroll
+        )}
+      />
     </View>
   )
 }

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -63,7 +63,15 @@ const CollapsibleSectionList = (props: CollapsibleSectionListProps) => {
           />
         </Portal>
       ) : null}
-      <Animated.SectionList {...other} {...scrollPropsAndRef} />
+      <Animated.SectionList
+        {...other}
+        {...scrollPropsAndRef}
+        // @ts-ignore `forkEvent` is not defined on the type but it exists
+        onScroll={Animated.forkEvent(
+          scrollPropsAndRef.onScroll,
+          props.onScroll
+        )}
+      />
     </View>
   )
 }


### PR DESCRIPTION
### Description

* Adds onto the fixes for onScroll being passed correctly to the SectionList/Flatlist. Our custom onScroll wasn't being called for the collapsible versions of these components

### Dragons

`forkEvent` https://reactnative.dev/docs/0.67/animated#forkevent

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight
