### PR TITLE
[PAY-199] Switch to new Scrollbar in NotificationPanel

### DIFF
--- a/packages/web/src/components/notification/NotificationPanel.module.css
+++ b/packages/web/src/components/notification/NotificationPanel.module.css
@@ -50,16 +50,10 @@
 }
 
 .scrollContent {
-  overflow-y: scroll;
   max-height: calc(100vh - 333px);
   background: var(--white);
   border-radius: 0px 0px 8px 8px;
 }
-
-.scrollContent::-webkit-scrollbar {
-  display: none;
-}
-
 /*
  * The simplebar doesn't do calculations correctly because it races
  * with the modal opening

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -1,12 +1,11 @@
 import React, { useRef, useCallback, useEffect } from 'react'
 
-import { Popup, PopupPosition } from '@audius/stems'
+import { Popup, PopupPosition, Scrollbar } from '@audius/stems'
 import cn from 'classnames'
 import InfiniteScroll from 'react-infinite-scroller'
 import Lottie from 'react-lottie'
 import { useDispatch, useSelector } from 'react-redux'
 import { useSearchParam } from 'react-use'
-import SimpleBar from 'simplebar-react'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'
 import { ReactComponent as IconNotification } from 'assets/img/iconNotification.svg'
@@ -37,11 +36,11 @@ import styles from './NotificationPanel.module.css'
 
 const getNotifications = makeGetAllNotifications()
 
-const simpleBarId = 'notificationsPanelScroll'
+const scrollbarId = 'notificationsPanelScroll'
 
 const getScrollParent = () => {
-  const simpleBarElement = window.document.getElementById(simpleBarId)
-  return simpleBarElement || null
+  const scrollbarElement = window.document.getElementById(scrollbarId)
+  return scrollbarElement || null
 }
 
 const messages = {
@@ -56,7 +55,7 @@ type NotificationPanelProps = {
 
 // The threshold of distance from the bottom of the scroll container in the
 // notification panel before requesting `loadMore` for more notifications
-const SCROLL_THRESHOLD = 1000
+const SCROLL_THRESHOLD = 400
 
 /** The notification panel displays the list of notifications w/ a
  * summary of each notification and a link to open the full
@@ -72,14 +71,9 @@ export const NotificationPanel = ({ anchorRef }: NotificationPanelProps) => {
   const isUserListOpen = useSelector(getIsUserListOpen)
 
   const panelRef = useRef<Nullable<HTMLDivElement>>(null)
-  const scrollRef = useRef<Nullable<HTMLDivElement>>(null)
 
   const dispatch = useDispatch()
   const openNotifications = useSearchParam('openNotifications')
-
-  const setSimpleBarRef = useCallback(el => {
-    el.recalculate()
-  }, [])
 
   const handleCloseNotificationModal = useCallback(() => {
     dispatch(setNotificationModal(false))
@@ -140,11 +134,7 @@ export const NotificationPanel = ({ anchorRef }: NotificationPanelProps) => {
             </div>
           ) : null}
           {hasLoaded && notifications.length > 0 ? (
-            <SimpleBar
-              className={styles.scrollContent}
-              ref={setSimpleBarRef}
-              scrollableNodeProps={{ id: simpleBarId, ref: scrollRef }}
-            >
+            <Scrollbar className={styles.scrollContent} id={scrollbarId}>
               <InfiniteScroll
                 pageStart={0}
                 loadMore={loadMore}
@@ -178,7 +168,7 @@ export const NotificationPanel = ({ anchorRef }: NotificationPanelProps) => {
                   ) : null}
                 </div>
               </InfiniteScroll>
-            </SimpleBar>
+            </Scrollbar>
           ) : null}
           {hasLoaded && notifications.length === 0 ? (
             <EmptyNotifications />


### PR DESCRIPTION
### Description
Old:
![notifsold](https://user-images.githubusercontent.com/36916764/170101136-c75cc806-2db0-4394-9d2f-4a994f5fdc71.gif)

The scrollbar had issues recalculating its size and when you closed and re-opened the panel, the scrollbar was extremely small no matter how few notifs there were.

New:
![notifsnew](https://user-images.githubusercontent.com/36916764/170101219-30817d9f-49be-4128-9c0e-18df9202a334.gif)

Now: issues are fixed

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in browser (Safari and Chrome) using accounts with and without enough notifs to trigger infinite scroll

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
