### PR TITLE
Fix border radius on profile mutuals tile

### DIFF
--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
@@ -24,7 +24,7 @@
   margin-top: 16px;
   padding: 16px 8px 8px;
   background: var(--white);
-  border-radius: 4px;
+  border-radius: 8px;
   box-shadow: 0px 2px 5px var(--tile-shadow-3), 0px 1px 0px var(--tile-shadow-2),
     0px 0px 1px var(--tile-shadow-1);
   transition: all 0.18s ease-in-out 0s;


### PR DESCRIPTION
### Description

Fix border radius on profile mutuals tile.
See that it's similar to the top supporters tile in the image below.

<img width="417" alt="Screen Shot 2022-06-08 at 4 40 46 PM" src="https://user-images.githubusercontent.com/9600175/172713141-7a362ad3-1725-43c2-8105-eaf5b813f549.png">

### Dragons

n/a

### How Has This Been Tested?

local dapp against stage

### How will this change be monitored?

n/a
