### PR TITLE
[PAY-46] Fix ProgressBar color in matrix mode

### DIFF
--- a/packages/web/src/utils/theme/matrix.ts
+++ b/packages/web/src/utils/theme/matrix.ts
@@ -33,10 +33,10 @@ const theme = {
   '--white': '#1F211F',
   '--darkmode-static-white': 'var(--white)',
 
+  '--page-header-gradient-color-1': '#4FF069',
+  '--page-header-gradient-color-2': '#09BD51',
   '--page-header-gradient':
-    'linear-gradient(323.08deg, #4FF069 36.13%, #09BD51 133.51%)',
-  '--page-header-gradient-color-1': 'var(--neutral-light-10)',
-  '--page-header-gradient-color-2': 'var(--neutral-light-10)',
+    'linear-gradient(323.08deg, var(--page-header-gradient-color-1) 36.13%, var(--page-header-gradient-color-2) 133.51%)',
 
   '--tile-shadow-1': 'rgba(0, 0, 0, 0.1)',
   '--tile-shadow-2': '#000000',


### PR DESCRIPTION
### Description

ProgressBar style was arranged differently than default and dark
modes: page-header-gradient used hardcoded values instead of
page-header-gradient-color-1 and -2 vars. Changed it to match
the other themes.

ProgressBar is the only component that uses
page-header-gradient-color-1 and -2 directly so it was the only
one that displayed the bug. Other components use
page-header-gradient. 

### Dragons

None

### How Has This Been Tested?

Manual testing on local web client. Set localStorage theme to matrix.

<img width="776" alt="Screen Shot 2022-06-21 at 5 35 45 PM" src="https://user-images.githubusercontent.com/3893871/174918753-807c2141-a07c-4fdc-82e0-12adbe2fa9ff.png">

### How will this change be monitored?

