### PR TITLE
Fix mutuals user list title

### DIFF
--- a/packages/web/src/components/user-list-modal/components/UserListModal.tsx
+++ b/packages/web/src/components/user-list-modal/components/UserListModal.tsx
@@ -139,7 +139,7 @@ const UserListModal = ({
       title = (
         <div className={styles.titleContainer}>
           <IconFollowing className={styles.icon} />
-          <span>{messages.supporting}</span>
+          <span>{messages.mutuals}</span>
         </div>
       )
       break


### PR DESCRIPTION
### Description

Right now it shows supporting as the title (introduced in PR that removed legacy user list modal https://github.com/AudiusProject/audius-client/pull/1405). This PR correctly changes it back to mutuals.

### Dragons

n/a

### How Has This Been Tested?

local dapp against stage.

### How will this change be monitored?

n/a
