### PR TITLE
Add feature flag helper for flag overrides

### DIFF
--- a/packages/web/src/components/artist/ArtistCard.tsx
+++ b/packages/web/src/components/artist/ArtistCard.tsx
@@ -9,12 +9,11 @@ import { setNotificationSubscription } from 'common/store/pages/profile/actions'
 import { followUser, unfollowUser } from 'common/store/social/users/actions'
 import FollowButton from 'components/follow-button/FollowButton'
 import Stats, { StatProps } from 'components/stats/Stats'
-import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 
 import styles from './ArtistCard.module.css'
 import { ArtistCardCover } from './ArtistCardCover'
 import { ArtistSupporting } from './ArtistSupporting'
-const { getFeatureEnabled } = remoteConfigInstance
 
 type ArtistCardProps = {
   artist: User

--- a/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.tsx
+++ b/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.tsx
@@ -14,6 +14,7 @@ import {
 } from 'common/hooks/useFeatureFlag'
 import { useModalState } from 'common/hooks/useModalState'
 import { FeatureFlags } from 'common/services/remote-config'
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useDevModeHotkey } from 'hooks/useHotkey'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import zIndex from 'utils/zIndex'
@@ -38,6 +39,7 @@ const setOverrideSetting = (flag: string, val: OverrideSetting) => {
 
 export const FeatureFlagOverrideModal = () => {
   const hotkeyToggle = useDevModeHotkey(70 /* f */)
+  const [remoteInstanceLoaded, setRemoteInstanceLoaded] = useState(false)
   const [hotkeyLoaded, setHotkeyLoaded] = useState(false)
   const [isOpen, setIsOpen] = useModalState('FeatureFlagOverride')
   const defaultSettings = useRef<Record<string, boolean>>({})
@@ -57,6 +59,7 @@ export const FeatureFlagOverrideModal = () => {
         }),
         {}
       )
+      setRemoteInstanceLoaded(true)
     }
 
     remoteConfigInstance.waitForUserRemoteConfig().then(updateDefaultSettings)
