### PR TITLE
Add response mode param to Oauth

### DIFF
--- a/packages/web/src/common/models/Analytics.ts
+++ b/packages/web/src/common/models/Analytics.ts
@@ -1186,6 +1186,7 @@ type AudiusOauthStart = {
   redirectUriParam: string | string[]
   originParam: string | string[] | undefined | null
   appNameParam: string | string[]
+  responseMode: string | string[] | undefined | null
 }
 
 type AudiusOauthSubmit = {

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
@@ -22,11 +22,13 @@ import { useHistory, useLocation } from 'react-router-dom'
 
 import HorizontalLogo from 'assets/img/publicSite/Horizontal-Logo-Full-Color@2x.png'
 import { Name } from 'common/models/Analytics'
+import { SquareSizes } from 'common/models/ImageSizes'
 import { User } from 'common/models/User'
 import { getAccountUser } from 'common/store/account/selectors'
 import Input from 'components/data-entry/Input'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { TipProfilePicture } from 'components/tipping/tip-audio/TipProfilePicture'
+import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
 import AudiusBackend from 'services/AudiusBackend'
 import { make, useRecord } from 'store/analytics/actions'
 import { ERROR_PAGE, SIGN_UP_PAGE } from 'utils/route'
@@ -112,7 +114,7 @@ export const OAuthLoginPage = () => {
         return 'postmessage'
       }
       try {
-        return new URL(redirect_uri)
+        return new URL(decodeURIComponent(redirect_uri))
       } catch {
         return null
       }
@@ -120,6 +122,11 @@ export const OAuthLoginPage = () => {
     return null
   }, [redirect_uri])
   const account = useSelector(getAccountUser)
+  const imageURL = useUserProfilePicture(
+    account?.user_id || null,
+    account?._profile_picture_sizes || null,
+    SquareSizes.SIZE_150_BY_150
+  )
   const isLoggedIn = Boolean(account)
   const [userEmail, setUserEmail] = useState<string | null>(null)
   useEffect(() => {
@@ -281,8 +288,7 @@ export const OAuthLoginPage = () => {
       name: account?.name,
       handle: account?.handle,
       verified: account?.is_verified,
-      // TODO(nkang): Get profile pic URL
-      // imageURL: account?._profile_picture_sizes,
+      imageURL,
       sub: account?.user_id,
       iat: timestamp
     }
@@ -325,10 +331,16 @@ export const OAuthLoginPage = () => {
         }
       } else {
         record(make(Name.AUDIUS_OAUTH_COMPLETE, {}))
-        const statePart = state != null ? `state=${state}&` : ''
-        const prefix = response_mode && response_mode === 'query' ? '?' : '#'
-        const addition = `${prefix}${statePart}token=${jwt}`
-        window.location.href = `${redirect_uri}${addition}`
+        if (response_mode && response_mode === 'query') {
+          if (state != null) {
+            parsedRedirectUri!.searchParams.append('state', state as string)
+          }
+          parsedRedirectUri!.searchParams.append('token', jwt)
+        } else {
+          const statePart = state != null ? `state=${state}&` : ''
+          parsedRedirectUri!.hash = `#${statePart}token=${jwt}`
+        }
+        window.location.href = parsedRedirectUri!.toString()
       }
     }
   }


### PR DESCRIPTION
### Description
Add option to send the auth response back in the query string instead of the fragment (default behavior).
Fragment is default behavior because it's better for security (since fragments don't get sent in requests to servers), but some consumers might need the query param option for their implementation.


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
