### PR TITLE
[PAY-296] Show display name in top supporters modal / drawer from feed

### DIFF
--- a/packages/mobile/src/components/feed-tip-tile/SenderDetails.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/SenderDetails.tsx
@@ -69,7 +69,10 @@ export const SenderDetails = ({ senders, receiver }: SenderDetailsProps) => {
 
   const handlePressTippers = useCallback(() => {
     navigation.push({
-      native: { screen: 'TopSupporters', params: { userId: receiver.user_id } }
+      native: {
+        screen: 'TopSupporters',
+        params: { userId: receiver.user_id, source: 'feed' }
+      }
     })
   }, [navigation, receiver])
 

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -53,7 +53,7 @@ export type AppTabScreenParamList = {
   SearchResults: { query: string }
   SupportingUsers: { userId: ID }
   TagSearch: { query: string }
-  TopSupporters: { userId: ID }
+  TopSupporters: { userId: ID; source: 'profile' | 'feed' }
   NotificationUsers: {
     id: string // uuid
     notificationType: NotificationType

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
@@ -85,7 +85,10 @@ export const TopSupporters = () => {
 
   const handlePress = useCallback(() => {
     navigation.push({
-      native: { screen: 'TopSupporters', params: { userId: user_id } }
+      native: {
+        screen: 'TopSupporters',
+        params: { userId: user_id, source: 'profile' }
+      }
     })
   }, [navigation, user_id])
 

--- a/packages/mobile/src/screens/user-list-screen/SupporterInfo.tsx
+++ b/packages/mobile/src/screens/user-list-screen/SupporterInfo.tsx
@@ -1,6 +1,6 @@
 import { User } from 'audius-client/src/common/models/User'
 import { getSupporters } from 'audius-client/src/common/store/tipping/selectors'
-import { getId as getSupportersId } from 'common/store/user-list/top-supporters/selectors'
+import { getId as getSupportersId } from 'audius-client/src/common/store/user-list/top-supporters/selectors'
 import { View } from 'react-native'
 
 import IconTrending from 'app/assets/images/iconTrending.svg'

--- a/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
@@ -10,7 +10,6 @@ import { View } from 'react-native'
 
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
 import { Screen, Text } from 'app/components/core'
-import UserBadges from 'app/components/user-badges'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useRoute } from 'app/hooks/useRoute'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
@@ -32,9 +31,6 @@ const useStyles = makeStyles(({ spacing }) => ({
   },
   titleName: {
     maxWidth: 120
-  },
-  badge: {
-    marginTop: -spacing(1)
   }
 }))
 
@@ -51,12 +47,6 @@ const HeaderTitle = ({ source }: { source: 'profile' | 'feed' }) => {
         <Text variant='h3' style={styles.titleName} numberOfLines={1}>
           {supportersUser.name}
         </Text>
-        <UserBadges
-          style={styles.badge}
-          user={supportersUser}
-          badgeSize={12}
-          hideName
-        />
         <Text variant='h3'>&apos;s&nbsp;{messages.title}</Text>
       </View>
     ) : (

--- a/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
@@ -1,13 +1,12 @@
 import { useCallback } from 'react'
 
-import { User } from 'audius-client/src/common/models/User'
 import { getUser } from 'audius-client/src/common/store/cache/users/selectors'
 import { setTopSupporters } from 'audius-client/src/common/store/user-list/top-supporters/actions'
 import {
   getUserList,
   getId as getSupportersId
 } from 'audius-client/src/common/store/user-list/top-supporters/selectors'
-import { TextStyle, View, ViewStyle } from 'react-native'
+import { View } from 'react-native'
 
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
 import { Screen, Text } from 'app/components/core'
@@ -39,15 +38,13 @@ const useStyles = makeStyles(({ spacing }) => ({
   }
 }))
 
-const headerTitle = ({
-  source,
-  supportersUser,
-  styles
-}: {
-  source: 'profile' | 'feed'
-  supportersUser: User | null
-  styles: { [K in keyof ReturnType<typeof useStyles>]: ViewStyle | TextStyle }
-}) => {
+const HeaderTitle = ({ source }: { source: 'profile' | 'feed' }) => {
+  const styles = useStyles()
+  const supportersId = useSelectorWeb(getSupportersId)
+  const supportersUser = useSelectorWeb(state =>
+    getUser(state, { id: supportersId })
+  )
+
   const title =
     source === 'feed' && supportersUser ? (
       <View style={styles.titleNameContainer}>
@@ -72,22 +69,14 @@ const headerTitle = ({
 export const TopSupportersScreen = () => {
   const { params } = useRoute<'TopSupporters'>()
   const { userId, source } = params
-  const styles = useStyles()
   const dispatchWeb = useDispatchWeb()
-  const supportersId = useSelectorWeb(getSupportersId)
-  const supportersUser = useSelectorWeb(state =>
-    getUser(state, { id: supportersId })
-  )
 
   const handleSetSupporters = useCallback(() => {
     dispatchWeb(setTopSupporters(userId))
   }, [dispatchWeb, userId])
 
   return (
-    <Screen
-      headerTitle={() => headerTitle({ source, supportersUser, styles })}
-      variant='white'
-    >
+    <Screen headerTitle={() => <HeaderTitle source={source} />} variant='white'>
       <UserList
         userSelector={getUserList}
         tag='TOP SUPPORTERS'

--- a/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/TopSupportersScreen.tsx
@@ -1,12 +1,21 @@
 import { useCallback } from 'react'
 
+import { User } from 'audius-client/src/common/models/User'
+import { getUser } from 'audius-client/src/common/store/cache/users/selectors'
 import { setTopSupporters } from 'audius-client/src/common/store/user-list/top-supporters/actions'
-import { getUserList } from 'audius-client/src/common/store/user-list/top-supporters/selectors'
+import {
+  getUserList,
+  getId as getSupportersId
+} from 'audius-client/src/common/store/user-list/top-supporters/selectors'
+import { TextStyle, View, ViewStyle } from 'react-native'
 
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
-import { Screen } from 'app/components/core'
+import { Screen, Text } from 'app/components/core'
+import UserBadges from 'app/components/user-badges'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
 import { useRoute } from 'app/hooks/useRoute'
+import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
+import { makeStyles } from 'app/styles'
 
 import { UserList } from './UserList'
 import { UserListTitle } from './UserListTitle'
@@ -15,21 +24,70 @@ const messages = {
   title: 'Top Supporters'
 }
 
-const headerTitle = () => (
-  <UserListTitle icon={IconTrophy} title={messages.title} />
-)
+const useStyles = makeStyles(({ spacing }) => ({
+  titleNameContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: -spacing(3)
+  },
+  titleName: {
+    maxWidth: 120
+  },
+  badge: {
+    marginTop: -spacing(1)
+  }
+}))
+
+const headerTitle = ({
+  source,
+  supportersUser,
+  styles
+}: {
+  source: 'profile' | 'feed'
+  supportersUser: User | null
+  styles: { [K in keyof ReturnType<typeof useStyles>]: ViewStyle | TextStyle }
+}) => {
+  const title =
+    source === 'feed' && supportersUser ? (
+      <View style={styles.titleNameContainer}>
+        <Text variant='h3' style={styles.titleName} numberOfLines={1}>
+          {supportersUser.name}
+        </Text>
+        <UserBadges
+          style={styles.badge}
+          user={supportersUser}
+          badgeSize={12}
+          hideName
+        />
+        <Text variant='h3'>&apos;s&nbsp;{messages.title}</Text>
+      </View>
+    ) : (
+      messages.title
+    )
+
+  return <UserListTitle icon={IconTrophy} title={title} />
+}
 
 export const TopSupportersScreen = () => {
   const { params } = useRoute<'TopSupporters'>()
-  const { userId } = params
+  const { userId, source } = params
+  const styles = useStyles()
   const dispatchWeb = useDispatchWeb()
+  const supportersId = useSelectorWeb(getSupportersId)
+  const supportersUser = useSelectorWeb(state =>
+    getUser(state, { id: supportersId })
+  )
 
   const handleSetSupporters = useCallback(() => {
     dispatchWeb(setTopSupporters(userId))
   }, [dispatchWeb, userId])
 
   return (
-    <Screen headerTitle={headerTitle} variant='white'>
+    <Screen
+      headerTitle={() => headerTitle({ source, supportersUser, styles })}
+      variant='white'
+    >
       <UserList
         userSelector={getUserList}
         tag='TOP SUPPORTERS'

--- a/packages/mobile/src/screens/user-list-screen/UserListTitle.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserListTitle.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(({ spacing }) => ({
 
 type UserListTitleProps = {
   icon: ComponentType<SvgProps>
-  title: string
+  title: JSX.Element | string
 }
 export const UserListTitle = (props: UserListTitleProps) => {
   const { icon: Icon, title } = props

--- a/packages/web/src/components/user-list-modal/components/UserListModal.module.css
+++ b/packages/web/src/components/user-list-modal/components/UserListModal.module.css
@@ -40,3 +40,18 @@
   overflow-y: auto;
   overflow-x: hidden;
 }
+
+.titleNameContainer {
+  display: flex;
+  align-items: center;
+}
+
+.titleName {
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.badge {
+  margin-left: 4px;
+}

--- a/packages/web/src/components/user-list-modal/components/UserListModal.module.css
+++ b/packages/web/src/components/user-list-modal/components/UserListModal.module.css
@@ -51,7 +51,3 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-
-.badge {
-  margin-left: 4px;
-}

--- a/packages/web/src/components/user-list-modal/components/UserListModal.tsx
+++ b/packages/web/src/components/user-list-modal/components/UserListModal.tsx
@@ -29,7 +29,6 @@ import {
   getId as getSupportersId
 } from 'common/store/user-list/top-supporters/selectors'
 import { UserListStoreState } from 'common/store/user-list/types'
-import UserBadges from 'components/user-badges/UserBadges'
 import UserList from 'components/user-list/UserList'
 import { USER_LIST_TAG as FAVORITES_TAG } from 'pages/favorites-page/sagas'
 import { USER_LIST_TAG as FOLLOWER_TAG } from 'pages/followers-page/sagas'
@@ -124,12 +123,6 @@ const UserListModal = ({
           {!profile && supportersUser && supportersId ? (
             <div className={styles.titleNameContainer}>
               <div className={styles.titleName}>{supportersUser.name}</div>
-              <UserBadges
-                userId={supportersId}
-                className={styles.badge}
-                badgeSize={10}
-                inline
-              />
               <span>&apos;s&nbsp;</span>
             </div>
           ) : null}

--- a/packages/web/src/components/user-list-modal/components/UserListModal.tsx
+++ b/packages/web/src/components/user-list-modal/components/UserListModal.tsx
@@ -10,6 +10,8 @@ import {
 
 import { ReactComponent as IconTip } from 'assets/img/iconTip.svg'
 import { useSelector } from 'common/hooks/useSelector'
+import { getUser } from 'common/store/cache/users/selectors'
+import { getProfileUser } from 'common/store/pages/profile/selectors'
 import { getUserList as favoritesSelector } from 'common/store/user-list/favorites/selectors'
 import { getUserList as followersSelector } from 'common/store/user-list/followers/selectors'
 import { getUserList as followingSelector } from 'common/store/user-list/following/selectors'
@@ -22,8 +24,12 @@ import {
 import { USER_LIST_TAG as NOTIFICATION_TAG } from 'common/store/user-list/notifications/types'
 import { getUserList as repostsSelector } from 'common/store/user-list/reposts/selectors'
 import { getUserList as supportingSelector } from 'common/store/user-list/supporting/selectors'
-import { getUserList as topSupportersSelector } from 'common/store/user-list/top-supporters/selectors'
+import {
+  getUserList as topSupportersSelector,
+  getId as getSupportersId
+} from 'common/store/user-list/top-supporters/selectors'
 import { UserListStoreState } from 'common/store/user-list/types'
+import UserBadges from 'components/user-badges/UserBadges'
 import UserList from 'components/user-list/UserList'
 import { USER_LIST_TAG as FAVORITES_TAG } from 'pages/favorites-page/sagas'
 import { USER_LIST_TAG as FOLLOWER_TAG } from 'pages/followers-page/sagas'
@@ -62,6 +68,11 @@ const UserListModal = ({
   let title: ReactElement | string
   const notificationTitle = useSelector(getPageTitle)
   const scrollParentRef = useRef<HTMLElement>()
+  const profile = useSelector(getProfileUser)
+  const supportersId = useSelector(getSupportersId)
+  const supportersUser = useSelector(state =>
+    getUser(state, { id: supportersId })
+  )
 
   switch (userListType) {
     case UserListType.FAVORITE:
@@ -110,6 +121,18 @@ const UserListModal = ({
       title = (
         <div className={styles.titleContainer}>
           <IconTrophy className={styles.icon} />
+          {!profile && supportersUser && supportersId ? (
+            <div className={styles.titleNameContainer}>
+              <div className={styles.titleName}>{supportersUser.name}</div>
+              <UserBadges
+                userId={supportersId}
+                className={styles.badge}
+                badgeSize={10}
+                inline
+              />
+              <span>&apos;s&nbsp;</span>
+            </div>
+          ) : null}
           <span>{messages.topSupporters}</span>
         </div>
       )


### PR DESCRIPTION
### Description

When user clicks on the tippers/senders from the feed tip tile, show the display name of the receiver in the list modal title.

See below for list modal titles on feed vs on profile page for both mobile and web

![Simulator Screen Shot - iPhone 13 - 2022-06-09 at 08 48 02](https://user-images.githubusercontent.com/9600175/172850948-b378292e-b993-475f-b74a-29fd07c17ccd.png)

![Simulator Screen Shot - iPhone 13 - 2022-06-09 at 08 48 10](https://user-images.githubusercontent.com/9600175/172850960-24f7d1ff-0214-4f93-aedf-d92cec928dee.png)

<img width="1102" alt="Screen Shot 2022-06-09 at 8 52 31 AM" src="https://user-images.githubusercontent.com/9600175/172851412-59281bc1-3af5-4d36-8e34-c0514ce34bf4.png">


<img width="932" alt="Screen Shot 2022-06-09 at 8 52 41 AM" src="https://user-images.githubusercontent.com/9600175/172851354-d3c36a42-b4f6-407f-966f-6ce57afdab69.png">


### Dragons

n/a

### How Has This Been Tested?

local dapp against stage. local mobile dev pointing to local dapp

### How will this change be monitored?

n/a
