### PR TITLE
[PAY-350] Web: Supporting Tile Redesign

### DIFF
--- a/packages/web/src/components/tipping/support/Support.module.css
+++ b/packages/web/src/components/tipping/support/Support.module.css
@@ -66,6 +66,9 @@
   border-radius: 8px;
 }
 .tileContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   box-shadow: 0px 2px 5px var(--tile-shadow-3), 0px 1px 0px var(--tile-shadow-2),
     0px 0px 1px var(--tile-shadow-1);
   transition: all 0.18s ease-in-out 0s;
@@ -83,30 +86,36 @@
 }
 
 .tileBackground {
-  display: flex;
-  align-items: flex-end;
-  height: 90px;
   background-position: center;
   background-size: cover;
-  border-radius: 8px 8px 0 0;
   background-blend-mode: multiply, normal;
 }
 
 .tileHeader {
-  display: flex;
-  align-items: center;
+  flex: 0;
+  align-self: flex-end;
   background: var(--white);
   color: var(--neutral-light-4);
   font-weight: var(--font-bold);
-  font-size: var(--font-xs);
-  padding: 8px 18px;
-  border-bottom-right-radius: 8px;
-  border-bottom-left-radius: 8px;
+  font-size: var(--font-m);
+  padding: 1px 4px;
+  margin: 8px;
+  width: fit-content;
+  height: 20px;
+  border-radius: 20px;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.15);
+
+  display: flex;
+  align-items: center;
+}
+.rankNumberSymbol {
+  font-size: var(--font-s);
+  margin-right: 2px;
 }
 .tileHeader .trophyIcon,
 .tileHeader .tipIcon,
 .tileHeader .tokenBadgeIcon {
-  margin-right: 8px;
+  margin-right: 4px;
 }
 .tileHeader .trophyIcon path {
   fill: var(--secondary);
@@ -116,10 +125,6 @@
 }
 .tileHeader .tipIcon path {
   fill: var(--neutral-light-4);
-}
-
-.badge {
-  margin-left: 4px;
 }
 
 .topFive {
@@ -134,13 +139,14 @@
 }
 
 .profilePictureContainer {
-  width: 100%;
+  display: flex;
+  align-items: center;
+  margin: 12px;
+  gap: 4px;
 }
 .profilePicture {
-  margin-left: 8px;
-  margin-bottom: 4px;
-  height: 40px;
-  border-radius: 40px;
+  height: 32px;
+  border-radius: 32px;
   border: 1px solid var(--white);
   background-size: cover;
   background-position: center;
@@ -148,20 +154,14 @@
   background-color: var(--default-profile-picture-background);
 }
 
