### PR TITLE
Prevent favorites tab from resetting on navigation

### DIFF
--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -109,7 +109,11 @@ export const TracksTab = () => {
   )
 
   return (
-    <WithLoader loading={savedTracksStatus === Status.LOADING}>
+    <WithLoader
+      loading={
+        savedTracksStatus === Status.LOADING && savedTracks.entries.length === 0
+      }
+    >
       <VirtualizedScrollView listKey='favorites-screen'>
         {!savedTracks.entries.length && !filterValue ? (
           <EmptyTab message={messages.emptyTabText} />

--- a/packages/web/src/pages/saved-page/SavedPageProvider.tsx
+++ b/packages/web/src/pages/saved-page/SavedPageProvider.tsx
@@ -38,6 +38,8 @@ import { profilePage } from 'utils/route'
 import { SavedPageProps as DesktopSavedPageProps } from './components/desktop/SavedPage'
 import { SavedPageProps as MobileSavedPageProps } from './components/mobile/SavedPage'
 
+const IS_NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
+
 const messages = {
   title: 'Favorites',
   description: "View tracks that you've favorited"
@@ -78,7 +80,9 @@ class SavedPage extends PureComponent<SavedPageProps, SavedPageState> {
   }
 
   componentWillUnmount() {
-    this.props.resetSavedTracks()
+    if (!IS_NATIVE_MOBILE) {
+      this.props.resetSavedTracks()
+    }
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
### Description

Fixes bug where favorites tab always resets causing bad user experience

Before: 

https://user-images.githubusercontent.com/8230000/171063496-4f817ce5-6304-4af6-8cea-4e08d8f33c59.MP4

After:

https://user-images.githubusercontent.com/8230000/171063688-004a2420-18be-4c60-ae03-d025db18f124.mov



### Dragons

Just to be safe, we prevent clear only on native
