### PR TITLE
Fix waudio amount check and error message

### DIFF
--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -63,9 +63,8 @@ function* sendAsync({
     yield put(sendFailed({ error: 'Not enough $AUDIO' }))
     return
   } else if (chain === Chain.Sol) {
-    const totalBalance = waudioWeiAmount.add(weiBNBalance)
-    if (weiBNAmount.gt(totalBalance)) {
-      yield put(sendFailed({ error: 'Missing social proof' }))
+    if (weiBNAmount.gt(weiBNBalance)) {
+      yield put(sendFailed({ error: 'Not enough $AUDIO' }))
       return
     }
   }


### PR DESCRIPTION
### Description

Account balance already includes eth and spl audio. And the total balance adds the spl audio again.
So, we are counting the spl audio balance twice in the balance check when sending $audio.

### Dragons

make sure that fix makes sense

### How Has This Been Tested?

did not test

### How will this change be monitored?

n/a
