### PR TITLE
[PAY-224] Dismiss Popover when navigating away

### DIFF
--- a/packages/web/src/components/artist/ArtistCard.tsx
+++ b/packages/web/src/components/artist/ArtistCard.tsx
@@ -18,10 +18,11 @@ const { getFeatureEnabled } = remoteConfigInstance
 
 type ArtistCardProps = {
   artist: User
+  onNavigateAway: () => void
 }
 
 export const ArtistCard = (props: ArtistCardProps) => {
-  const { artist } = props
+  const { artist, onNavigateAway } = props
   const {
     user_id,
     bio,
@@ -39,6 +40,7 @@ export const ArtistCard = (props: ArtistCardProps) => {
 
   const handleClick: MouseEventHandler = useCallback(event => {
     event.stopPropagation()
+    event.nativeEvent.stopImmediatePropagation()
   }, [])
 
   const stats = useMemo((): StatProps[] => {
@@ -95,7 +97,9 @@ export const ArtistCard = (props: ArtistCardProps) => {
         </div>
         <div className={styles.contentContainer}>
           <div>
-            {isTippingEnabled ? <ArtistSupporting artist={artist} /> : null}
+            {isTippingEnabled ? (
+              <ArtistSupporting artist={artist} onClick={onNavigateAway} />
+            ) : null}
             <div className={styles.description}>{bio}</div>
             <FollowButton
               className={styles.followButton}

--- a/packages/web/src/components/artist/ArtistCard.tsx
+++ b/packages/web/src/components/artist/ArtistCard.tsx
@@ -40,7 +40,6 @@ export const ArtistCard = (props: ArtistCardProps) => {
 
   const handleClick: MouseEventHandler = useCallback(event => {
     event.stopPropagation()
-    event.nativeEvent.stopImmediatePropagation()
   }, [])
 
   const stats = useMemo((): StatProps[] => {
@@ -86,7 +85,11 @@ export const ArtistCard = (props: ArtistCardProps) => {
   return (
     <div className={styles.popoverContainer} onClick={handleClick}>
       <div className={styles.artistCardContainer}>
-        <ArtistCardCover artist={artist} isArtist={isArtist} />
+        <ArtistCardCover
+          artist={artist}
+          isArtist={isArtist}
+          onNavigateAway={onNavigateAway}
+        />
         <div className={styles.artistStatsContainer}>
           <Stats
             userId={user_id}
@@ -98,7 +101,10 @@ export const ArtistCard = (props: ArtistCardProps) => {
         <div className={styles.contentContainer}>
           <div>
             {isTippingEnabled ? (
-              <ArtistSupporting artist={artist} onClick={onNavigateAway} />
+              <ArtistSupporting
+                artist={artist}
+                onNavigateAway={onNavigateAway}
+              />
             ) : null}
             <div className={styles.description}>{bio}</div>
             <FollowButton

--- a/packages/web/src/components/artist/ArtistCardCover.tsx
+++ b/packages/web/src/components/artist/ArtistCardCover.tsx
@@ -20,10 +20,11 @@ const gradient = `linear-gradient(180deg, rgba(0, 0, 0, 0.001) 0%, rgba(0, 0, 0,
 type ArtistCoverProps = {
   artist: User
   isArtist: boolean
+  onNavigateAway?: () => void
 }
 
 export const ArtistCardCover = (props: ArtistCoverProps) => {
-  const { isArtist, artist } = props
+  const { isArtist, artist, onNavigateAway } = props
 
   const {
     user_id,
@@ -49,8 +50,11 @@ export const ArtistCardCover = (props: ArtistCoverProps) => {
   const darkenedCoverPhoto = `${gradient}, url(${coverPhoto})`
 
   const handleClickUser = useCallback(() => {
+    if (onNavigateAway) {
+      onNavigateAway()
+    }
     dispatch(push(profilePage(handle)))
-  }, [dispatch, handle])
+  }, [dispatch, handle, onNavigateAway])
 
   return (
     <DynamicImage

--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, ReactNode } from 'react'
+import React, { useCallback, ReactNode, useState } from 'react'
 
 import Popover from 'antd/lib/popover'
 import cn from 'classnames'
@@ -47,6 +47,7 @@ export const ArtistPopover = ({
   mouseEnterDelay = 0.5,
   component: Component = 'div'
 }: ArtistPopoverProps) => {
+  const [isPopupVisible, setIsPopupVisible] = useState(false)
   const creator = useSelector((state: CommonState) =>
     getUser(state, { handle: handle.toLowerCase() })
   )
@@ -74,7 +75,12 @@ export const ArtistPopover = ({
 
   const content =
     creator && userId !== creator.user_id ? (
-      <ArtistCard artist={creator} />
+      <ArtistCard
+        artist={creator}
+        onNavigateAway={() => {
+          setIsPopupVisible(false)
+        }}
+      />
     ) : null
 
   let popupContainer
@@ -98,9 +104,14 @@ export const ArtistPopover = ({
       <Popover
         mouseEnterDelay={mouseEnterDelay}
         content={content}
-        overlayClassName={styles.overlayStyle}
+        overlayClassName={cn(styles.overlayStyle)}
         placement={placement}
         getPopupContainer={popupContainer}
+        defaultVisible={false}
+        visible={isPopupVisible}
+        onVisibleChange={visible => {
+          setIsPopupVisible(visible)
+        }}
       >
         {children}
       </Popover>

--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -104,7 +104,7 @@ export const ArtistPopover = ({
       <Popover
         mouseEnterDelay={mouseEnterDelay}
         content={content}
-        overlayClassName={cn(styles.overlayStyle)}
+        overlayClassName={styles.overlayStyle}
         placement={placement}
         getPopupContainer={popupContainer}
         defaultVisible={false}

--- a/packages/web/src/components/artist/ArtistSupporting.tsx
+++ b/packages/web/src/components/artist/ArtistSupporting.tsx
@@ -31,9 +31,10 @@ const messages = {
 
 type ArtistSupportingProps = {
   artist: User
+  onClick: () => void
 }
 export const ArtistSupporting = (props: ArtistSupportingProps) => {
-  const { artist } = props
+  const { artist, onClick } = props
   const { user_id, supporting_count } = artist
   const dispatch = useDispatch()
 
@@ -73,9 +74,12 @@ export const ArtistSupporting = (props: ArtistSupportingProps) => {
   }, [dispatch, hasNotPreviouslyFetchedSupportingForArtist, user_id])
 
   const handleClick = useCallback(() => {
+    // This needs to come first so that if the modal is already visible,
+    // it gets dismissed BEFORE we set it to be visible
+    onClick()
     /**
      * It's possible that we are already in the supporting
-     * user list modal, and that we are hovering oover one
+     * user list modal, and that we are hovering over one
      * of the users.
      * Clicking on the supporting section is supposed to
      * load a new user list modal that shows the users who
@@ -92,7 +96,7 @@ export const ArtistSupporting = (props: ArtistSupportingProps) => {
     )
     dispatch(loadMore(SUPPORTING_TAG))
     dispatch(setVisibility(true))
-  }, [dispatch, user_id])
+  }, [dispatch, user_id, onClick])
 
   return rankedSupportingList.length > 0 ? (
     <div className={styles.supportingContainer} onClick={handleClick}>

--- a/packages/web/src/components/artist/ArtistSupporting.tsx
+++ b/packages/web/src/components/artist/ArtistSupporting.tsx
@@ -31,10 +31,10 @@ const messages = {
 
 type ArtistSupportingProps = {
   artist: User
-  onClick: () => void
+  onNavigateAway?: () => void
 }
 export const ArtistSupporting = (props: ArtistSupportingProps) => {
-  const { artist, onClick } = props
+  const { artist, onNavigateAway } = props
   const { user_id, supporting_count } = artist
   const dispatch = useDispatch()
 
@@ -74,9 +74,6 @@ export const ArtistSupporting = (props: ArtistSupportingProps) => {
   }, [dispatch, hasNotPreviouslyFetchedSupportingForArtist, user_id])
 
   const handleClick = useCallback(() => {
-    // This needs to come first so that if the modal is already visible,
-    // it gets dismissed BEFORE we set it to be visible
-    onClick()
     /**
      * It's possible that we are already in the supporting
      * user list modal, and that we are hovering over one
@@ -95,8 +92,17 @@ export const ArtistSupporting = (props: ArtistSupportingProps) => {
       })
     )
     dispatch(loadMore(SUPPORTING_TAG))
-    dispatch(setVisibility(true))
-  }, [dispatch, user_id, onClick])
+    // Wait until event bubbling finishes so that any modals are already dismissed
+    // Without this, the user list won't be visible if the popover is from an existing user list
+    setTimeout(() => {
+      dispatch(setVisibility(true))
+    }, 0)
+
+    // Used to dismiss popovers etc
+    if (onNavigateAway) {
+      onNavigateAway()
+    }
+  }, [dispatch, user_id, onNavigateAway])
 
   return rankedSupportingList.length > 0 ? (
     <div className={styles.supportingContainer} onClick={handleClick}>


### PR DESCRIPTION
### Description

Dismisses the artist hover tile when an interaction within it causes a modal to pop or the page to navigate.
- *Note:* The page navigation one is redundant, as it was being dismissed anyway due to its parent being unmounted. Added support anyway for consistency

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

- Required some particularly gritty debugging and also requires https://github.com/AudiusProject/stems/pull/136
  - Before the stems change, the hover tile would get unmounted before the click event would even fire since the modal (its parent) would dismiss via a listener to mousedown
  - Putting the modal `useOutsideClick` on the click event makes it part of the same event bubbling, thus the outside click happens _after_ the supporting tile is clicked, so the order of what happens if the hover tile is from a UserListModal looks like:
    - ArtistSupporting handles click, dispatches action making user list visible
    - UserListModal handles click from `useOutsideClick`, dispatches action making user list invisible
  - To remedy this, I had to put the ArtistSupporting dispatch inside a `setTimeout` (using a microtask via a promise didn't work for some reason? I don't understand why) so that the dispatch that makes modals visible happens _after_ all modals have already dismissed.


### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested locally on Chrome web against stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
N/A