### PR TITLE
[C-416] Fix swiping behavior with tabs/notifications on android

### DIFF
--- a/packages/mobile/src/components/top-tab-bar/TopTabNavigator.tsx
+++ b/packages/mobile/src/components/top-tab-bar/TopTabNavigator.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from 'react'
+import { ComponentType, ReactNode, useContext } from 'react'
 
 import {
   createMaterialTopTabNavigator,
@@ -7,6 +7,7 @@ import {
 import { SvgProps } from 'react-native-svg'
 
 import { TopTabBar } from 'app/components/top-tab-bar'
+import { NotificationsDrawerNavigationContext } from 'app/screens/notifications-screen/NotificationsDrawerNavigationContext'
 import { makeStyles } from 'app/styles'
 
 const Tab = createMaterialTopTabNavigator()
@@ -29,6 +30,9 @@ export const TabNavigator = ({
   screenOptions
 }: TabNavigatorProps) => {
   const styles = useStyles()
+
+  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
+
   return (
     <Tab.Navigator
       initialRouteName={initialScreenName}
@@ -38,6 +42,12 @@ export const TabNavigator = ({
         tabBarLabelStyle: styles.label,
         tabBarIndicatorStyle: styles.indicator,
         ...screenOptions
+      }}
+      screenListeners={{
+        state: (e: any) => {
+          const { index } = e?.data?.state
+          drawerNavigation?.setOptions({ swipeEnabled: index === 0 })
+        }
       }}
     >
       {children}

--- a/packages/mobile/src/components/top-tab-bar/TopTabNavigator.tsx
+++ b/packages/mobile/src/components/top-tab-bar/TopTabNavigator.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode, useContext } from 'react'
+import { ComponentType, ReactNode } from 'react'
 
 import {
   createMaterialTopTabNavigator,
@@ -7,7 +7,6 @@ import {
 import { SvgProps } from 'react-native-svg'
 
 import { TopTabBar } from 'app/components/top-tab-bar'
-import { NotificationsDrawerNavigationContext } from 'app/screens/notifications-screen/NotificationsDrawerNavigationContext'
 import { makeStyles } from 'app/styles'
 
 const Tab = createMaterialTopTabNavigator()
@@ -31,8 +30,6 @@ export const TabNavigator = ({
 }: TabNavigatorProps) => {
   const styles = useStyles()
 
-  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
-
   return (
     <Tab.Navigator
       initialRouteName={initialScreenName}
@@ -42,12 +39,6 @@ export const TabNavigator = ({
         tabBarLabelStyle: styles.label,
         tabBarIndicatorStyle: styles.indicator,
         ...screenOptions
-      }}
-      screenListeners={{
-        state: (e: any) => {
-          const { index } = e?.data?.state
-          drawerNavigation?.setOptions({ swipeEnabled: index === 0 })
-        }
       }}
     >
       {children}

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -104,8 +104,9 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
           } else {
             // If on the first tab (or the first stack screen isn't a tab navigator),
             // enable the drawer
+            const isOnFirstTab = !e?.data?.state.routes[0].state?.index
             drawerNavigation?.setOptions({
-              swipeEnabled: !e?.data?.state.routes[0].state?.index
+              swipeEnabled: isOnFirstTab
             })
           }
         },

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -104,10 +104,9 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
           } else {
             // If on the first tab (or the first stack screen isn't a tab navigator),
             // enable the drawer
-            const isOnFirstTab = !e?.data?.state.routes[0].state?.index
-            if (isOnFirstTab) {
-              drawerNavigation?.setOptions({ swipeEnabled: true })
-            }
+            drawerNavigation?.setOptions({
+              swipeEnabled: !e?.data?.state.routes[0].state?.index
+            })
           }
         },
         beforeRemove: e => {

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -1,10 +1,6 @@
-import { useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 
-import {
-  EventArg,
-  NavigationState,
-  useNavigation
-} from '@react-navigation/native'
+import { EventArg, NavigationState } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { FavoriteType } from 'audius-client/src/common/models/Favorite'
 import { ID } from 'audius-client/src/common/models/Identifiers'
@@ -33,6 +29,7 @@ import {
 import { SearchPlaylist, SearchTrack } from 'app/store/search/types'
 
 import { EditPlaylistScreen } from '../edit-playlist-screen/EditPlaylistScreen'
+import { NotificationsDrawerNavigationContext } from '../notifications-screen/NotificationsDrawerNavigationContext'
 import { TrackRemixesScreen } from '../track-screen/TrackRemixesScreen'
 
 import { useAppScreenOptions } from './useAppScreenOptions'
@@ -83,8 +80,7 @@ type AppTabScreenProps = {
 export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
   const dispatchWeb = useDispatchWeb()
   const screenOptions = useAppScreenOptions()
-  const navigation = useNavigation()
-  const drawerNavigation = navigation.getParent()?.getParent()
+  const { drawerNavigation } = useContext(NotificationsDrawerNavigationContext)
   const { isOpen: isNowPlayingDrawerOpen } = useDrawer('NowPlaying')
 
   useEffect(() => {
@@ -106,7 +102,12 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
             // If coming from notifs allow swipe to open notifs drawer
             drawerNavigation?.setOptions({ swipeEnabled: !!isFromNotifs })
           } else {
-            drawerNavigation?.setOptions({ swipeEnabled: true })
+            // If on the first tab (or the first stack screen isn't a tab navigator),
+            // enable the drawer
+            const isOnFirstTab = !e?.data?.state.routes[0].state?.index
+            if (isOnFirstTab) {
+              drawerNavigation?.setOptions({ swipeEnabled: true })
+            }
           }
         },
         beforeRemove: e => {

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -76,12 +76,12 @@ export const useAppScreenOptions = () => {
   const navigation = useNavigation<
     AppScreenParamList & AppTabScreenParamList['Search']
   >()
-  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
+  const { drawerHelpers } = useContext(NotificationsDrawerNavigationContext)
 
   const handlePressNotification = useCallback(() => {
-    drawerNavigation?.openDrawer()
+    drawerHelpers?.openDrawer()
     dispatchWeb(markAllAsViewed())
-  }, [dispatchWeb, drawerNavigation])
+  }, [dispatchWeb, drawerHelpers])
 
   const handlePressHome = useCallback(() => {
     navigation.navigate({
@@ -135,7 +135,7 @@ export const useAppScreenOptions = () => {
                   {...other}
                   onPress={() => {
                     if (isFromNotifs) {
-                      drawerNavigation?.openDrawer()
+                      drawerHelpers?.openDrawer()
                     }
 
                     navigation.goBack()
@@ -199,7 +199,7 @@ export const useAppScreenOptions = () => {
       }
     },
     [
-      drawerNavigation,
+      drawerHelpers,
       handlePressNotification,
       handlePressHome,
       handlePressSearch,

--- a/packages/mobile/src/screens/notifications-screen/NotificationBlock.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationBlock.tsx
@@ -201,10 +201,10 @@ const NotificationBlock = ({ notification }: NotificationBlockProps) => {
     fromNotifications: true
   })
   const notificationRoute = getNotificationRoute(notification)
-  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
+  const { drawerHelpers } = useContext(NotificationsDrawerNavigationContext)
   const navigation = useNavigation<
     AppTabScreenParamList & ProfileTabScreenParamList
-  >({ customNativeNavigation: drawerNavigation })
+  >({ customNativeNavigation: drawerHelpers })
 
   const onPress = useCallback(() => {
     if (notificationRoute && notificationScreen) {

--- a/packages/mobile/src/screens/notifications-screen/NotificationsDrawerNavigationContext.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationsDrawerNavigationContext.tsx
@@ -1,24 +1,32 @@
 import { createContext, ReactNode } from 'react'
 
 import { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
+import { NavigationProp } from '@react-navigation/native'
 
 type NotificationsDrawerNavigationContextValue =
-  | DrawerNavigationHelpers
-  | undefined
+  | {
+      drawerHelpers: DrawerNavigationHelpers
+      drawerNavigation?: NavigationProp<any>
+    }
+  | Record<string, never>
 
 export const NotificationsDrawerNavigationContext = createContext<
   NotificationsDrawerNavigationContextValue
->(undefined)
+>({})
 
 export const NotificationsDrawerNavigationContextProvider = ({
+  drawerHelpers,
   drawerNavigation,
   children
 }: {
-  drawerNavigation: DrawerNavigationHelpers
+  drawerHelpers: DrawerNavigationHelpers
+  drawerNavigation?: NavigationProp<any>
   children: ReactNode
 }) => {
   return (
-    <NotificationsDrawerNavigationContext.Provider value={drawerNavigation}>
+    <NotificationsDrawerNavigationContext.Provider
+      value={{ drawerHelpers, drawerNavigation }}
+    >
       {children}
     </NotificationsDrawerNavigationContext.Provider>
   )

--- a/packages/mobile/src/screens/notifications-screen/NotificationsScreen.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationsScreen.tsx
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
  */
 export const NotificationsScreen = memo(() => {
   const dispatchWeb = useDispatchWeb()
-  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
+  const { drawerHelpers } = useContext(NotificationsDrawerNavigationContext)
   const isDrawerOpen = useDrawerStatus() === 'open'
   const wasDrawerOpen = usePrevious(isDrawerOpen)
   useEffect(() => {
@@ -37,8 +37,8 @@ export const NotificationsScreen = memo(() => {
   }, [isDrawerOpen, wasDrawerOpen, dispatchWeb])
 
   const onClickTopBarClose = useCallback(() => {
-    drawerNavigation?.closeDrawer()
-  }, [drawerNavigation])
+    drawerHelpers?.closeDrawer()
+  }, [drawerHelpers])
 
   const containerStyle = useTheme(styles.container, {
     backgroundColor: 'background'

--- a/packages/mobile/src/screens/notifications-screen/content/Entity.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/Entity.tsx
@@ -27,8 +27,8 @@ type EntityProps = {
 
 const Entity = ({ entity, entityType }: EntityProps) => {
   const dispatch = useDispatch()
-  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
-  const navigation = useNavigation({ customNativeNavigation: drawerNavigation })
+  const { drawerHelpers } = useContext(NotificationsDrawerNavigationContext)
+  const navigation = useNavigation({ customNativeNavigation: drawerHelpers })
   const onPress = useCallback(() => {
     navigation.navigate({
       native: getEntityScreen(entity, entityType, {

--- a/packages/mobile/src/screens/notifications-screen/content/User.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/User.tsx
@@ -24,8 +24,8 @@ type UserProps = {
 
 const User = ({ user }: UserProps) => {
   const dispatch = useDispatch()
-  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
-  const navigation = useNavigation({ customNativeNavigation: drawerNavigation })
+  const { drawerHelpers } = useContext(NotificationsDrawerNavigationContext)
+  const navigation = useNavigation({ customNativeNavigation: drawerHelpers })
 
   const onPress = useCallback(() => {
     navigation.navigate({

--- a/packages/mobile/src/screens/notifications-screen/content/UserImages.tsx
+++ b/packages/mobile/src/screens/notifications-screen/content/UserImages.tsx
@@ -49,8 +49,8 @@ const UserImage = ({
   allowPress?: boolean
 }) => {
   const dispatch = useDispatch()
-  const drawerNavigation = useContext(NotificationsDrawerNavigationContext)
-  const navigation = useNavigation({ customNativeNavigation: drawerNavigation })
+  const { drawerHelpers } = useContext(NotificationsDrawerNavigationContext)
+  const navigation = useNavigation({ customNativeNavigation: drawerHelpers })
 
   const handlePress = useCallback(() => {
     navigation.navigate({

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -3,7 +3,7 @@ import {
   DrawerContentComponentProps
 } from '@react-navigation/drawer'
 import { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
-import { NavigatorScreenParams } from '@react-navigation/native'
+import { NavigatorScreenParams, useNavigation } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { Dimensions } from 'react-native'
 import { useSelector } from 'react-redux'
@@ -48,9 +48,17 @@ const SignOnStack = () => {
 /**
  * The main stack after signing up or signing in
  */
-const MainStack = ({ navigation }: { navigation: DrawerNavigationHelpers }) => {
+const MainStack = ({
+  navigation: drawerHelpers
+}: {
+  navigation: DrawerNavigationHelpers
+}) => {
+  const drawerNavigation = useNavigation()
   return (
-    <NotificationsDrawerNavigationContextProvider drawerNavigation={navigation}>
+    <NotificationsDrawerNavigationContextProvider
+      drawerNavigation={drawerNavigation}
+      drawerHelpers={drawerHelpers}
+    >
       <Stack.Navigator
         screenOptions={{ gestureEnabled: false, headerShown: false }}
       >
@@ -64,10 +72,10 @@ const MainStack = ({ navigation }: { navigation: DrawerNavigationHelpers }) => {
  * The contents of the notifications drawer, which swipes in
  */
 const NotificationsDrawerContents = ({
-  navigation
+  navigation: drawerHelpers
 }: DrawerContentComponentProps) => {
   return (
-    <NotificationsDrawerNavigationContextProvider drawerNavigation={navigation}>
+    <NotificationsDrawerNavigationContextProvider drawerHelpers={drawerHelpers}>
       <NotificationsScreen />
     </NotificationsDrawerNavigationContextProvider>
   )


### PR DESCRIPTION
### Description
* Prevents the notification drawer from opening when swiping tabs on android. Luckily android doesn't have the same nondeterminism in gesture handlers so I was able to do this completely in js, didn't have to touch native android code

https://user-images.githubusercontent.com/19916043/167898569-99c9f7c1-4924-42e9-8bcd-0416ab30c861.mp4

* Refactors the NotificationDrawer context to provide the actual drawer navigation as well as the drawer helpers

### Dragons

Toggling the notification drawer on and off has a slight delay so occasionally if swiping very quickly it can still open when it shouldn't. It's pretty minor though

### How Has This Been Tested?

android and ios

### How will this change be monitored?

TestFlight / play store beta
