### PR TITLE
Close user list modals when a nested popover triggers a navigation

### DIFF
--- a/packages/web/src/components/artist/ArtistChip.tsx
+++ b/packages/web/src/components/artist/ArtistChip.tsx
@@ -28,17 +28,24 @@ type ArtistIdentifierProps = {
   handle: string
   showPopover: boolean
   popoverMount?: MountPlacement
+  onNavigateAway?: () => void
 } & ComponentPropsWithoutRef<'div'>
 const ArtistIdentifier = ({
   userId,
   name,
   handle,
   showPopover,
-  popoverMount
+  popoverMount,
+  onNavigateAway
 }: ArtistIdentifierProps) => {
   return showPopover ? (
     <div>
-      <ArtistPopover handle={handle} mouseEnterDelay={0.3} mount={popoverMount}>
+      <ArtistPopover
+        handle={handle}
+        mouseEnterDelay={0.3}
+        mount={popoverMount}
+        onNavigateAway={onNavigateAway}
+      >
         <div className={styles.name}>
           <span>{name}</span>
           <UserBadges
@@ -49,7 +56,12 @@ const ArtistIdentifier = ({
           />
         </div>
       </ArtistPopover>
-      <ArtistPopover handle={handle} mouseEnterDelay={0.3} mount={popoverMount}>
+      <ArtistPopover
+        handle={handle}
+        mouseEnterDelay={0.3}
+        mount={popoverMount}
+        onNavigateAway={onNavigateAway}
+      >
         <div className={styles.handle}>@{handle}</div>
       </ArtistPopover>
     </div>
@@ -76,6 +88,7 @@ type ArtistChipProps = {
   tag?: string
   className?: string
   popoverMount?: MountPlacement
+  onNavigateAway?: () => void
 }
 const ArtistChip = ({
   user,
@@ -83,7 +96,8 @@ const ArtistChip = ({
   showPopover = true,
   tag,
   className = '',
-  popoverMount = MountPlacement.PAGE
+  popoverMount = MountPlacement.PAGE,
+  onNavigateAway
 }: ArtistChipProps) => {
   const {
     user_id: userId,
@@ -112,6 +126,7 @@ const ArtistChip = ({
           handle={handle}
           mouseEnterDelay={0.3}
           mount={popoverMount}
+          onNavigateAway={onNavigateAway}
         >
           <DynamicImage
             wrapperClassName={styles.profilePictureWrapper}
@@ -139,6 +154,7 @@ const ArtistChip = ({
             handle={handle}
             showPopover
             popoverMount={popoverMount}
+            onNavigateAway={onNavigateAway}
           />
         </div>
         <ArtistChipFollowers

--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -37,6 +37,7 @@ type ArtistPopoverProps = {
   children: ReactNode
   mouseEnterDelay?: number
   component?: 'div' | 'span'
+  onNavigateAway?: () => void
 }
 
 export const ArtistPopover = ({
@@ -45,7 +46,8 @@ export const ArtistPopover = ({
   placement = Placement.RightBottom,
   mount = MountPlacement.PAGE,
   mouseEnterDelay = 0.5,
-  component: Component = 'div'
+  component: Component = 'div',
+  onNavigateAway
 }: ArtistPopoverProps) => {
   const [isPopupVisible, setIsPopupVisible] = useState(false)
   const creator = useSelector((state: CommonState) =>
@@ -79,6 +81,7 @@ export const ArtistPopover = ({
         artist={creator}
         onNavigateAway={() => {
           setIsPopupVisible(false)
+          onNavigateAway?.()
         }}
       />
     ) : null

--- a/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
+++ b/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
@@ -85,7 +85,11 @@ export const ProfilePicture = (props: ProfilePictureProps) => {
   if (disablePopover) return profilePictureElement
 
   return (
-    <ArtistPopover handle={user.handle} component='span'>
+    <ArtistPopover
+      handle={user.handle}
+      component='span'
+      onNavigateAway={handleNavigateAway}
+    >
       {profilePictureElement}
     </ArtistPopover>
   )

--- a/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
+++ b/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
@@ -6,13 +6,13 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { SquareSizes } from 'common/models/ImageSizes'
 import { User } from 'common/models/User'
+import { toggleNotificationPanel } from 'common/store/notifications/actions'
+import { getNotificationPanelIsOpen } from 'common/store/notifications/selectors'
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
 
 import styles from './ProfilePicture.module.css'
-import { toggleNotificationPanel } from 'common/store/notifications/actions'
-import { getNotificationPanelIsOpen } from 'common/store/notifications/selectors'
 
 const imageLoadDelay = 250
 

--- a/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
+++ b/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
@@ -2,7 +2,7 @@ import { MouseEventHandler, useCallback, useEffect, useState } from 'react'
 
 import cn from 'classnames'
 import { push } from 'connected-react-router'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { SquareSizes } from 'common/models/ImageSizes'
 import { User } from 'common/models/User'
@@ -11,6 +11,8 @@ import DynamicImage from 'components/dynamic-image/DynamicImage'
 import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
 
 import styles from './ProfilePicture.module.css'
+import { toggleNotificationPanel } from 'common/store/notifications/actions'
+import { getNotificationPanelIsOpen } from 'common/store/notifications/selectors'
 
 const imageLoadDelay = 250
 
@@ -63,6 +65,13 @@ export const ProfilePicture = (props: ProfilePictureProps) => {
     },
     [stopPropagation, disableClick, dispatch, handle]
   )
+
+  const isNotificationPanelOpen = useSelector(getNotificationPanelIsOpen)
+  const handleNavigateAway = useCallback(() => {
+    if (isNotificationPanelOpen) {
+      dispatch(toggleNotificationPanel())
+    }
+  }, [dispatch, isNotificationPanelOpen])
 
   const profilePictureElement = (
     <DynamicImage

--- a/packages/web/src/components/notification/Notification/components/UserNameLink.tsx
+++ b/packages/web/src/components/notification/Notification/components/UserNameLink.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Name } from 'common/models/Analytics'
 import { User } from 'common/models/User'
 import { toggleNotificationPanel } from 'common/store/notifications/actions'
+import { getNotificationPanelIsOpen } from 'common/store/notifications/selectors'
 import { Notification } from 'common/store/notifications/types'
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import UserBadges from 'components/user-badges/UserBadges'
@@ -15,7 +16,6 @@ import { isMobile } from 'utils/clientUtil'
 import { profilePage } from 'utils/route'
 
 import styles from './UserNameLink.module.css'
-import { getNotificationPanelIsOpen } from 'common/store/notifications/selectors'
 
 const messages = {
   deactivated: 'Deactivated'

--- a/packages/web/src/components/notification/Notification/components/UserNameLink.tsx
+++ b/packages/web/src/components/notification/Notification/components/UserNameLink.tsx
@@ -2,7 +2,7 @@ import { MouseEventHandler, useCallback } from 'react'
 
 import cn from 'classnames'
 import { push } from 'connected-react-router'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { Name } from 'common/models/Analytics'
 import { User } from 'common/models/User'
@@ -15,6 +15,7 @@ import { isMobile } from 'utils/clientUtil'
 import { profilePage } from 'utils/route'
 
 import styles from './UserNameLink.module.css'
+import { getNotificationPanelIsOpen } from 'common/store/notifications/selectors'
 
 const messages = {
   deactivated: 'Deactivated'
@@ -52,6 +53,13 @@ export const UserNameLink = (props: UserNameLinkProps) => {
     [dispatch, handle, record, type, profileLink]
   )
 
+  const isNotificationPanelOpen = useSelector(getNotificationPanelIsOpen)
+  const handleNavigateAway = useCallback(() => {
+    if (isNotificationPanelOpen) {
+      dispatch(toggleNotificationPanel())
+    }
+  }, [dispatch, isNotificationPanelOpen])
+
   const rootClassName = cn(styles.root, className)
 
   if (is_deactivated) {
@@ -79,7 +87,11 @@ export const UserNameLink = (props: UserNameLinkProps) => {
 
   if (!isMobile()) {
     userNameElement = (
-      <ArtistPopover handle={handle} component='span'>
+      <ArtistPopover
+        handle={handle}
+        component='span'
+        onNavigateAway={handleNavigateAway}
+      >
         {userNameElement}
       </ArtistPopover>
     )

--- a/packages/web/src/components/user-list-modal/components/UserListModal.tsx
+++ b/packages/web/src/components/user-list-modal/components/UserListModal.tsx
@@ -174,6 +174,7 @@ const UserListModal = ({
           tag={tag}
           getScrollParent={() => scrollParentRef.current || null}
           beforeClickArtistName={onClose}
+          onNavigateAway={onClose}
         />
       </Scrollbar>
     </Modal>

--- a/packages/web/src/components/user-list/UserList.tsx
+++ b/packages/web/src/components/user-list/UserList.tsx
@@ -35,6 +35,7 @@ type ConnectedUserListOwnProps = {
   afterUnfollow?: () => void
   beforeClickArtistName?: () => void
   getScrollParent?: () => HTMLElement | null
+  onNavigateAway?: () => void
 }
 
 type ConnectedUserListProps = ConnectedUserListOwnProps &
@@ -96,6 +97,7 @@ const ConnectedUserList = (props: ConnectedUserListProps) => {
       isMobile={props.isMobile}
       getScrollParent={props.getScrollParent}
       tag={props.tag}
+      onNavigateAway={props.onNavigateAway}
     />
   )
 }

--- a/packages/web/src/components/user-list/components/UserList.tsx
+++ b/packages/web/src/components/user-list/components/UserList.tsx
@@ -25,6 +25,7 @@ type UserListProps = {
   onFollow: (userId: ID) => void
   onUnfollow: (userId: ID) => void
   getScrollParent?: () => HTMLElement | null
+  onNavigateAway?: () => void
 }
 
 const UserList = (props: UserListProps) => {
@@ -51,6 +52,7 @@ const UserList = (props: UserListProps) => {
               onClickArtistName={() => {
                 props.onClickArtistName(user.handle)
               }}
+              onNavigateAway={props.onNavigateAway}
               showPopover={!props.isMobile}
               tag={props.tag}
               className={styles.artistChipContainer}


### PR DESCRIPTION
### Description

Pass through a handler to trigger the modal to close if a nested popover navigates.

It looks like this works in part because the handler that triggers the modal to reappear will trigger after the event is finished bubbling, so the hide happens first:
https://github.com/AudiusProject/audius-client/blob/9ab24da187ff7b54745e62fc61ac95cc526691af/packages/web/src/components/artist/ArtistSupporting.tsx#L95-L99

This was the piece I was wary of, it may have been missing the last time we attempted this route.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

- Are there other modals that have popovers inside?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested locally against stage.

Supporting -> Supporting works

Please help me test vigorously!

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
