### PR TITLE
[C-415] Fix search styling on android

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -46714,9 +46714,9 @@
       "integrity": "sha512-mubYMN6+1HXa8z3EJKBvNBkl4UoVM4McjESeB2PgvRMSngmJtC5yUMRdhbbrIAn5Liu3hFGao/14s5hQIgtkRQ=="
     },
     "lottie-react-native": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/lottie-react-native/-/lottie-react-native-5.0.1.tgz",
-      "integrity": "sha512-V+ODPqiHOSRzEWg8VsfrJBicgc2k0ZPlCjk3J7ULUkh94smL1nrsF/n4OGukj4MLZwonpv+frVK7pPh5U7t3rQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lottie-react-native/-/lottie-react-native-4.1.3.tgz",
+      "integrity": "sha512-RgQrn1VYRXMV3YTZE9DgZy/UqNsMmZvzXBU4eEUWDOTY9cemOoWmCg2BHrL7nNtDJqtsu1Mi/6e8hp0yN2mcBA==",
       "requires": {
         "invariant": "^2.2.2",
         "prop-types": "^15.5.10",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -68,7 +68,7 @@
     "fxa-common-password-list": "0.0.4",
     "lodash.samplesize": "4.2.0",
     "lottie-ios": "3.2.3",
-    "lottie-react-native": "5.0.1",
+    "lottie-react-native": "4.1.3",
     "moment": "2.24.0",
     "numeral": "2.0.6",
     "path-dirname": "1.0.2",

--- a/packages/mobile/src/components/core/FormTextInput.tsx
+++ b/packages/mobile/src/components/core/FormTextInput.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => {
   return {
     root: {
       flexDirection: 'row',
-      alignItems: 'flex-start',
+      alignItems: 'center',
       borderBottomWidth: 1,
       borderBottomColor: palette.neutralLight8,
       width: Dimensions.get('window').width,
@@ -43,10 +43,13 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => {
     },
     input: {
       ...inputText,
+      padding: 0,
       width: '100%',
       flexShrink: 1
     },
-    prefix: inputText
+    prefix: {
+      ...inputText
+    }
   }
 })
 

--- a/packages/mobile/src/components/core/SearchInput.tsx
+++ b/packages/mobile/src/components/core/SearchInput.tsx
@@ -24,7 +24,8 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
   input: {
     flex: 1,
     color: palette.neutral,
-    fontFamily: typography.fontByWeight.medium
+    fontFamily: typography.fontByWeight.medium,
+    padding: 0
   },
   icon: {
     fill: palette.neutralLight5,

--- a/packages/mobile/src/components/core/SegmentedControl.tsx
+++ b/packages/mobile/src/components/core/SegmentedControl.tsx
@@ -65,7 +65,6 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
     paddingRight: 0
   },
   tab: {
-    elevation: 3,
     paddingVertical: spacing(2),
     paddingHorizontal: spacing(4),
     borderRadius: 4,
@@ -87,7 +86,6 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   },
   slider: {
     position: 'absolute',
-    elevation: 2,
     top: 3,
     bottom: 3,
     borderRadius: 4,


### PR DESCRIPTION
### Description

* Fixes styling issues around TextInputs on android
* Downgrades lottie-react-native to what we had before because it caused a crash on certain animations using colorFilters
* Removes shadow from segmented control on android

### Dragons

Styling could affect ios, but I double checked and everything looks good!

### How Has This Been Tested?

Android and ios

### How will this change be monitored?

TestFlight / playstore
