### PR TITLE
Fix Modals/Popups closing on open

### DIFF
--- a/packages/stems/src/hooks/useClickOutside.ts
+++ b/packages/stems/src/hooks/useClickOutside.ts
@@ -35,7 +35,10 @@ export const useClickOutside = (
     }
 
     if (isVisible) {
-      document.addEventListener('click', handleClick)
+      // Don't attach the listener until all the current events are finished bubbling
+      setTimeout(() => {
+        document.addEventListener('click', handleClick)
+      }, 0)
     }
     return () => document.removeEventListener('click', handleClick)
   }, [onClick, ignoreClick, isVisible])


### PR DESCRIPTION
### Description

Ran into another Modal/Popup issue, again the modals were closing on open. I believe this is due to the handler of the click event setting the Modal to visible _before_ the click event bubbles to the document, so by the time the event bubbles to the document the listener is ready. Uses a `setTimeout` to ensure that the handler is only added _after_ any currently bubbling event is finished bubbling.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Modals/Popups are very widespread in usage.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested locally on Chrome Mac against stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A
