### PR TITLE
[C-545] Fix native screen transition jank

### DIFF
--- a/packages/mobile/src/components/core/Screen.tsx
+++ b/packages/mobile/src/components/core/Screen.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, useEffect } from 'react'
+import { ReactElement, ReactNode, useLayoutEffect } from 'react'
 
 import { useNavigation } from '@react-navigation/native'
 import { Nullable } from 'audius-client/src/common/utils/typeUtils'
@@ -48,7 +48,7 @@ export const Screen = (props: ScreenProps) => {
   const styles = useStyles({ variant })
   const navigation = useNavigation()
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     navigation.setOptions(
       removeUndefined({
         headerLeft: topbarLeft === undefined ? undefined : () => topbarLeft,


### PR DESCRIPTION
### Description

Fixes pesky issue where header elements clash between transitioning screens:
Before: 

https://user-images.githubusercontent.com/8230000/170350616-325f8305-7f90-4a8a-8d7c-303ece41b174.mov

After: 

https://user-images.githubusercontent.com/8230000/170350725-47dd1042-eb29-4355-b85c-2f9abc3baa3a.mov
