### PR TITLE
[C-552] Fix expandible-bio link render issue

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
+++ b/packages/mobile/src/screens/profile-screen/ExpandableBio.tsx
@@ -54,6 +54,7 @@ export const ExpandableBio = () => {
   const [fullBioHeight, setFullBioHeight] = useState(0)
   const hasSites = Boolean(website || donation)
   const [shouldShowMore, setShouldShowMore] = useState(hasSites)
+  const [isHeightCalculationDone, setIsHeightCalculationDone] = useState(false)
   const [isExpanded, setIsExpanded] = useToggle(false)
 
   const handleBioLayout = useCallback(
@@ -62,8 +63,11 @@ export const ExpandableBio = () => {
 
       if (!fullBioHeight) {
         setFullBioHeight(height)
-      } else if (fullBioHeight > height) {
-        setShouldShowMore(true)
+      } else {
+        if (fullBioHeight > height) {
+          setShouldShowMore(true)
+        }
+        setIsHeightCalculationDone(true)
       }
     },
     [fullBioHeight]
@@ -95,15 +99,23 @@ export const ExpandableBio = () => {
             pointerEvents='box-none'
             style={styles.bioContainer}
           >
-            <Hyperlink
-              source='profile page'
-              style={[
-                styles.bioText,
-                { height: fullBioHeight && !isExpanded ? 32 : 'auto' }
-              ]}
-              text={squashNewLines(bio) ?? ''}
-              allowPointerEventsToPassThrough
-            />
+            {!isHeightCalculationDone || (shouldShowMore && !isExpanded) ? (
+              <Text
+                style={[
+                  styles.bioText,
+                  { height: fullBioHeight ? 32 : 'auto' }
+                ]}
+              >
+                {squashNewLines(bio)}
+              </Text>
+            ) : (
+              <Hyperlink
+                source='profile page'
+                style={[styles.bioText]}
+                text={squashNewLines(bio) ?? ''}
+                allowPointerEventsToPassThrough
+              />
+            )}
           </View>
         ) : null}
         {hasSites && isExpanded ? <Sites /> : null}


### PR DESCRIPTION
### Description

Fixes issue where expandible bio links were rendering on top of one another: 
Before: 
<img width="411" src="https://user-images.githubusercontent.com/8230000/170804438-838ccb93-d4d6-488f-821d-9c2d67913309.jpg">
After: 
<img width="411" alt="image" src="https://user-images.githubusercontent.com/8230000/170804760-37eca92b-32a2-4184-acc8-22d9feb97f74.png">
<img width="411" alt="image" src="https://user-images.githubusercontent.com/8230000/170804767-e7f97515-0860-4384-9a19-f328d0d24463.png">

The render flow that seems to fix this is:

1. Render the bio with `Text` component
2. Check that it's size is large enough to show `expand` button
  - If it's not large enough, replace `Text` with `Hyperlink` component
  - If it is large enough, keep rendering the `Text` component with 32 height when not expanded (setting height on `Hyperlink` is causing the issue i believe), and replace `Text` with `Hyperlink` when expanded

### Dragons

The one not perfect case is when the bio is expandable, but closed. in that case we still render the text element, so any links on the first two lines of bio wont be clickable till the bio is expanded.