### PR TITLE
[C427] Fix malformed js calls error

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -155,7 +155,14 @@ export const Lineup = ({
   const countOrDefault = count !== undefined ? count : MAX_TILES_COUNT
 
   const handleLoadMore = useCallback(() => {
-    const { deleted, nullCount, entries, hasMore, page, status } = lineup
+    const {
+      deleted = 0,
+      nullCount = 0,
+      entries,
+      hasMore,
+      page,
+      status
+    } = lineup
 
     const lineupLength = entries.length
     const offset = lineupLength + deleted + nullCount


### PR DESCRIPTION
### Description

* On android a "Malformed js calls" error was crashing the app because the lineup `limit` and `offset` were `NaN` because `deleted` and `nullCount` were undefined. Defaulting to 0 fixes the issue

### Dragons

No dragons but this was a pain to debug. If we see this in the future, this stackoverflow answer helped a lot: https://stackoverflow.com/a/67100389/5705462

### How Has This Been Tested?

Android and ios

### How will this change be monitored?

TestFlight / playstore
