### PR TITLE
[AUD-1899] Reduce notif rerenders on navigation

### DIFF
--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -72,7 +72,7 @@ export const useAppScreenOptions = () => {
   const navigation = useNavigation<
     AppScreenParamList & AppTabScreenParamList['Search']
   >()
-  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
+  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
 
   const handlePressNotification = useCallback(() => {
     drawerNavigation?.openDrawer()

--- a/packages/mobile/src/screens/notifications-screen/NotificationBlock.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationBlock.tsx
@@ -195,7 +195,7 @@ const NotificationBlock = ({ notification }: NotificationBlockProps) => {
     transitionSpec: onlyAnimateOut
   })
   const notificationRoute = getNotificationRoute(notification)
-  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
+  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
   const navigation = useNavigation<
     AppTabScreenParamList & ProfileTabScreenParamList
   >({ customNativeNavigation: drawerNavigation })

--- a/packages/mobile/src/screens/notifications-screen/NotificationsDrawerNavigationContext.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationsDrawerNavigationContext.tsx
@@ -2,15 +2,13 @@ import { createContext, ReactNode } from 'react'
 
 import { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
 
-type NotificationsDrawerNavigationContextProps = {
-  drawerNavigation: DrawerNavigationHelpers | undefined
-}
+type NotificationsDrawerNavigationContextValue =
+  | DrawerNavigationHelpers
+  | undefined
 
 export const NotificationsDrawerNavigationContext = createContext<
-  NotificationsDrawerNavigationContextProps
->({
-  drawerNavigation: undefined
-})
+  NotificationsDrawerNavigationContextValue
+>(undefined)
 
 export const NotificationsDrawerNavigationContextProvider = ({
   drawerNavigation,
@@ -20,11 +18,7 @@ export const NotificationsDrawerNavigationContextProvider = ({
   children: ReactNode
 }) => {
   return (
-    <NotificationsDrawerNavigationContext.Provider
-      value={{
-        drawerNavigation
-      }}
-    >
+    <NotificationsDrawerNavigationContext.Provider value={drawerNavigation}>
       {children}
     </NotificationsDrawerNavigationContext.Provider>
   )

--- a/packages/mobile/src/screens/notifications-screen/NotificationsScreen.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect } from 'react'
+import { memo, useCallback, useContext, useEffect } from 'react'
 
 import { useDrawerStatus } from '@react-navigation/drawer'
 import { markAllAsViewed } from 'audius-client/src/common/store/notifications/actions'
@@ -25,9 +25,9 @@ const styles = StyleSheet.create({
 /**
  * A component that renders a user's notifications
  */
-export const NotificationsScreen = () => {
+export const NotificationsScreen = memo(() => {
   const dispatchWeb = useDispatchWeb()
-  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
+  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
   const isDrawerOpen = useDrawerStatus() === 'open'
   const wasDrawerOpen = usePrevious(isDrawerOpen)
   useEffect(() => {
@@ -50,4 +50,4 @@ export const NotificationsScreen = () => {
       <List />
     </View>
   )
-}
+})

--- a/packages/mobile/src/screens/notifications-screen/content/Entity.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/Entity.tsx
@@ -28,7 +28,7 @@ type EntityProps = {
 
 const Entity = ({ entity, entityType }: EntityProps) => {
   const dispatch = useDispatch()
-  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
+  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
   const navigation = useNavigation({ customNativeNavigation: drawerNavigation })
   const onPress = useCallback(() => {
     navigation.navigate({

--- a/packages/mobile/src/screens/notifications-screen/content/User.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/User.tsx
@@ -24,7 +24,7 @@ type UserProps = {
 
 const User = ({ user }: UserProps) => {
   const dispatch = useDispatch()
-  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
+  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
   const navigation = useNavigation({ customNativeNavigation: drawerNavigation })
 
   const onPress = useCallback(() => {

--- a/packages/mobile/src/screens/notifications-screen/content/UserImages.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/UserImages.tsx
@@ -50,7 +50,7 @@ const UserImage = ({
   allowPress?: boolean
 }) => {
   const dispatch = useDispatch()
-  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
+  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
   const navigation = useNavigation({ customNativeNavigation: drawerNavigation })
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -35,6 +35,7 @@ export const TracksTab = () => {
     '_artist_pick'
   ])
 
+  // TODO: use fetchPayload (or change Remixes page)
   const loadMore = useCallback(
     (offset: number, limit: number) => {
       dispatchWeb(


### PR DESCRIPTION
### Description

* Prevents notif rerenders on navigation by changing the NotificationsDrawerNavigationContext to not provide an object and wrapping NotificationScreen in memo

### Dragons

Could prevent the notifs screen from being render when it was before so could see some state out of sync

### How Has This Been Tested?

iOS sim

### How will this change be monitored?
TestFlight
