### PR TITLE
[PAY-303] Native Mobile QA

### DIFF
--- a/packages/mobile/src/components/feed-tip-tile/SenderDetails.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/SenderDetails.tsx
@@ -24,7 +24,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     flexDirection: 'row',
     alignItems: 'center',
     flex: 1,
-    flexWrap: 'wrap'
+    flexWrap: 'wrap',
+    marginLeft: spacing(1)
   },
   wasTippedBy: {
     marginLeft: spacing(1.5),

--- a/packages/mobile/src/screens/notifications-screen/Notifications/SupporterAndSupportingNotificationContent.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/SupporterAndSupportingNotificationContent.tsx
@@ -1,0 +1,62 @@
+import { User } from 'audius-client/src/common/models/User'
+import { View } from 'react-native'
+
+import IconTip from 'app/assets/images/iconTip.svg'
+import IconTrending from 'app/assets/images/iconTrending.svg'
+import { makeStyles } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
+import { useThemeColors } from 'app/utils/theme'
+
+import {
+  NotificationHeader,
+  NotificationTitle,
+  ProfilePicture,
+  UserNameLink,
+  NotificationText
+} from '../Notification'
+
+const useStyles = makeStyles(() => ({
+  trendingIcon: {
+    marginRight: spacing(2)
+  },
+  textContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center'
+  }
+}))
+
+type SupporterAndSupportingNotificationContentProps = {
+  user: User
+  title: string
+  body: string
+}
+
+export const SupporterAndSupportingNotificationContent = ({
+  user,
+  title,
+  body
+}: SupporterAndSupportingNotificationContentProps) => {
+  const styles = useStyles()
+  const { neutralLight4 } = useThemeColors()
+
+  return (
+    <>
+      <NotificationHeader icon={IconTip}>
+        <NotificationTitle>{title}</NotificationTitle>
+      </NotificationHeader>
+      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        <ProfilePicture profile={user} />
+        <UserNameLink user={user} />
+      </View>
+      <View style={styles.textContainer}>
+        <IconTrending
+          fill={neutralLight4}
+          style={styles.trendingIcon}
+          height={18}
+        />
+        <NotificationText>{body}</NotificationText>
+      </View>
+    </>
+  )
+}

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipSentNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipSentNotification.tsx
@@ -43,9 +43,14 @@ export const TipSentNotification = (props: TipSentNotificationProps) => {
       <NotificationHeader icon={IconTip}>
         <NotificationTitle>{messages.title}</NotificationTitle>
       </NotificationHeader>
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center'
+        }}
+      >
         <ProfilePicture profile={user} />
-        <NotificationText>
+        <NotificationText style={{ flexShrink: 1 }}>
           {messages.sent} <TipText value={uiAmount} /> {messages.to}{' '}
           <UserNameLink user={user} />
         </NotificationText>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TopSupporterNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TopSupporterNotification.tsx
@@ -1,20 +1,11 @@
 import { getNotificationUser } from 'audius-client/src/common/store/notifications/selectors'
 import { SupporterRankUp } from 'common/store/notifications/types'
-import { View } from 'react-native'
 
-import IconTip from 'app/assets/images/iconTip.svg'
-import IconTrending from 'app/assets/images/iconTrending.svg'
 import { isEqual, useSelectorWeb } from 'app/hooks/useSelectorWeb'
-import { useThemeColors } from 'app/utils/theme'
 
