### PR TITLE
Add error message helper

### DIFF
--- a/packages/web/src/store/token-dashboard/sagas.ts
+++ b/packages/web/src/store/token-dashboard/sagas.ts
@@ -65,6 +65,7 @@ import connectWeb3Wallet, {
 } from 'services/web3-modal/index'
 import { requestConfirmation } from 'store/confirmer/actions'
 import { confirmTransaction } from 'store/confirmer/sagas'
+import { getErrorMessage } from 'utils/error'
 
 const CONNECT_WALLET_CONFIRMATION_UID = 'CONNECT_WALLET'
 
@@ -286,10 +287,10 @@ function* connectWallet() {
     } else {
       yield call(connectEthWallet, web3Instance)
     }
-  } catch (err) {
+  } catch (error) {
     // if error is "Cannot use 'in' operator to search for 'message' in Modal closed by user",
     // do not show error message because user closed the modal
-    const errorMessage = err.message.includes('Modal closed by user')
+    const errorMessage = getErrorMessage(error).includes('Modal closed by user')
       ? null
       : 'An error occured while connecting a wallet with your account.'
     yield put(

--- a/packages/web/src/utils/error.ts
+++ b/packages/web/src/utils/error.ts
@@ -1,0 +1,28 @@
+type ErrorWithMessage = {
+  message: string
+}
+
+function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as Record<string, unknown>).message === 'string'
+  )
+}
+
+function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
+  if (isErrorWithMessage(maybeError)) return maybeError
+
+  try {
+    return new Error(JSON.stringify(maybeError))
+  } catch {
+    // fallback in case there's an error stringifying the maybeError
+    // like with circular references for example.
+    return new Error(String(maybeError))
+  }
+}
+
+export function getErrorMessage(error: unknown) {
+  return toErrorWithMessage(error).message
+}


### PR DESCRIPTION
### Description

Adds error message helper, which gracefully handles extracting error message from catch block error.
Fixes one of our many error cases

Note, this will be useful for the incoming typescript upgrade from v3 to v4 in web.

Information about the type situation, and inspiration for helper: 
https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript
