### PR TITLE
[C-403] Fix lineup with artist pick

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -155,10 +155,10 @@ export const Lineup = ({
   const countOrDefault = count !== undefined ? count : MAX_TILES_COUNT
 
   const handleLoadMore = useCallback(() => {
-    const { deleted, entries, hasMore, page, status } = lineup
+    const { deleted, nullCount, entries, hasMore, page, status } = lineup
 
     const lineupLength = entries.length
-    const offset = lineupLength + deleted
+    const offset = lineupLength + deleted + nullCount
 
     const shouldLoadMore =
       // Lineup has more items to load

--- a/packages/web/src/common/models/Lineup.ts
+++ b/packages/web/src/common/models/Lineup.ts
@@ -10,6 +10,7 @@ export type Lineup<T, ExtraProps = {}> = {
   }
   total: number
   deleted: number
+  nullCount: number
   status: Status
   hasMore: boolean
   inView: boolean
@@ -29,6 +30,7 @@ export type LineupState<T> = {
   order: Order
   total: number
   deleted: number
+  nullCount: number
   status: Status
   hasMore: boolean
   inView: boolean

--- a/packages/web/src/common/store/lineup/actions.ts
+++ b/packages/web/src/common/store/lineup/actions.ts
@@ -113,14 +113,16 @@ export class LineupActions {
     entries: unknown,
     offset: number,
     limit: number,
-    deleted: boolean
+    deleted: boolean,
+    nullCount: boolean
   ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS_SUCCEEDED),
       entries,
       offset,
       limit,
-      deleted
+      deleted,
+      nullCount
     }
   }
 

--- a/packages/web/src/common/store/lineup/reducer.ts
+++ b/packages/web/src/common/store/lineup/reducer.ts
@@ -29,6 +29,7 @@ export const initialLineupState = {
   isMetadataLoading: false,
   total: 0,
   deleted: 0,
+  nullCount: 0,
   status: Status.LOADING,
   hasMore: true,
   inView: false,
@@ -58,6 +59,7 @@ type FetchLineupMetadatasSucceededAction<T> = {
   type: typeof FETCH_LINEUP_METADATAS_SUCCEEDED
   entries: LineupStateTrack<T>[]
   deleted: number
+  nullCount: number
   limit: number
   offset: number
 }
@@ -158,7 +160,8 @@ export const actionsMap = {
     } else {
       newState.entries = newState.entries.concat(action.entries)
     }
-    newState.deleted += action.deleted || 0
+    newState.deleted += Math.max(action.deleted || 0, 0)
+    newState.nullCount += Math.max(action.nullCount || 0, 0)
     newState.entries.forEach((entry, i) => {
       if (!entry.uid) entry.uid = `${entry.id.toString()}-${i.toString()}`
     })

--- a/packages/web/src/common/store/pages/profile/lineups/tracks/reducer.js
+++ b/packages/web/src/common/store/pages/profile/lineups/tracks/reducer.js
@@ -5,7 +5,7 @@ import { PREFIX } from 'common/store/pages/profile/lineups/tracks/actions'
 const initialState = {
   ...initialLineupState,
   prefix: PREFIX,
-  containsDeleted: false
+  containsDeleted: true
 }
 
 const actionsMap = {

--- a/packages/web/src/common/store/pages/profile/lineups/tracks/reducer.js
+++ b/packages/web/src/common/store/pages/profile/lineups/tracks/reducer.js
@@ -5,7 +5,7 @@ import { PREFIX } from 'common/store/pages/profile/lineups/tracks/actions'
 const initialState = {
   ...initialLineupState,
   prefix: PREFIX,
-  containsDeleted: true
+  containsDeleted: false
 }
 
 const actionsMap = {

--- a/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
@@ -79,12 +79,12 @@ function* getTracks({ offset, limit, payload }) {
       return pinnedTrack.concat(processed)
     } else {
       // If we're paginating w/ offset > 0
-      // just slice out the pinned track because
-      // we already have it.
+      // set the pinned track as null.
+      // This will be handled by `filterDeletes` via `nullCount`
       if (pinnedTrackIndex !== -1) {
-        return processed
-          .slice(0, pinnedTrackIndex)
-          .concat(processed.slice(pinnedTrackIndex + 1))
+        return processed.map((track, i) =>
+          i === pinnedTrackIndex ? null : track
+        )
       }
       return processed
     }

--- a/packages/web/src/common/store/pages/search-results/reducer.ts
+++ b/packages/web/src/common/store/pages/search-results/reducer.ts
@@ -31,6 +31,7 @@ const initialState: SearchPageState = {
     order: {},
     total: 0,
     deleted: 0,
+    nullCount: 0,
     status: Status.LOADING,
     hasMore: true,
     inView: false,

--- a/packages/web/src/components/lineup/Lineup.tsx
+++ b/packages/web/src/components/lineup/Lineup.tsx
@@ -42,6 +42,7 @@ Lineup.defaultProps = {
     order: {},
     total: 0,
     deleted: 0,
+    nullCount: 0,
     status: Status.LOADING,
     hasMore: true,
     inView: true,

--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -298,7 +298,7 @@ class LineupProvider extends PureComponent<CombinedProps, LineupProviderState> {
       initialTrackLoadCount
     } = this.state
     const lineupLength = lineup.entries.length
-    const offset = lineupLength + lineup.deleted
+    const offset = lineupLength + lineup.deleted + lineup.nullCount
     if (
       (!limit || lineupLength !== limit) &&
       loadMore &&


### PR DESCRIPTION
### Description

* Instead of slicing the artist pick out of the response, set it to null and keep track of the null count to avoid messing up the offset

### Dragons

This could break lineups

### How Has This Been Tested?

Locally against prod, web and ios

### How will this change be monitored?

Michael will confirm fix
