### PR TITLE
[PAY-228][PAY-300][PAY-301] Various "Send a Tip" Modal Bugfixes

### DIFF
--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { Button, ButtonType, IconCheck } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
+import { Transition, animated } from 'react-spring/renderprops'
 
 import { ReactComponent as IconCaretLeft } from 'assets/img/iconCaretLeft.svg'
 import { ReactComponent as IconSend } from 'assets/img/iconSend.svg'
@@ -35,13 +36,25 @@ const ConfirmInfo = () => (
   </div>
 )
 
-const ConvertingInfo = () => (
-  <div className={cn(styles.info)}>
-    <p>{messages.maintenance}</p>
-    <br />
-    <p>{messages.fewMinutes}</p>
-    <p>{messages.holdOn}</p>
-  </div>
+const ConvertingInfo = ({ isVisible }: { isVisible: boolean }) => (
+  <Transition
+    items={isVisible}
+    from={{ opacity: 0 }}
+    enter={{ opacity: 1 }}
+    leave={{}}
+    unique
+  >
+    {item => style =>
+      item ? (
+        <animated.div style={style} className={styles.info}>
+          <p>{messages.maintenance}</p>
+          <p>{JSON.stringify(item)}</p>
+          <br />
+          <p>{messages.fewMinutes}</p>
+          <p>{messages.holdOn}</p>
+        </animated.div>
+      ) : null}
+  </Transition>
 )
 
 export const ConfirmSendTip = () => {
@@ -107,7 +120,7 @@ export const ConfirmSendTip = () => {
     <div className={styles.container}>
       {renderSendingAudio()}
       <TipProfilePicture user={receiver} />
-      {isConverting ? <ConvertingInfo /> : null}
+      <ConvertingInfo isVisible={isConverting} />
       {hasError ? renderError() : null}
       {!isSending ? <ConfirmInfo /> : null}
       <div className={cn(styles.flexCenter, styles.buttonContainer)}>

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -1,4 +1,5 @@
 .tipIconTextContainer {
+  min-height: 24px;
   display: flex;
   align-items: center;
 }
@@ -13,13 +14,23 @@
 }
 
 .modalContentContainer {
-  margin: 24px 0;
   position: relative;
+  height: 100%;
 }
 
 .modalContentContainer > div {
   position: absolute;
-  width: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+}
+
+.container > div {
+  margin-top: 24px;
+  margin-bottom: 24px;
 }
 
 .container {
@@ -36,17 +47,11 @@
   text-align: center;
 }
 
-.receiver {
-  margin-top: 32px;
-  margin-bottom: 24px;
-}
-
 .confirmReceiver {
   margin-top: 0;
 }
 
 .becomeTopSupporter {
-  margin-bottom: 24px;
   padding: 8px 0;
   font-size: var(--font-m);
   font-weight: var(--font-demi-bold);
@@ -70,14 +75,16 @@
 }
 
 .amountToSend {
-  margin: 0 24px 24px 24px;
+  margin-left: 24px;
+  margin-right: 24px;
 }
 
 .amountAvailableContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 0 24px 24px 24px;
+  margin-left: 40px;
+  margin-right: 40px;
   color: var(--neutral-light-4);
   font-weight: var(--font-heavy);
 }
@@ -114,10 +121,6 @@
   width: 100%;
 }
 
-.buttonContainer {
-  margin-bottom: 24px;
-}
-
 .buttonText {
   font-size: var(--font-l) !important;
 }
@@ -128,7 +131,7 @@
   align-items: center;
   flex-direction: row;
   flex-shrink: 0;
-  margin-bottom: 4px;
+  padding-bottom: 4px;
   color: var(--neutral);
   transition: all ease-in-out 0.18s;
 }
@@ -225,7 +228,8 @@
 .info {
   font-size: var(--font-m);
   font-weight: var(--font-demi-bold);
-  margin-bottom: 24px;
+  text-align: center;
+  line-height: 150%;
 }
 
 .empty {
@@ -233,13 +237,13 @@
 }
 
 .goBackContainer {
-  width: 80px;
-  margin: 24px auto;
+  text-align: center;
   cursor: pointer;
 }
 .goBack {
   margin-left: 4px;
   font-weight: var(--font-bold);
+  font-size: var(--font-l);
   color: var(--neutral-light-4);
 }
 .goBackContainer:hover .goBack {
@@ -265,13 +269,18 @@
   stroke: var(--static-white) !important;
 }
 
