### PR TITLE
[C-422] Add pull to refresh on android

### DIFF
--- a/packages/mobile/src/components/core/FlatList.tsx
+++ b/packages/mobile/src/components/core/FlatList.tsx
@@ -4,9 +4,13 @@ import {
   Animated,
   FlatList as RNFlatList,
   FlatListProps as RNFlatListProps,
+  Platform,
+  RefreshControl,
   View
 } from 'react-native'
 import { useCollapsibleScene } from 'react-native-collapsible-tab-view'
+
+import { useThemeColors } from 'app/utils/theme'
 
 import { CollapsibleTabNavigatorContext } from '../top-tab-bar'
 
@@ -21,8 +25,9 @@ type CollapsibleFlatListProps = {
 
 const CollapsibleFlatList = (props: CollapsibleFlatListProps) => {
   const { sceneName, ...other } = props
-  const { onRefresh } = other
+  const { refreshing, onRefresh } = other
   const scrollPropsAndRef = useCollapsibleScene(sceneName)
+  const { neutral } = useThemeColors()
   return (
     <View>
       {onRefresh ? <PullToRefresh /> : null}
@@ -34,6 +39,16 @@ const CollapsibleFlatList = (props: CollapsibleFlatListProps) => {
           scrollPropsAndRef.onScroll,
           props.onScroll
         )}
+        refreshControl={
+          Platform.OS === 'ios' ? undefined : (
+            <RefreshControl
+              progressViewOffset={scrollPropsAndRef.progressViewOffset}
+              refreshing={!!refreshing}
+              onRefresh={onRefresh ?? undefined}
+              colors={[neutral]}
+            />
+          )
+        }
       />
     </View>
   )
@@ -45,6 +60,7 @@ const AnimatedFlatList = forwardRef<RNFlatList, FlatListProps>(
     ref: MutableRefObject<RNFlatList<any> | null>
   ) {
     const scrollRef = useRef<Animated.FlatList>(null)
+    const { neutral } = useThemeColors()
 
     const {
       isRefreshing,
@@ -74,6 +90,15 @@ const AnimatedFlatList = forwardRef<RNFlatList, FlatListProps>(
         <Animated.FlatList
           {...other}
           scrollToOverflowEnabled
+          refreshControl={
+            Platform.OS === 'ios' ? undefined : (
+              <RefreshControl
+                refreshing={!!isRefreshing}
+                onRefresh={onRefresh ?? undefined}
+                colors={[neutral]}
+              />
+            )
+          }
           ref={ref || scrollRef}
           onScroll={handleScroll}
           onScrollBeginDrag={onScrollBeginDrag}

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -4,6 +4,8 @@ import { Portal } from '@gorhom/portal'
 import {
   Animated,
   DefaultSectionT,
+  Platform,
+  RefreshControl,
   SectionList as RNSectionList,
   SectionListProps as RNSectionListProps,
   View
@@ -48,7 +50,7 @@ const CollapsibleSectionList = (props: CollapsibleSectionListProps) => {
   )
 
   const scrollPropsAndRef = useCollapsibleSectionListScene(sceneName)
-  const { staticWhite } = useThemeColors()
+  const { neutral, staticWhite } = useThemeColors()
 
   return (
     <View>
@@ -71,6 +73,16 @@ const CollapsibleSectionList = (props: CollapsibleSectionListProps) => {
           scrollPropsAndRef.onScroll,
           props.onScroll
         )}
+        refreshControl={
+          Platform.OS === 'ios' ? undefined : (
+            <RefreshControl
+              progressViewOffset={scrollPropsAndRef.progressViewOffset}
+              refreshing={!!refreshing}
+              onRefresh={onRefresh ?? undefined}
+              colors={[neutral]}
+            />
+          )
+        }
       />
     </View>
   )
@@ -82,6 +94,7 @@ const AnimatedSectionList = forwardRef<RNSectionList, SectionListProps>(
     ref: MutableRefObject<RNSectionList<any, DefaultSectionT> | null>
   ) {
     const { refreshing, onRefresh, onScroll, ...other } = props
+    const { neutral } = useThemeColors()
     const scrollResponder = ref?.current?.getScrollResponder()
     const {
       isRefreshing,
@@ -108,9 +121,19 @@ const AnimatedSectionList = forwardRef<RNSectionList, SectionListProps>(
             isRefreshDisabled={isRefreshDisabled}
           />
         ) : null}
+
         <Animated.SectionList
           {...other}
           scrollToOverflowEnabled
+          refreshControl={
+            Platform.OS === 'ios' ? undefined : (
+              <RefreshControl
+                refreshing={!!isRefreshing}
+                onRefresh={onRefresh ?? undefined}
+                colors={[neutral]}
+              />
+            )
+          }
           ref={ref}
           onScroll={handleScroll}
           onScrollBeginDrag={onScrollBeginDrag}


### PR DESCRIPTION
### Description

* Adds pull to refresh on android

Unfortunately, android does not support "overscrolling" or scrolling past the ends of a scrollview (contrary to what this prob would lead you to believe https://reactnative.dev/docs/scrollview#overscrollmode-android). So there is no way to use the same refresh indicator as we do on ios. Instead, we can use the native android one which looks a lot better than on ios

The only strange part of this is on the collapsible tabs on the profile screen. The indicator shows at the top of the list instead of at the top of the screen, which looks a little weird when scrolling down while the indicator is visible. But I think probably the best we can do for now because when shown at the top, the header covers the indicator and there seems to be no way of bringing the indicator to the front

https://user-images.githubusercontent.com/19916043/166322742-0f9d12cb-1326-4343-a613-b367fc51c1e8.mp4


### Dragons

Possible pull to refresh bugs

### How Has This Been Tested?

android and ios

### How will this change be monitored?

Testflight / playstore
