### PR TITLE
[PAY-350][PAY-355] Mobile: Supporting Tile Redesign

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingList.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingList.tsx
@@ -9,6 +9,7 @@ import { Dimensions, FlatList } from 'react-native'
 
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
 
 import { useSelectProfile } from '../selectors'
 
@@ -86,6 +87,12 @@ export const SupportingList = () => {
 
   return (
     <FlatList<Supporting | SkeletonData | ViewAllData>
+      style={{
+        marginHorizontal: spacing(-3)
+      }}
+      contentContainerStyle={{
+        paddingHorizontal: spacing(2)
+      }}
       horizontal
       showsHorizontalScrollIndicator={false}
       data={supportingListData}

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
@@ -57,9 +57,9 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
     paddingVertical: spacing(0.5),
     paddingHorizontal: spacing(1.125),
     borderWidth: 1,
-    borderColor: palette.neutralLight8,
+    borderColor: palette.staticNeutralLight8,
     borderRadius: spacing(4),
-    backgroundColor: palette.white
+    backgroundColor: palette.staticWhite
   },
   rankNumberSymbol: {
     marginStart: spacing(1),

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
@@ -8,7 +8,6 @@ import { profilePage } from 'audius-client/src/utils/route'
 import { ImageBackground, StyleProp, View, ViewStyle } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 
-import IconTip from 'app/assets/images/iconTip.svg'
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
 import { Text, Tile } from 'app/components/core'
 import { ProfilePicture } from 'app/components/user'
@@ -20,47 +19,59 @@ import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
 
-const messages = {
-  supporter: 'Supporter'
-}
-
 const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
     marginTop: spacing(2),
     paddingBottom: spacing(1),
-    width: 220,
     marginRight: spacing(2)
   },
-  supporterInfo: {
-    borderTopLeftRadius: 8,
-    borderTopRightRadius: 8,
+  backgroundImage: {
+    borderRadius: 8,
     overflow: 'hidden'
   },
-  supporterInfoRoot: {
+  gradient: {
+    flexDirection: 'column',
+    width: 220,
+    height: 88,
+    justifyContent: 'space-between',
+    padding: spacing(2)
+  },
+  supportingInfo: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: spacing(4),
-    paddingHorizontal: spacing(2)
+    alignSelf: 'flex-start',
+    margin: spacing(1)
   },
   profilePicture: {
     height: spacing(8),
     width: spacing(8),
-    marginRight: spacing(1),
+    marginEnd: spacing(1),
     borderWidth: 1,
     borderColor: palette.staticWhite
   },
-  rankRoot: {
+  rank: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: spacing(2),
-    paddingHorizontal: spacing(4)
+    alignSelf: 'flex-end',
+    paddingVertical: spacing(0.5),
+    paddingHorizontal: spacing(1.125),
+    borderWidth: 1,
+    borderColor: palette.neutralLight8,
+    borderRadius: spacing(4),
+    backgroundColor: palette.white
+  },
+  rankNumberSymbol: {
+    marginStart: spacing(1),
+    marginEnd: spacing(0.5)
   },
   rankText: {
-    textTransform: 'uppercase'
+    textTransform: 'uppercase',
+    marginTop: spacing(-1),
+    marginBottom: spacing(-1)
   },
   nameText: {
     color: palette.staticWhite,
-    maxWidth: spacing(32)
+    flexShrink: 1
   }
 }))
 
@@ -73,7 +84,7 @@ export const SupportingTile = (props: SupportingTileProps) => {
   const { supporting, style } = props
   const styles = useStyles()
   const navigation = useNavigation()
-  const { secondary, neutralLight4 } = useThemeColors()
+  const { secondary } = useThemeColors()
   const user = useSelectorWeb(state => {
     return getUser(state, { id: supporting.receiver_id })
   })
@@ -97,48 +108,58 @@ export const SupportingTile = (props: SupportingTileProps) => {
   }, [navigation, handle])
 
   const iconProps = {
-    height: spacing(3),
-    width: spacing(3),
-    marginRight: 6
+    height: spacing(3.75),
+    width: spacing(3.75)
   }
-
-  const supporterIcon = isTopRank ? (
-    <IconTrophy fill={secondary} {...iconProps} />
-  ) : (
-    <IconTip fill={neutralLight4} {...iconProps} />
-  )
 
   return user ? (
     <Tile style={[styles.root, style]} onPress={handlePress}>
       <ImageBackground
-        style={styles.supporterInfo}
+        style={styles.backgroundImage}
         source={{ uri: coverPhoto }}
       >
         <LinearGradient
-          colors={['#0000004D', '#0000001A']}
+          colors={['#0000001A', '#0000004D']}
           useAngle
-          angle={45}
+          angle={180}
           angleCenter={{ x: 0.5, y: 0.5 }}
-          style={styles.supporterInfoRoot}
+          style={styles.gradient}
         >
-          <ProfilePicture style={styles.profilePicture} profile={user} />
-          <Text style={styles.nameText} variant='h3' noGutter numberOfLines={1}>
-            {name}
-          </Text>
-          <UserBadges user={user} hideName />
+          {isTopRank ? (
+            <View style={styles.rank}>
+              <IconTrophy fill={secondary} {...iconProps} />
+              <Text
+                style={styles.rankNumberSymbol}
+                variant='label'
+                color='secondary'
+                fontSize='small'
+              >
+                #
+              </Text>
+              <Text
+                style={styles.rankText}
+                variant='label'
+                color='secondary'
+                fontSize='large'
+              >
+                {supporting.rank}
+              </Text>
+            </View>
+          ) : null}
+          <View style={styles.supportingInfo}>
+            <ProfilePicture style={styles.profilePicture} profile={user} />
+            <Text
+              style={styles.nameText}
+              variant='h3'
+              noGutter
+              numberOfLines={1}
+            >
+              {name}
+            </Text>
+            <UserBadges user={user} hideName />
+          </View>
         </LinearGradient>
       </ImageBackground>
-      <View style={styles.rankRoot}>
-        {supporterIcon}
-        <Text
-          style={styles.rankText}
-          variant='label'
-          color={isTopRank ? 'secondary' : 'neutral'}
-        >
-          {isTopRank ? `#${supporting.rank} ` : null}
-          {messages.supporter}
-        </Text>
-      </View>
     </Tile>
   ) : null
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
@@ -23,7 +23,9 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
     marginTop: spacing(2),
     paddingBottom: spacing(1),