-import {
-  NotificationTile,
-  NotificationHeader,
-  NotificationTitle,
-  NotificationText,
-  ProfilePicture,
-  UserNameLink
-} from '../Notification'
+import { NotificationTile } from '../Notification'
+
+import { SupporterAndSupportingNotificationContent } from './SupporterAndSupportingNotificationContent'
 
 const messages = {
   title: 'Top Supporter',
@@ -31,7 +22,6 @@ export const TopSupporterNotification = (
 ) => {
   const { notification } = props
   const { rank } = notification
-  const { neutral } = useThemeColors()
 
   const user = useSelectorWeb(
     state => getNotificationUser(state, notification),
@@ -41,19 +31,11 @@ export const TopSupporterNotification = (
 
   return (
     <NotificationTile notification={notification}>
-      <NotificationHeader icon={IconTip}>
-        <NotificationTitle>
-          #{rank} {messages.title}
-        </NotificationTitle>
-      </NotificationHeader>
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <ProfilePicture profile={user} />
-        <UserNameLink user={user} />
-      </View>
-      <NotificationText>
-        <IconTrending fill={neutral} />
-        {messages.supporterChange} #{rank} {messages.supporter}
-      </NotificationText>
+      <SupporterAndSupportingNotificationContent
+        user={user}
+        title={`#${rank} ${messages.title}`}
+        body={`${messages.supporterChange} #${rank} ${messages.supporter}`}
+      />
     </NotificationTile>
   )
 }

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TopSupportingNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TopSupportingNotification.tsx
@@ -1,20 +1,11 @@
 import { getNotificationUser } from 'audius-client/src/common/store/notifications/selectors'
 import { SupportingRankUp } from 'common/store/notifications/types'
-import { View } from 'react-native'
 
-import IconTip from 'app/assets/images/iconTip.svg'
-import IconTrending from 'app/assets/images/iconTrending.svg'
 import { isEqual, useSelectorWeb } from 'app/hooks/useSelectorWeb'
-import { useThemeColors } from 'app/utils/theme'
 
-import {
-  NotificationTile,
-  NotificationHeader,
-  NotificationTitle,
-  ProfilePicture,
-  UserNameLink,
-  NotificationText
-} from '../Notification'
+import { NotificationTile } from '../Notification'
+
+import { SupporterAndSupportingNotificationContent } from './SupporterAndSupportingNotificationContent'
 
 const messages = {
   title: 'Top Supporter',
@@ -31,7 +22,6 @@ export const TopSupportingNotification = (
 ) => {
   const { notification } = props
   const { rank } = notification
-  const { neutral } = useThemeColors()
 
   const user = useSelectorWeb(
     state => getNotificationUser(state, notification),
@@ -42,19 +32,11 @@ export const TopSupportingNotification = (
 
   return (
     <NotificationTile notification={notification}>
-      <NotificationHeader icon={IconTip}>
-        <NotificationTitle>
-          #{rank} {messages.title}
-        </NotificationTitle>
-      </NotificationHeader>
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-        <ProfilePicture profile={user} />
-        <UserNameLink user={user} />
-      </View>
-      <NotificationText>
-        <IconTrending fill={neutral} />
-        {messages.supporterChange} #{rank} {messages.supporter}
-      </NotificationText>
+      <SupporterAndSupportingNotificationContent
+        title={`#${rank} ${messages.title}`}
+        body={`${messages.supporterChange} #${rank} ${messages.supporter}`}
+        user={user}
+      />
     </NotificationTile>
   )
 }


### PR DESCRIPTION
### Description
- Consolidates top supporter/supporting notifs, since the styling is the same
Fixes:
Old
<img width="874" alt="Screen Shot 2022-06-14 at 7 26 55 PM" src="https://user-images.githubusercontent.com/6780028/173705567-582298a5-2465-44b8-a360-1d9eecaf3346.png">
New
<img width="447" alt="Screen Shot 2022-06-14 at 7 28 40 PM" src="https://user-images.githubusercontent.com/6780028/173705735-57efaafd-72f5-4e9b-833e-f2c276f4482d.png">


Old
<img width="864" alt="Screen Shot 2022-06-14 at 7 26 49 PM" src="https://user-images.githubusercontent.com/6780028/173705578-0a225914-deb2-47a7-b2be-8f91c82b7506.png">
New
<img width="452" alt="Screen Shot 2022-06-14 at 7 28 16 PM" src="https://user-images.githubusercontent.com/6780028/173705691-c879431a-c216-447c-ab72-03e20bd3870d.png">

New (just minor alignment fix)
<img width="438" alt="Screen Shot 2022-06-14 at 7 14 58 PM" src="https://user-images.githubusercontent.com/6780028/173705594-d79d22f5-14b1-4574-b0bf-e97fe1d0b2d8.png">


### Dragons
None

### How Has This Been Tested?

Tested on simulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
