### PR TITLE
[C-413] Fix PlayBar offset on Android

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -180,7 +180,7 @@ PODS:
     - GoogleUtilities/Logger
   - libevent (2.1.12)
   - lottie-ios (3.2.3)
-  - lottie-react-native (5.0.1):
+  - lottie-react-native (4.1.3):
     - lottie-ios (~> 3.2.3)
     - React-Core
   - nanopb (2.30908.0):
@@ -837,7 +837,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
-  lottie-react-native: a029a86e1689c86a07169c520ae770e84348cd20
+  lottie-react-native: b561920bba7ec727ec94a473b683cffba00faece
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   Permission-Notifications: 2662b6885535a98892b8e48da04b74fc898d70f8

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -180,7 +180,7 @@ PODS:
     - GoogleUtilities/Logger
   - libevent (2.1.12)
   - lottie-ios (3.2.3)
-  - lottie-react-native (4.1.3):
+  - lottie-react-native (5.0.1):
     - lottie-ios (~> 3.2.3)
     - React-Core
   - nanopb (2.30908.0):
@@ -391,6 +391,8 @@ PODS:
   - React-jsinspector (0.66.3)
   - React-logger (0.66.3):
     - glog
+  - react-native-android-navbar-height (0.1.0):
+    - React-Core
   - react-native-blur (0.8.0):
     - React
   - react-native-config (1.4.5):
@@ -590,6 +592,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-android-navbar-height (from `../node_modules/react-native-android-navbar-height`)
   - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
   - react-native-config (from `../node_modules/react-native-config`)
   - react-native-google-cast (from `../node_modules/react-native-google-cast/ios`)
@@ -712,6 +715,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-android-navbar-height:
+    :path: "../node_modules/react-native-android-navbar-height"
   react-native-blur:
     :path: "../node_modules/@react-native-community/blur"
   react-native-config:
@@ -832,7 +837,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
-  lottie-react-native: b561920bba7ec727ec94a473b683cffba00faece
+  lottie-react-native: a029a86e1689c86a07169c520ae770e84348cd20
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   Permission-Notifications: 2662b6885535a98892b8e48da04b74fc898d70f8
@@ -850,6 +855,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 433a691aee158533a6a6ee9c86cb4a1684fa2853
   React-jsinspector: d9c8eb0b53f0da206fed56612b289fec84991157
   React-logger: e522e76fa3e9ec3e7d7115b49485cc065cf4ae06
+  react-native-android-navbar-height: f975207ac8c2a5cfa885a01447851bf3b491c951
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-config: 6502b1879f97ed5ac570a029961fc35ea606cd14
   react-native-google-cast: 553c31d49840e2f357fde9a3dd0977fbe28d79ba

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -49523,6 +49523,10 @@
         }
       }
     },
+    "react-native-android-navbar-height": {
+      "version": "github:ConnectyCube/react-native-android-navbar-height#3b04b4b66ce1bcc1b316fd44b368575cf8b3432d",
+      "from": "github:ConnectyCube/react-native-android-navbar-height#3b04b4b66ce1bcc1b316fd44b368575cf8b3432d"
+    },
     "react-native-animatable": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -89,6 +89,7 @@
     "react-native-markdown-display": "7.0.0-alpha.2",
     "react-native-modal": "11.5.4",
     "react-native-music-control": "1.4.0",
+    "react-native-android-navbar-height": "github:ConnectyCube/react-native-android-navbar-height.git#3b04b4b66ce1bcc1b316fd44b368575cf8b3432d",
     "react-native-pager-view": "5.4.6",
     "react-native-permissions": "3.0.5",
     "react-native-push-notification": "7.4.0",

--- a/packages/mobile/src/components/drawer/constants.ts
+++ b/packages/mobile/src/components/drawer/constants.ts
@@ -1,5 +1,6 @@
-import { Dimensions } from 'react-native'
+import { Dimensions, StatusBar } from 'react-native'
 
-const { height } = Dimensions.get('window')
+// Not using 'window' because it isn't accurate on android
+const { height } = Dimensions.get('screen')
 
-export const FULL_DRAWER_HEIGHT = height
+export const FULL_DRAWER_HEIGHT = height - (StatusBar.currentHeight ?? 0)

--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -21,6 +21,7 @@ import Drawer, {
   FULL_DRAWER_HEIGHT
 } from 'app/components/drawer'
 import { Scrubber } from 'app/components/scrubber'
+import { useAndroidNavigationBarHeight } from 'app/hooks/useAndroidNavigationBarHeight'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useDrawer } from 'app/hooks/useDrawer'
 import { useNavigation } from 'app/hooks/useNavigation'
@@ -86,6 +87,7 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
   const dispatch = useDispatch()
   const dispatchWeb = useDispatchWeb()
   const insets = useSafeAreaInsets()
+  const androidNavigationBarHeight = useAndroidNavigationBarHeight()
   const staticTopInset = useRef(insets.top)
   const bottomBarHeight = BOTTOM_BAR_HEIGHT + insets.bottom
   const styles = useStyles()
@@ -244,7 +246,9 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
       isOpen={isOpen}
       onClose={handleDrawerCloseFromSwipe}
       onOpen={onDrawerOpen}
-      initialOffsetPosition={bottomBarHeight + PLAY_BAR_HEIGHT}
+      initialOffsetPosition={
+        bottomBarHeight + PLAY_BAR_HEIGHT + androidNavigationBarHeight
+      }
       shouldCloseToInitialOffset={isPlayBarShowing}
       animationStyle={DrawerAnimationStyle.SPRINGY}
       shouldBackgroundDim={false}

--- a/packages/mobile/src/hooks/useAndroidNavigationBarHeight.ts
+++ b/packages/mobile/src/hooks/useAndroidNavigationBarHeight.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+
+import { Dimensions } from 'react-native'
+import { getNavigationBarHeight } from 'react-native-android-navbar-height'
+
+export const useAndroidNavigationBarHeight = () => {
+  const [androidNavigationBarHeight, setAndroidNavigationBarHeight] = useState(
+    0
+  )
+
+  const getAndroidNavigationBarHeight = async () => {
+    const scale = Dimensions.get('screen').scale
+    const navigationBarHeight = await getNavigationBarHeight()
+    setAndroidNavigationBarHeight(navigationBarHeight / scale)
+  }
+  useEffect(() => {
+    getAndroidNavigationBarHeight()
+  }, [])
+  return androidNavigationBarHeight
+}


### PR DESCRIPTION
### Description

* Fixes the positioning of the PlayBar on android. The problem was that we were using `window` dimensions when `screen` dimensions are more accurate on android. With screen dimensions we also need to account for the status bar and navigation bar. But it results in perfect positioning of the PlayBar:
![Screenshot_20220503-103808](https://user-images.githubusercontent.com/19916043/166488880-4ca7acdc-38a0-43eb-a83d-a13b8806a768.jpg)

### Dragons

Had to pull in a dependency to accurately get the navbar height. I did a quick audit of the code and it seems safe, but is not published on npm so I pinned it to a commit on github

### How Has This Been Tested?

Android and iOS (multiple screen sizes)

### How will this change be monitored?

TestFlight / playstore
