### PR TITLE
[C-576] Fix NotificationUsersScreen title, large list

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/routeUtil.ts
+++ b/packages/mobile/src/screens/notifications-screen/routeUtil.ts
@@ -121,7 +121,7 @@ export const getNotificationScreen = (
     case NotificationType.Announcement:
       return null
     case NotificationType.Follow: {
-      const users = notification.users
+      const { userIds, users } = notification
       const isMultiUser = !!users && users.length > 1
       if (isMultiUser) {
         return {
@@ -129,7 +129,7 @@ export const getNotificationScreen = (
           params: {
             ...contextualParams,
             notificationType: notification.type,
-            count: users.length,
+            count: userIds.length,
             id: notification.id
           }
         }

--- a/packages/mobile/src/screens/user-list-screen/NotificationUsersScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/NotificationUsersScreen.tsx
@@ -28,10 +28,10 @@ export const NotificationUsersScreen = () => {
   }, [notificationType, count])
 
   return (
-    <Screen title={getTitle()} variant='secondary'>
+    <Screen title={getTitle()} variant='white'>
       <UserList
         userSelector={getUserList}
-        tag='NOTIFICATION_USERS_SCREEN'
+        tag='NOTIFICATION'
         setUserList={handleSetNotificationId}
       />
     </Screen>


### PR DESCRIPTION
### Description

Fixes two issues with native follow notifications with 8+ followers
- Fixes incorrect title count by using `userIds` instead of `users` (which is limited to 8)
- Fixes user-list loading by renaming the tag correctly
