### PR TITLE
Stems: Fix for modals not reopening after close

### DIFF
--- a/packages/stems/package-lock.json
+++ b/packages/stems/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/stems",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/stems/package.json
+++ b/packages/stems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/stems",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "description": "The Audius React component library",
   "author": "",
   "license": "",

--- a/packages/stems/src/hooks/useClickOutside.ts
+++ b/packages/stems/src/hooks/useClickOutside.ts
@@ -40,7 +40,12 @@ export const useClickOutside = (
         document.addEventListener('click', handleClick)
       }, 0)
     }
-    return () => document.removeEventListener('click', handleClick)
+    return () => {
+      // Don't remove the listener until after the listener has been attached
+      setTimeout(() => {
+        document.removeEventListener('click', handleClick)
+      }, 0)
+    }
   }, [onClick, ignoreClick, isVisible])
 
   return ref


### PR DESCRIPTION
### Description

In #1462 , I added `setTimeout` to delay the event listener for the click outside from getting attached to _after_ the current event bubbling was done. However, what I didn't realize was that the _removal_ of that event listener was firing _before_ the handler was attached! So the handler never got detatched and the bug would occur again once a modal had been opened once.

This PR changes the cleanup method to _also_ wait until after events are done bubbling, and thus it waits until after the handler is listening before removing it.

Also bumps stems to v0.3.40

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
