### PR TITLE
[PAY-324] Add +N UI on mobile profile picture list component

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
@@ -1,21 +1,51 @@
 import { User } from 'audius-client/src/common/models/User'
-import { StyleProp, View, ViewStyle } from 'react-native'
+import { formatCount } from 'audius-client/src/common/utils/formatUtil'
+import { StyleProp, View, ViewStyle, Text } from 'react-native'
 
 import { makeStyles } from 'app/styles'
 
 import { ProfilePicture } from './ProfilePicture'
 
-const useStyles = makeStyles(({ spacing }) => ({
-  root: {
-    flexDirection: 'row'
-  },
-  image: {
-    marginRight: spacing(-2)
-  }
-}))
+const USER_LENGTH_LIMIT = 9
+
+/**
+ * Not all profile picture lists have the same profile picture size.
+ * Some components pass in the dimensions (width and height) while others
+ * use the default of spacing(10) - 2 (which is equal to 38).
+ * We use the dimensions to determine how to position the
+ * extra profile picture +N text.
+ */
+const defaultImageDimensions = { width: 38, height: 38 }
+
+const useStyles = makeStyles(
+  ({ spacing, palette, typography }, { imageDimensions }) => ({
+    root: {
+      flexDirection: 'row'
+    },
+    image: {
+      marginRight: spacing(-2)
+    },
+    imageExtraRoot: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center'
+    },
+    imageCount: {
+      width: imageDimensions.width,
+      marginLeft: spacing(2) - imageDimensions.width,
+      textAlign: 'center',
+      color: palette.white,
+      fontSize: typography.fontSize.small,
+      fontFamily: typography.fontByWeight.bold
+    }
+  })
+)
 
 type ProfilePictureListProps = {
   users: User[]
+  totalUserCount?: number
+  limit?: number
   style?: StyleProp<ViewStyle>
   navigationType?: 'push' | 'navigate'
   interactive?: boolean
@@ -26,20 +56,49 @@ type ProfilePictureListProps = {
 }
 
 export const ProfilePictureList = (props: ProfilePictureListProps) => {
-  const { users, style, navigationType, interactive, imageStyles } = props
-  const styles = useStyles()
+  const {
+    users,
+    totalUserCount = users.length,
+    limit = USER_LENGTH_LIMIT,
+    style,
+    navigationType,
+    interactive,
+    imageStyles
+  } = props
+  const styles = useStyles({
+    imageDimensions: imageStyles || defaultImageDimensions
+  })
+  const showUserListDrawer = totalUserCount > limit
+  const remainingUsersCount = totalUserCount - limit + 1
+  const sliceLimit = showUserListDrawer ? limit - 1 : limit
 
   return (
     <View style={[styles.root, style]}>
-      {users.map(user => (
-        <ProfilePicture
-          profile={user}
-          key={user.user_id}
-          style={{ ...styles.image, ...imageStyles }}
-          navigationType={navigationType}
-          interactive={interactive}
-        />
-      ))}
+      {users
+        .filter(u => !u.is_deactivated)
+        .slice(0, sliceLimit)
+        .map(user => (
+          <ProfilePicture
+            profile={user}
+            key={user.user_id}
+            style={{ ...styles.image, ...imageStyles }}
+            navigationType={navigationType}
+            interactive={interactive}
+          />
+        ))}
+      {showUserListDrawer ? (
+        <View style={styles.imageExtraRoot}>
+          <ProfilePicture
+            profile={users[limit]}
+            style={{ ...styles.image, ...imageStyles }}
+            navigationType={navigationType}
+            interactive={interactive}
+          />
+          <Text style={styles.imageCount}>
+            {`+${formatCount(remainingUsersCount)}`}
+          </Text>
+        </View>
+      ) : null}
     </View>
   )
 }

--- a/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
@@ -89,7 +89,7 @@ export const ProfilePictureList = (props: ProfilePictureListProps) => {
       {showUserListDrawer ? (
         <View style={styles.imageExtraRoot}>
           <ProfilePicture
-            profile={users[limit]}
+            profile={users[limit - 1]}
             style={{ ...styles.image, ...imageStyles }}
             navigationType={navigationType}
             interactive={interactive}

--- a/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { User } from 'audius-client/src/common/models/User'
 import { formatCount } from 'audius-client/src/common/utils/formatUtil'
 import { StyleProp, View, ViewStyle, Text } from 'react-native'
@@ -65,9 +67,13 @@ export const ProfilePictureList = (props: ProfilePictureListProps) => {
     interactive,
     imageStyles
   } = props
-  const styles = useStyles({
-    imageDimensions: imageStyles || defaultImageDimensions
-  })
+  const stylesConfig = useMemo(
+    () => ({
+      imageDimensions: imageStyles || defaultImageDimensions
+    }),
+    [imageStyles]
+  )
+  const styles = useStyles(stylesConfig)
   const showUserListDrawer = totalUserCount > limit
   const remainingUsersCount = totalUserCount - limit + 1
   const sliceLimit = showUserListDrawer ? limit - 1 : limit

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
@@ -66,7 +66,10 @@ export const TopSupporters = () => {
   const styles = useStyles()
   const { secondary, neutral } = useThemeColors()
   const navigation = useNavigation()
-  const { user_id } = useSelectProfile(['user_id'])
+  const { user_id, supporter_count } = useSelectProfile([
+    'user_id',
+    'supporter_count'
+  ])
   const supportersForProfile: SupportersMapForUser =
     useSelectorWeb(state => getSupportersForUser(state, user_id)) || {}
   const rankedSupporterIds = Object.keys(supportersForProfile)
@@ -92,7 +95,9 @@ export const TopSupporters = () => {
   return rankedSupporters.length > 0 ? (
     <View style={styles.root}>
       <ProfilePictureList
-        users={rankedSupporters.slice(0, MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS)}
+        users={rankedSupporters}
+        totalUserCount={supporter_count}
+        limit={MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS}
         style={styles.profilePictureList}
         navigationType='push'
         interactive={false}

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
@@ -5,6 +5,7 @@ import { getUsers } from 'audius-client/src/common/store/cache/users/selectors'
 import { getSupportingForUser } from 'audius-client/src/common/store/tipping/selectors'
 import { SupportingMapForUser } from 'audius-client/src/common/store/tipping/types'
 import { stringWeiToBN } from 'audius-client/src/common/utils/wallet'
+import { MAX_PROFILE_SUPPORTING_TILES } from 'audius-client/src/utils/constants'
 
 import IconArrow from 'app/assets/images/iconArrow.svg'
 import { Tile, TextButton } from 'app/components/core'
@@ -81,8 +82,8 @@ export const ViewAllSupportingTile = () => {
       onPress={handlePress}
     >
       <ProfilePictureList
-        users={rankedSupporting}
-        totalUserCount={supporting_count}
+        users={rankedSupporting.slice(MAX_PROFILE_SUPPORTING_TILES)}
+        totalUserCount={supporting_count - MAX_PROFILE_SUPPORTING_TILES}
         limit={MAX_PROFILE_SUPPORTING_VIEW_ALL_USERS}
         style={styles.profilePictureList}
         navigationType='push'

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
@@ -43,7 +43,10 @@ export const ViewAllSupportingTile = () => {
   const styles = useStyles()
   const navigation = useNavigation()
 
-  const { user_id } = useSelectProfile(['user_id'])
+  const { user_id, supporting_count } = useSelectProfile([
+    'user_id',
+    'supporting_count'
+  ])
   const supportingForProfile: SupportingMapForUser =
     useSelectorWeb(state => getSupportingForUser(state, user_id)) || {}
   const rankedSupportingIds = Object.keys(supportingForProfile)
@@ -78,7 +81,9 @@ export const ViewAllSupportingTile = () => {
       onPress={handlePress}
     >
       <ProfilePictureList
-        users={rankedSupporting.slice(0, MAX_PROFILE_SUPPORTING_VIEW_ALL_USERS)}
+        users={rankedSupporting}
+        totalUserCount={supporting_count}
+        limit={MAX_PROFILE_SUPPORTING_VIEW_ALL_USERS}
         style={styles.profilePictureList}
         navigationType='push'
         interactive={false}


### PR DESCRIPTION
### Description

Add +N UI on mobile profile picture list component

_(the first two images do not represent the accurate number of profile pictures for notififications and profile top supporters that would trigger the limit for the +N UI, it's only for illustration purposes)_
![Simulator Screen Shot - iPhone 13 - 2022-06-10 at 11 16 55](https://user-images.githubusercontent.com/9600175/173097936-89b89053-e2dd-4d9e-9eb5-e52b9b1ddfef.png)
![Simulator Screen Shot - iPhone 13 - 2022-06-10 at 11 17 02](https://user-images.githubusercontent.com/9600175/173097968-61d0ed3c-9653-4429-b8d2-33da9082b5d4.png)
![Simulator Screen Shot - iPhone 13 - 2022-06-10 at 11 17 09](https://user-images.githubusercontent.com/9600175/173097985-dc6b927b-d4b6-4bc3-bd6e-b21d37cab7d3.png)

### Dragons

make sure that the correct number of profile pictures is displayed on different components that use the profile picture list

### How Has This Been Tested?

local mobile vs local dapp vs stage

### How will this change be monitored?

n/a
