### PR TITLE
Rename trending ThisYear to AllTime

### DIFF
--- a/packages/mobile/src/screens/trending-screen/TrendingScreen.tsx
+++ b/packages/mobile/src/screens/trending-screen/TrendingScreen.tsx
@@ -28,7 +28,7 @@ const ThisMonthTab = () => {
   return <TrendingLineup timeRange={TimeRange.MONTH} />
 }
 
-const ThisYearTab = () => {
+const AllTimeTab = () => {
   return <TrendingLineup timeRange={TimeRange.ALL_TIME} />
 }
 
@@ -46,10 +46,10 @@ const trendingScreens = [
     component: ThisMonthTab
   },
   {
-    name: 'ThisYear',
-    label: 'This Year',
+    name: 'AllTime',
+    label: 'All Time',
     Icon: IconAllTime,
-    component: ThisYearTab
+    component: AllTimeTab
   }
 ]
 


### PR DESCRIPTION
### Description

* Rename trending ThisYear to AllTime (This was done on web already)
<img width="470" alt="image" src="https://user-images.githubusercontent.com/19916043/163829758-67fac8ce-8141-4a72-ba0d-717fd889bd48.png"> 

### Dragons

N/A

### How Has This Been Tested?

iOS simulator

### How will this change be monitored?

TestFlight
