### PR TITLE
[C-537] Add button corner prop, text inherit color

### DIFF
--- a/packages/mobile/src/components/core/Button.tsx
+++ b/packages/mobile/src/components/core/Button.tsx
@@ -317,8 +317,6 @@ export const Button = (props: ButtonProps) => {
 
   const PressableComponent = url ? Link : Pressable
 
-  console.log(styles.root)
-
   return (
     <View
       style={rootHeightRef.current ? { height: rootHeightRef.current } : null}

--- a/packages/mobile/src/components/core/Button.tsx
+++ b/packages/mobile/src/components/core/Button.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, useCallback, useRef, useState } from 'react'
+import { ComponentType, useCallback, useMemo, useRef, useState } from 'react'
 
 import { merge } from 'lodash'
 import {
@@ -24,7 +24,10 @@ import { useThemeColors } from 'app/utils/theme'
 import { Link } from './Link'
 
 const useStyles = makeStyles(
-  ({ palette, spacing, typography }, { isPressing, size, variant }) => {
+  (
+    { palette, spacing, typography },
+    { isPressing, size, variant, corners }
+  ) => {
     const variantStyles = {
       primary: {
         root: {
@@ -146,12 +149,24 @@ const useStyles = makeStyles(
       }
     }
 
+    const cornerStyles = {
+      rounded: {
+        root: {
+          borderRadius: spacing(1)
+        }
+      },
+      pill: {
+        root: {
+          borderRadius: spacing(10)
+        }
+      }
+    }
+
     const baseStyles = {
       root: {
         ...flexRowCentered(),
         justifyContent: 'center',
-        alignSelf: 'center',
-        borderRadius: 4
+        alignSelf: 'center'
       },
       button: {
         ...flexRowCentered(),
@@ -167,7 +182,8 @@ const useStyles = makeStyles(
       baseStyles,
       variantStyles[variant],
       isPressing && variantPressingStyles[variant],
-      sizeStyles[size]
+      sizeStyles[size],
+      cornerStyles[corners]
     )
   }
 )
@@ -189,6 +205,7 @@ export type ButtonProps = RNButtonProps &
     variant?: 'primary' | 'secondary' | 'common' | 'commonAlt'
     haptics?: boolean | 'light' | 'medium'
     url?: string
+    corners?: 'rounded' | 'pill'
   }
 
 export const Button = (props: ButtonProps) => {
@@ -208,10 +225,17 @@ export const Button = (props: ButtonProps) => {
     variant = 'primary',
     haptics,
     url,
+    corners = 'rounded',
     ...other
   } = props
   const [isPressing, setIsPressing] = useState(false)
-  const styles = useStyles({ isPressing, size, variant })
+  const stylesConfig = useMemo(() => ({ isPressing, size, variant, corners }), [
+    isPressing,
+    size,
+    variant,
+    corners
+  ])
+  const styles = useStyles(stylesConfig)
   const rootHeightRef = useRef(0)
   const {
     scale,
@@ -292,6 +316,8 @@ export const Button = (props: ButtonProps) => {
   ) : null
 
   const PressableComponent = url ? Link : Pressable
+
+  console.log(styles.root)
 
   return (
     <View

--- a/packages/mobile/src/components/core/Text.tsx
+++ b/packages/mobile/src/components/core/Text.tsx
@@ -7,7 +7,7 @@ import { FontWeight, makeStyles, typography } from 'app/styles'
 export type TextProps = RNTextProps & {
   variant?: keyof typeof typography
   noGutter?: boolean
-  color?: 'primary' | 'secondary' | 'neutral' | 'neutralLight4'
+  color?: 'primary' | 'secondary' | 'neutral' | 'neutralLight4' | 'inherit'
   weight?: FontWeight
 }
 
@@ -15,7 +15,7 @@ const useStyles = makeStyles(
   ({ typography, palette }, { variant, noGutter, color, weight }) => ({
     root: {
       ...typography[variant],
-      color: palette[color],
+      ...(color === 'inherit' ? null : { color: palette[color] }),
       ...(weight ? { fontFamily: typography.fontByWeight[weight] } : null),
       ...(noGutter && { marginBottom: 0 })
     }


### PR DESCRIPTION
### Description

- Adds `corner` prop to button
- Adds `inherit` option for `color` prop for text

<img width="389" alt="image" src="https://user-images.githubusercontent.com/8230000/169897573-83fcb227-d02f-4bbe-b185-8c37ab0ac94e.png">


### Dragons

is `corner` the prop type we want here? the goal is to have a "variant" type option for pill vs rounded buttons.