### PR TITLE
[PAY-365] Web: Disable profile picture clicks in Top Supporters tile

### DIFF
--- a/packages/web/src/components/tipping/support/TopSupporters.tsx
+++ b/packages/web/src/components/tipping/support/TopSupporters.tsx
@@ -77,7 +77,7 @@ export const TopSupporters = () => {
         users={rankedSupporters}
         totalUserCount={profile.supporter_count}
         limit={MAX_PROFILE_TOP_SUPPORTERS}
-        stopPropagation
+        disableProfileClick
       />
     </div>
   )


### PR DESCRIPTION
### Description

The Mutuals tile and Top Supporters tile have different behaviors for user profile pictures. Per recent discussion surrounding the user profile pictures in the mutuals tile, use that behavior.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

- Need to verify this behavior with product

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
