### PR TITLE
[AUD-1930] Avoid showing content that gets a 403 (stop-gap)

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -70,6 +70,14 @@
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
       "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
     },
+    "@audius/anchor-audius-data": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@audius/anchor-audius-data/-/anchor-audius-data-0.0.1.tgz",
+      "integrity": "sha512-gl9t27kizPAWoQQmyH6m9Oxz9KFR9MUiAW5VPDAxr3ByVAa8KpGtOrdMh5ROmX2nz5KPD+7PE2RiVsab/u9+Vw==",
+      "requires": {
+        "@project-serum/anchor": "0.24.1"
+      }
+    },
     "@audius/hedgehog": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@audius/hedgehog/-/hedgehog-1.0.12.tgz",
@@ -84,16 +92,18 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.107",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.107.tgz",
-      "integrity": "sha512-+68HiC+140HpQEwPPT3AkwtDi6w4aVBGXCeGwR/QuKn1mMiKwnR4VreC7zkDtv8+k7bnqb8P2mu5DETR8rTmmw==",
+      "version": "1.2.111",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.111.tgz",
+      "integrity": "sha512-w/jEhsZre0bi9Oznvccvu+RPLN8B4MjkOs5zituBQgPfO50uODOxDLgP+qdDknlq5hjw3Z1TMpPt21klKN5AbQ==",
       "requires": {
+        "@audius/anchor-audius-data": "0.0.1",
         "@audius/hedgehog": "1.0.12",
         "@certusone/wormhole-sdk": "0.1.1",
         "@ethersproject/solidity": "5.0.5",
         "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
+        "@project-serum/anchor": "0.24.1",
         "@solana/spl-token": "0.1.6",
-        "@solana/web3.js": "1.31.0",
+        "@solana/web3.js": "1.37.1",
         "abi-decoder": "1.2.0",
         "ajv": "6.12.2",
         "async-retry": "1.3.1",
@@ -1441,6 +1451,15 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
         },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "rxjs": {
           "version": "7.5.5",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
@@ -1735,9 +1754,9 @@
       }
     },
     "@ethereumjs/common": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.3.tgz",
-      "integrity": "sha512-mQwPucDL7FDYIg9XQ8DL31CnIYZwGhU5hyOO5E+BMmT71G0+RHvIT5rIkLBirJEKxV6+Rcf9aEIY0kXInxUWpQ==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.4.tgz",
+      "integrity": "sha512-RDJh/R/EAr+B7ZRg5LfJ0BIpf/1LydFgYdvZEuTraojCbVypO2sQ+QnpP5u2wJf9DASyooKqu8O4FJEWUV6NXw==",
       "requires": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.4"
@@ -3563,6 +3582,90 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
       "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
     },
+    "@project-serum/anchor": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.24.1.tgz",
+      "integrity": "sha512-Oab6rPKsoBKf7/m/AyZcx3ahzcRiOFbqYRoDX6Gnxiqeu2zLKS+LyV6v/2XEVnwhIhOtwETtsgSZAwbqjM5Ywg==",
+      "requires": {
+        "@project-serum/borsh": "^0.2.5",
+        "@solana/web3.js": "^1.36.0",
+        "base64-js": "^1.5.1",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^5.3.1",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "js-sha256": "^0.9.0",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "toml": "^3.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "pako": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+          "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@project-serum/borsh": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.5.tgz",
+      "integrity": "sha512-UmeUkUoKdQ7rhx6Leve1SssMR/Ghv8qrEiyywyxSWg7ooV7StdpPBhciiy5eB3T0qU1BXvdRNC8TdrkxK7WC5Q==",
+      "requires": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+          "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        }
+      }
+    },
     "@project-serum/sol-wallet-adapter": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@project-serum/sol-wallet-adapter/-/sol-wallet-adapter-0.2.5.tgz",
@@ -3828,11 +3931,22 @@
       }
     },
     "@solana/buffer-layout": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-3.0.0.tgz",
-      "integrity": "sha512-MVdgAKKL39tEs0l8je0hKaXLQFb7Rdfb0Xg2LjFZd8Lfdazkg6xiS98uAZrEKvaoF3i4M95ei9RydkGIDMeo3w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
+      "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
       "requires": {
         "buffer": "~6.0.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "@solana/spl-token": {
@@ -3852,19 +3966,28 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
         }
       }
     },
     "@solana/web3.js": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.31.0.tgz",
