### PR TITLE
Upgrade libs to 1.2.112, use core entrypoint

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -92,9 +92,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.2.111",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.111.tgz",
-      "integrity": "sha512-w/jEhsZre0bi9Oznvccvu+RPLN8B4MjkOs5zituBQgPfO50uODOxDLgP+qdDknlq5hjw3Z1TMpPt21klKN5AbQ==",
+      "version": "1.2.112",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.2.112.tgz",
+      "integrity": "sha512-jFx/c0uqps3HW8lp9O+cejS/sMbZ7c/mMff4IAAWWOZ+1ZVajMoF14Bh69YF0/1mDeHvkaa68h48M2bGLKEn6g==",
       "requires": {
         "@audius/anchor-audius-data": "0.0.1",
         "@audius/hedgehog": "1.0.12",
@@ -1469,9 +1469,9 @@
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -4221,9 +4221,9 @@
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -4274,25 +4274,25 @@
       },
       "dependencies": {
         "@walletconnect/browser-utils": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.7.tgz",
-          "integrity": "sha512-6Mt7DSPaG0FKnHhuVzkU1hgtsCpGvl2nfbfRytLpyDY05iWMzMg5uK1DzV+0k4hCt9pVli0JVNt6dh9a6Xm94w==",
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.7.8.tgz",
+          "integrity": "sha512-iCL0XCWOZaABIc0lqA79Vyaybr3z26nt8mxiwvfrG8oaKUf5Y21Of4dj+wIXQ4Hhblre6SgDlU0Ffb39+1THOw==",
           "requires": {
             "@walletconnect/safe-json": "1.0.0",
-            "@walletconnect/types": "^1.7.7",
+            "@walletconnect/types": "^1.7.8",
             "@walletconnect/window-getters": "1.0.0",
             "@walletconnect/window-metadata": "1.0.0",
             "detect-browser": "5.2.0"
           }
         },
         "@walletconnect/core": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.7.tgz",
-          "integrity": "sha512-XsF2x4JcBS1V2Nk/Uh38dU7ZlLmW/R5oxHp4+tVgCwTID6nZlo3vUSHBOqM7jgDRblKOHixANollm0r94bM8Cg==",
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-1.7.8.tgz",
+          "integrity": "sha512-9xcQ0YNf9JUFb0YOX1Mpy4Yojt+6w2yQz/0aIEyj2X/s9D71NW0fTYsMcdhkLOI7mn2cqVbx2t1lRvdgqsbrSQ==",
           "requires": {
-            "@walletconnect/socket-transport": "^1.7.7",
-            "@walletconnect/types": "^1.7.7",
-            "@walletconnect/utils": "^1.7.7"
+            "@walletconnect/socket-transport": "^1.7.8",
+            "@walletconnect/types": "^1.7.8",
+            "@walletconnect/utils": "^1.7.8"
           }
         },
         "@walletconnect/crypto": {
@@ -4317,13 +4317,13 @@
           }
         },
         "@walletconnect/iso-crypto": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.7.tgz",
-          "integrity": "sha512-t8RKJZkFtFyWMFrl0jPz/3RAGhM5yext+MLFq3L/KTPxLgMZuT1yFHRUiV7cAN3+LcCmk6Sy/rV1yQPTiB158Q==",
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@walletconnect/iso-crypto/-/iso-crypto-1.7.8.tgz",
+          "integrity": "sha512-Qo6qDcMG0Ac+9fpWE0h/oE55NHLk6eM2vlXpWlQDN/me7RZGrkvk+LXsAkQ3UiYPEiPfq4eswcyRWC9AcrAscg==",
           "requires": {
             "@walletconnect/crypto": "^1.0.2",
-            "@walletconnect/types": "^1.7.7",
-            "@walletconnect/utils": "^1.7.7"
+            "@walletconnect/types": "^1.7.8",
+            "@walletconnect/utils": "^1.7.8"
           }
         },
         "@walletconnect/randombytes": {
@@ -4337,12 +4337,12 @@
           }
         },
         "@walletconnect/socket-transport": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.7.tgz",
