### PR TITLE
Add native notification error boundary

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/NotificationErrorBoundary.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import { PureComponent } from 'react'
+
+import * as Sentry from '@sentry/react-native'
+
+export class NotificationErrorBoundary extends PureComponent {
+  state = {
+    error: null
+  }
+
+  componentDidCatch(error: Error | null, errorInfo: any) {
+    this.setState({ error: error?.message })
+
+    Sentry.withScope(scope => {
+      scope.setExtras(errorInfo)
+      Sentry.captureException(error)
+    })
+  }
+
+  render() {
+    const { error } = this.state
+    const { children } = this.props
+
+    if (error) return null
+    return <>{children}</>
+  }
+}

--- a/packages/mobile/src/screens/notifications-screen/NotificationListItem.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationListItem.tsx
@@ -3,6 +3,7 @@ import {
   NotificationType
 } from 'audius-client/src/common/store/notifications/types'
 
+import { NotificationErrorBoundary } from './NotificationErrorBoundary'
 import {
   FavoriteNotification,
   FollowNotification,
@@ -22,30 +23,39 @@ type NotificationListItemProps = {
 }
 export const NotificationListItem = (props: NotificationListItemProps) => {
   const { notification } = props
-  switch (notification.type) {
-    case NotificationType.Announcement:
-      return <AnnouncementNotification notification={notification} />
-    case NotificationType.ChallengeReward:
-      return <ChallengeRewardNotification notification={notification} />
-    case NotificationType.Favorite:
-      return <FavoriteNotification notification={notification} />
-    case NotificationType.Follow:
-      return <FollowNotification notification={notification} />
-    case NotificationType.Milestone:
-      return <MilestoneNotification notification={notification} />
-    case NotificationType.RemixCosign:
-      return <RemixCosignNotification notification={notification} />
-    case NotificationType.RemixCreate:
-      return <RemixCreateNotification notification={notification} />
-    case NotificationType.Repost:
-      return <RepostNotification notification={notification} />
-    case NotificationType.TierChange:
-      return <TierChangeNotification notification={notification} />
-    case NotificationType.TrendingTrack:
-      return <TrendingTrackNotification notification={notification} />
-    case NotificationType.UserSubscription:
-      return <UserSubscriptionNotification notification={notification} />
-    default:
-      return null
+
+  const renderNotification = () => {
+    switch (notification.type) {
+      case NotificationType.Announcement:
+        return <AnnouncementNotification notification={notification} />
+      case NotificationType.ChallengeReward:
+        return <ChallengeRewardNotification notification={notification} />
+      case NotificationType.Favorite:
+        return <FavoriteNotification notification={notification} />
+      case NotificationType.Follow:
+        return <FollowNotification notification={notification} />
+      case NotificationType.Milestone:
+        return <MilestoneNotification notification={notification} />
+      case NotificationType.RemixCosign:
+        return <RemixCosignNotification notification={notification} />
+      case NotificationType.RemixCreate:
+        return <RemixCreateNotification notification={notification} />
+      case NotificationType.Repost:
+        return <RepostNotification notification={notification} />
+      case NotificationType.TierChange:
+        return <TierChangeNotification notification={notification} />
+      case NotificationType.TrendingTrack:
+        return <TrendingTrackNotification notification={notification} />
+      case NotificationType.UserSubscription:
+        return <UserSubscriptionNotification notification={notification} />
+      default:
+        return null
+    }
   }
+
+  return (
+    <NotificationErrorBoundary>
+      {renderNotification()}
+    </NotificationErrorBoundary>
+  )
 }


### PR DESCRIPTION
### Description

Adds native notification error boundary to prevent weird notification type edge cases from breaking app. This is temporary until we properly type all notifications to prevent run time errors.
