### PR TITLE
aud-1172 show lofi in trending genre pickers

### DIFF
--- a/packages/web/src/common/utils/genres.ts
+++ b/packages/web/src/common/utils/genres.ts
@@ -118,7 +118,7 @@ export const GENRES = [
   )
 ]
 
-const NEWLY_ADDED_GENRES: string[] = [Genre.LOFI]
+const NEWLY_ADDED_GENRES: string[] = []
 
 export const TRENDING_GENRES = GENRES.filter(
   g => !NEWLY_ADDED_GENRES.includes(g)


### PR DESCRIPTION
### Description

Previously, the Lo-Fi genre was filtered out of trending genres due to being a new genre. At this point we have enough music to show, so this change reveals lofi music in trending.

### Dragons

N/A

### How Has This Been Tested?

ran client locally against stage

### How will this change be monitored?
N/A
