### PR TITLE
[C-414] Fix size of PlayButton on android

### DIFF
--- a/packages/mobile/src/components/core/AnimatedButton.tsx
+++ b/packages/mobile/src/components/core/AnimatedButton.tsx
@@ -33,6 +33,7 @@ export type AnimatedButtonProps = {
   onLongPress?: GestureResponderHandler
   onPress?: GestureResponderHandler
   renderUnderlay?: (state: PressableStateCallbackType) => ReactNode
+  resizeMode?: AnimatedLottieViewProps['resizeMode']
   style?: PressableProps['style']
   wrapperStyle?: StyleProp<ViewStyle>
   haptics?: Haptics
@@ -48,6 +49,7 @@ export const AnimatedButton = ({
   onLongPress,
   onPress,
   renderUnderlay,
+  resizeMode,
   style,
   wrapperStyle,
   haptics,
@@ -197,6 +199,7 @@ export const AnimatedButton = ({
               progress={progress}
               loop={false}
               source={source}
+              resizeMode={resizeMode}
             />
           </View>
         </>

--- a/packages/mobile/src/components/now-playing-drawer/PlayButton.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/PlayButton.tsx
@@ -59,6 +59,7 @@ export const PlayButton = ({ isActive, ...props }: PlayButtonProps) => {
   return (
     <AnimatedButton
       {...props}
+      resizeMode='cover'
       haptics
       iconJSON={iconJSON}
       onPress={handlePress}


### PR DESCRIPTION
### Description

* Adds resizeMode='cover' to the play button to fix the sizing on android. Not entirely sure why it's only needed on the play button and not other animated buttons but some context here: https://github.com/lottie-react-native/lottie-react-native/issues/428

### Dragons

Sizing of play button could be off

### How Has This Been Tested?

Tested on android and ios

### How will this change be monitored?

TestFlight / playstore
