### PR TITLE
[C-405] Fix legacy android build profile freeze

### DIFF
--- a/packages/mobile/src/components/audio-rewards/TierText.tsx
+++ b/packages/mobile/src/components/audio-rewards/TierText.tsx
@@ -4,7 +4,7 @@ import { GradientText, GradientTextProps } from 'app/components/core'
 
 const tierGradientMap = {
   none: {
-    colors: []
+    colors: undefined
   },
   bronze: {
     colors: ['rgba(141, 48, 8, 0.5)', 'rgba(182, 97, 11, 1)']


### PR DESCRIPTION
### Description

Fixes app breaking bug on legacy android app. Issue was due to linear gradient breaking when not receiving at least 2 colors.