### PR TITLE
[PAY-323] Don't dismiss modal when clicking the follow button

### DIFF
--- a/packages/web/src/components/follow-button/FollowButton.js
+++ b/packages/web/src/components/follow-button/FollowButton.js
@@ -29,13 +29,22 @@ const FollowButton = props => {
     [styles.medium]: props.size === 'medium',
     [styles.small]: props.size === 'small'
   }
-  const { following, onUnfollow, onFollow, isDisabled } = props
+  const { following, onUnfollow, onFollow, isDisabled, stopPropagation } = props
 
-  const onClick = useCallback(() => {
-    if (following) onUnfollow()
-    else onFollow()
-    setIsHoveringClicked(true)
-  }, [following, onUnfollow, onFollow, setIsHoveringClicked])
+  const onClick = useCallback(
+    e => {
+      if (following) {
+        onUnfollow()
+      } else {
+        onFollow()
+      }
+      setIsHoveringClicked(true)
+      if (stopPropagation) {
+        e.stopPropagation()
+      }
+    },
+    [following, onUnfollow, onFollow, setIsHoveringClicked, stopPropagation]
+  )
 
   useEffect(() => {
     if (!isHovering && isHoveringClicked) setIsHoveringClicked(false)
@@ -102,7 +111,8 @@ FollowButton.propTypes = {
   following: PropTypes.bool,
   onFollow: PropTypes.func,
   onUnfollow: PropTypes.func,
-  isDisabled: PropTypes.bool
+  isDisabled: PropTypes.bool,
+  stopPropagation: PropTypes.bool
 }
 
 FollowButton.defaultProps = {
@@ -111,7 +121,8 @@ FollowButton.defaultProps = {
   showIcon: true,
   size: 'medium',
   messages: messages,
-  isDisabled: false
+  isDisabled: false,
+  stopPropagation: false
 }
 
 export default FollowButton

--- a/packages/web/src/components/user-list/components/UserList.tsx
+++ b/packages/web/src/components/user-list/components/UserList.tsx
@@ -65,6 +65,7 @@ const UserList = (props: UserListProps) => {
                 onFollow={() => props.onFollow(user.user_id)}
                 onUnfollow={() => props.onUnfollow(user.user_id)}
                 showIcon
+                stopPropagation
               />
             ) : null}
           </div>


### PR DESCRIPTION
### Description

After adding the event listener to the modal user list rows, clicking the follow button shouldn't propagate the click to the row.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested against stage (Mac Chrome)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
