### PR TITLE
Reduce the delay for the lineup metadata saga

### DIFF
--- a/packages/web/src/store/lineup/sagas.js
+++ b/packages/web/src/store/lineup/sagas.js
@@ -120,7 +120,7 @@ function* fetchLineupMetadatasAsync(
       // Let page animations on mobile have time to breathe
       // TODO: Get rid of this once we figure out how to make loading better
       if (isMobile()) {
-        yield delay(1000)
+        yield delay(20)
       }
 
       const lineupMetadatasResponse = yield call(lineupMetadatasCall, {


### PR DESCRIPTION
### Description
Reduce the delay to speed up the lineup metadata saga

### Dragons

N/A

### How Has This Been Tested?

Tested for a while, and didn't notice any issues or places where lineups did not load.

### How will this change be monitored?

N/A
