### PR TITLE
Fix Snapchat browser going to GA

### DIFF
--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -22,7 +22,7 @@ function checkIsBot(val) {
     return false
   }
   const botTest = new RegExp(
-    'altavista|baiduspider|bingbot|discordbot|duckduckbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|msnbot|nextgensearchbot|reaper|slackbot|snap|telegrambot|twitterbot|whatsapp|whatsup|yahoo|yandex|yeti|yodaobot|zend|zoominfobot|embedly',
+    'altavista|baiduspider|bingbot|discordbot|duckduckbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|msnbot|nextgensearchbot|reaper|slackbot|snap[^;]*;[^;]*?bot;|telegrambot|twitterbot|whatsapp|whatsup|yahoo|yandex|yeti|yodaobot|zend|zoominfobot|embedly',
     'i'
   )
   return botTest.test(val)

--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -22,7 +22,7 @@ function checkIsBot(val) {
     return false
   }
   const botTest = new RegExp(
-    'altavista|baiduspider|bingbot|discordbot|duckduckbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|msnbot|nextgensearchbot|reaper|slackbot|snap[^;]*;[^;]*?bot;|telegrambot|twitterbot|whatsapp|whatsup|yahoo|yandex|yeti|yodaobot|zend|zoominfobot|embedly',
+    'altavista|baiduspider|bingbot|discordbot|duckduckbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|msnbot|nextgensearchbot|reaper|slackbot|snap url preview service|telegrambot|twitterbot|whatsapp|whatsup|yahoo|yandex|yeti|yodaobot|zend|zoominfobot|embedly',
     'i'
   )
   return botTest.test(val)


### PR DESCRIPTION
### Description

Currently the snapchat browser is treated as a bot and gets the GA meta response:
![image](https://user-images.githubusercontent.com/3690498/171967636-d04dff27-5a8c-4151-90b8-46d8fccfc6ff.png)

According to https://developers.snap.com/robots the correct user agent for a bot is "Snap URL Preview Service; bot; https://developer.snapchat.com/robots". This updates our regex to look not just for `snap` but for `snap url preview` to not treat the normal snap browser (which has a user agent that looks like "Snapchat/11.69.0.36 (SM-S908B; Android 12#S908BXXU1AVC6#31; gzip) V/MUSHROOM") as a bot.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Possible other user agent strings for Snapchat preview things?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

❗ N/A 👻  - tested the regex against user agent strings manually but not using Snapchat on mobile or anything yet.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A