-    marginRight: spacing(2)
+    marginHorizontal: spacing(1),
+    borderRadius: 8,
+    overflow: 'hidden'
   },
   backgroundImage: {
     borderRadius: 8,

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
@@ -32,7 +32,6 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
     overflow: 'hidden'
   },
   gradient: {
-    flexDirection: 'column',
     width: 220,
     height: 88,
     justifyContent: 'space-between',

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
@@ -20,15 +20,16 @@ const MAX_PROFILE_SUPPORTING_VIEW_ALL_USERS = 5
 
 const useStyles = makeStyles(({ spacing }) => ({
   root: {
-    marginTop: spacing(3),
-    paddingBottom: spacing(1),
-    marginRight: spacing(2)
+    marginTop: spacing(2),
+    marginHorizontal: spacing(1)
   },
   content: {
-    paddingTop: spacing(4),
     paddingHorizontal: spacing(5),
-    paddingBottom: spacing(2),
-    alignItems: 'center'
+    paddingVertical: spacing(2),
+    alignItems: 'center',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    height: 88
   },
   profilePictureList: {
     marginBottom: spacing(3),

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/ViewAllSupportingTile.tsx
@@ -27,7 +27,6 @@ const useStyles = makeStyles(({ spacing }) => ({
     paddingHorizontal: spacing(5),
     paddingVertical: spacing(2),
     alignItems: 'center',
-    flexDirection: 'column',
     justifyContent: 'center',
     height: 88
   },

--- a/packages/mobile/src/utils/theme.ts
+++ b/packages/mobile/src/utils/theme.ts
@@ -77,6 +77,7 @@ export const defaultTheme = {
   shadow: '#E3E3E3',
   staticTwitterBlue: '#1BA1F1',
   staticWhite: '#FFFFFF',
+  staticNeutralLight8: '#F2F2F4',
   staticAccentGreenLight1: '#23AD1A',
   pageHeaderGradientColor1: '#5B23E1',
   pageHeaderGradientColor2: '#A22FEB',
@@ -126,6 +127,7 @@ export const darkTheme = {
   shadow: '#35364F',
   staticTwitterBlue: '#1BA1F1',
   staticWhite: '#FFFFFF',
+  staticNeutralLight8: '#F2F2F4',
   staticAccentGreenLight1: '#23AD1A',
   pageHeaderGradientColor1: '#7652CC',
   pageHeaderGradientColor2: '#B05CE6',
@@ -218,6 +220,7 @@ export type ThemeColors = {
   shadow: string
   staticTwitterBlue: string
   staticWhite: string
+  staticNeutralLight8: string
   staticAccentGreenLight1: string
   pageHeaderGradientColor1: string
   pageHeaderGradientColor2: string


### PR DESCRIPTION
### Description

https://www.figma.com/file/Q67LDHvSoc5KMLwU5esC24/%F0%9F%92%B8-Tipping?node-id=2628%3A36127

See image below

Note:
- Removes hardcoded `maxWidth` of the name contents, opting to use `flexShrink` instead to trigger ellipses
- Renames style references (eg. `backgroundImage` and `gradient` vs `supporterInfo` and `supporterInfoRoot`) mostly for my own benefit but can go back to old "root" convention if wanted
- Also fixes [PAY-355](https://linear.app/audius/issue/PAY-355/supporting-tiles-are-clipping-before-the-edges-of-the-device)

### Dragons
- Had to use negative margins on the rank text to achieve correct padding, as otherwise the container left space for ascenders and descenders in the font which aren't necessary for numbers (we only need cap height)
- Cheesed the size of the trophy icon to match Figma, since the Figma has the icon using a slightly smaller width/height than the container it's in and on mobile it seems it goes to the edges
- The badge icons seem larger than on Figma
- It looks terrible on my Android emulator, but that might be my emulator being junk (was having other problems too) - will try to run on device today
- Uses some janky/hacky negative margins to fix PAY-355

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

iPhone 13 iOS 15.0 Simulator
![image](https://user-images.githubusercontent.com/3690498/174735870-01ab8d0c-d296-4e6e-9a73-71fb4417f88e.png)

Google Pixel 4 API 29 Android Emulator
![image](https://user-images.githubusercontent.com/3690498/174739104-679a1f27-4205-427e-98b0-e2465f02b1cb.png)
