### PR TITLE
[PAY-307][PAY-226][PAY-310][PAY-249] Hotfixes for Mutuals Tile

### DIFF
--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
@@ -47,4 +47,5 @@
   color: var(--white);
   font-size: var(--font-m);
   font-weight: var(--font-bold);
+  text-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
 }

--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
@@ -21,6 +21,10 @@
   margin-right: calc(var(--unit-2) * -1);
 }
 
+.profilePicture > div {
+  border-color: var(--neutral-light-10);
+}
+
 .profilePictureExtraRoot {
   position: relative;
 }

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
@@ -46,10 +46,6 @@
 .contentContainer:hover .viewAll path {
   fill: var(--secondary);
 }
-.profilePictureWrapper {
-  width: 40px;
-  height: 40px;
-}
 .profilePictureWrapper:hover {
   transform: none;
 }

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
@@ -47,8 +47,8 @@
   fill: var(--secondary);
 }
 .profilePictureWrapper {
-  width: 39px;
-  height: 39px;
+  width: 40px;
+  height: 40px;
 }
 .profilePictureWrapper:hover {
   transform: none;

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
@@ -21,8 +21,8 @@
 }
 
 .contentContainer {
-  margin-top: 16px;
-  padding: 16px 8px 8px;
+  margin-top: 12px;
+  padding: 16px 8px 8px 12px;
   background: var(--white);
   border-radius: 4px;
   box-shadow: 0px 2px 5px var(--tile-shadow-3), 0px 1px 0px var(--tile-shadow-2),

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
@@ -28,7 +28,7 @@ const messages = {
   viewAll: 'View All'
 }
 
-const MAX_MUTUALS = 5
+const MAX_MUTUALS = 4
 
 const selectMutuals = createSelector(
   [getFolloweeFollows, getUsers],


### PR DESCRIPTION
### Description

See commits

![image](https://user-images.githubusercontent.com/3690498/172723089-010b082d-d845-44c8-b632-1406f0977dc2.png)

[PAY-307](https://linear.app/audius/issue/PAY-307/[currently-live]-too-much-space-below-title-margin-top-should-be-12px)
[PAY-226](https://linear.app/audius/issue/PAY-226/profile-picture-list)
[PAY-310](https://linear.app/audius/issue/PAY-310/[currently-live]-change-the-border-of-the-photos-to-neutral-light-10)
[PAY-249](https://linear.app/audius/issue/PAY-249/[currently-live]-hover-state-shadow-is-wrong-on-supporter-supporting)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Note: Need to update supporter/supporting tiles as well!

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
