### PR TITLE
[AUD-1888] Notification transitions

### DIFF
--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -6,11 +6,12 @@ import {
   useNavigation as useNavigationNative
 } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
-import { StackNavigationOptions } from '@react-navigation/stack'
 
 import { AppTabScreenParamList } from 'app/screens/app-screen/AppTabScreen'
 
 import { usePushRouteWeb } from './usePushRouteWeb'
+
+export type ContextualParams = { fromNotifications?: boolean }
 
 type UseNavigationConfig<
   ParamList extends ParamListBase,
@@ -18,7 +19,7 @@ type UseNavigationConfig<
 > = {
   native: {
     screen: RouteName
-    params?: ParamList[RouteName] & StackNavigationOptions
+    params?: ParamList[RouteName] & ContextualParams
   }
   web?: {
     route: string

--- a/packages/mobile/src/hooks/usePopToTopOnDrawerOpen.ts
+++ b/packages/mobile/src/hooks/usePopToTopOnDrawerOpen.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+
+import { useNavigation } from '@react-navigation/core'
+import { useDrawerStatus } from '@react-navigation/drawer'
+import { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { usePrevious } from 'react-use'
+
+/**
+ * Hook for use in top level stack screens that will reset the stack when the notifications drawer opens.
+ * This is needed when the user goes from a notification to a nested stack screen, then swipes back to notifications.
+ * When closing the notification drawer the stack will be back at the base screen
+ */
+export const usePopToTopOnDrawerOpen = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<any>>()
+  const isDrawerOpen = useDrawerStatus() === 'open'
+  const wasDrawerOpen = usePrevious(isDrawerOpen)
+  useEffect(() => {
+    if (!wasDrawerOpen && isDrawerOpen) {
+      if (navigation.getState().routes.length > 1) {
+        navigation.popToTop()
+      }
+    }
+  }, [isDrawerOpen, wasDrawerOpen, navigation])
+}

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -1,14 +1,7 @@
 import { useEffect } from 'react'
 
-import {
-  ParamListBase,
-  RouteProp,
-  useNavigation
-} from '@react-navigation/native'
-import {
-  createNativeStackNavigator,
-  NativeStackNavigationOptions
-} from '@react-navigation/native-stack'
+import { useNavigation } from '@react-navigation/native'
+import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { FavoriteType } from 'audius-client/src/common/models/Favorite'
 import { ID } from 'audius-client/src/common/models/Identifiers'
 import { NotificationType } from 'audius-client/src/common/store/notifications/types'
@@ -71,27 +64,6 @@ type AppTabScreenProps = {
   Stack: ReturnType<typeof createNativeStackNavigator>
 }
 
-const stackScreenOptions = ({ route }: { route: RouteProp<ParamListBase> }) => {
-  const params = route.params
-  // The manual typing is unfortunate here. There may be a better way, but
-  // the tricky bit is that StackNavigationOptions aren't known to the RouteProp.
-  // A better solution may be to wrap <Stack.Screen> in our own variant that
-  // can do some better generics & inference.
-  const options: NativeStackNavigationOptions = {}
-  if (params) {
-    // TODO: The following behavior is not supported by native stack, so it is disabled.
-    // Notifications currently uses this in order to remove animations when going from the drawer
-    // to a nested stack screen.
-    // if ('animationEnabled' in params) {
-    //   options.animationEnabled = (params as StackNavigationOptions).animationEnabled
-    // }
-    // if ('transitionSpec' in params) {
-    //   options.transitionSpec = (params as StackNavigationOptions).transitionSpec
-    // }
-  }
-  return options
-}
-
 /**
  * This is the base tab screen that includes common screens
  * like track and profile
@@ -115,7 +87,12 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
           // @ts-ignore: this is cool, but doesn't exist according to types
           const isStackOpen = e?.data?.state?.routes.length > 1
           if (isStackOpen) {
-            drawerNavigation?.setOptions({ swipeEnabled: false })
+            const isFromNotifs =
+              // @ts-ignore
+              e?.data?.state?.routes[1].params?.fromNotifications
+
+            // If coming from notifs allow swipe to open notifs drawer
+            drawerNavigation?.setOptions({ swipeEnabled: !!isFromNotifs })
           } else {
             drawerNavigation?.setOptions({ swipeEnabled: true })
           }
@@ -143,73 +120,73 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
       <Stack.Screen
         name='Track'
         component={TrackScreen}
-        options={stackScreenOptions}
+        options={screenOptions}
       />
       <Stack.Screen
         name='TrackRemixes'
         component={TrackRemixesScreen}
-        options={stackScreenOptions}
+        options={screenOptions}
       />
       <Stack.Screen
         name='Collection'
         component={CollectionScreen}
-        options={stackScreenOptions}
+        options={screenOptions}
       />
       <Stack.Screen
         name='EditPlaylist'
         component={EditPlaylistScreen}
-        options={stackScreenOptions}
+        options={screenOptions}
       />
       <Stack.Screen
         name='Profile'
         component={ProfileScreen}
-        options={stackScreenOptions}
+        options={screenOptions}
       />
       <Stack.Group>
         <Stack.Screen
           name='Search'
           component={SearchScreen}
           options={props => ({
-            ...stackScreenOptions(props),
+            ...screenOptions(props),
             cardStyleInterpolator: forFade
           })}
         />
         <Stack.Screen
           name='SearchResults'
           component={SearchResultsScreen}
-          options={stackScreenOptions}
+          options={screenOptions}
         />
         <Stack.Screen
           name='TagSearch'
           component={TagSearchScreen}
-          options={stackScreenOptions}
+          options={screenOptions}
         />
       </Stack.Group>
       <Stack.Group>
         <Stack.Screen
           name='Followers'
           component={FollowersScreen}
-          options={stackScreenOptions}
+          options={screenOptions}
         />
         <Stack.Screen
           name='Following'
           component={FollowingScreen}
-          options={stackScreenOptions}
+          options={screenOptions}
         />
         <Stack.Screen
           name='Favorited'
           component={FavoritedScreen}
-          options={stackScreenOptions}
+          options={screenOptions}
         />
         <Stack.Screen
           name='Reposts'
           component={RepostsScreen}
-          options={stackScreenOptions}
+          options={screenOptions}
         />
         <Stack.Screen
           name='NotificationUsers'
           component={NotificationUsersScreen}
-          options={stackScreenOptions}
+          options={screenOptions}
         />
       </Stack.Group>
     </Stack.Navigator>

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -89,6 +89,8 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
           if (isStackOpen) {
             const isFromNotifs =
               // @ts-ignore
+              e?.data?.state?.routes.length === 2 &&
+              // @ts-ignore
               e?.data?.state?.routes[1].params?.fromNotifications
 
             // If coming from notifs allow swipe to open notifs drawer

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from 'react'
 
-import { useNavigation } from '@react-navigation/native'
+import {
+  EventArg,
+  NavigationState,
+  useNavigation
+} from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { FavoriteType } from 'audius-client/src/common/models/Favorite'
 import { ID } from 'audius-client/src/common/models/Identifiers'
@@ -10,6 +14,7 @@ import { MessageType } from 'audius-client/src/services/native-mobile-interface/
 
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useDrawer } from 'app/hooks/useDrawer'
+import { ContextualParams } from 'app/hooks/useNavigation'
 import { CollectionScreen } from 'app/screens/collection-screen/CollectionScreen'
 import { ProfileScreen } from 'app/screens/profile-screen'
 import {
@@ -83,15 +88,19 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
     <Stack.Navigator
       screenOptions={screenOptions}
       screenListeners={{
-        state: e => {
-          // @ts-ignore: this is cool, but doesn't exist according to types
+        state: (
+          e: EventArg<
+            'state',
+            false,
+            { state: NavigationState<AppTabScreenParamList> }
+          >
+        ) => {
           const isStackOpen = e?.data?.state?.routes.length > 1
           if (isStackOpen) {
             const isFromNotifs =
-              // @ts-ignore
               e?.data?.state?.routes.length === 2 &&
-              // @ts-ignore
-              e?.data?.state?.routes[1].params?.fromNotifications
+              (e?.data?.state?.routes[1].params as ContextualParams)
+                ?.fromNotifications
 
             // If coming from notifs allow swipe to open notifs drawer
             drawerNavigation?.setOptions({ swipeEnabled: !!isFromNotifs })

--- a/packages/mobile/src/screens/app-screen/transitionSpec.ts
+++ b/packages/mobile/src/screens/app-screen/transitionSpec.ts
@@ -1,7 +1,0 @@
-import { TransitionPresets } from '@react-navigation/stack'
-import { TransitionSpec } from '@react-navigation/stack/lib/typescript/src/types'
-
-export const onlyAnimateOut = {
-  open: { animation: 'timing', config: { duration: 0 } } as TransitionSpec,
-  close: TransitionPresets.DefaultTransition.transitionSpec.close
-}

--- a/packages/mobile/src/screens/explore-screen/ExploreScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/ExploreScreen.tsx
@@ -5,6 +5,7 @@ import IconUser from 'app/assets/images/iconUser.svg'
 import { Screen } from 'app/components/core'
 import { Header } from 'app/components/header'
 import { TopTabNavigator } from 'app/components/top-tab-bar'
+import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
 
 import { ArtistsTab } from './tabs/ArtistsTab'
 import { ForYouTab } from './tabs/ForYouTab'
@@ -36,6 +37,8 @@ const exploreScreens = [
 ]
 
 const ExploreScreen = () => {
+  usePopToTopOnDrawerOpen()
+
   return (
     <Screen>
       <Header text='Explore' />

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -4,6 +4,7 @@ import IconPlaylists from 'app/assets/images/iconPlaylists.svg'
 import { Screen } from 'app/components/core'
 import { Header } from 'app/components/header'
 import { TopTabNavigator } from 'app/components/top-tab-bar'
+import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
 
 import { AlbumsTab } from './AlbumsTab'
 import { PlaylistsTab } from './PlaylistsTab'
@@ -28,6 +29,8 @@ const favoritesScreens = [
 ]
 
 const FavoritesScreen = () => {
+  usePopToTopOnDrawerOpen()
+
   return (
     <Screen>
       <Header text='Favorites' />

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -15,6 +15,7 @@ import { Screen } from 'app/components/core'
 import { Header } from 'app/components/header'
 import { Lineup } from 'app/components/lineup'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { getIsSignedIn } from 'app/store/lifecycle/selectors'
 import { make, track } from 'app/utils/analytics'
@@ -28,6 +29,8 @@ const messages = {
 }
 
 export const FeedScreen = () => {
+  usePopToTopOnDrawerOpen()
+
   const dispatchWeb = useDispatchWeb()
   const feedLineup = useSelectorWeb(getFeedLineup, (a, b) => {
     const omitUneeded = o => omit(o, ['inView'])

--- a/packages/mobile/src/screens/notifications-screen/NotificationBlock.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationBlock.tsx
@@ -48,8 +48,6 @@ import { NotificationsDrawerNavigationContext } from 'app/screens/notifications-
 import { close } from 'app/store/notifications/actions'
 import { useColor, useTheme } from 'app/utils/theme'
 
-import { onlyAnimateOut } from '../app-screen/transitionSpec'
-
 import NotificationContent from './content/NotificationContent'
 import { getNotificationRoute, getNotificationScreen } from './routeUtil'
 
@@ -192,7 +190,7 @@ const NotificationBlock = ({ notification }: NotificationBlockProps) => {
   notification.entities = entities
 
   const notificationScreen = getNotificationScreen(notification, {
-    transitionSpec: onlyAnimateOut
+    fromNotifications: true
   })
   const notificationRoute = getNotificationRoute(notification)
   const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)

--- a/packages/mobile/src/screens/notifications-screen/content/Entity.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/Entity.tsx
@@ -5,7 +5,6 @@ import { StyleSheet, Text } from 'react-native'
 import { useDispatch } from 'react-redux'
 
 import { useNavigation } from 'app/hooks/useNavigation'
-import { onlyAnimateOut } from 'app/screens/app-screen/transitionSpec'
 import { NotificationsDrawerNavigationContext } from 'app/screens/notifications-screen/NotificationsDrawerNavigationContext'
 import { close } from 'app/store/notifications/actions'
 import { useTheme } from 'app/utils/theme'
@@ -33,7 +32,7 @@ const Entity = ({ entity, entityType }: EntityProps) => {
   const onPress = useCallback(() => {
     navigation.navigate({
       native: getEntityScreen(entity, entityType, {
-        transitionSpec: onlyAnimateOut
+        fromNotifications: true
       }),
       web: { route: getEntityRoute(entity, entityType) }
     })

--- a/packages/mobile/src/screens/notifications-screen/content/User.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/User.tsx
@@ -29,7 +29,10 @@ const User = ({ user }: UserProps) => {
 
   const onPress = useCallback(() => {
     navigation.navigate({
-      native: { screen: 'Profile', params: { handle: user.handle } },
+      native: {
+        screen: 'Profile',
+        params: { handle: user.handle, fromNotifications: true }
+      },
       web: { route: getUserRoute(user), fromPage: NOTIFICATION_PAGE }
     })
     dispatch(close())

--- a/packages/mobile/src/screens/notifications-screen/content/UserImages.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/UserImages.tsx
@@ -12,7 +12,6 @@ import { DynamicImage } from 'app/components/core'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useUserProfilePicture } from 'app/hooks/useUserProfilePicture'
-import { onlyAnimateOut } from 'app/screens/app-screen/transitionSpec'
 import { NotificationsDrawerNavigationContext } from 'app/screens/notifications-screen/NotificationsDrawerNavigationContext'
 import { close } from 'app/store/notifications/actions'
 import { getUserRoute } from 'app/utils/routes'
@@ -57,7 +56,7 @@ const UserImage = ({
     navigation.navigate({
       native: {
         screen: 'Profile',
-        params: { handle: user.handle, transitionSpec: onlyAnimateOut }
+        params: { handle: user.handle, fromNotifications: true }
       },
       web: { route: getUserRoute(user), fromPage: NOTIFICATION_PAGE }
     })

--- a/packages/mobile/src/screens/notifications-screen/routeUtil.ts
+++ b/packages/mobile/src/screens/notifications-screen/routeUtil.ts
@@ -1,4 +1,3 @@
-import { StackNavigationOptions } from '@react-navigation/stack'
 import { Track } from 'audius-client/src/common/models/Track'
 import {
   Achievement,
@@ -8,6 +7,7 @@ import {
 } from 'audius-client/src/common/store/notifications/types'
 import Config from 'react-native-config'
 
+import { ContextualParams } from 'app/hooks/useNavigation'
 import {
   getTrackRoute,
   getUserRoute,
@@ -44,24 +44,24 @@ export const getEntityRoute = (
 export const getEntityScreen = (
   entity: any,
   entityType: Entity,
-  screenOptions: StackNavigationOptions
+  contextualParams: ContextualParams
 ) => {
   switch (entityType) {
     case Entity.Track:
       return {
         screen: 'Track' as const,
-        params: { id: entity.track_id, ...screenOptions }
+        params: { id: entity.track_id, ...contextualParams }
       }
     case Entity.User:
       return {
         screen: 'Profile' as const,
-        params: { handle: entity.handle, ...screenOptions }
+        params: { handle: entity.handle, ...contextualParams }
       }
     case Entity.Album:
     case Entity.Playlist:
       return {
         screen: 'Collection' as const,
-        params: { id: entity.playlist_id, ...screenOptions }
+        params: { id: entity.playlist_id, ...contextualParams }
       }
   }
 }
@@ -115,7 +115,7 @@ export const getNotificationRoute = (notification: Notification) => {
 
 export const getNotificationScreen = (
   notification: Notification,
-  screenOptions: StackNavigationOptions
+  contextualParams: ContextualParams
 ) => {
   switch (notification.type) {
     case NotificationType.Announcement:
@@ -127,7 +127,7 @@ export const getNotificationScreen = (
         return {
           screen: 'NotificationUsers' as const,
           params: {
-            ...screenOptions,
+            ...contextualParams,
             notificationType: notification.type,
             count: users.length,
             id: notification.id
@@ -139,7 +139,7 @@ export const getNotificationScreen = (
       return {
         screen: 'Profile' as const,
         params: {
-          ...screenOptions,
+          ...contextualParams,
           handle: firstUser.handle
         }
       }
@@ -149,19 +149,19 @@ export const getNotificationScreen = (
       return getEntityScreen(
         notification.entities[0],
         notification.entityType,
-        screenOptions
+        contextualParams
       )
     case NotificationType.Favorite:
       return getEntityScreen(
         notification.entity,
         notification.entityType,
-        screenOptions
+        contextualParams
       )
     case NotificationType.Repost:
       return getEntityScreen(
         notification.entity,
         notification.entityType,
-        screenOptions
+        contextualParams
       )
     case NotificationType.Milestone:
       if (notification.achievement === Achievement.Followers) {
@@ -169,37 +169,37 @@ export const getNotificationScreen = (
         const { handle } = notification.user
         return {
           screen: 'Profile' as const,
-          params: { ...screenOptions, handle }
+          params: { ...contextualParams, handle }
         }
       }
       return getEntityScreen(
         notification.entity,
         notification.entityType,
-        screenOptions
+        contextualParams
       )
     case NotificationType.RemixCosign: {
       const original = notification.entities.find(
         (track: Track) => track.owner_id === notification.parentTrackUserId
       )
-      return getEntityScreen(original, Entity.Track, screenOptions)
+      return getEntityScreen(original, Entity.Track, contextualParams)
     }
     case NotificationType.RemixCreate: {
       const remix = notification.entities.find(
         (track: Track) => track.track_id === notification.childTrackId
       )
-      return getEntityScreen(remix, Entity.Track, screenOptions)
+      return getEntityScreen(remix, Entity.Track, contextualParams)
     }
     case NotificationType.TrendingTrack:
       return getEntityScreen(
         notification.entity,
         notification.entityType,
-        screenOptions
+        contextualParams
       )
     case NotificationType.ChallengeReward:
     case NotificationType.TierChange:
       return {
         screen: 'AudioScreen' as const,
-        params: screenOptions
+        params: contextualParams
       }
   }
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -13,6 +13,7 @@ import IconSettings from 'app/assets/images/iconSettings.svg'
 import { Screen } from 'app/components/core'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { TopBarIconButton } from 'app/screens/app-screen'
 import { makeStyles } from 'app/styles/makeStyles'
@@ -62,6 +63,7 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
 }))
 
 export const ProfileScreen = () => {
+  usePopToTopOnDrawerOpen()
   const styles = useStyles()
   const profile = useSelectProfileRoot(['user_id', 'does_current_user_follow'])
   const accountId = useSelectorWeb(getUserId)

--- a/packages/mobile/src/screens/trending-screen/TrendingScreen.tsx
+++ b/packages/mobile/src/screens/trending-screen/TrendingScreen.tsx
@@ -8,6 +8,7 @@ import { RewardsBanner } from 'app/components/audio-rewards'
 import { Screen } from 'app/components/core'
 import { Header } from 'app/components/header'
 import { TopTabNavigator } from 'app/components/top-tab-bar'
+import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 
 import { TrendingFilterButton } from './TrendingFilterButton'
@@ -53,6 +54,8 @@ const trendingScreens = [
 ]
 
 export const TrendingScreen = () => {
+  usePopToTopOnDrawerOpen()
+
   return (
     <Screen>
       <Header text='Trending'>


### PR DESCRIPTION
### Description

* Disables transition animations on the stack when coming from notifications so that the content is immediately there
* Changes back button and swiping gesture to open the notifications drawer after going to a nested stack screen from a notification

https://user-images.githubusercontent.com/19916043/163479038-48abb9c4-30f0-425d-a691-b85e26f496f3.mov

### Dragons

This touches a lot so I think we should probably hold off on merging this until we have the release cut

### How Has This Been Tested?

iOS simulator

### How will this change be monitored?

TestFlight
