### PR TITLE
[PAY-323] Stop immediate propagation on follow button click

### DIFF
--- a/packages/web/src/components/follow-button/FollowButton.js
+++ b/packages/web/src/components/follow-button/FollowButton.js
@@ -41,6 +41,7 @@ const FollowButton = props => {
       setIsHoveringClicked(true)
       if (stopPropagation) {
         e.stopPropagation()
+        e.nativeEvent.stopImmediatePropagation()
       }
     },
     [following, onUnfollow, onFollow, setIsHoveringClicked, stopPropagation]


### PR DESCRIPTION
### Description

Looks like the button was also triggering `useClickOutside` when clicking the icon for some reason. This hotfix should fix that.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally against stage on Chrome Mac

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