-.sendingContainer {
-  margin-top: 8px;
-  margin-bottom: 8px;
+.modalContentHeaderTitle {
   color: var(--neutral-light-4);
   font-size: var(--font-s);
   font-weight: var(--font-bold);
   letter-spacing: 0.1em;
+}
+
+.modalContentHeaderSubtitle {
+  font-size: var(--font-3xl);
+  font-weight: var(--font-heavy);
+  color: var(--neutral-light-4);
+  padding: 8px 0;
 }
 
 .sendingIcon {
@@ -287,32 +296,9 @@
   fill: var(--neutral-light-4) !important;
 }
 
-.sendingAudio {
-  font-size: var(--font-3xl);
-  font-weight: var(--font-heavy);
-  color: var(--neutral-light-4);
-  margin-bottom: 28px;
-}
-
 .sendAmount {
   margin-right: 4px;
   color: var(--neutral);
-}
-
-.sentAudio {
-  font-size: var(--font-3xl);
-  font-weight: var(--font-heavy);
-  color: var(--neutral-light-4);
-  margin-bottom: 24px;
-}
-
-.sentSuccessfullyContainer {
-  font-size: var(--font-s);
-  font-weight: var(--font-bold);
-  color: var(--neutral-light-4);
-  margin-top: 48px;
-  margin-bottom: 8px;
-  letter-spacing: 0.1em;
 }
 
 .sentSuccessfullyIcon {
@@ -334,7 +320,6 @@
 }
 
 .support {
-  margin-bottom: 24px;
   font-size: var(--font-m);
   font-weight: var(--font-demi-bold);
 }
@@ -360,7 +345,6 @@
   font-size: var(--font-m);
   font-weight: var(--font-demi-bold);
   color: var(--accent-red);
-  margin-bottom: 24px;
 }
 
 .button:hover {

--- a/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
@@ -20,6 +20,7 @@ import { TipSent } from './TipSent'
 const messages = {
   sendATip: 'Send Tip',
   confirm: 'Confirm',
+  sending: 'Sending',
   tipSent: 'Tip Sent',
   holdOn: '⚠️ Hold On a Moment'
 }
@@ -50,7 +51,7 @@ const titlesMap: { [key in TippingSendStatus]?: JSX.Element | string } = {
   SENDING: (
     <div className={styles.tipIconTextContainer}>
       <GoldBadgeIconImage />
-      <span className={styles.tipText}>{messages.confirm}</span>
+      <span className={styles.tipText}>{messages.sending}</span>
     </div>
   ),
   CONVERTING: (

--- a/packages/web/src/components/tipping/tip-audio/TipSent.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipSent.tsx
@@ -53,18 +53,18 @@ export const TipSent = () => {
   }, [account, recipient, record, sendAmount, source])
 
   const renderSentAudio = () => (
-    <>
-      <div className={cn(styles.flexCenter, styles.sentSuccessfullyContainer)}>
+    <div className={styles.modalContentHeader}>
+      <div className={cn(styles.flexCenter, styles.modalContentHeaderTitle)}>
         <span className={styles.sentSuccessfullyIcon}>
           <IconCheck />
         </span>
         {messages.sentSuccessfully}
       </div>
-      <div className={cn(styles.flexCenter, styles.sentAudio)}>
+      <div className={cn(styles.flexCenter, styles.modalContentHeaderSubtitle)}>
         <span className={styles.sendAmount}>{sendAmount}</span>
         $AUDIO
       </div>
-    </>
+    </div>
   )
 
   return recipient ? (

--- a/packages/web/src/store/tipping/sagas.ts
+++ b/packages/web/src/store/tipping/sagas.ts
@@ -1,5 +1,13 @@
 import BN from 'bn.js'
-import { call, put, select, takeEvery } from 'typed-redux-saga/macro'
+import {
+  call,
+  delay,
+  put,
+  select,
+  takeEvery,
+  fork,
+  cancel
+} from 'typed-redux-saga/macro'
 
 import { Name } from 'common/models/Analytics'
 import { ID } from 'common/models/Identifiers'
@@ -198,8 +206,14 @@ function* sendTipAsync() {
     // If transferring spl wrapped audio and there are insufficent funds with only the
     // user bank balance, transfer all eth AUDIO to spl wrapped audio
     if (weiBNAmount.gt(waudioWeiAmount)) {
-      yield put(convert())
+      // Wait for a second before showing the notice that this might take a while
+      const showConvertingMessage = yield* fork(function* () {
+        yield delay(1000)
+        yield put(convert())
+      })
       yield call(walletClient.transferTokensFromEthToSol)
+      // Cancel showing the notice if the conversion was magically super quick
+      yield cancel(showConvertingMessage)
     }
 
     yield call(() =>


### PR DESCRIPTION
### Description

- Fixes issue where switching between screens would "flicker" as the state would change and the modal contents would swap out while animating
- Fixes "jitter" on the "Hold on a moment" screen due to the header size not staying the same and the state quickly switching between "Sending" and "Converting" (added a 1s delay)
- Fixes spacing issue on the "Hold on a moment" screen
- Normalizes spacing for elements in the transition container so that they all have 24px margins
- Consolidates the styles for the header/subheader in the modal contents
- Changes the header to "Sending" for the sending screen

(pics below)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

- Seems like the modal should have a 24px bottom padding as well as the side paddings - the contents seem too low?
- Sending/Converting screens don't have dismiss icon, Figma does
- The spacing of the header/subheader varies on Figma
- Should converting text fade in?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested locally (Chrome Mac) against staging, awaiting design signoff

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A

<img width="505" alt="image" src="https://user-images.githubusercontent.com/3690498/173462508-e7a43000-f960-4699-8c7b-86bc13e353b2.png">
<img width="508" alt="image" src="https://user-images.githubusercontent.com/3690498/173462533-96453b72-2dbd-4945-8108-94a7377f5e22.png">
<img width="504" alt="image" src="https://user-images.githubusercontent.com/3690498/173462592-6fb3bc0b-3869-4f5d-86f0-2d5050a5cdf4.png">
<img width="507" alt="image" src="https://user-images.githubusercontent.com/3690498/173462648-129ad30e-fb45-4d21-9377-b965f5a00d0d.png">
<img width="508" alt="image" src="https://user-images.githubusercontent.com/3690498/173462475-baffd81a-6184-4a27-bc50-eb2098d3e5e0.png">
