### PR TITLE
Remove CI steps for old way of handling AASA file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ workflows:
           mapping: |
             packages/web/.* run-web-workflow true
             packages/mobile/.* run-mobile-workflow true
+            .circleci/.* run-web-workflow true
+            .circleci/.* run-mobile-workflow true
           name: trigger-relevant-workflows
           filters:
             branches:

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -192,8 +192,7 @@ web-deploy-staging-s3:
     - run:
         name: Deploy to S3
         command: |
-          aws s3 sync --exclude ./packages/web/resources/apple-app-site-association --exclude "packages/web/sitemaps/*" packages/web/build-staging s3://staging.audius.co --delete --cache-control max-age=0
-          aws s3 cp ./packages/web/resources/apple-app-site-association s3://staging.audius.co --cache-control max-age=0 --content-type 'application/json' --metadata-directive REPLACE
+          aws s3 sync --exclude "packages/web/sitemaps/*" packages/web/build-staging s3://staging.audius.co --delete --cache-control max-age=0
 
 web-deploy-staging-cloudflare:
   working_directory: ~/audius-client
@@ -261,9 +260,8 @@ web-deploy-production-s3:
         name: Deploy to S3
         # Deploy, but exclude sourcemaps
         command: |
-          aws s3 sync --exclude "*.map" --exclude ./packages/web/resources/apple-app-site-association --exclude robots.txt --exclude "packages/web/sitemaps/*" packages/web/build-production s3://audius.co --delete --cache-control max-age=604800
+          aws s3 sync --exclude "*.map" --exclude robots.txt --exclude "packages/web/sitemaps/*" packages/web/build-production s3://audius.co --delete --cache-control max-age=604800
           aws s3 cp s3://audius.co/index.html s3://audius.co/index.html --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --metadata-directive REPLACE --acl public-read
-          aws s3 cp ./packages/web/resources/apple-app-site-association s3://audius.co --cache-control max-age=0 --content-type 'application/json' --metadata-directive REPLACE
           aws s3 cp packages/web/robots.txt s3://audius.co --cache-control max-age=0 --content-type 'application/json' --metadata-directive REPLACE
     - run:
         name: Invalidate cache


### PR DESCRIPTION
### Description

* A couple of build steps are failing because they are looking for the old location of the AASA file. I believe these steps are no longer necessary because the AASA file is part of the build in the public folder now
* Updates ci config to trigger both web and mobile flows when only ci config has changed

### Dragons

Possibly breaking AASA

### How Has This Been Tested?

Waiting for CI steps to pass

### How will this change be monitored?

Verify that CI passes and universal links continue to function