-.nameAndBadge {
-  padding-left: 8px;
-  height: 25px;
+.name {
   color: var(--white);
   font-weight: var(--font-bold);
   font-size: var(--font-s);
-  line-height: 17px;
-  padding-bottom: 4px;
-  padding-right: 4px;
+  line-height: 120%; /* identical to box height, or 17px */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: flex;
-  align-items: center;
 }
 
 .name {

--- a/packages/web/src/components/tipping/support/SupportingList.module.css
+++ b/packages/web/src/components/tipping/support/SupportingList.module.css
@@ -1,0 +1,39 @@
+.container {
+  margin-top: 32px;
+}
+
+.tile {
+  margin-top: 16px;
+}
+
+.tipIcon {
+  width: 18px;
+  height: 18px;
+}
+.tipIcon path {
+  fill: var(--neutral);
+}
+
+.arrowIcon {
+  width: 20px;
+  height: 20px;
+}
+.arrowIcon path {
+  fill: var(--neutral-light-4);
+}
+
+.seeMore {
+  display: flex;
+  align-items: center;
+  margin-top: 16px;
+  font-weight: var(--font-bold);
+  font-size: var(--font-s);
+  color: var(--neutral-light-4);
+}
+.seeMore:hover {
+  cursor: pointer;
+  transform: scale3d(1.01, 1.01, 1.01);
+}
+.seeMore:active {
+  transform: scale3d(0.99, 0.99, 0.99);
+}

--- a/packages/web/src/components/tipping/support/SupportingList.tsx
+++ b/packages/web/src/components/tipping/support/SupportingList.tsx
@@ -20,7 +20,7 @@ import {
 } from 'store/application/ui/userListModal/types'
 import { MAX_PROFILE_SUPPORTING_TILES } from 'utils/constants'
 
-import styles from './Support.module.css'
+import styles from './SupportingList.module.css'
 import { SupportingTile } from './SupportingTile'
 
 const messages = {

--- a/packages/web/src/components/tipping/support/SupportingTile.module.css
+++ b/packages/web/src/components/tipping/support/SupportingTile.module.css
@@ -35,11 +35,12 @@
   color: var(--secondary);
   font-weight: var(--font-bold);
   font-size: var(--font-m);
-  padding: 1px 4px;
+  padding: 2px 4px;
   margin: 8px;
   width: fit-content;
   height: 20px;
-  border-radius: 20px;
+  border-radius: 16px;
+  border: 1px solid var(--neutral-light-8);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.15);
 
   display: flex;

--- a/packages/web/src/components/tipping/support/SupportingTile.module.css
+++ b/packages/web/src/components/tipping/support/SupportingTile.module.css
@@ -31,7 +31,7 @@
 .tileHeader {
   flex: 0;
   align-self: flex-end;
-  background: var(--white);
+  background: var(--static-white);
   color: var(--secondary);
   font-weight: var(--font-bold);
   font-size: var(--font-m);
@@ -40,7 +40,7 @@
   width: fit-content;
   height: 20px;
   border-radius: 16px;
-  border: 1px solid var(--neutral-light-8);
+  border: 1px solid var(--static-neutral-light-8);
   box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.15);
 
   display: flex;
@@ -81,7 +81,7 @@
 .profilePicture {
   height: 32px;
   border-radius: 32px;
-  border: 1px solid var(--white);
+  border: 1px solid var(--static-white);
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -89,7 +89,7 @@
 }
 
 .name {
-  color: var(--white);
+  color: var(--static-white);
   font-weight: var(--font-bold);
   font-size: var(--font-s);
   line-height: 120%; /* identical to box height, or 17px */

--- a/packages/web/src/components/tipping/support/SupportingTile.module.css
+++ b/packages/web/src/components/tipping/support/SupportingTile.module.css
@@ -1,66 +1,3 @@
-.container {
-  margin-top: 32px;
-}
-
-.titleContainer {
-  display: flex;
-  align-items: center;
-}
-.titleText {
-  margin-left: 6px;
-  font-weight: var(--font-bold);
-  font-size: var(--font-s);
-}
-
-.line {
-  margin-left: 12px;
-  background: var(--neutral-light-7);
-  width: 100%;
-  height: 1px;
-}
-.topSupportersLine {
-  width: 68px;
-}
-
-.tile {
-  margin-top: 16px;
-}
-
-.seeMore {
-  display: flex;
-  align-items: center;
-  margin-top: 16px;
-  font-weight: var(--font-bold);
-  font-size: var(--font-s);
-  color: var(--neutral-light-4);
-}
-.seeMore:hover {
-  cursor: pointer;
-  transform: scale3d(1.01, 1.01, 1.01);
-}
-.seeMore:active {
-  transform: scale3d(0.99, 0.99, 0.99);
-}
-
-.tipIcon {
-  width: 18px;
-  height: 18px;
-}
-.tipIcon path {
-  fill: var(--neutral);
-}
-.trophyIcon {
-  width: 18px;
-  height: 18px;
-}
-.arrowIcon {
-  width: 20px;
-  height: 20px;
-}
-.arrowIcon path {
-  fill: var(--neutral-light-4);
-}
-
 .tileContainer {
   height: 122px;
   border-radius: 8px;
@@ -95,7 +32,7 @@
   flex: 0;
   align-self: flex-end;
   background: var(--white);
-  color: var(--neutral-light-4);
+  color: var(--secondary);
   font-weight: var(--font-bold);
   font-size: var(--font-m);
   padding: 1px 4px;
@@ -107,10 +44,6 @@
 
   display: flex;
   align-items: center;
-}
-.rankNumberSymbol {
-  font-size: var(--font-s);
-  margin-right: 2px;
 }
 .tileHeader .trophyIcon,
 .tileHeader .tipIcon,
@@ -127,15 +60,14 @@
   fill: var(--neutral-light-4);
 }
 
-.topFive {
-  color: var(--secondary);
+.trophyIcon {
+  width: 18px;
+  height: 18px;
 }
 
-.coverPhoto {
-  width: 100%;
-  height: 100%;
-  border-top-right-radius: 8px;
-  border-top-left-radius: 8px;
+.rankNumberSymbol {
+  font-size: var(--font-s);
+  margin-right: 2px;
 }
 
 .profilePictureContainer {
@@ -144,6 +76,7 @@
   margin: 12px;
   gap: 4px;
 }
+
 .profilePicture {
   height: 32px;
   border-radius: 32px;
@@ -162,18 +95,4 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.name {
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-.viewAll {
-  display: flex;
-  align-items: center;
-  margin-top: 12px;
-  font-weight: var(--font-bold);
-  font-size: var(--font-s);
-  color: var(--neutral-light-4);
 }

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -18,7 +18,7 @@ import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
 import { AppState } from 'store/types'
 import { TIPPING_TOP_RANK_THRESHOLD } from 'utils/constants'
 
-import styles from './Support.module.css'
+import styles from './SupportingTile.module.css'
 
 type SupportingCardProps = {
   supporting: Supporting

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -55,7 +55,7 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
       style={{
         backgroundImage: `url(${coverPhoto}), linear-gradient(
           180deg,
-          rgba(0, 0, 0, 0.1) 0%,
+          rgba(0, 0, 0, 0.1) 50%,
           rgba(0, 0, 0, 0.3) 100%
         )`
       }}

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -5,7 +5,6 @@ import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { ReactComponent as IconTip } from 'assets/img/iconTip.svg'
 import imageCoverPhotoBlank from 'assets/img/imageCoverPhotoBlank.jpg'
 import profilePicEmpty from 'assets/img/imageProfilePicEmpty2X.png'
 import { SquareSizes, WidthSizes } from 'common/models/ImageSizes'
@@ -20,10 +19,6 @@ import { AppState } from 'store/types'
 import { TIPPING_TOP_RANK_THRESHOLD } from 'utils/constants'
 
 import styles from './Support.module.css'
-
-const messages = {
-  supporter: 'SUPPORTER'
-}
 
 type SupportingCardProps = {
   supporting: Supporting
@@ -55,43 +50,33 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
   }, [dispatch, handle])
 
   return receiver ? (
-    <div className={styles.tileContainer} onClick={handleClick}>
-      <div
-        className={styles.tileBackground}
-        style={{
-          backgroundImage: `url(${coverPhoto}), linear-gradient(
+    <div
+      className={cn(styles.tileContainer, styles.tileBackground)}
+      style={{
+        backgroundImage: `url(${coverPhoto}), linear-gradient(
           180deg,
-          rgba(0, 0, 0, 0.0001) 50.54%,
-          rgba(0, 0, 0, 0.05) 57.88%,
-          rgba(0, 0, 0, 0.2) 100%
+          rgba(0, 0, 0, 0.1) 0%,
+          rgba(0, 0, 0, 0.3) 100%
         )`
-        }}
-      >
-        <div className={styles.profilePictureContainer}>
-          <img className={styles.profilePicture} src={profileImage} />
-          <div className={styles.nameAndBadge}>
-            <span className={styles.name}>{receiver.name}</span>
-            <UserBadges
-              className={styles.badge}
-              userId={receiver.user_id}
-              badgeSize={12}
-            />
-          </div>
-        </div>
-      </div>
+      }}
+      onClick={handleClick}
+    >
       {isTopRank ? (
         <div className={cn(styles.tileHeader, styles.topFive)}>
           <IconTrophy className={styles.trophyIcon} />
-          <span>
-            #{rank} {messages.supporter}
-          </span>
+          <span className={styles.rankNumberSymbol}>#</span>
+          <span>{rank}</span>
         </div>
-      ) : (
-        <div className={styles.tileHeader}>
-          <IconTip className={styles.tipIcon} />
-          <span>{messages.supporter}</span>
-        </div>
-      )}
+      ) : null}
+      <div className={styles.profilePictureContainer}>
+        <img className={styles.profilePicture} src={profileImage} />
+        <span className={styles.name}>{receiver.name}</span>
+        <UserBadges
+          className={styles.badge}
+          userId={receiver.user_id}
+          badgeSize={12}
+        />
+      </div>
     </div>
   ) : null
 }

--- a/packages/web/src/components/tipping/support/TopSupporters.module.css
+++ b/packages/web/src/components/tipping/support/TopSupporters.module.css
@@ -1,0 +1,8 @@
+.container {
+  margin-top: 32px;
+}
+
+.trophyIcon {
+  width: 18px;
+  height: 18px;
+}

--- a/packages/web/src/components/tipping/support/TopSupporters.tsx
+++ b/packages/web/src/components/tipping/support/TopSupporters.tsx
@@ -21,7 +21,7 @@ import {
 import { AppState } from 'store/types'
 import { MAX_PROFILE_TOP_SUPPORTERS } from 'utils/constants'
 
-import styles from './Support.module.css'
+import styles from './TopSupporters.module.css'
 
 const messages = {
   topSupporters: 'Top Supporters'


### PR DESCRIPTION
### Description

Easiest way to review is probably commit by commit, since I did a refactor of the CSS in the second commit where all I did was split the CSS into separate files and remove unused classes.

Figma: https://www.figma.com/file/Q67LDHvSoc5KMLwU5esC24/%F0%9F%92%B8-Tipping?node-id=2628%3A36127

Before:
![image](https://user-images.githubusercontent.com/3690498/174201823-38f553df-d6ec-4b06-9d31-5d7e0795ea94.png)

After:
![image](https://user-images.githubusercontent.com/3690498/174201839-0d0e0ce0-7f91-4598-8722-cf5fd6b3e0c2.png)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

- [x] Verify that the darker gradient is intentional
- [x] Verify pill padding fits design pattern (it's `1px 4px`)

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally against stage (Chrome Mac)
- Tested long user names got ellipses
- Tested usernames with "g"s don't get cut off
- Tested buttons still work and have proper animation

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

N/A