-          "integrity": "sha512-RxeFkT+5BqdaZzPtPYIw6+KSVh6Q1NaYqTiAzWWh9RPuvuTajIEsi+fUXizfkpmyi9UTYBvdFXnKcB+eSImpDg==",
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@walletconnect/socket-transport/-/socket-transport-1.7.8.tgz",
+          "integrity": "sha512-bqEjLxfSzG79v2OT7XVOZoyUkg6g3yng0fURrdLusWs42fYHWnrSrIZDejFn8N5PiZk5R2edrggkQ7w0VUUAfw==",
           "requires": {
-            "@walletconnect/types": "^1.7.7",
-            "@walletconnect/utils": "^1.7.7",
+            "@walletconnect/types": "^1.7.8",
+            "@walletconnect/utils": "^1.7.8",
             "ws": "7.5.3"
           },
           "dependencies": {
@@ -4354,19 +4354,19 @@
           }
         },
         "@walletconnect/types": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.7.tgz",
-          "integrity": "sha512-yXJrLxwLLCXtWgd/e8FjfY9v5DKds12Z7EEPzUrPSq6v7WtXpqate577KwlFQ6UYzioQzIEDE8+98j+0aiZbsw=="
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.8.tgz",
+          "integrity": "sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA=="
         },
         "@walletconnect/utils": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.7.tgz",
-          "integrity": "sha512-slNlnROS4DEusGFx53hshIBylYhzd5JtGF+AJpza+Tc616+u8ozjQ9aKKUaV85bucnv5Q42bTwLYrYrXiydmuw==",
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-1.7.8.tgz",
+          "integrity": "sha512-DSpfH6Do0TQmdrgzu+SyjVhupVjN0WEMvNWGK9K4VlSmLFpCWfme7qxzrvuxBZ47gDqs1kGWvjyJmviWqvOnAg==",
           "requires": {
-            "@walletconnect/browser-utils": "^1.7.7",
+            "@walletconnect/browser-utils": "^1.7.8",
             "@walletconnect/encoding": "^1.0.1",
             "@walletconnect/jsonrpc-utils": "^1.0.0",
-            "@walletconnect/types": "^1.7.7",
+            "@walletconnect/types": "^1.7.8",
             "bn.js": "4.11.8",
             "js-sha3": "0.8.0",
             "query-string": "6.13.5"
@@ -4401,9 +4401,9 @@
           "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -4419,9 +4419,9 @@
       },
       "dependencies": {
         "@walletconnect/types": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.7.tgz",
-          "integrity": "sha512-yXJrLxwLLCXtWgd/e8FjfY9v5DKds12Z7EEPzUrPSq6v7WtXpqate577KwlFQ6UYzioQzIEDE8+98j+0aiZbsw=="
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.7.8.tgz",
+          "integrity": "sha512-0oSZhKIrtXRJVP1jQ0EDTRtotQY6kggGjDcmm/LLQBKnOZXdPeo0sPkV/7DjT5plT3O7Cjc6JvuXt9WOY0hlCA=="
         }
       }
     },
@@ -4444,9 +4444,9 @@
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -4467,9 +4467,9 @@
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -4561,9 +4561,9 @@
           }
         },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -5285,9 +5285,9 @@
       "dev": true
     },
     "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -9456,11 +9456,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "circular-json": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ=="
     },
     "cjs-module-lexer": {
       "version": "0.6.0",
@@ -16900,9 +16895,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.0.tgz",
-      "integrity": "sha512-hhXv5IKLDIkb0pEm53G053UZGhRAhw3wM5Jk7ly5sGIQRkO1s63FaDqM9QjlrPHygKEE2awUlLP9fFrG6M9vfQ=="
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
+      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
     },
     "got": {
       "version": "9.6.0",
@@ -17981,18 +17976,18 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs-unixfs": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.6.tgz",
-      "integrity": "sha512-gTkjYKXuHnqIf6EFfS+ESaYEl3I3aaQQ0UX8MhpNzreMLEuMnuqpoI/uLLllTZa31WRplKixabbpRTSmTYRNwA==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-6.0.7.tgz",
+      "integrity": "sha512-5mKbQgvux6n5lQ+upGWWPKcoswXahdOcyGQ2SbIIRV6eBJMzxLprzKsyb0GMsg80tHX2wnNOxBKSCiSGjb+54A==",
       "requires": {
         "err-code": "^3.0.1",
         "protobufjs": "^6.10.2"
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.6.tgz",
-      "integrity": "sha512-FgzODqg4pvToEMZ88mFkHcU0s25CljmnqX2VX7K/VQDckiZIxhIiUTQRqQg/C7Em4uCzVp8YCxKUvl++w6kvNg==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.7.tgz",
+      "integrity": "sha512-UQnvIqeECDZ9x85v7/KAT3mzGiGLVSyfJxlnL0bjC8iMtfp9yBrh/imr7go5XApZ6c4tSJUrekM9GouHggPPBA==",
       "requires": {
         "@ipld/dag-pb": "^2.0.2",
         "@multiformats/murmur3": "^1.0.3",
@@ -18000,7 +17995,7 @@
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
         "interface-blockstore": "^1.0.0",
-        "ipfs-unixfs": "^6.0.6",
+        "ipfs-unixfs": "^6.0.0",
         "it-all": "^1.0.5",
         "it-batch": "^1.0.8",
         "it-first": "^1.0.6",
@@ -18811,9 +18806,9 @@
           "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
         },
         "@types/node": {
-          "version": "12.20.48",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.48.tgz",
-          "integrity": "sha512-4kxzqkrpwYtn6okJUcb2lfUu9ilnb3yhUOH6qX3nug8D2DupZ2drIkff2yJzYcNJVl3begnlcaBJ7tqiTTzjnQ=="
+          "version": "12.20.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
+          "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -25253,9 +25248,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "17.0.25",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-          "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w=="
+          "version": "17.0.29",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.29.tgz",
+          "integrity": "sha512-tx5jMmMFwx7wBwq/V7OohKDVb/JwJU5qCVkeLMh1//xycAJ/ESuw9aJ9SEtlCZDYi2pBfe4JkisSoAtbOsBNAA=="
         }
       }
     },
