### PR TITLE
[PAY-261] Refactor tipping slice amount type from BNWei to StringAudio

### DIFF
--- a/packages/web/src/common/models/Wallet.ts
+++ b/packages/web/src/common/models/Wallet.ts
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import { Brand } from 'common/utils/typeUtils'
 
 export type StringWei = Brand<string, 'stringWEI'>
-export type StringAudio = Brand<string, 'stringAudio'>
+export type StringAudio = string
 export type BNWei = Brand<BN, 'BNWei'>
 export type BNAudio = Brand<BN, 'BNAudio'>
 

--- a/packages/web/src/common/store/tipping/slice.ts
+++ b/packages/web/src/common/store/tipping/slice.ts
@@ -1,10 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import BN from 'bn.js'
 
 import { ID } from 'common/models/Identifiers'
 import { Supporter, Supporting, UserTip } from 'common/models/Tipping'
 import { User } from 'common/models/User'
-import { BNWei } from 'common/models/Wallet'
 import { TippingState } from 'common/store/tipping/types'
 
 export type RefreshSupportPayloadAction = {
@@ -20,7 +18,7 @@ const initialState: TippingState = {
   send: {
     status: null,
     user: null,
-    amount: new BN('0') as BNWei,
+    amount: '0',
     error: null
   },
   recentTips: [],
@@ -77,7 +75,7 @@ const slice = createSlice({
       state.send.status = 'SEND'
       state.send.user = action.payload.user
     },
-    sendTip: (state, action: PayloadAction<{ amount: BNWei }>) => {
+    sendTip: (state, action: PayloadAction<{ amount: string }>) => {
       if (state.send.status !== 'SEND') {
         return
       }
@@ -106,7 +104,7 @@ const slice = createSlice({
     resetSend: state => {
       state.send.status = null
       state.send.user = null
-      state.send.amount = new BN('0') as BNWei
+      state.send.amount = '0'
       state.send.error = null
     },
     fetchRecentTips: _ => {},

--- a/packages/web/src/common/store/tipping/types.ts
+++ b/packages/web/src/common/store/tipping/types.ts
@@ -1,7 +1,7 @@
 import { ID } from 'common/models/Identifiers'
 import { Supporter, Supporting, UserTip } from 'common/models/Tipping'
 import { User } from 'common/models/User'
-import { BNWei } from 'common/models/Wallet'
+import { StringAudio } from 'common/models/Wallet'
 import { Nullable } from 'common/utils/typeUtils'
 
 export type TippingSendStatus =
@@ -42,7 +42,7 @@ export type TippingState = {
   send: {
     status: Nullable<TippingSendStatus>
     user: Nullable<User>
-    amount: BNWei
+    amount: StringAudio
     error: Nullable<string>
   }
   recentTips: UserTip[]

--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -12,7 +12,6 @@ import {
   getSendUser
 } from 'common/store/tipping/selectors'
 import { confirmSendTip, beginTip } from 'common/store/tipping/slice'
-import { formatWei } from 'common/utils/wallet'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 
 import styles from './TipAudio.module.css'
@@ -83,7 +82,7 @@ export const ConfirmSendTip = () => {
         {messages.sending}
       </div>
       <div className={cn(styles.flexCenter, styles.sendingAudio)}>
-        <span className={styles.sendAmount}>{formatWei(sendAmount, true)}</span>
+        <span className={styles.sendAmount}>{sendAmount}</span>
         $AUDIO
       </div>
     </>

--- a/packages/web/src/components/tipping/tip-audio/SendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/SendTip.tsx
@@ -56,10 +56,7 @@ export const SendTip = () => {
   const accountBalance = (useSelector(getAccountBalance) ??
     new BN('0')) as BNWei
 
-  const [tipAmount, setTipAmount] = useState<StringAudio>('' as StringAudio)
-  const [tipAmountBNWei, setTipAmountBNWei] = useState<BNWei>(
-    new BN('0') as BNWei
-  )
+  const [tipAmount, setTipAmount] = useState('')
 
   const { tier } = getTierAndNumberForBalance(weiToString(accountBalance))
   const audioBadge = audioTierMapPng[tier as BadgeTier]
@@ -120,7 +117,6 @@ export const SendTip = () => {
   useEffect(() => {
     const zeroWei = stringWeiToBN('0' as StringWei)
     const newAmountWei = parseAudioInputToWei(tipAmount) ?? zeroWei
-    setTipAmountBNWei(newAmountWei)
 
     const hasInsufficientBalance = newAmountWei.gt(accountBalance)
     setIsDisabled(hasInsufficientBalance || newAmountWei.lte(zeroWei))
@@ -165,8 +161,8 @@ export const SendTip = () => {
   }, [hasError, account, topSupporter, supporting, accountBalance])
 
   const handleSendClick = useCallback(() => {
-    dispatch(sendTip({ amount: tipAmountBNWei }))
-  }, [dispatch, tipAmountBNWei])
+    dispatch(sendTip({ amount: tipAmount }))
+  }, [dispatch, tipAmount])
 
   const renderBecomeFirstSupporter = () => (
     <div className={cn(styles.flexCenter, styles.becomeTopSupporter)}>

--- a/packages/web/src/components/tipping/tip-audio/TipSent.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipSent.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'common/hooks/useSelector'
 import { Name } from 'common/models/Analytics'
 import { getAccountUser } from 'common/store/account/selectors'
 import { getSendTipData } from 'common/store/tipping/selectors'
-import { formatWei } from 'common/utils/wallet'
+import { formatNumberCommas } from 'common/utils/formatUtil'
 import { useRecord, make } from 'store/analytics/actions'
 import { openTwitterLink } from 'utils/tweet'
 
@@ -30,10 +30,11 @@ export const TipSent = () => {
   const { user: recipient, amount: sendAmount } = sendTipData
 
   const handleShareClick = useCallback(() => {
+    const formattedSendAmount = formatNumberCommas(sendAmount)
     if (account && recipient) {
-      let recipientAndAmount = `${recipient.name} ${formatWei}`
+      let recipientAndAmount = `${recipient.name} ${formattedSendAmount}`
       if (recipient.twitter_handle) {
-        recipientAndAmount = `@${recipient.twitter_handle} ${sendAmount}`
+        recipientAndAmount = `@${recipient.twitter_handle} ${formattedSendAmount}`
       }
       const message = `${messages.twitterCopyPrefix}${recipientAndAmount}${messages.twitterCopySuffix}`
       openTwitterLink(null, message)

--- a/packages/web/src/components/tipping/tip-audio/TipSent.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipSent.tsx
@@ -7,7 +7,7 @@ import { useSelector } from 'common/hooks/useSelector'
 import { Name } from 'common/models/Analytics'
 import { getAccountUser } from 'common/store/account/selectors'
 import { getSendTipData } from 'common/store/tipping/selectors'
-import { formatWei, weiToAudioString } from 'common/utils/wallet'
+import { formatWei } from 'common/utils/wallet'
 import { useRecord, make } from 'store/analytics/actions'
 import { openTwitterLink } from 'utils/tweet'
 
@@ -31,15 +31,9 @@ export const TipSent = () => {
 
   const handleShareClick = useCallback(() => {
     if (account && recipient) {
-      let recipientAndAmount = `${recipient.name} ${formatWei(
-        sendAmount,
-        true
-      )}`
+      let recipientAndAmount = `${recipient.name} ${formatWei}`
       if (recipient.twitter_handle) {
-        recipientAndAmount = `@${recipient.twitter_handle} ${formatWei(
-          sendAmount,
-          true
-        )}`
+        recipientAndAmount = `@${recipient.twitter_handle} ${sendAmount}`
       }
       const message = `${messages.twitterCopyPrefix}${recipientAndAmount}${messages.twitterCopySuffix}`
       openTwitterLink(null, message)
@@ -49,7 +43,7 @@ export const TipSent = () => {
           recipientWallet: recipient.spl_wallet,
           senderHandle: account.handle,
           recipientHandle: recipient.handle,
-          amount: weiToAudioString(sendAmount)
+          amount: sendAmount
         })
       )
     }
@@ -64,7 +58,7 @@ export const TipSent = () => {
         {messages.sentSuccessfully}
       </div>
       <div className={cn(styles.flexCenter, styles.sentAudio)}>
-        <span className={styles.sendAmount}>{formatWei(sendAmount, true)}</span>
+        <span className={styles.sendAmount}>{sendAmount}</span>
         $AUDIO
       </div>
     </>

--- a/packages/web/src/store/tipping/sagas.ts
+++ b/packages/web/src/store/tipping/sagas.ts
@@ -26,7 +26,11 @@ import {
 } from 'common/store/tipping/slice'
 import { getAccountBalance } from 'common/store/wallet/selectors'
 import { decreaseBalance } from 'common/store/wallet/slice'
-import { weiToAudioString, weiToString } from 'common/utils/wallet'
+import {
+  parseAudioInputToWei,
+  weiToAudioString,
+  weiToString
+} from 'common/utils/wallet'
 import {
   fetchRecentUserTips,
   fetchSupporters,
@@ -57,11 +61,12 @@ function* sendTipAsync() {
   }
 
   const sendTipData = yield* select(getSendTipData)
-  const { user: recipient, amount: weiBNAmount } = sendTipData
+  const { user: recipient, amount } = sendTipData
   if (!recipient) {
     return
   }
 
+  const weiBNAmount = parseAudioInputToWei(amount) ?? (new BN('0') as BNWei)
   const recipientWallet = recipient.spl_wallet
   const weiBNBalance: BNWei = yield select(getAccountBalance) ??
     (new BN('0') as BNWei)


### PR DESCRIPTION
### Description

Changes tipping slice amount type from BNWei to StringAudio, which fixes case where `dispatchWeb` incorrectly serializes BNWei (by calling .toString()), resulting in different mobile vs web behavior. Moving to StringWei helps since that is directly serializable across apps.

Also changes StringWei type to be a string alias since it's unclear how these types are actually `string & {_brand: string}` maybe in the future we can change the stringaudio data to properly match these types though.

### Dragons

Changing the underlying type may have messed up the tipping flow, so lets def check this works before merging

### How Has This Been Tested?

Types pass, but a local run-through is needed
