### PR TITLE
Add mobile profile top supporters

### DIFF
--- a/packages/mobile/src/components/feed-tip-tile/ReceiverDetails.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/ReceiverDetails.tsx
@@ -78,10 +78,7 @@ export const ReceiverDetails = ({ receiver }: ReceiverDetailsProps) => {
   return (
     <View style={styles.receiver}>
       <TouchableOpacity onPress={goToReceiverProfile}>
-        <ProfilePicture
-          profile={receiver}
-          profilePhotoStyles={styles.profilePicture}
-        />
+        <ProfilePicture profile={receiver} style={styles.profilePicture} />
       </TouchableOpacity>
       <View style={styles.receiverInfo}>
         <Text

--- a/packages/mobile/src/components/user/ProfilePicture.tsx
+++ b/packages/mobile/src/components/user/ProfilePicture.tsx
@@ -20,14 +20,10 @@ const useStyles = makeStyles(({ palette }) => ({
 
 export type ProfilePictureProps = Partial<DynamicImageProps> & {
   profile: User
-  profilePhotoStyles?: {
-    width?: number | string | undefined
-    height?: number | string | undefined
-  }
 }
 
 export const ProfilePicture = (props: ProfilePictureProps) => {
-  const { styles: stylesProp, profilePhotoStyles, profile, ...other } = props
+  const { styles: stylesProp, profile, ...other } = props
   const styles = useStyles()
 
   const profilePicture = useUserProfilePicture({
@@ -43,8 +39,7 @@ export const ProfilePicture = (props: ProfilePictureProps) => {
         ...stylesProp,
         ...{
           root: {
-            ...styles.profilePhoto,
-            ...profilePhotoStyles
+            ...styles.profilePhoto
           }
         }
       }}

--- a/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
@@ -19,10 +19,14 @@ type ProfilePictureListProps = {
   style?: StyleProp<ViewStyle>
   navigationType?: 'push' | 'navigate'
   interactive?: boolean
+  imageStyles?: {
+    width?: number | string | undefined
+    height?: number | string | undefined
+  }
 }
 
 export const ProfilePictureList = (props: ProfilePictureListProps) => {
-  const { users, style, navigationType, interactive } = props
+  const { users, style, navigationType, interactive, imageStyles } = props
   const styles = useStyles()
 
   return (
@@ -31,7 +35,7 @@ export const ProfilePictureList = (props: ProfilePictureListProps) => {
         <ProfilePicture
           profile={user}
           key={user.user_id}
-          style={styles.image}
+          style={{ ...styles.image, ...imageStyles }}
           navigationType={navigationType}
           interactive={interactive}
         />

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ProfileHeaderV2.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ProfileHeaderV2.tsx
@@ -20,6 +20,7 @@ import { useSelectProfileRoot } from '../selectors'
 import { CollapsedSection } from './CollapsedSection'
 import { ExpandHeaderToggleButton } from './ExpandHeaderToggleButton'
 import { ExpandedSection } from './ExpandedSection'
+import { TopSupporters } from './TopSupporters'
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
   header: {
@@ -84,6 +85,7 @@ export const ProfileHeaderV2 = (props: ProfileHeaderV2Props) => {
           <ArtistRecommendations onClose={handleCloseArtistRecs} />
         )}
         {isOwner ? <UploadTrackButton /> : <TipArtistButton />}
+        <TopSupporters />
       </View>
     </>
   )

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
@@ -8,6 +8,7 @@ import { Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 
 import IconCaretRight from 'app/assets/images/iconCaretRight.svg'
+import IconTrophy from 'app/assets/images/iconTrophy.svg'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { ProfilePictureList } from 'app/screens/notifications-screen/Notification'
@@ -26,7 +27,7 @@ const MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS = 6
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   root: {
     backgroundColor: palette.white,
-    padding: spacing(2),
+    padding: spacing(4),
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
@@ -44,6 +45,9 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     flexDirection: 'row',
     alignItems: 'center'
   },
+  icon: {
+    marginRight: spacing(2)
+  },
   viewTopSupportersText: {
     marginRight: spacing(4),
     color: palette.neutral,
@@ -60,7 +64,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
 
 export const TopSupporters = () => {
   const styles = useStyles()
-  const { secondary } = useThemeColors()
+  const { secondary, neutral } = useThemeColors()
   const navigation = useNavigation()
   const { user_id } = useSelectProfile(['user_id'])
   const supportersForProfile: SupportersMapForUser =
@@ -95,6 +99,7 @@ export const TopSupporters = () => {
         imageStyles={styles.profilePicture}
       />
       <View style={styles.alignRowCenter}>
+        <IconTrophy style={styles.icon} fill={neutral} />
         <Text style={styles.viewTopSupportersText}>
           {messages.topSupporters}
         </Text>

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
@@ -1,0 +1,110 @@
+import { useCallback } from 'react'
+
+import { ID } from 'audius-client/src/common/models/Identifiers'
+import { getUsers } from 'audius-client/src/common/store/cache/users/selectors'
+import { getSupportersForUser } from 'audius-client/src/common/store/tipping/selectors'
+import { SupportersMapForUser } from 'audius-client/src/common/store/tipping/types'
+import { Text, View } from 'react-native'
+import { TouchableOpacity } from 'react-native-gesture-handler'
+
+import IconCaretRight from 'app/assets/images/iconCaretRight.svg'
+import { useNavigation } from 'app/hooks/useNavigation'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { ProfilePictureList } from 'app/screens/notifications-screen/Notification'
+import { makeStyles } from 'app/styles'
+import { useThemeColors } from 'app/utils/theme'
+
+import { useSelectProfile } from '../selectors'
+
+const messages = {
+  topSupporters: 'Top Supporters',
+  buttonTitle: 'View'
+}
+
+const MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS = 6
+
+const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+  root: {
+    backgroundColor: palette.white,
+    padding: spacing(2),
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  profilePictureList: {
+    marginRight: spacing(6)
+  },
+  profilePicture: {
+    width: 28,
+    height: 28
+  },
+  alignRowCenter: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  viewTopSupportersText: {
+    marginRight: spacing(4),
+    color: palette.neutral,
+    fontSize: typography.fontSize.small,
+    fontFamily: typography.fontByWeight.bold
+  },
+  viewTopSupportersButtonText: {
+    marginRight: spacing(1),
+    color: palette.secondary,
+    fontSize: typography.fontSize.small,
+    fontFamily: typography.fontByWeight.bold
+  }
+}))
+
+export const TopSupporters = () => {
+  const styles = useStyles()
+  const { secondary } = useThemeColors()
+  const navigation = useNavigation()
+  const { user_id } = useSelectProfile(['user_id'])
+  const supportersForProfile: SupportersMapForUser =
+    useSelectorWeb(state => getSupportersForUser(state, user_id)) || {}
+  const rankedSupporterIds = Object.keys(supportersForProfile)
+    .sort((k1, k2) => {
+      return (
+        supportersForProfile[(k1 as unknown) as ID].rank -
+        supportersForProfile[(k2 as unknown) as ID].rank
+      )
+    })
+    .map(k => supportersForProfile[(k as unknown) as ID])
+    .map(s => s.sender_id)
+  const rankedSupporters = useSelectorWeb(state => {
+    const usersMap = getUsers(state, { ids: rankedSupporterIds })
+    return rankedSupporterIds.map(id => usersMap[id]).filter(Boolean)
+  })
+
+  const handlePress = useCallback(() => {
+    navigation.push({
+      native: { screen: 'TopSupporters', params: { userId: user_id } }
+    })
+  }, [navigation, user_id])
+
+  return (
+    <View style={styles.root}>
+      <ProfilePictureList
+        users={rankedSupporters.slice(0, MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS)}
+        style={styles.profilePictureList}
+        navigationType='push'
+        interactive={false}
+        imageStyles={styles.profilePicture}
+      />
+      <View style={styles.alignRowCenter}>
+        <Text style={styles.viewTopSupportersText}>
+          {messages.topSupporters}
+        </Text>
+        <TouchableOpacity style={styles.alignRowCenter} onPress={handlePress}>
+          <Text style={styles.viewTopSupportersButtonText}>
+            {messages.buttonTitle}
+          </Text>
+          <IconCaretRight fill={secondary} width={14} height={14} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  )
+}

--- a/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
@@ -24,7 +24,7 @@ export const TopSupportersScreen = () => {
   const { userId } = params
   const dispatchWeb = useDispatchWeb()
 
-  const handleSetSupporting = useCallback(() => {
+  const handleSetSupporters = useCallback(() => {
     dispatchWeb(setTopSupporters(userId))
   }, [dispatchWeb, userId])
 
@@ -33,7 +33,7 @@ export const TopSupportersScreen = () => {
       <UserList
         userSelector={getUserList}
         tag='TOP SUPPORTERS'
-        setUserList={handleSetSupporting}
+        setUserList={handleSetSupporters}
       />
     </Screen>
   )

--- a/packages/mobile/src/screens/user-list-screen/UserList.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserList.tsx
@@ -8,6 +8,7 @@ import { getUserId } from 'audius-client/src/common/store/account/selectors'
 import { getUsers } from 'audius-client/src/common/store/cache/users/selectors'
 import {
   loadMore,
+  reset,
   setLoading
 } from 'audius-client/src/common/store/user-list/actions'
 import { UserListStoreState } from 'audius-client/src/common/store/user-list/types'
@@ -86,6 +87,10 @@ export const UserList = (props: UserListProps) => {
       setUserList()
       dispatchWeb(setLoading(tag, true))
       dispatchWeb(loadMore(tag))
+
+      return () => {
+        dispatchWeb(reset(tag))
+      }
     }, [dispatchWeb, setUserList, tag])
   )
 
@@ -112,7 +117,7 @@ export const UserList = (props: UserListProps) => {
   }, [hasMore, isFocused, dispatchWeb, tag])
 
   const data =
-    isRefreshing || loading || !isFocused || users.length === 0
+    isEmpty || isRefreshing || loading || !isFocused
       ? cachedUsers.current
       : users
 


### PR DESCRIPTION
### Description

Add mobile profile top supporters section below the tip audio button (or upload button if user in own profile)

![Simulator Screen Shot - iPhone 13 - 2022-06-07 at 14 05 23](https://user-images.githubusercontent.com/9600175/172452429-bb5c2c5c-00ec-447f-8d12-3636cb303ac9.png)
![Simulator Screen Shot - iPhone 13 - 2022-06-07 at 14 05 43](https://user-images.githubusercontent.com/9600175/172452448-b31aa577-7757-4d05-bd92-9e810b5cf0db.png)
![Simulator Screen Shot - iPhone 13 - 2022-06-06 at 18 29 34](https://user-images.githubusercontent.com/9600175/172418563-d8ae8d9b-61f4-4751-ad39-131097353e4e.png)

### Dragons

n/a

### How Has This Been Tested?

on native ios locally against local dapp pointing to staging

### How will this change be monitored?

n/a
