### PR TITLE
[PAY-342][PAY-344] Fix user list modal issues

### DIFF
--- a/packages/web/src/components/user-list/UserList.tsx
+++ b/packages/web/src/components/user-list/UserList.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -59,10 +59,15 @@ const ConnectedUserList = (props: ConnectedUserListProps) => {
 
   const { loadMore, reset } = props
 
+  const [hasLoaded, setHasLoaded] = useState(false)
+
   useEffect(() => {
     // Load initially
-    loadMore()
-  }, [loadMore])
+    if (!hasLoaded) {
+      loadMore()
+      setHasLoaded(true)
+    }
+  }, [hasLoaded, loadMore])
 
   useEffect(() => {
     return () => {

--- a/packages/web/src/components/user-list/UserList.tsx
+++ b/packages/web/src/components/user-list/UserList.tsx
@@ -71,7 +71,14 @@ const ConnectedUserList = (props: ConnectedUserListProps) => {
 
   useEffect(() => {
     return () => {
-      reset()
+      // Immediately resetting the user list state causes
+      // the modal contents to clear while the modal header
+      // remains visible for a bit longer, until the modal
+      // visibility is set to false, which hides the modal.
+      // This is a bit startling, therefore, we wait a bit
+      // before resetting the state, allowing the modal to
+      // hide first.
+      setTimeout(reset, 100)
     }
   }, [reset])
 

--- a/packages/web/src/components/user-list/UserList.tsx
+++ b/packages/web/src/components/user-list/UserList.tsx
@@ -62,25 +62,26 @@ const ConnectedUserList = (props: ConnectedUserListProps) => {
   const [hasLoaded, setHasLoaded] = useState(false)
 
   useEffect(() => {
-    // Load initially
     if (!hasLoaded) {
+      /**
+       * Reset on initial load in case the list modal for the
+       * given tag was already open before for another user.
+       * If we do no reset on initial load (or on exiting the modal),
+       * then the list modal will be confused and may not refresh
+       * for the current user, or it may refresh but not have the
+       * correct total count which messes up the logic for loading
+       * more users as we scroll down the modal.
+       * The reason why we reset on initial load rather than on
+       * exiting the modal is because it's possible that one modal
+       * opens another (e.g. clicking artist hover tile supporting section),
+       * and resetting on modal exit in that case may reset the data for the
+       * incoming modal after it loads and end up showing an empty modal.
+       */
+      reset()
       loadMore()
       setHasLoaded(true)
     }
-  }, [hasLoaded, loadMore])
-
-  useEffect(() => {
-    return () => {
-      // Immediately resetting the user list state causes
-      // the modal contents to clear while the modal header
-      // remains visible for a bit longer, until the modal
-      // visibility is set to false, which hides the modal.
-      // This is a bit startling, therefore, we wait a bit
-      // before resetting the state, allowing the modal to
-      // hide first.
-      setTimeout(reset, 100)
-    }
-  }, [reset])
+  }, [reset, hasLoaded, loadMore])
 
   return (
     <UserList


### PR DESCRIPTION
### Description

- Closing the modal should not reset state and be in loading state before hiding the modal.
- Switching between user list modals should not lead to wrong content

https://user-images.githubusercontent.com/9600175/174846627-c271c3a3-b323-4bbb-8074-ad2350fa724d.mov

### Dragons

we now reset the list modal state on initial load rather than on exit, but should not really cause issues.

### How Has This Been Tested?

local dapp against stage. also check out the loom video

### How will this change be monitored?

n/a
