### PR TITLE
Udpate profile support and mutuals tiles and and content transitions

### DIFF
--- a/packages/web/src/components/tipping/support/Support.module.css
+++ b/packages/web/src/components/tipping/support/Support.module.css
@@ -75,14 +75,14 @@
 .topSupportersContainer:hover {
   box-shadow: 1px 10px 20px var(--tile-shadow-1-alt),
     0 1px 0 0 var(--tile-shadow-2), 0 2px 10px -2px var(--tile-shadow-3);
-  transform: scale3d(1.005, 1.005, 1.005);
+  transform: scale3d(1.01, 1.01, 1.01);
   cursor: pointer;
 }
 .tileContainer:active,
 .topSupportersContainer:active {
   box-shadow: 0px 0px 1px -2px var(--tile-shadow-2),
     0px 1px 0px -2px var(--tile-shadow-2), 1px 2px 5px var(--tile-shadow-2);
-  transform: scale3d(0.995, 0.995, 0.995);
+  transform: scale3d(0.99, 0.99, 0.99);
 }
 
 .tileBackground {
@@ -197,10 +197,10 @@
 .topSupportersContainer:hover .viewAll {
   cursor: pointer;
   color: var(--secondary);
-  transition: color 0.18s ease-out;
+  transition: color 0.07s ease-out;
 }
 
 .topSupportersContainer:hover .viewAll path {
   fill: var(--secondary);
-  transition: fill 0.18s ease-out;
+  transition: fill 0.07s ease-out;
 }

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
@@ -32,21 +32,21 @@
 .contentContainer:hover {
   box-shadow: 1px 10px 20px var(--tile-shadow-1-alt),
     0 1px 0 0 var(--tile-shadow-2), 0 2px 10px -2px var(--tile-shadow-3);
-  transform: scale3d(1.005, 1.005, 1.005);
+  transform: scale3d(1.01, 1.01, 1.01);
   cursor: pointer;
 }
 .contentContainer:active {
   box-shadow: 0px 0px 1px -2px var(--tile-shadow-2),
     0px 1px 0px -2px var(--tile-shadow-2), 1px 2px 5px var(--tile-shadow-2);
-  transform: scale3d(0.995, 0.995, 0.995);
+  transform: scale3d(0.99, 0.99, 0.99);
 }
 .contentContainer:hover .viewAll {
   color: var(--secondary);
-  transition: color 0.18s ease-out;
+  transition: color 0.07s ease-out;
 }
 .contentContainer:hover .viewAll path {
   fill: var(--secondary);
-  transition: fill 0.18s ease-out;
+  transition: fill 0.07s ease-out;
 }
 .profilePictureWrapper:hover {
   transform: none;


### PR DESCRIPTION
### Description

Udpate profile support and mutuals tiles and and content transitions based on:
- On Hover, let’s make all of these mutuals/supporters/supporting tiles grow by 1.01 (instead of 1.005)
- let’s change the active state on tiles from .995 to .99
- And let’s keep duration of .18s for the tile
- lets do .07s for the purple (both the text and the arrow icon)

### Dragons

n/a

### How Has This Been Tested?

local dapp against stage

### How will this change be monitored?

n/a
