### PR TITLE
[AUD-1904] Use high res artwork on NowPlaying

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/Artwork.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/Artwork.tsx
@@ -47,7 +47,7 @@ export const Artwork = ({ track }: ArtworkProps) => {
   const image = useTrackCoverArt({
     id: track.track_id,
     sizes: track._cover_art_sizes,
-    size: SquareSizes.SIZE_480_BY_480
+    size: SquareSizes.SIZE_1000_BY_1000
   })
 
   const dominantColors = useSelectorWeb(state =>


### PR DESCRIPTION
### Description

* Uses 1000x1000 art on NowPlaying

Before & After
![Simulator Screen Shot - iPhone 13 - 2022-04-18 at 10 51 54](https://user-images.githubusercontent.com/19916043/163835644-fb9ae518-dd64-4718-844e-b2136728cb98.png)
![Simulator Screen Shot - iPhone 13 - 2022-04-18 at 10 51 31](https://user-images.githubusercontent.com/19916043/163835653-23ea5096-85e2-4045-b771-778c7088cc5d.png)

### Dragons

Slow load times for images in NowPlaying

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
