### PR TITLE
Hide profile top supporters on mobile if none

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
@@ -89,7 +89,7 @@ export const TopSupporters = () => {
     })
   }, [navigation, user_id])
 
-  return (
+  return rankedSupporters.length > 0 ? (
     <View style={styles.root}>
       <ProfilePictureList
         users={rankedSupporters.slice(0, MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS)}
@@ -111,5 +111,5 @@ export const TopSupporters = () => {
         </TouchableOpacity>
       </View>
     </View>
-  )
+  ) : null
 }


### PR DESCRIPTION
### Description

Currently, we show profile top supporters even if there are none. Clicking on it shows an empty list modal. This PR hides that section altogether if the profile has no supporters.

![simulator_screenshot_E40806B8-AC5A-48CC-B371-B4412AC44DD1](https://user-images.githubusercontent.com/9600175/172858144-a148e323-d384-46e3-8b95-0cfab152baf7.png)

### Dragons

n/a

### How Has This Been Tested?

local mobile app vs local dapp vs stage

### How will this change be monitored?

n/a
