### PR TITLE
[AUD-1927] Vertically align user badges on now playing

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/TrackInfo.tsx
@@ -20,6 +20,7 @@ const useStyles = makeStyles(({ typography, spacing }) => ({
     paddingHorizontal: spacing(3)
   },
   artist: {
+    marginBottom: 0,
     fontFamily: typography.fontByWeight.medium
   }
 }))


### PR DESCRIPTION
### Description

* Vertically align user badges on now playing
![Simulator Screen Shot - iPhone 13 - 2022-04-18 at 14 18 38](https://user-images.githubusercontent.com/19916043/163863394-18eb6efa-b080-4de8-a119-daf2858a09fd.png)

### Dragons

Possible layout changes on different sized screens

### How Has This Been Tested?

iOS sim

### How will this change be monitored?

TestFlight QA
