### PR TITLE
[PAY-315] Fix mutuals profile pics loading

### DIFF
--- a/packages/web/src/common/store/cache/users/sagas.js
+++ b/packages/web/src/common/store/cache/users/sagas.js
@@ -253,7 +253,7 @@ function* watchFetchProfilePicture() {
     inProgress.add(key)
 
     try {
-      let user = yield select(getUser, { id: userId })
+      const user = yield select(getUser, { id: userId })
       if (!user || (!user.profile_picture_sizes && !user.profile_picture))
         return
       const gateways = getCreatorNodeIPFSGateways(user.creator_node_endpoint)
@@ -264,14 +264,20 @@ function* watchFetchProfilePicture() {
           size,
           gateways
         )
+
         if (url) {
-          user = yield select(getUser, { id: userId })
-          user._profile_picture_sizes = {
-            ...user._profile_picture_sizes,
-            [size]: url
+          const updatedUser = yield select(getUser, { id: userId })
+          const userWithProfilePicture = {
+            ...updatedUser,
+            _profile_picture_sizes: {
+              ...user._profile_picture_sizes,
+              [size]: url
+            }
           }
           yield put(
-            cacheActions.update(Kind.USERS, [{ id: userId, metadata: user }])
+            cacheActions.update(Kind.USERS, [
+              { id: userId, metadata: userWithProfilePicture }
+            ])
           )
         }
       } else if (user.profile_picture) {
@@ -282,13 +288,18 @@ function* watchFetchProfilePicture() {
           gateways
         )
         if (url) {
-          user = yield select(getUser, { id: userId })
-          user._profile_picture_sizes = {
-            ...user._profile_picture_sizes,
-            [DefaultSizes.OVERRIDE]: url
+          const updatedUser = yield select(getUser, { id: userId })
+          const userWithProfilePicture = {
+            ...updatedUser,
+            _profile_picture_sizes: {
+              ...user._profile_picture_sizes,
+              [DefaultSizes.OVERRIDE]: url
+            }
           }
           yield put(
-            cacheActions.update(Kind.USERS, [{ id: userId, metadata: user }])
+            cacheActions.update(Kind.USERS, [
+              { id: userId, metadata: userWithProfilePicture }
+            ])
           )
         }
       }


### PR DESCRIPTION
### Description

Wouldn't you know it, mutable state strikes again!

I noticed that even with the cache update action commented out the pictures were still loading. It turns out that the `user._profile_picture_sizes` was updating the user object and the cache update action wasn't causing the `getProfile` selector to run again.

Changing this to an immutable update causes the cache update to actually rerender the profile page. 

### Dragons

I was having a hard time reproing the initial issue, so I added some long delays on the picture fetching to recreate the issue. Would love if someone who can repro the initial issue could double check this fix!

### How Has This Been Tested?

Locally against prod

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
