### PR TITLE
[PAY-292] Adjust Supporting tile gradient

### DIFF
--- a/packages/web/src/components/tipping/support/Support.module.css
+++ b/packages/web/src/components/tipping/support/Support.module.css
@@ -86,22 +86,12 @@
 }
 
 .tileBackground {
+  display: flex;
+  align-items: flex-end;
   height: 90px;
   background-position: center;
   background-size: cover;
   border-radius: 8px 8px 0 0;
-}
-.tileBackgroundGradient {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: flex-end;
-  background: linear-gradient(
-    180deg,
-    rgba(0, 0, 0, 0.0001) 50.54%,
-    rgba(0, 0, 0, 0.05) 57.88%,
-    rgba(0, 0, 0, 0.2) 100%
-  );
   background-blend-mode: multiply, normal;
 }
 

--- a/packages/web/src/components/tipping/support/Support.module.css
+++ b/packages/web/src/components/tipping/support/Support.module.css
@@ -86,12 +86,23 @@
 }
 
 .tileBackground {
-  display: flex;
-  align-items: flex-end;
   height: 90px;
   background-position: center;
   background-size: cover;
   border-radius: 8px 8px 0 0;
+}
+.tileBackgroundGradient {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.0001) 50.54%,
+    rgba(0, 0, 0, 0.05) 57.88%,
+    rgba(0, 0, 0, 0.2) 100%
+  );
+  background-blend-mode: multiply, normal;
 }
 
 .tileHeader {
@@ -159,13 +170,6 @@
 .nameAndBadge {
   padding-left: 8px;
   height: 25px;
-  background: linear-gradient(
-    180deg,
-    rgba(0, 0, 0, 0.02) 30%,
-    rgba(0, 0, 0, 0.1) 60%,
-    rgba(0, 0, 0, 0.2) 100%
-  );
-  background-blend-mode: multiply;
   color: var(--white);
   font-weight: var(--font-bold);
   font-size: var(--font-s);

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -60,15 +60,17 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
         className={styles.tileBackground}
         style={{ backgroundImage: `url(${coverPhoto})` }}
       >
-        <div className={styles.profilePictureContainer}>
-          <img className={styles.profilePicture} src={profileImage} />
-          <div className={styles.nameAndBadge}>
-            <span className={styles.name}>{receiver.name}</span>
-            <UserBadges
-              className={styles.badge}
-              userId={receiver.user_id}
-              badgeSize={12}
-            />
+        <div className={styles.tileBackgroundGradient}>
+          <div className={styles.profilePictureContainer}>
+            <img className={styles.profilePicture} src={profileImage} />
+            <div className={styles.nameAndBadge}>
+              <span className={styles.name}>{receiver.name}</span>
+              <UserBadges
+                className={styles.badge}
+                userId={receiver.user_id}
+                badgeSize={12}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -58,19 +58,24 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
     <div className={styles.tileContainer} onClick={handleClick}>
       <div
         className={styles.tileBackground}
-        style={{ backgroundImage: `url(${coverPhoto})` }}
+        style={{
+          backgroundImage: `url(${coverPhoto}), linear-gradient(
+          180deg,
+          rgba(0, 0, 0, 0.0001) 50.54%,
+          rgba(0, 0, 0, 0.05) 57.88%,
+          rgba(0, 0, 0, 0.2) 100%
+        )`
+        }}
       >
-        <div className={styles.tileBackgroundGradient}>
-          <div className={styles.profilePictureContainer}>
-            <img className={styles.profilePicture} src={profileImage} />
-            <div className={styles.nameAndBadge}>
-              <span className={styles.name}>{receiver.name}</span>
-              <UserBadges
-                className={styles.badge}
-                userId={receiver.user_id}
-                badgeSize={12}
-              />
-            </div>
+        <div className={styles.profilePictureContainer}>
+          <img className={styles.profilePicture} src={profileImage} />
+          <div className={styles.nameAndBadge}>
+            <span className={styles.name}>{receiver.name}</span>
+            <UserBadges
+              className={styles.badge}
+              userId={receiver.user_id}
+              badgeSize={12}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Description

Fixes the background of the supporting tiles to have the gradient matching figma

![image](https://user-images.githubusercontent.com/3690498/172508047-18eb5aa2-874e-49c6-8305-b63ddc1a2854.png)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Note the values of the gradient - I pulled these from Figma but they vary based on which supporting tile I inspected in the figma. I picked the values that matched the bug description appearance the closest.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally against staging using Chrome on Mac

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A