### PR TITLE
[C-419] Fix react native Android profile screen crash

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -6306,7 +6306,7 @@
     "audius-client": {
       "version": "file:../web",
       "requires": {
-        "@audius/libs": "1.2.105",
+        "@audius/libs": "1.2.111",
         "@audius/stems": "0.3.28",
         "@craco/craco": "6.4.3",
         "@fingerprintjs/fingerprintjs-pro": "3.5.6",

--- a/packages/mobile/src/screens/profile-screen/CoverPhoto.tsx
+++ b/packages/mobile/src/screens/profile-screen/CoverPhoto.tsx
@@ -1,6 +1,6 @@
 import { BlurView } from '@react-native-community/blur'
 import { WidthSizes } from 'audius-client/src/common/models/ImageSizes'
-import { Animated, StyleSheet } from 'react-native'
+import { Animated, Platform, StyleSheet } from 'react-native'
 
 import BadgeArtist from 'app/assets/images/badgeArtist.svg'
 import { DynamicImage } from 'app/components/core'
@@ -64,16 +64,23 @@ export const CoverPhoto = ({ scrollY }: { scrollY?: Animated.Value }) => {
         uri={coverPhoto}
         styles={{ root: styles.imageRoot, image: styles.image }}
       >
-        <AnimatedBlurView
-          blurType={'dark'}
-          blurAmount={100}
-          style={[
-            { ...StyleSheet.absoluteFillObject, zIndex: 2 },
-            scrollY
-              ? { opacity: interpolateBlurViewOpacity(scrollY) }
-              : undefined
-          ]}
-        />
+        {/*
+          Disable blur on android because it causes a crash.
+          See https://github.com/software-mansion/react-native-screens/pull/1406
+          TODO: C-423 pull in new version of react screens when the fix is released
+        */}
+        {Platform.OS === 'ios' ? (
+          <AnimatedBlurView
+            blurType={'dark'}
+            blurAmount={100}
+            style={[
+              { ...StyleSheet.absoluteFillObject, zIndex: 2 },
+              scrollY
+                ? { opacity: interpolateBlurViewOpacity(scrollY) }
+                : undefined
+            ]}
+          />
+        ) : null}
       </DynamicImage>
       {isArtist ? (
         <Animated.View


### PR DESCRIPTION
### Description

* Fixes crash on profile screen by disabling blur view (added an issue to update `react-native-screens` when the fix is released)

### Dragons

There will be no blur on android cover photo on scroll

### How Has This Been Tested?

Android device

### How will this change be monitored?

TestFlight / playstore beta
