### PR TITLE
Revert ArtistPopover zIndex value to its previous value

### DIFF
--- a/packages/web/src/utils/zIndex.ts
+++ b/packages/web/src/utils/zIndex.ts
@@ -22,13 +22,14 @@ export enum zIndex {
   CREATE_PLAYLIST_MODAL = 1000,
   EDIT_PLAYLIST_MODAL = 1001,
   IMAGE_SELECTION_POPUP = 1002,
-  ARTIST_POPOVER_POPUP = 1003,
 
   // Web3 wallet connect modal
   WEB3_WALLET_CONNECT_MODAL = 10001,
 
   // cognito flow modal
-  COGNITO_FLOW_MODAL = 10001
+  COGNITO_FLOW_MODAL = 10001,
+
+  ARTIST_POPOVER_POPUP = 20000
 }
 
 export default zIndex


### PR DESCRIPTION
### Description
Small issue with the zindex value of the artist popover where the popup would show up behind modals.
Reverting to its previous value of 20000 which seems like overkill, but it works

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A
