### PR TITLE
Add new waitForUserRemoteConfig for feature flags that depend on user

### DIFF
--- a/packages/web/src/pages/profile-page/sagas.js
+++ b/packages/web/src/pages/profile-page/sagas.js
@@ -49,7 +49,8 @@ import { waitForValue } from 'utils/sagaHelpers'
 const {
   getRemoteVar,
   getFeatureEnabled,
-  waitForRemoteConfig
+  waitForRemoteConfig,
+  waitForUserRemoteConfig
 } = remoteConfigInstance
 
 function* watchFetchProfile() {
@@ -141,7 +142,13 @@ export function* fetchSolanaCollectibles(user) {
 }
 
 function* fetchSupportersAndSupporting(userId) {
-  yield call(waitForRemoteConfig)
+  try {
+    yield call(waitForUserRemoteConfig)
+  } catch (e) {
+    console.error(`Error waiting for user remote config: ${e.message}`)
+    return
+  }
+
   const isTippingEnabled = getFeatureEnabled(FeatureFlags.TIPPING_ENABLED)
   if (!isTippingEnabled) {
     return

--- a/packages/web/src/pages/profile-page/sagas.js
+++ b/packages/web/src/pages/profile-page/sagas.js
@@ -142,13 +142,7 @@ export function* fetchSolanaCollectibles(user) {
 }
 
 function* fetchSupportersAndSupporting(userId) {
-  try {
-    yield call(waitForUserRemoteConfig)
-  } catch (e) {
-    console.error(`Error waiting for user remote config: ${e.message}`)
-    return
-  }
-
+  yield call(waitForUserRemoteConfig)
   const isTippingEnabled = getFeatureEnabled(FeatureFlags.TIPPING_ENABLED)
   if (!isTippingEnabled) {
     return

--- a/packages/web/src/store/account/sagas.js
+++ b/packages/web/src/store/account/sagas.js
@@ -2,6 +2,7 @@ import { call, put, fork, select, takeEvery } from 'redux-saga/effects'
 
 import Kind from 'common/models/Kind'
 import Status from 'common/models/Status'
+import { USER_ID_AVAILABLE_EVENT } from 'common/services/remote-config/remote-config'
 import * as accountActions from 'common/store/account/reducer'
 import {
   getUserId,
@@ -184,8 +185,12 @@ export function* fetchAccountAsync(action) {
     return
   }
 
-  // Set account ID in remote-config provider
+  // Set account ID and let remote-config provider
+  // know that the user id is available
   remoteConfigInstance.setUserId(account.user_id)
+  const event = new CustomEvent(USER_ID_AVAILABLE_EVENT)
+  window.dispatchEvent(event)
+
   // Fire-and-forget fp identify
   fingerprintClient.identify(account.user_id)
 


### PR DESCRIPTION
### Description

Add new waitForUserRemoteConfig for feature flags that depend on user

### Dragons

n/a

### How Has This Been Tested?

local against stage and tested the tipping feature flag returns true on profile sagas; it used to always be false.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
