### PR TITLE
Respect order as audio nfts load

### DIFF
--- a/packages/web/src/common/models/User.ts
+++ b/packages/web/src/common/models/User.ts
@@ -36,6 +36,7 @@ export type UserMetadata = {
   spl_wallet: SolanaWalletAddress
   has_collectibles: boolean
   collectibles?: CollectiblesMetadata
+  collectiblesOrderUnset?: boolean
   collectibleList?: Collectible[]
   solanaCollectibleList?: Collectible[]
 

--- a/packages/web/src/pages/profile-page/sagas.js
+++ b/packages/web/src/pages/profile-page/sagas.js
@@ -78,6 +78,14 @@ function* fetchProfileCustomizedCollectibles(user) {
         ])
       )
     } else {
+      yield put(
+        cacheActions.update(Kind.USERS, [
+          {
+            id: user.user_id,
+            metadata: { ...metadata, collectiblesOrderUnset: true }
+          }
+        ])
+      )
       console.log('something went wrong, could not get user collectibles order')
     }
   }


### PR DESCRIPTION
### Description

* Respects the collectible order the user has set as audio nfts dynamically load in
* Respects collectibles that the user has hidden via the collectible `order`
* Improves logic for getting duration and hasAudio to more consistently load as many nfts as possible

This 

### Dragons

This is already released to prod, just merging this final thing from the release branch back onto main.

Some users don't have an `order` set, but there was a racecase where sometimes the `order` simply didn't load quickly enough for a user that did have one set. So I had to update the user metadata with `collectiblesOrderUnset` to disambiguate between these too cases

### How Has This Been Tested?

Locally and in prod

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
