### PR TITLE
Fix swipe on first tab

### DIFF
--- a/packages/mobile/patches/@react-navigation+drawer+6.3.1.patch
+++ b/packages/mobile/patches/@react-navigation+drawer+6.3.1.patch
@@ -1,8 +1,15 @@
 diff --git a/node_modules/@react-navigation/drawer/src/views/legacy/Drawer.tsx b/node_modules/@react-navigation/drawer/src/views/legacy/Drawer.tsx
-index bebfcbf..0211168 100644
+index bebfcbf..1fbd6f4 100644
 --- a/node_modules/@react-navigation/drawer/src/views/legacy/Drawer.tsx
 +++ b/node_modules/@react-navigation/drawer/src/views/legacy/Drawer.tsx
-@@ -530,7 +530,13 @@ export default class DrawerView extends React.Component<DrawerProps> {
+@@ -527,10 +527,25 @@ export default class DrawerView extends React.Component<DrawerProps> {
+ 
+     const progress = drawerType === 'permanent' ? ANIMATED_ONE : this.progress;
+ 
++    const failOffsetXWhenClosed = swipeEnabled
++      ? [-1, Number.MAX_SAFE_INTEGER]
++      : [-1, 1]
++
      return (
        <DrawerProgressContext.Provider value={progress}>
          <PanGestureHandler
@@ -13,6 +20,11 @@ index bebfcbf..0211168 100644
 +            isOpen
 +              ? [-SWIPE_DISTANCE_MINIMUM, Number.MAX_SAFE_INTEGER]
 +              : [-1 * Number.MAX_SAFE_INTEGER, SWIPE_DISTANCE_MINIMUM]
++          }
++          failOffsetX={
++            isOpen
++              ? [-1 * Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]
++              : failOffsetXWhenClosed
 +          }
            failOffsetY={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
            onGestureEvent={this.handleGestureEvent}


### PR DESCRIPTION
### Description

* Fixes 2 issues with swiping from the first tab in a tab navigator:
  * Swiping perfectly horizontally wouldn't register as a swipe
  * Swiping to go back from a pushed stack screen didn't register every time

https://user-images.githubusercontent.com/19916043/163634521-6c93d63f-db92-4638-93a8-cacf5693a874.mov

### Dragons

Another patch, arbitrarily set `-1` and `1` values. Seems to work but I might have broken something else

### How Has This Been Tested?

iOS sim. swiping tabs, stack screens, notifications, etc

### How will this change be monitored?

TestFlight QA
