### PR TITLE
[PAY-281] Fetch current user tip amount if not already loaded when tipping

### DIFF
--- a/packages/web/src/components/tipping/tip-audio/SendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/SendTip.tsx
@@ -9,7 +9,7 @@ import { ReactComponent as IconQuestionCircle } from 'assets/img/iconQuestionCir
 import IconNoTierBadge from 'assets/img/tokenBadgeNoTier.png'
 import { BadgeTier } from 'common/models/BadgeTier'
 import { ID } from 'common/models/Identifiers'
-import { Supporter, Supporting } from 'common/models/Tipping'
+import { Supporter } from 'common/models/Tipping'
 import { BNWei, StringAudio, StringWei } from 'common/models/Wallet'
 import { getAccountUser } from 'common/store/account/selectors'
 import {
@@ -31,6 +31,7 @@ import {
 import Tooltip from 'components/tooltip/Tooltip'
 import { audioTierMapPng } from 'components/user-badges/UserBadges'
 import ButtonWithArrow from 'pages/audio-rewards-page/components/ButtonWithArrow'
+import AudiusAPIClient from 'services/audius-api-client/AudiusAPIClient'
 
 import styles from './TipAudio.module.css'
 import { TipProfilePicture } from './TipProfilePicture'
@@ -68,7 +69,9 @@ export const SendTip = () => {
     amountToTipToBecomeTopSupporter,
     setAmountToTipToBecomeTopSupporter
   ] = useState<Nullable<BNWei>>(null)
-  const [supporting, setSupporting] = useState<Nullable<Supporting>>(null)
+  const [supportingAmount, setSupportingAmount] = useState<Nullable<StringWei>>(
+    null
+  )
   const [topSupporter, setTopSupporter] = useState<Nullable<Supporter>>(null)
   const [isFirstSupporter, setIsFirstSupporter] = useState(false)
 
@@ -79,14 +82,25 @@ export const SendTip = () => {
    */
   useEffect(() => {
     if (!account || !receiver) return
+    if (supportingAmount) return
 
     const supportingForAccount = supportingMap[account.user_id] ?? {}
     const accountSupportingReceiver =
       supportingForAccount[receiver.user_id] ?? null
     if (accountSupportingReceiver) {
-      setSupporting(accountSupportingReceiver)
+      setSupportingAmount(accountSupportingReceiver.amount)
+    } else {
+      AudiusAPIClient.getUserSupporter({
+        currentUserId: account.user_id,
+        userId: receiver.user_id,
+        supporterUserId: account.user_id
+      }).then(supporterResponse => {
+        if (supporterResponse) {
+          setSupportingAmount(supporterResponse.amount)
+        }
+      })
     }
-  }, [account, receiver, supportingMap])
+  }, [account, receiver, supportingMap, supportingAmount])
 
   /**
    * Get user who is top supporter to later check whether it is
@@ -145,8 +159,8 @@ export const SendTip = () => {
     let newAmountToTipToBecomeTopSupporter = topSupporterAmountWei.add(
       oneAudioToWeiBN
     ) as BNWei
-    if (supporting) {
-      const supportingAmountWei = stringWeiToBN(supporting.amount)
+    if (supportingAmount) {
+      const supportingAmountWei = stringWeiToBN(supportingAmount)
       newAmountToTipToBecomeTopSupporter = newAmountToTipToBecomeTopSupporter.sub(
         supportingAmountWei
       ) as BNWei
@@ -157,7 +171,7 @@ export const SendTip = () => {
     ) {
       setAmountToTipToBecomeTopSupporter(newAmountToTipToBecomeTopSupporter)
     }
-  }, [hasError, account, topSupporter, supporting, accountBalance])
+  }, [hasError, account, topSupporter, supportingAmount, accountBalance])
 
   const handleSendClick = useCallback(() => {
     dispatch(sendTip({ amount: tipAmount }))

--- a/packages/web/src/components/tipping/tip-audio/SendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/SendTip.tsx
@@ -90,15 +90,17 @@ export const SendTip = () => {
     if (accountSupportingReceiver) {
       setSupportingAmount(accountSupportingReceiver.amount)
     } else {
-      AudiusAPIClient.getUserSupporter({
-        currentUserId: account.user_id,
-        userId: receiver.user_id,
-        supporterUserId: account.user_id
-      }).then(supporterResponse => {
+      const fn = async () => {
+        const supporterResponse = await AudiusAPIClient.getUserSupporter({
+          currentUserId: account.user_id,
+          userId: receiver.user_id,
+          supporterUserId: account.user_id
+        })
         if (supporterResponse) {
           setSupportingAmount(supporterResponse.amount)
         }
-      })
+      }
+      fn()
     }
   }, [account, receiver, supportingMap, supportingAmount])
 


### PR DESCRIPTION
### Description

Ensures that the tip amount suggested to become top supporter takes into account the current tipped amount.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Decided to have it _not_ cache the result as the cache would serve very little utility, as sending repeat tips to the same artists warrants a refetch anyway.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested manually locally against staging accounts using stage DN1.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A