### PR TITLE
Reset scroll threshold to 1000

### DIFF
--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -55,7 +55,7 @@ type NotificationPanelProps = {
 
 // The threshold of distance from the bottom of the scroll container in the
 // notification panel before requesting `loadMore` for more notifications
-const SCROLL_THRESHOLD = 400
+const SCROLL_THRESHOLD = 1000
 
 /** The notification panel displays the list of notifications w/ a
  * summary of each notification and a link to open the full


### PR DESCRIPTION
### Description
Context: https://audius-internal.slack.com/archives/C03C2V84A1L/p1653598933291159

Scroll threshold for loading in new notifications was recently changed to 400 - increasing back to 1000 to minimize occurrences of "jumping" when you hit the bottom and more notifs load.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