@@ -28135,23 +28130,35 @@
       }
     },
     "rpc-websockets": {
-      "version": "7.4.17",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.4.17.tgz",
-      "integrity": "sha512-eolVi/qlXS13viIUH9aqrde902wzSLAai0IjmOZSRefp5I3CSG/vCnD0c0fDSYCWuEyUoRL1BHQA8K1baEUyow==",
+      "version": "7.4.18",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.4.18.tgz",
+      "integrity": "sha512-bVu+4qM5CkGVlTqJa6FaAxLbb5uRnyH4te7yjFvoCzbnif7PT4BcvXtNTprHlNvsH+/StB81zUQicxMrUrIomA==",
       "requires": {
-        "@babel/runtime": "^7.11.2",
+        "@babel/runtime": "^7.17.2",
         "bufferutil": "^4.0.1",
-        "circular-json": "^0.5.9",
         "eventemitter3": "^4.0.7",
         "utf-8-validate": "^5.0.2",
-        "uuid": "^8.3.0",
-        "ws": "^7.4.5"
+        "uuid": "^8.3.2",
+        "ws": "^8.5.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
         }
       }
     },
@@ -28885,9 +28892,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "version": "1.1.5",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.2.111",
+    "@audius/libs": "1.2.112",
     "@audius/stems": "0.3.28",
     "@craco/craco": "6.4.3",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",

--- a/packages/web/src/services/AudiusBackend.js
+++ b/packages/web/src/services/AudiusBackend.js
@@ -1,6 +1,6 @@
 /* globals web3, localStorage, fetch, Image */
+import { IdentityAPI } from '@audius/libs/dist/core'
 import * as DiscoveryAPI from '@audius/libs/src/services/discoveryProvider/requests'
-import * as IdentityAPI from '@audius/libs/src/services/identity/requests'
 import { ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import {
   PublicKey,

--- a/packages/web/src/services/LocalStorage.ts
+++ b/packages/web/src/services/LocalStorage.ts
@@ -1,9 +1,9 @@
+import { CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY } from '@audius/libs/dist/core'
+
 import { User } from 'common/models/User'
 
-// TODO: the following should come from @audius/libs/constants when we build
-// it with esm. Importing with common-js breaks the app since it tries
-// to import all of libs, which we try to do async later on.
-const CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY = '@audius/libs:found-user'
+// TODO: the following should come from @audius/libs/dist/core when
+// discoveryProvider/constants is migrated to typescript.
 const DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-node-timestamp'
 
 const AUDIUS_ACCOUNT_KEY = '@audius/account'


### PR DESCRIPTION
### Description

Upgrades libs to latest, which includes large typescript refactor. Along with this we can start using the new dist/core entrypoint for constants and other values that need to be used separately from the libs main entrypoint (since that is dynamically imported)