### PR TITLE
[C-546] Fix USER_ID cohort feature flags on native

### DIFF
--- a/packages/mobile/src/message/handlers/lifecycle.ts
+++ b/packages/mobile/src/message/handlers/lifecycle.ts
@@ -1,3 +1,4 @@
+import { remoteConfigInstance } from 'app/services/remote-config/remote-config-instance'
 import * as lifecycleActions from 'app/store/lifecycle/actions'
 import * as oauthActions from 'app/store/oauth/actions'
 import * as signonActions from 'app/store/signon/actions'
@@ -14,6 +15,7 @@ export const messageHandlers: Partial<MessageHandlers> = {
     reload()
   },
   [MessageType.SIGNED_IN]: ({ message, dispatch }) => {
+    remoteConfigInstance.setUserId(message.account.user_id)
     dispatch(lifecycleActions.signedIn(message.account))
   },
   [MessageType.SIGNED_OUT]: ({ message, dispatch }) => {


### PR DESCRIPTION
### Description

* The user id was never being set on the optimizely client on native, resulting in feature flags with the user_id cohort to always return false. Fixed by setting the user id on the `signed_in` message 

### Dragons

n/a

### How Has This Been Tested?

Confirmed that the TikTok feature flag returns true

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
