### PR TITLE
[PAY-212] Add ErrorBoundary to NotificationTile

### DIFF
--- a/packages/web/src/components/notification/Notification/Notification.tsx
+++ b/packages/web/src/components/notification/Notification/Notification.tsx
@@ -13,6 +13,7 @@ import {
   Notification as Notifications,
   NotificationType
 } from 'common/store/notifications/types'
+import ErrorWrapper from 'components/error-wrapper/ErrorWrapper'
 
 import { AnnouncementNotification } from './AnnouncementNotification'
 import { ChallengeRewardNotification } from './ChallengeRewardNotification'
@@ -64,57 +65,66 @@ export const Notification = (props: NotificationProps) => {
     entities
   } as unknown) as Notifications
 
-  switch (notification.type) {
-    case NotificationType.Announcement: {
-      return <AnnouncementNotification notification={notification} />
-    }
-    case NotificationType.ChallengeReward: {
-      return <ChallengeRewardNotification notification={notification} />
-    }
-    case NotificationType.Favorite: {
-      return <FavoriteNotification notification={notification} />
-    }
-    case NotificationType.Follow: {
-      return <FollowNotification notification={notification} />
-    }
-    case NotificationType.Milestone: {
-      return <MilestoneNotification notification={notification} />
-    }
-    case NotificationType.RemixCosign: {
-      return <RemixCosignNotification notification={notification} />
-    }
-    case NotificationType.RemixCreate: {
-      return <RemixCreateNotification notification={notification} />
-    }
-    case NotificationType.Repost: {
-      return <RepostNotification notification={notification} />
-    }
-    case NotificationType.TierChange: {
-      return <TierChangeNotification notification={notification} />
-    }
-    case NotificationType.TipReaction: {
-      return <TipReactionNotification notification={notification} />
-    }
-    case NotificationType.TipReceived: {
-      return <TipReceivedNotification notification={notification} />
-    }
-    case NotificationType.TipSent: {
-      return <TipSentNotification notification={notification} />
-    }
-    case NotificationType.TopSupporter: {
-      return <TopSupporterNotification notification={notification} />
-    }
-    case NotificationType.TopSupporting: {
-      return <TopSupportingNotification notification={notification} />
-    }
-    case NotificationType.TrendingTrack: {
-      return <TrendingTrackNotification notification={notification} />
-    }
-    case NotificationType.UserSubscription: {
-      return <UserSubscriptionNotification notification={notification} />
-    }
-    default: {
-      return null
+  const getNotificationElement = () => {
+    switch (notification.type) {
+      case NotificationType.Announcement: {
+        return <AnnouncementNotification notification={notification} />
+      }
+      case NotificationType.ChallengeReward: {
+        return <ChallengeRewardNotification notification={notification} />
+      }
+      case NotificationType.Favorite: {
+        return <FavoriteNotification notification={notification} />
+      }
+      case NotificationType.Follow: {
+        return <FollowNotification notification={notification} />
+      }
+      case NotificationType.Milestone: {
+        return <MilestoneNotification notification={notification} />
+      }
+      case NotificationType.RemixCosign: {
+        return <RemixCosignNotification notification={notification} />
+      }
+      case NotificationType.RemixCreate: {
+        return <RemixCreateNotification notification={notification} />
+      }
+      case NotificationType.Repost: {
+        return <RepostNotification notification={notification} />
+      }
+      case NotificationType.TierChange: {
+        return <TierChangeNotification notification={notification} />
+      }
+      case NotificationType.TipReaction: {
+        return <TipReactionNotification notification={notification} />
+      }
+      case NotificationType.TipReceived: {
+        return <TipReceivedNotification notification={notification} />
+      }
+      case NotificationType.TipSent: {
+        return <TipSentNotification notification={notification} />
+      }
+      case NotificationType.TopSupporter: {
+        return <TopSupporterNotification notification={notification} />
+      }
+      case NotificationType.TopSupporting: {
+        return <TopSupportingNotification notification={notification} />
+      }
+      case NotificationType.TrendingTrack: {
+        return <TrendingTrackNotification notification={notification} />
+      }
+      case NotificationType.UserSubscription: {
+        return <UserSubscriptionNotification notification={notification} />
+      }
+      default: {
+        return null
+      }
     }
   }
+  return (
+    <ErrorWrapper
+      errorMessage={`Could not render notification ${notification.id}`}
+    >
+      {getNotificationElement()}
+    </ErrorWrapper>
+  )
 }

--- a/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
+++ b/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
@@ -13,6 +13,7 @@ import {
   toggleNotificationPanel
 } from 'common/store/notifications/actions'
 import { Notification } from 'common/store/notifications/types'
+import ErrorWrapper from 'components/error-wrapper/ErrorWrapper'
 
 import styles from './NotificationTile.module.css'
 
@@ -43,16 +44,18 @@ export const NotificationTile = (props: NotificationTileProps) => {
   )
 
   return (
-    <div
-      className={cn(styles.root, {
-        [styles.read]: isRead,
-        [styles.active]: !disabled
-      })}
-      tabIndex={0}
-      role='button'
-      onClick={handleClick}
-    >
-      {children}
-    </div>
+    <ErrorWrapper errorMessage={`Could not render notification ${id}`}>
+      <div
+        className={cn(styles.root, {
+          [styles.read]: isRead,
+          [styles.active]: !disabled
+        })}
+        tabIndex={0}
+        role='button'
+        onClick={handleClick}
+      >
+        {children}
+      </div>
+    </ErrorWrapper>
   )
 }

--- a/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
+++ b/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
@@ -13,7 +13,6 @@ import {
   toggleNotificationPanel
 } from 'common/store/notifications/actions'
 import { Notification } from 'common/store/notifications/types'
-import ErrorWrapper from 'components/error-wrapper/ErrorWrapper'
 
 import styles from './NotificationTile.module.css'
 
@@ -44,18 +43,16 @@ export const NotificationTile = (props: NotificationTileProps) => {
   )
 
   return (
-    <ErrorWrapper errorMessage={`Could not render notification ${id}`}>
-      <div
-        className={cn(styles.root, {
-          [styles.read]: isRead,
-          [styles.active]: !disabled
-        })}
-        tabIndex={0}
-        role='button'
-        onClick={handleClick}
-      >
-        {children}
-      </div>
-    </ErrorWrapper>
+    <div
+      className={cn(styles.root, {
+        [styles.read]: isRead,
+        [styles.active]: !disabled
+      })}
+      tabIndex={0}
+      role='button'
+      onClick={handleClick}
+    >
+      {children}
+    </div>
   )
 }


### PR DESCRIPTION
### Description

Adds ErrorBoundary to NotificationTile so issues with notification tiles don't break the whole page. This is necessary because we are still not strictly typing notification types, so there are cases where we expect users to be present when they aren't. Hoping to address this after native notifications, since the notification types need to be changed wholesale!
