### PR TITLE
[AUD-1645] Prevent app error on resize

### DIFF
--- a/packages/web/src/components/nav/store/context.tsx
+++ b/packages/web/src/components/nav/store/context.tsx
@@ -40,7 +40,14 @@ type LeftElement = LeftPreset | ReactNode | null
 type CenterElement = CenterPreset | string | null
 type RightElement = RightPreset | ReactNode | null
 
-export const NavContext = createContext<NavContextProps | null>(null)
+export const NavContext = createContext<NavContextProps>({
+  setLeft: () => {},
+  setCenter: () => {},
+  setRight: () => {},
+  leftElement: LeftPreset.NOTIFICATION,
+  centerElement: CenterPreset.LOGO,
+  rightElement: RightPreset.SEARCH
+})
 
 export const useNavContext = () => {
   const [leftElement, setLeft] = useState<LeftElement>(LeftPreset.NOTIFICATION)


### PR DESCRIPTION
### Description

It's annoying that the entire app breaks when switching from mobile to desktop requiring a refresh. This moves us towards the path of gracefully handling window changes.
