### PR TITLE
[PAY-231][PAY-180] Fix Tip Modal Animation Transitions

### DIFF
--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -14,8 +14,12 @@
 
 .modalContentContainer {
   margin: 24px 0;
-  display: flex;
-  justify-content: center;
+  position: relative;
+}
+
+.modalContentContainer > div {
+  position: absolute;
+  width: 100%;
 }
 
 .container {


### PR DESCRIPTION
### Description

Fixes transitions in the tip modal by not getting the state from the selector inside of `ModalContent`. Also gets rid of the custom durations and simplifies the "next/previous" logic.

Before:


https://user-images.githubusercontent.com/3690498/170397327-dcf41827-e0b1-47e9-899b-4655713b6e0e.mov

After:

https://user-images.githubusercontent.com/3690498/170397496-b72d8a4f-8dac-4b0b-b01b-230f92335989.mov

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested locally against stage. Needs QA from design.