@@ -84,32 +87,36 @@ export const FeatureFlagOverrideModal = () => {
         <ModalTitle title={messages.title} />
       </ModalHeader>
       <ModalContent>
-        <div className={styles.optionContainer}>
-          {flags.map(flag => (
-            <div key={flag} className={styles.option}>
-              <span>{flag}: </span>
-              <SegmentedControl
-                options={[
-                  {
-                    key: 'default',
-                    text: `Default (${
-                      defaultSettings.current[flag] ? 'Enabled' : 'Disabled'
-                    })`
-                  },
-                  { key: 'enabled', text: 'Enabled' },
-                  { key: 'disabled', text: 'Disabled' }
-                ]}
-                selected={overrideSettings[flag] ?? 'default'}
-                onSelectOption={(key: string) => {
-                  const val: OverrideSetting =
-                    key === 'default' ? null : (key as OverrideSetting)
-                  setOverrideSettings(prev => ({ ...prev, [flag]: val }))
-                  setOverrideSetting(flag as FeatureFlags, val)
-                }}
-              />
-            </div>
-          ))}
-        </div>
+        {remoteInstanceLoaded ? (
+          <div className={styles.optionContainer}>
+            {flags.map(flag => (
+              <div key={flag} className={styles.option}>
+                <span>{flag}: </span>
+                <SegmentedControl
+                  options={[
+                    {
+                      key: 'default',
+                      text: `Default (${
+                        defaultSettings.current[flag] ? 'Enabled' : 'Disabled'
+                      })`
+                    },
+                    { key: 'enabled', text: 'Enabled' },
+                    { key: 'disabled', text: 'Disabled' }
+                  ]}
+                  selected={overrideSettings[flag] ?? 'default'}
+                  onSelectOption={(key: string) => {
+                    const val: OverrideSetting =
+                      key === 'default' ? null : (key as OverrideSetting)
+                    setOverrideSettings(prev => ({ ...prev, [flag]: val }))
+                    setOverrideSetting(flag as FeatureFlags, val)
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <LoadingSpinner />
+        )}
       </ModalContent>
     </Modal>
   )

--- a/packages/web/src/components/notification/store/sagas.ts
+++ b/packages/web/src/components/notification/store/sagas.ts
@@ -42,6 +42,7 @@ import { fetchReactionValues } from 'common/store/ui/reactions/slice'
 import { getBalance } from 'common/store/wallet/slice'
 import AudiusBackend from 'services/AudiusBackend'
 import { ResetNotificationsBadgeCount } from 'services/native-mobile-interface/notifications'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import { make } from 'store/analytics/actions'
 import { waitForBackendSetup } from 'store/backend/sagas'
@@ -129,9 +130,7 @@ export function* fetchNotifications(
     const timeOffset = lastNotification
       ? lastNotification.timestamp
       : moment().toISOString()
-    const withTips = remoteConfigInstance.getFeatureEnabled(
-      FeatureFlags.TIPPING_ENABLED
-    )
+    const withTips = getFeatureEnabled(FeatureFlags.TIPPING_ENABLED)
     const notificationsResponse: NotificationsResponse = yield* call(
       AudiusBackend.getNotifications,
       {
@@ -490,9 +489,7 @@ export function* getNotifications(isFirstFetch: boolean) {
       )
       if (!hasAccount) return
       const timeOffset = moment().toISOString()
-      const withTips = remoteConfigInstance.getFeatureEnabled(
-        FeatureFlags.TIPPING_ENABLED
-      )
+      const withTips = getFeatureEnabled(FeatureFlags.TIPPING_ENABLED)
 
       const notificationsResponse:
         | NotificationsResponse

--- a/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.tsx
+++ b/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.tsx
@@ -17,7 +17,7 @@ import { ArtistPopover } from 'components/artist/ArtistPopover'
 import { ProfilePicture } from 'components/notification/Notification/components/ProfilePicture'
 import Skeleton from 'components/skeleton/Skeleton'
 import UserBadges from 'components/user-badges/UserBadges'
-import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { useRecord, make } from 'store/analytics/actions'
 import {
   setUsers,
@@ -35,8 +35,6 @@ import { AppState } from 'store/types'
 import { NUM_FEED_TIPPERS_DISPLAYED } from 'utils/constants'
 
 import styles from './FeedTipTile.module.css'
-
-const { getFeatureEnabled } = remoteConfigInstance
 
 const messages = {
   wasTippedBy: 'Was Tipped By',

--- a/packages/web/src/pages/audio-rewards-page/WalletModal.tsx
+++ b/packages/web/src/pages/audio-rewards-page/WalletModal.tsx
@@ -30,7 +30,7 @@ import { Nullable } from 'common/utils/typeUtils'
 import { stringWeiToBN, weiToString } from 'common/utils/wallet'
 import SocialProof from 'components/social-proof/SocialProof'
 import { useWithMobileStyle } from 'hooks/useWithMobileStyle'
-import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { isMobile } from 'utils/clientUtil'
 import { useSelector } from 'utils/reducer'
 import { AUDIUS_DISCORD_LINK } from 'utils/route'
@@ -47,8 +47,6 @@ import SendInputConfirmation from './components/SendInputConfirmation'
 import SendInputSuccess from './components/SendInputSuccess'
 import SendingModalBody from './components/SendingModalBody'
 import ModalDrawer from './components/modals/ModalDrawer'
-
-const { getFeatureEnabled } = remoteConfigInstance
 
 const messages = {
   receive: 'Receive $AUDIO',

--- a/packages/web/src/pages/audio-rewards-page/components/ReceiveBody.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/ReceiveBody.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import { SolanaWalletAddress, WalletAddress } from 'common/models/Wallet'
 import { FeatureFlags } from 'common/services/remote-config'
 import { useLocalStorage } from 'hooks/useLocalStorage'
-import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 
 import { ModalBodyWrapper } from '../WalletModal'
 
@@ -16,7 +16,6 @@ type ReceiveBodyProps = {
   solWallet: SolanaWalletAddress
 }
 
-const { getFeatureEnabled } = remoteConfigInstance
 const messages = {
   warning: 'PROCEED WITH CAUTION',
   warning2: 'If $AUDIO is sent to the wrong address it will be lost.',

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputBody.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputBody.tsx
@@ -26,6 +26,7 @@ import {
   stringWeiToBN,
   weiToAudio
 } from 'common/utils/wallet'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import { MIN_TRANSFERRABLE_WEI } from 'services/wallet-client/WalletClient'
 
@@ -34,7 +35,7 @@ import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
 import DashboardTokenValueSlider from './DashboardTokenValueSlider'
 import styles from './SendInputBody.module.css'
 
-const { getRemoteVar, getFeatureEnabled } = remoteConfigInstance
+const { getRemoteVar } = remoteConfigInstance
 
 const messages = {
   warningTitle: 'PROCEED WITH CAUTION',

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -19,15 +19,13 @@ import ProfilePageBadge from 'components/user-badges/ProfilePageBadge'
 import { Type } from 'pages/profile-page/components/SocialLink'
 import SocialLinkInput from 'pages/profile-page/components/SocialLinkInput'
 import { ProfileTags } from 'pages/profile-page/components/desktop/ProfileTags'
-import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { make, useRecord } from 'store/analytics/actions'
 import { UPLOAD_PAGE } from 'utils/route'
 
 import { ProfileBio } from './ProfileBio'
 import { ProfileMutuals } from './ProfileMutuals'
 import styles from './ProfilePage.module.css'
-
-const { getFeatureEnabled } = remoteConfigInstance
 
 const messages = {
   aboutYou: 'About You',

--- a/packages/web/src/pages/profile-page/sagas.js
+++ b/packages/web/src/pages/profile-page/sagas.js
@@ -31,6 +31,7 @@ import AudiusBackend, { fetchCID } from 'services/AudiusBackend'
 import { setAudiusAccountUser } from 'services/LocalStorage'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
 import OpenSeaClient from 'services/opensea-client/OpenSeaClient'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import SolanaClient from 'services/solana-client/SolanaClient'
 import { waitForBackendSetup } from 'store/backend/sagas'
@@ -48,7 +49,6 @@ import { waitForValue } from 'utils/sagaHelpers'
 
 const {
   getRemoteVar,
-  getFeatureEnabled,
   waitForRemoteConfig,
   waitForUserRemoteConfig
 } = remoteConfigInstance

--- a/packages/web/src/pages/sign-on/store/sagas.js
+++ b/packages/web/src/pages/sign-on/store/sagas.js
@@ -32,6 +32,7 @@ import { getIGUserUrl } from 'components/instagram-auth/InstagramAuth'
 import AudiusBackend from 'services/AudiusBackend'
 import { getCityAndRegion } from 'services/Location'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import { fetchAccountAsync, reCacheAccount } from 'store/account/sagas'
 import { identify, make } from 'store/analytics/actions'
@@ -54,7 +55,7 @@ import { getRouteOnCompletion, getSignOn } from './selectors'
 import { FollowArtistsCategory, Pages } from './types'
 import { checkHandle } from './verifiedChecker'
 
-const { getFeatureEnabled, waitForRemoteConfig } = remoteConfigInstance
+const { waitForRemoteConfig } = remoteConfigInstance
 
 const IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production'
 const IS_PRODUCTION = process.env.REACT_APP_ENVIRONMENT === 'production'

--- a/packages/web/src/services/AudiusBackend.js
+++ b/packages/web/src/services/AudiusBackend.js
@@ -30,6 +30,7 @@ import CIDCache from 'common/store/cache/CIDCache'
 import { uuid } from 'common/utils/uid'
 import * as schemas from 'schemas'
 import { ClientRewardsReporter } from 'services/audius-backend/Rewards'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import { IS_MOBILE_USER_KEY } from 'store/account/mobileSagas'
 import { track } from 'store/analytics/providers/amplitude'
@@ -495,10 +496,10 @@ class AudiusBackend {
           ? undefined
           : { siteKey: RECAPTCHA_SITE_KEY },
         isServer: false,
-        preferHigherPatchForPrimary: remoteConfigInstance.getFeatureEnabled(
+        preferHigherPatchForPrimary: getFeatureEnabled(
           FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY
         ),
-        preferHigherPatchForSecondaries: remoteConfigInstance.getFeatureEnabled(
+        preferHigherPatchForSecondaries: getFeatureEnabled(
           FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES
         )
       })
@@ -951,9 +952,7 @@ class AudiusBackend {
       const listen = await audiusLibs.Track.logTrackListen(
         trackId,
         unauthenticatedUuid,
-        remoteConfigInstance.getFeatureEnabled(
-          FeatureFlags.SOLANA_LISTEN_ENABLED
-        )
+        getFeatureEnabled(FeatureFlags.SOLANA_LISTEN_ENABLED)
       )
       return listen
     } catch (err) {
@@ -2373,12 +2372,7 @@ class AudiusBackend {
    * @param {playlistId} playlistId playlist id or folder id
    */
   static async updatePlaylistLastViewedAt(playlistId) {
-    if (
-      !remoteConfigInstance.getFeatureEnabled(
-        FeatureFlags.PLAYLIST_UPDATES_ENABLED
-      )
-    )
-      return
+    if (!getFeatureEnabled(FeatureFlags.PLAYLIST_UPDATES_ENABLED)) return
 
     await waitForLibsInit()
     const account = audiusLibs.Account.getCurrentUser()

--- a/packages/web/src/services/remote-config/featureFlagHelpers.ts
+++ b/packages/web/src/services/remote-config/featureFlagHelpers.ts
@@ -1,0 +1,18 @@
+import {
+  FEATURE_FLAG_OVERRIDE_KEY,
+  OverrideSetting
+} from 'common/hooks/useFeatureFlag'
+import { FeatureFlags } from 'common/services/remote-config'
+
+import { remoteConfigInstance } from './remote-config-instance'
+
+const getLocalStorageItem = (key: string) => window.localStorage.getItem(key)
+
+export const getFeatureEnabled = (flag: FeatureFlags) => {
+  const overrideKey = `${FEATURE_FLAG_OVERRIDE_KEY}:${flag}`
+  const override = getLocalStorageItem?.(overrideKey) as OverrideSetting
+  if (override === 'enabled') return true
+  if (override === 'disabled') return false
+
+  return remoteConfigInstance.getFeatureEnabled(flag)
+}

--- a/packages/web/src/store/tipping/sagas.ts
+++ b/packages/web/src/store/tipping/sagas.ts
@@ -67,6 +67,7 @@ import {
   UserTipRequest
 } from 'services/audius-backend/Tipping'
 import { UpdateTipsStorageMessage } from 'services/native-mobile-interface/tipping'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import walletClient from 'services/wallet-client/WalletClient'
 import { make } from 'store/analytics/actions'
@@ -82,7 +83,7 @@ import { updateTipsStorage } from './storageUtils'
 
 const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
-const { getFeatureEnabled, waitForRemoteConfig } = remoteConfigInstance
+const { waitForRemoteConfig } = remoteConfigInstance
 
 function* overrideSupportingForUser({
   amountBN,

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -24,13 +24,11 @@ import {
   decreaseBalance
 } from 'common/store/wallet/slice'
 import { stringWeiToBN, weiToString } from 'common/utils/wallet'
-import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import walletClient from 'services/wallet-client/WalletClient'
 import { make } from 'store/analytics/actions'
 import { SETUP_BACKEND_SUCCEEDED } from 'store/backend/actions'
 import { getErrorMessage } from 'utils/error'
-
-const { getFeatureEnabled } = remoteConfigInstance
 
 // TODO: handle errors
 const errors = {


### PR DESCRIPTION
### Description
Adding feature flag helper for the areas that cant use the hook to maintain the override logic

### Dragons

Should this file live somewhere else?
Should we build in the waitForUserRemoteConfig logic or keep that separate?
Should the components that are using this be updated to use the useFlag hook?

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A
