### PR TITLE
[PAY-317][PAY-321] Fix tooltip, +N tile in mutuals tile

### DIFF
--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
@@ -36,6 +36,19 @@
   position: absolute;
 }
 
+.profilePictureExtra::after {
+  content: ' ';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.1);
+  margin: 2px;
+  border-radius: 50%;
+  z-index: 3;
+}
+
 .profilePictureCount {
   composes: profilePictureBase;
   position: absolute;

--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
@@ -27,6 +27,8 @@
 
 .profilePictureExtraRoot {
   position: relative;
+  width: 40px;
+  height: 40px;
 }
 
 .profilePictureExtra {

--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
@@ -7,7 +7,7 @@
   transform: scale3d(1, 1, 1);
 }
 
-.profilePictureBase:hover {
+.profilePictureBase:not(.disabled):hover {
   transform: scale3d(0.95, 0.95, 0.95);
 }
 
@@ -26,13 +26,13 @@
 }
 
 .profilePictureExtraRoot {
+  composes: profilePicture;
   position: relative;
   width: 40px;
   height: 40px;
 }
 
 .profilePictureExtra {
-  composes: profilePicture;
   position: absolute;
 }
 
@@ -50,7 +50,6 @@
 }
 
 .profilePictureCount {
-  composes: profilePictureBase;
   position: absolute;
   z-index: 2;
   height: 40px;

--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
@@ -8,7 +8,7 @@
 }
 
 .profilePictureBase:not(.disabled):hover {
-  transform: scale3d(0.95, 0.95, 0.95);
+  transform: scale3d(1.05, 1.05, 1.05);
 }
 
 .userHeader {

--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.tsx
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.tsx
@@ -63,7 +63,7 @@ export const UserProfilePictureList = ({
           />
         ))}
       {showUserListModal ? (
-        <Tooltip text={messages.viewAllTooltip}>
+        <Tooltip text={messages.viewAllTooltip} disabled={disableProfileClick}>
           <div
             className={cn(styles.profilePictureExtraRoot, {
               [styles.disabled]: disableProfileClick

--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.tsx
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.tsx
@@ -53,7 +53,9 @@ export const UserProfilePictureList = ({
         .map(user => (
           <ProfilePicture
             key={user.user_id}
-            className={cn(styles.profilePicture, profilePictureClassname)}
+            className={cn(styles.profilePicture, profilePictureClassname, {
+              [styles.disabled]: disableProfileClick
+            })}
             user={user}
             disableClick={disableProfileClick}
             disablePopover={disablePopover}
@@ -62,12 +64,17 @@ export const UserProfilePictureList = ({
         ))}
       {showUserListModal ? (
         <Tooltip text={messages.viewAllTooltip}>
-          <div className={styles.profilePictureExtraRoot}>
+          <div
+            className={cn(styles.profilePictureExtraRoot, {
+              [styles.disabled]: disableProfileClick
+            })}
+          >
             <ProfilePicture
               disablePopover
               className={cn(
                 styles.profilePictureExtra,
-                profilePictureClassname
+                profilePictureClassname,
+                { [styles.disabled]: disableProfileClick }
               )}
               user={users[limit]}
             />

--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.tsx
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.tsx
@@ -73,8 +73,7 @@ export const UserProfilePictureList = ({
               disablePopover
               className={cn(
                 styles.profilePictureExtra,
-                profilePictureClassname,
-                { [styles.disabled]: disableProfileClick }
+                profilePictureClassname
               )}
               user={users[limit]}
             />

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.module.css
@@ -46,9 +46,6 @@
 .contentContainer:hover .viewAll path {
   fill: var(--secondary);
 }
-.profilePictureWrapper:hover {
-  transform: none;
-}
 .followingIcon {
   width: 32px;
 }

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
@@ -73,7 +73,7 @@ export const ProfileMutuals = () => {
           users={mutuals}
           totalUserCount={mutuals.length}
           limit={MAX_MUTUALS}
-          profilePictureClassname={styles.profilePictureWrapper}
+          disableProfileClick
         />
         <div className={styles.viewAll}>
           <span>{messages.viewAll}</span>


### PR DESCRIPTION
### Description

Review by commit if necessary
- Centers the tooltip in the profile picture list by giving the container a size of 40x40
- Adds a shadow overlay to the +N profile picture tile by adding a semitransparent overlay circle (would have done `filter` but that affects the profile picture border)
- Disables clicking the profile pictures in mutuals
- Makes profile images grow instead of shrink
- Disables grow effect if not clickable

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
