### PR TITLE
[C-460] Enable os back on android

### DIFF
--- a/packages/mobile/src/components/web/WebApp.tsx
+++ b/packages/mobile/src/components/web/WebApp.tsx
@@ -13,7 +13,6 @@ import {
   Platform,
   NativeSyntheticEvent,
   Linking,
-  BackHandler,
   StatusBar,
   StyleSheet
 } from 'react-native'
@@ -270,37 +269,6 @@ const WebApp = ({
   useEffect(() => {
     resetServerInterval()
   }, [resetServerInterval])
-
-  const backHandler = useCallback(() => {
-    if (webRef.current) {
-      if (isOnFirstPage && Platform.OS === 'android') {
-        BackHandler.exitApp()
-      } else {
-        if (Platform.OS === 'android') {
-          postMessage(webRef.current, {
-            type: MessageType.GO_BACK,
-            isAction: true
-          })
-        } else {
-          webRef.current.goBack()
-        }
-      }
-      // Prevent default (exit app)
-      return true
-    }
-    return false
-  }, [webRef, isOnFirstPage])
-
-  useEffect(() => {
-    if (Platform.OS === 'android') {
-      BackHandler.addEventListener('hardwareBackPress', backHandler)
-    }
-    return () => {
-      if (Platform.OS === 'android') {
-        BackHandler.removeEventListener('hardwareBackPress', backHandler)
-      }
-    }
-  }, [backHandler])
 
   const pushRoute = useCallback(
     (routeUrl: string) => {


### PR DESCRIPTION
### Description
* Allow os back button to be handled by react navigation by removing custom handler in WebView

### Dragons

Previously we were sending a `nav-go-back` action to web but I believe this is no longer necessary because we are updating the web route after the native route changes

### How Has This Been Tested?

android and ios

### How will this change be monitored?

TestFlight / play store beta
