### PR TITLE
[PAY-351] Prevent re-toasting for the same new disbursement

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/store/sagas.ts
+++ b/packages/web/src/pages/audio-rewards-page/store/sagas.ts
@@ -415,6 +415,8 @@ function* fetchUserChallengesAsync() {
   }
 }
 
+const challengesWithNewDispursementsThisSesssion = new Set<string>([])
+
 function* checkForNewDisbursements(
   action: ReturnType<typeof fetchUserChallengesSucceeded>
 ) {
@@ -439,9 +441,11 @@ function* checkForNewDisbursements(
       challenge.is_disbursed &&
       prevChallenge &&
       !prevChallenge.is_disbursed && // it wasn't already claimed
-      (!challengeOverrides || !challengeOverrides.is_disbursed) // we didn't claim this session
+      (!challengeOverrides || !challengeOverrides.is_disbursed) && // we didn't claim this session
+      !challengesWithNewDispursementsThisSesssion.has(challenge.challenge_id) // and we didn't notify the user about this yet
     ) {
       newDisbursement = true
+      challengesWithNewDispursementsThisSesssion.add(challenge.challenge_id)
     }
   }
   if (newDisbursement) {


### PR DESCRIPTION
### Description

Was seeing a bug where I was repeatedly getting toasted for new disbursements.
https://www.loom.com/share/8b1b2036e0524452a217b832a082241e

I realize we don't dedupe this anyway. There may be a more canonical way to do this, lmk if you have thoughts. This appears to fix it, but would only toast once per session per challenge id. Maybe that's ok?

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally vs. staging. Can share creds for this acct if useful.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
