### PR TITLE
[PAY-286][PAY-291] Fix cover photo stretch and displayname overflow in supporting tiles

### DIFF
--- a/packages/web/src/components/tipping/support/Support.module.css
+++ b/packages/web/src/components/tipping/support/Support.module.css
@@ -86,7 +86,12 @@
 }
 
 .tileBackground {
+  display: flex;
+  align-items: flex-end;
   height: 90px;
+  background-position: center;
+  background-size: cover;
+  border-radius: 8px 8px 0 0;
 }
 
 .tileHeader {
@@ -129,10 +134,6 @@
   border-top-left-radius: 8px;
 }
 
-.profilePictureContainer {
-  position: relative;
-  top: -74px;
-}
 .profilePicture {
   margin-left: 8px;
   margin-bottom: 4px;

--- a/packages/web/src/components/tipping/support/Support.module.css
+++ b/packages/web/src/components/tipping/support/Support.module.css
@@ -156,7 +156,7 @@
   transform: none;
 }
 
-.name {
+.nameAndBadge {
   padding-left: 8px;
   height: 25px;
   background: linear-gradient(
@@ -177,6 +177,11 @@
   text-overflow: ellipsis;
   display: flex;
   align-items: center;
+}
+
+.name {
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .topSupportersContainer {

--- a/packages/web/src/components/tipping/support/Support.module.css
+++ b/packages/web/src/components/tipping/support/Support.module.css
@@ -134,6 +134,9 @@
   border-top-left-radius: 8px;
 }
 
+.profilePictureContainer {
+  width: 100%;
+}
 .profilePicture {
   margin-left: 8px;
   margin-bottom: 4px;

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -62,8 +62,8 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
       >
         <div className={styles.profilePictureContainer}>
           <img className={styles.profilePicture} src={profileImage} />
-          <div className={styles.name}>
-            {receiver.name}
+          <div className={styles.nameAndBadge}>
+            <span className={styles.name}>{receiver.name}</span>
             <UserBadges
               className={styles.badge}
               userId={receiver.user_id}

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -56,9 +56,11 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
 
   return receiver ? (
     <div className={styles.tileContainer} onClick={handleClick}>
-      <div className={styles.tileBackground}>
-        <img className={styles.coverPhoto} src={coverPhoto} />
-        <div className={styles.profilePictureContainer}>
+      <div
+        className={styles.tileBackground}
+        style={{ backgroundImage: `url(${coverPhoto})` }}
+      >
+        <div>
           <img className={styles.profilePicture} src={profileImage} />
           <div className={styles.name}>
             {receiver.name}

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -60,7 +60,7 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
         className={styles.tileBackground}
         style={{ backgroundImage: `url(${coverPhoto})` }}
       >
-        <div>
+        <div className={styles.profilePictureContainer}>
           <img className={styles.profilePicture} src={profileImage} />
           <div className={styles.name}>
             {receiver.name}


### PR DESCRIPTION
### Description

Before:
![image](https://user-images.githubusercontent.com/3690498/171911964-5cc52e9e-5d9a-4530-9e71-8c66e4ab1e9b.png)
After:
![image](https://user-images.githubusercontent.com/3690498/171911994-aed058a0-ac60-40f7-8923-6571ffb183dd.png)

Before:
![image](https://user-images.githubusercontent.com/3690498/171912084-abe77028-f0f9-401f-8bfc-9f0014879fd9.png)
After:
![image](https://user-images.githubusercontent.com/3690498/171912160-e260e878-f04f-4bfd-a3ec-f79f320636da.png)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally against stage.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A