### PR TITLE
[PAY-364] Web: Use static white for the +N in UserProfilePictureList

### DIFF
--- a/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
+++ b/packages/web/src/components/notification/Notification/components/UserProfilePictureList.module.css
@@ -58,7 +58,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  color: var(--white);
+  color: var(--static-white);
   font-size: var(--font-m);
   font-weight: var(--font-bold);
   text-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
See title.

Before:
![image](https://user-images.githubusercontent.com/3690498/174915119-058cc8fa-1cc8-48e6-a907-81645eb70f96.png)

After:
![image](https://user-images.githubusercontent.com/3690498/174915181-d90c356c-8e3d-42c3-aecc-e05377e97fdb.png)
