### PR TITLE
Fix android crash when restoring from background

### DIFF
--- a/packages/mobile/android/app/src/main/java/com/audiusreactnative/MainActivity.java
+++ b/packages/mobile/android/app/src/main/java/com/audiusreactnative/MainActivity.java
@@ -25,8 +25,8 @@ public class MainActivity extends ReactActivity {
   }
 
   @Override
-  protected void onCreate(@Nullable Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
 
     // lazy load Google Cast context
     CastContext.getSharedInstance(this);


### PR DESCRIPTION
### Description

Fixes cases where android app crashes when restoring from background
sentry: https://sentry.io/organizations/audius/issues/3272855032/?query=is%3Aunresolved+release.version%3A1.1.114&statsPeriod=14d
issue: https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-989623502
fix: https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project

### Dragons

Not sure if this affects the chromecast context call