-      "integrity": "sha512-7nHHx1JNFnrt15e9y8m38I/EJCbaB+bFC3KZVM1+QhybCikFxGMtGA5r7PDC3GEL1R2RZA8yKoLkDKo3vzzqnw==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.37.1.tgz",
+      "integrity": "sha512-1zm1blRU6ANb8bOfONibKkNKoMyzE1e0Z88MagyRLF1AmfHc+18lFvqxSQKUdazLMHcioZ28h+GfyAaeCT63iA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@ethersproject/sha2": "^5.5.0",
-        "@solana/buffer-layout": "^3.0.0",
+        "@solana/buffer-layout": "^4.0.0",
         "bn.js": "^5.0.0",
-        "borsh": "^0.4.0",
+        "borsh": "^0.7.0",
         "bs58": "^4.0.1",
         "buffer": "6.0.1",
         "cross-fetch": "^3.1.4",
@@ -3881,13 +4004,14 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
           "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
         },
-        "buffer": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
-          "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
+        "borsh": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+          "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
           "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
+            "bn.js": "^5.2.0",
+            "bs58": "^4.0.0",
+            "text-encoding-utf-8": "^1.0.2"
           }
         },
         "cross-fetch": {
@@ -8687,9 +8811,9 @@
       "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
     },
     "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
+      "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -10143,6 +10267,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
+      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="
     },
     "crypto-js": {
       "version": "3.3.0",
@@ -17892,6 +18021,15 @@
             "readable-stream": "^3.4.0"
           }
         },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "interface-blockstore": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.2.tgz",
@@ -18668,14 +18806,14 @@
       },
       "dependencies": {
         "@types/lodash": {
-          "version": "4.14.181",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
-          "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag=="
+          "version": "4.14.182",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+          "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
         },
         "@types/node": {
-          "version": "12.20.47",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.47.tgz",
-          "integrity": "sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg=="
+          "version": "12.20.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.48.tgz",
+          "integrity": "sha512-4kxzqkrpwYtn6okJUcb2lfUu9ilnb3yhUOH6qX3nug8D2DupZ2drIkff2yJzYcNJVl3begnlcaBJ7tqiTTzjnQ=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -20887,6 +21025,11 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
       "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-sha3": {
       "version": "0.8.0",
@@ -25110,9 +25253,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "17.0.23",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-          "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+          "version": "17.0.25",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
+          "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w=="
         }
       }
     },
@@ -25367,6 +25510,15 @@
             "buffer": "^6.0.3",
             "inherits": "^2.0.4",
             "readable-stream": "^3.4.0"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
           }
         },
         "debug": {
@@ -28723,6 +28875,22 @@
       "dev": true,
       "optional": true
     },
+    "snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        }
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -31580,6 +31748,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "totalist": {
       "version": "1.1.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "version": "1.1.5",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.107",
+    "@audius/libs": "1.2.111",
     "@audius/stems": "0.3.28",
     "@craco/craco": "6.4.3",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",

--- a/packages/web/src/common/store/cache/reducer.js
+++ b/packages/web/src/common/store/cache/reducer.js
@@ -71,6 +71,11 @@ export const mergeCustomizer = (objValue, srcValue, key) => {
     return srcValue
   }
 
+  // Delete is unidirectional (after marked deleted, future updates are not reflected)
+  if (key === 'is_delete' && objValue === true && srcValue === false) {
+    return objValue
+  }
+
   // For playlist_contents, this is trickier.
   // We want to never merge because playlists can have
   // tracks be deleted since last time, but

--- a/packages/web/src/services/AudiusBackend.js
+++ b/packages/web/src/services/AudiusBackend.js
@@ -175,6 +175,9 @@ export const fetchCID = async (
     }
     return res?.data ?? null
   } catch (e) {
+    if (e?.message === 'Unauthorized') {
+      return e.message
+    }
     console.error(e)
     return asUrl ? '' : null
   }


### PR DESCRIPTION
### Description

When we get Unauthorized (403) from the getCID route: https://github.com/AudiusProject/audius-protocol/pull/2951, avoid showing the content.

Note this is a stop gap solution in favor of a broader fix that indexes this data and makes it available to discovery nodes: https://linear.app/audius/project/better-track-unavailability-ui-c676176f9b93

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally vs. production data on tracks getting 403s.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
