### PR TITLE
Fix casting for android, setting for ios

### DIFF
--- a/packages/mobile/src/screens/settings-screen/CastSettingsRow.tsx
+++ b/packages/mobile/src/screens/settings-screen/CastSettingsRow.tsx
@@ -5,6 +5,7 @@ import {
   CastMethod,
   updateMethod
 } from 'audius-client/src/common/store/cast/slice'
+import { getMethod as getCastMethod } from 'common/store/cast/selectors'
 
 import Appearance from 'app/assets/images/emojis/waning-crescent-moon.png'
 import { SegmentedControl } from 'app/components/core'
@@ -26,6 +27,7 @@ const messages = {
 export const CastSettingsRow = () => {
   const dispatchWeb = useDispatchWeb()
   const accountUser = useSelectorWeb(getAccountUser)
+  const castMethod = useSelectorWeb(getCastMethod)
 
   const setCastMethod = useCallback(
     (method: CastMethod) => {
@@ -53,7 +55,7 @@ export const CastSettingsRow = () => {
         <SegmentedControl
           fullWidth
           options={castOptions}
-          defaultSelected={'airplay'}
+          defaultSelected={castMethod}
           onSelectOption={setCastMethod}
         />
       </SettingsRowContent>


### PR DESCRIPTION
### Description

Fixes pretty bad bug where now-playing drawer always shows airplay for android devices, always leading to fatal error when clicked. Users can't switch to chromecast either since we dont show the option in settings.

Also fixes bug where ios cast setting doesn't default to the actually selected cast method.
