### PR TITLE
[PAY-277] Fix spacing between rank and audio amount

### DIFF
--- a/packages/web/src/components/artist/ArtistChip.module.css
+++ b/packages/web/src/components/artist/ArtistChip.module.css
@@ -107,22 +107,24 @@
 }
 
 .tipContainer .rank {
-  margin-right: 4px;
+  margin-right: 24px;
 }
 .tipContainer .topSupporter,
 .tipContainer .supporter {
   display: flex;
   align-items: center;
-  width: 128px;
   font-size: var(--font-s);
   font-weight: var(--font-medium);
 }
 .tipContainer .topSupporter {
   color: var(--secondary);
 }
-.tipContainer .rankNumber {
+.tipContainer .topRankNumber {
   font-weight: var(--font-bold);
   margin-right: 4px;
+}
+.tipContainer .rankNumber {
+  font-weight: var(--font-bold);
 }
 .tipContainer .topSupporter .icon path {
   fill: var(--secondary);

--- a/packages/web/src/components/artist/ArtistChipTips.tsx
+++ b/packages/web/src/components/artist/ArtistChipTips.tsx
@@ -63,7 +63,7 @@ export const ArtistChipTips = ({ artistId, tag }: ArtistChipTipsProps) => {
           {rank && rank >= 1 && rank <= TIPPING_TOP_RANK_THRESHOLD ? (
             <div className={styles.topSupporter}>
               <IconTrophy className={styles.icon} />
-              <span className={styles.rankNumber}>#{rank}</span>
+              <span className={styles.topRankNumber}>#{rank}</span>
               <span>{messages.supporter}</span>
             </div>
           ) : (


### PR DESCRIPTION
### Description

Fix spacing between rank and audio amount in the top supporters list modal

<img width="621" alt="Screen Shot 2022-06-09 at 12 59 27 PM" src="https://user-images.githubusercontent.com/9600175/172903061-7e1fdc9a-ce49-4124-84d5-ee1b12e0d0e2.png">

### Dragons

n/a

### How Has This Been Tested?

local dapp against stage

### How will this change be monitored?

n/a
