### PR TITLE
c-456 Fix pending tx every session load

### DIFF
--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -24,6 +24,7 @@ import {
   addPlaylistToFolder,
   containsTempPlaylist,
   findInPlaylistLibrary,
+  getPlaylistsNotInLibrary,
   isInsideFolder,
   reorderPlaylistLibrary
 } from 'common/store/playlist-library/helpers'
@@ -319,26 +320,7 @@ const PlaylistLibrary = ({
   /* if the user's library itself does not contain some of the playlists (for example, if a write failed).
   /* This computes those playlists that are attached to the user's account but are not in the user library. */
   const playlistsNotInLibrary = useMemo(() => {
-    const result = { ...playlists }
-    const helpComputePlaylistsNotInLibrary = (
-      libraryContentsLevel: PlaylistLibraryType['contents']
-    ) => {
-      libraryContentsLevel.forEach(content => {
-        if (content.type === 'temp_playlist' || content.type === 'playlist') {
-          const playlist = playlists[Number(content.playlist_id)]
-          if (playlist) {
-            delete result[Number(content.playlist_id)]
-          }
-        } else if (content.type === 'folder') {
-          helpComputePlaylistsNotInLibrary(content.contents)
-        }
-      })
-    }
-
-    if (library && playlists) {
-      helpComputePlaylistsNotInLibrary(library.contents)
-    }
-    return result
+    return getPlaylistsNotInLibrary(library, playlists)
   }, [library, playlists])
 
   /** Iterate over playlist library and render out available explore/smart

--- a/packages/web/src/store/playlist-library/helpers.test.js
+++ b/packages/web/src/store/playlist-library/helpers.test.js
@@ -11,7 +11,8 @@ import {
   addPlaylistToFolder,
   extractTempPlaylistsFromLibrary,
   replaceTempWithResolvedPlaylists,
-  removePlaylistLibraryTempPlaylists
+  removePlaylistLibraryTempPlaylists,
+  getPlaylistsNotInLibrary
 } from 'common/store/playlist-library/helpers'
 
 describe('findInPlaylistLibrary', () => {
@@ -2006,6 +2007,89 @@ describe('replaceTempWithResolvedPlaylists', () => {
           ]
         }
       ]
+    })
+  })
+})
+
+describe('getPlaylistsNotInLibrary', () => {
+  it('returns the playlists that are not already in the library', () => {
+    const library = {
+      contents: [
+        { type: 'playlist', playlist_id: 1 },
+        { type: 'playlist', playlist_id: 2 },
+        { type: 'explore_playlist', playlist_id: 'Heavy Rotation' },
+        { type: 'temp_playlist', playlist_id: 'e' },
+        {
+          type: 'folder',
+          id: 'my id',
+          name: 'Favorites',
+          contents: [
+            { type: 'playlist', playlist_id: 10 },
+            { type: 'playlist', playlist_id: 11 },
+            { type: 'temp_playlist', playlist_id: 'd' }
+          ]
+        }
+      ]
+    }
+    const playlists = {
+      1: {
+        id: 1,
+        is_album: false,
+        name: 'test',
+        user: {
+          handle: 'nikki',
+          id: 49408
+        }
+      },
+      2: {
+        id: 2,
+        is_album: false,
+        name: 'test',
+        user: {
+          handle: 'nikki',
+          id: 49408
+        }
+      },
+      10: {
+        id: 10,
+        is_album: false,
+        name: 'ten',
+        user: {
+          handle: 'nikki',
+          id: 49408
+        }
+      },
+      11: {
+        id: 11,
+        is_album: false,
+        name: 'eleven',
+        user: {
+          handle: 'nikki',
+          id: 49408
+        }
+      },
+      12: {
+        id: 12,
+        is_album: false,
+        name: 'twelve',
+        user: {
+          handle: 'nikki',
+          id: 49408
+        }
+      }
+    }
+
+    const ret = getPlaylistsNotInLibrary(library, playlists)
+    expect(ret).toEqual({
+      12: {
+        id: 12,
+        is_album: false,
+        name: 'twelve',
+        user: {
+          handle: 'nikki',
+          id: 49408
+        }
+      }
     })
   })
 })


### PR DESCRIPTION
### Description
Before:
There was a pending USER transaction on every app session load if the user had any playlist folders. This was because we compute playlists that are in the user's account but missing in their library - and if there are any, we update the playlist library. If the user had a folder with at least one playlist, the missing playlists were computed incorrectly - which caused the `update profile` operation to be called on every load.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
