### PR TITLE
[C-475] Fix RemixesScreen header text alignment

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -6306,8 +6306,8 @@
     "audius-client": {
       "version": "file:../web",
       "requires": {
-        "@audius/libs": "1.2.112",
-        "@audius/stems": "0.3.28",
+        "@audius/libs": "1.2.115",
+        "@audius/stems": "0.3.32",
         "@craco/craco": "6.4.3",
         "@fingerprintjs/fingerprintjs-pro": "3.5.6",
         "@hcaptcha/react-hcaptcha": "0.3.6",

--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -7,7 +7,7 @@ import {
   getCount
 } from 'audius-client/src/common/store/pages/remixes/selectors'
 import { pluralize } from 'audius-client/src/common/utils/formatUtil'
-import { Pressable, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 
 import { Screen } from 'app/components/core'
 import { Header } from 'app/components/header'
@@ -36,13 +36,12 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     ...flexRowCentered()
   },
   text: {
-    ...typography.body
+    ...typography.body,
+    textAlign: 'center',
+    lineHeight: 20
   },
   link: {
     color: palette.secondary
-  },
-  user: {
-    ...flexRowCentered()
   }
 }))
 
@@ -76,6 +75,9 @@ export const TrackRemixesScreen = () => {
     })
   }
 
+  const remixesText = pluralize(messages.remix, count, 'es', !count)
+  const remixesCountText = `${count || ''} ${remixesText} ${messages.of}`
+
   return (
     <Screen>
       <Header text={messages.header} />
@@ -85,26 +87,19 @@ export const TrackRemixesScreen = () => {
         header={
           track && user ? (
             <View style={styles.header}>
+              <Text style={styles.text}>{remixesCountText}</Text>
               <Text style={styles.text}>
-                {`${count || ''} ${pluralize(
-                  messages.remix,
-                  count,
-                  'es',
-                  !count
-                )} ${messages.of}`}
-              </Text>
-              <View style={styles.track}>
-                <Pressable onPress={handlePressTrack}>
-                  <Text style={[styles.text, styles.link]}>{track.title}</Text>
-                </Pressable>
-                <Text style={styles.text}>&nbsp;{messages.by}&nbsp;</Text>
-                <Pressable style={styles.user} onPress={handlePressArtistName}>
-                  <Text style={[styles.text, styles.link]}>{user.name}</Text>
+                <Text style={styles.link} onPress={handlePressTrack}>
+                  {track.title}
+                </Text>{' '}
+                <Text>{messages.by}</Text>{' '}
+                <Text onPress={handlePressArtistName}>
+                  <Text style={styles.link}>{user.name}</Text>
                   {user ? (
                     <UserBadges user={user} badgeSize={10} hideName />
                   ) : null}
-                </Pressable>
-              </View>
+                </Text>
+              </Text>
             </View>
           ) : null
         }

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -5306,6 +5306,12 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
+    "@types/numeral": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-2.0.2.tgz",
+      "integrity": "sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==",
+      "dev": true
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -200,6 +200,7 @@
     "@types/linkifyjs": "2.1.3",
     "@types/lodash": "4.14.149",
     "@types/node": "12.12.35",
+    "@types/numeral": "^2.0.2",
     "@types/react": "17.0.2",
     "@types/react-beautiful-dnd": "11.0.5",
     "@types/react-dom": "17.0.2",

--- a/packages/web/src/common/utils/formatUtil.ts
+++ b/packages/web/src/common/utils/formatUtil.ts
@@ -1,6 +1,8 @@
 import BN from 'bn.js'
 import numeral from 'numeral'
 
+import { BNWei } from 'common/models/Wallet'
+
 /**
  * The format for counting numbers should be 4 characters if possible (3 numbers and 1 Letter) without trailing 0
  * ie.
@@ -10,7 +12,7 @@ import numeral from 'numeral'
  * 443,123 => 443K
  * 4,001,000 => 4M Followers
  */
-export const formatCount = count => {
+export const formatCount = (count: number) => {
   if (count >= 1000) {
     const countStr = count.toString()
     if (countStr.length % 3 === 0) {
@@ -36,9 +38,8 @@ export const formatCount = count => {
  * ie.
  * 1024 => 1.00 KB
  * 3072 => 3.07 KB
- * @param {number} bytes
  */
-export const formatBytes = bytes => {
+export const formatBytes = (bytes: number) => {
   return numeral(bytes).format('0.00 b')
 }
 
@@ -47,9 +48,8 @@ export const formatBytes = bytes => {
  *  Removes reserved URL characters
  *  Replaces white space with -
  *  Lower cases
- * @param {string} name
  */
-export const formatUrlName = name => {
+export const formatUrlName = (name: string) => {
   if (!name) return ''
   return (
     name
@@ -66,48 +66,45 @@ export const formatUrlName = name => {
  * Using window.location will automatically decode
  * the encoded component, so using the above formatUrlName(string) can
  * be used to compare results with the window.location directly.
- * @param {string} name
  */
-export const encodeUrlName = name => {
+export const encodeUrlName = (name: string) => {
   return encodeURIComponent(formatUrlName(name))
 }
 
 /**
  * Formats a message for sharing
- * @param {string} name
  */
-export const formatShareText = (title, creator) => {
+export const formatShareText = (title: string, creator: string) => {
   return `${title} by ${creator} on Audius`
 }
 
 /**
  * Reduces multiple sequential newlines (> 3) into max `\n\n` and
  * trims both leading and trailing newlines
- * @param {string} str
  */
-export const squashNewLines = str => {
+export const squashNewLines = (str: string) => {
   return str ? str.replace(/\n\s*\n\s*\n/g, '\n\n').trim() : str
 }
 
 /** Trims a string to alphanumeric values only */
-export const trimToAlphaNumeric = string => {
+export const trimToAlphaNumeric = (string: string) => {
   if (!string) return string
   return string.replace(/[#|\W]+/g, '')
 }
 
 export const pluralize = (
-  message,
-  count,
+  message: string,
+  count: number | null,
   suffix = 's',
   pluralizeAnyway = false
-) => `${message}${count > 1 || pluralizeAnyway ? suffix : ''}`
+) => `${message}${(count ?? 0) > 1 || pluralizeAnyway ? suffix : ''}`
 
 /**
  * Format a BN to the shortened $AUDIO currency without decimals
- * @param {BN} amount The wei amount
- * @returns {string} $AUDIO The $AUDIO amount
+ * @param amount The wei amount
+ * @returns $AUDIO The $AUDIO amount
  */
-export const formatAudio = amount => {
+export const formatAudio = (amount: BN) => {
   if (!BN.isBN(amount)) return ''
   let aud = amount.div(WEI).toString()
   aud = numeral(aud).format('0,0')
@@ -116,16 +113,15 @@ export const formatAudio = amount => {
 
 // Wei -> Audio
 
-export const formatWeiToAudioString = wei => {
+export const formatWeiToAudioString = (wei: BNWei) => {
   const aud = wei.div(WEI)
   return aud.toString()
 }
 
 /**
  * Format a number to have commas
- * @param {number|string} num
  */
-export const formatNumberCommas = num => {
+export const formatNumberCommas = (num: number | string) => {
   const parts = num.toString().split('.')
   return (
     parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',') +
@@ -133,18 +129,18 @@ export const formatNumberCommas = num => {
   )
 }
 
-export const trimRightZeros = number => {
+export const trimRightZeros = (number: string) => {
   return number.replace(/(\d)0+$/gm, '$1')
 }
 
 export const WEI = new BN('1000000000000000000')
 
-export const checkOnlyNumeric = number => {
+export const checkOnlyNumeric = (number: string) => {
   const reg = /^\d+$/
   return reg.test(number)
 }
 
-export const checkOnlyWeiFloat = number => {
+export const checkOnlyWeiFloat = (number: string) => {
   const reg = /^[+-]?\d+(\.\d+)?$/
   const isFloat = reg.test(number)
   if (!isFloat) return false
@@ -155,7 +151,7 @@ export const checkOnlyWeiFloat = number => {
   return true
 }
 
-export const convertFloatToWei = number => {
+export const convertFloatToWei = (number: string) => {
   const nums = number.split('.')
   if (nums.length !== 2) return null
   if (!checkOnlyNumeric(nums[0]) || !checkOnlyNumeric(nums[1])) return null
@@ -165,12 +161,12 @@ export const convertFloatToWei = number => {
   return aud.add(wei)
 }
 
-export const checkWeiNumber = number => {
+export const checkWeiNumber = (number: string) => {
   return checkOnlyNumeric(number) || checkOnlyWeiFloat(number)
 }
 
 // Audio -> Wei
-export const parseWeiNumber = number => {
+export const parseWeiNumber = (number: string) => {
   if (checkOnlyNumeric(number)) {
     return new BN(number).mul(WEI)
   } else if (checkOnlyWeiFloat(number)) {


### PR DESCRIPTION
### Description

Fixes issue where long titles mess up RemixesScreen text wrapping

Before:
![367B05C3-5FD2-481C-81D7-1B77BC47CAA0](https://user-images.githubusercontent.com/8230000/167750086-3462d264-f641-4830-a9d5-f8683d61baf8.png)
After: 
<img width="417" alt="image" src="https://user-images.githubusercontent.com/8230000/167750107-e4743a25-6f12-4281-9b30-f70d1ef130a0.png">


Learned that Pressable has a bug where it doesn't align well with text, the suggested workaround is to just use the onPress on Text components since we don't care about onPresIn, onPressOut: https://stackoverflow.com/questions/66590167/vertically-align-pressable-inside-a-text-component 