### PR TITLE
[C-424] Fix profile screen bio links on android

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -101,4 +101,19 @@
 
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="mailto"/>
+        </intent>
+    </queries>
+
 </manifest>

--- a/packages/mobile/src/components/core/Hyperlink.tsx
+++ b/packages/mobile/src/components/core/Hyperlink.tsx
@@ -21,6 +21,9 @@ const messages = {
 }
 
 const useStyles = makeStyles(({ palette, typography }) => ({
+  root: {
+    marginBottom: 3
+  },
   link: {
     color: palette.primary
   },
@@ -31,8 +34,10 @@ const useStyles = makeStyles(({ palette, typography }) => ({
     position: 'absolute'
   },
   hiddenLink: {
-    marginBottom: -3,
     opacity: 0
+  },
+  hiddenLinkText: {
+    marginTop: -3
   }
 }))
 
@@ -121,7 +126,7 @@ export const Hyperlink = (props: HyperlinkProps) => {
         }}
         style={styles.hiddenLink}
       >
-        <Text style={styles.linkText}>{text}</Text>
+        <Text style={[styles.linkText, styles.hiddenLinkText]}>{text}</Text>
       </View>
     ),
     [links, styles]
@@ -139,7 +144,7 @@ export const Hyperlink = (props: HyperlinkProps) => {
           renderLink={allowPointerEventsToPassThrough ? renderLink : undefined}
           email
           url
-          style={[style, stylesProp?.root]}
+          style={[styles.root, style, stylesProp?.root]}
           {...other}
         />
       </View>

--- a/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
+++ b/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   bioContainer: {
     overflow: 'hidden'
   },
-  bio: {
+  bioText: {
     ...typography.body,
     color: palette.neutralLight2
   },
@@ -97,9 +97,11 @@ export const ExpandableBio = () => {
           >
             <Hyperlink
               source='profile page'
-              numberOfLines={fullBioHeight && !isExpanded ? 2 : 0}
+              style={[
+                styles.bioText,
+                { height: fullBioHeight && !isExpanded ? 32 : 'auto' }
+              ]}
               text={squashNewLines(bio) ?? ''}
-              style={styles.bio}
               allowPointerEventsToPassThrough
             />
           </View>


### PR DESCRIPTION
### Description
* Fixes the positioning and functionality of bio links on android
![Screenshot_20220510-141739](https://user-images.githubusercontent.com/19916043/167705600-a8374d65-7bb2-42d2-960d-dc6865ee7531.jpg)
* Fixes issue without text cut off due to `numberOfLines=2`

### Dragons

This was already pretty fragile code and now it's even more fragile. Have to use `measureInWindow` on the refs of the links to get the position instead of `onLayout` because `onLayout` doesn't return correct values on android

### How Has This Been Tested?

iOS and android

### How will this change be monitored?

TestFlight, play store
