### PR TITLE
Fix slider handle position when re-entering from background

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -4369,6 +4369,11 @@
         }
       }
     },
+    "@react-native-community/hooks": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/hooks/-/hooks-2.8.1.tgz",
+      "integrity": "sha512-DCmCIC0Gn9m6K0Mlg2MwNmTxMEpBu5lTLsI6b/XUAv/vLGa6o+X7RhCai4FWeqkjCU36+ZOwaLzDo4NBWMXaoQ=="
+    },
     "@react-native-community/netinfo": {
       "version": "5.9.10",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-5.9.10.tgz",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -43,6 +43,7 @@
     "@react-native-async-storage/async-storage": "1.15.14",
     "@react-native-clipboard/clipboard": "1.9.0",
     "@react-native-community/blur": "3.6.0",
+    "@react-native-community/hooks": "^2.8.1",
     "@react-native-community/netinfo": "5.9.10",
     "@react-native-community/push-notification-ios": "1.10.1",
     "@react-native-firebase/analytics": "14.5.1",

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'react'
 
+import { useAppState } from '@react-native-community/hooks'
 import {
   StyleSheet,
   View,
@@ -281,6 +282,24 @@ export const Slider = memo(
         pause()
       }
     }, [isPlaying, play, pause, mediaKey, durationRef])
+
+    const appState = useAppState()
+
+    /**
+     * Ensures the slider handle's position is correctly updated when app
+     * becomes active.
+     */
+    useEffect(() => {
+      if (appState === 'active') {
+        const { currentTime } = global.progress
+        const percentComplete = currentTime / durationRef.current
+        translationAnim.setValue(percentComplete * railWidth)
+        setHandlePosition(percentComplete * railWidth)
+        if (isPlaying && durationRef.current !== undefined) {
+          play((durationRef.current - currentTime) * 1000)
+        }
+      }
+    }, [isPlaying, appState, play, railWidth, translationAnim])
 
     return (
       <View style={styles.root}>


### PR DESCRIPTION
### Description

Fixes bug where now-playing scrubber is incorrectly positioned when coming back to app, esp after a new song starts.

### Dragons

The code here in general is a bit complex, and this adds yet another useEffect. there are cases where this may be a duplicate call with another useEffect when mediaKey changes. From what i can tell this is okay, though ideally we look at all thees effects and consider ways to make them simpler/work together.
