### PR TITLE
Remove numeric separators to fix react native build

### DIFF
--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -359,7 +359,7 @@ export const AudioScreen = () => {
           tierNumber={3}
           title='gold'
           colors={['rgb(236, 173, 11)', 'rgb(236, 173, 11)']}
-          minAmount={10_000}
+          minAmount={10000}
           image={<Image source={Gold} />}
           isCurrentTier={tierNumber === 2}
         />
@@ -367,7 +367,7 @@ export const AudioScreen = () => {
           tierNumber={4}
           title='platinum'
           colors={['rgb(179, 236, 249)', 'rgb(87, 194, 215)']}
-          minAmount={100_000}
+          minAmount={100000}
           image={<Image source={Platinum} />}
           isCurrentTier={tierNumber === 3}
         />


### PR DESCRIPTION
### Description
* Numeric separators break the react native build 😞 : https://app.circleci.com/pipelines/github/AudiusProject/audius-client/5183/workflows/8846317f-18b8-4bb4-9c81-ac2ccd5977d2/jobs/38878

Tried some solutions in here https://github.com/facebook/metro/issues/645 but they didn't work so I opted to remove the separators

### Dragons

n/a

### How Has This Been Tested?

built locally

### How will this change be monitored?

circle ci
