### PR TITLE
Bump resource class size

### DIFF
--- a/.circleci/src/jobs/@mobile-jobs.yml
+++ b/.circleci/src/jobs/@mobile-jobs.yml
@@ -48,7 +48,7 @@ mobile-build-production-web-app:
   working_directory: ~/audius-client
   docker:
     - image: circleci/node:14.18
-  resource_class: large
+  resource_class: xlarge
   steps:
     - mobile-build-web-app:
         build-type: "mobile-prod"
@@ -57,7 +57,7 @@ mobile-build-staging-web-app:
   working_directory: ~/audius-client
   docker:
     - image: circleci/node:14.18
-  resource_class: large
+  resource_class: xlarge
   steps:
     - mobile-build-web-app:
         build-type: "mobile-stage"

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -49,7 +49,7 @@ web-build-demo:
   working_directory: ~/audius-client
   docker:
     - image: circleci/node:14.18
-  resource_class: large
+  resource_class: xlarge
   steps:
     - checkout
     - attach_workspace:
@@ -72,7 +72,7 @@ web-build-staging:
   working_directory: ~/audius-client
   docker:
     - image: circleci/node:14.18
-  resource_class: large
+  resource_class: xlarge
   steps:
     - web-build:
         build-type: stage
@@ -82,7 +82,7 @@ web-build-ipfs-staging:
   working_directory: ~/audius-client
   docker:
     - image: circleci/node:14.18
-  resource_class: large
+  resource_class: xlarge
   steps:
     - web-build:
         build-type: ipfs-stage
@@ -140,7 +140,7 @@ web-build-production:
   working_directory: ~/audius-client
   docker:
     - image: circleci/node:14.18
-  resource_class: large
+  resource_class: xlarge
   steps:
     - web-build:
         build-type: prod-source-maps
@@ -150,7 +150,7 @@ web-build-ipfs-production:
   working_directory: ~/audius-client
   docker:
     - image: circleci/node:14.18
-  resource_class: large
+  resource_class: xlarge
   steps:
     - web-build:
         build-type: ipfs-prod


### PR DESCRIPTION
### Description

Builds have been failing a decent bit for resource issues. Bump the resource spec from large to xlarge for web builds. Ideally this wouldn't be necessary, but not a huge deal.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

On CI via release branch

https://app.circleci.com/pipelines/github/AudiusProject/audius-client?branch=release-4-20-22&filter=all

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
