### PR TITLE
[PAY-373] Mobile: Fix default cover art on supporting tile

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SupportingTile.tsx
@@ -98,6 +98,7 @@ export const SupportingTile = (props: SupportingTileProps) => {
     sizes: _cover_photo_sizes ?? null,
     size: WidthSizes.SIZE_640
   })
+  const isDefaultImage = coverPhoto && /imageCoverPhotoBlank/.test(coverPhoto)
 
   const handlePress = useCallback(() => {
     if (handle) {
@@ -117,7 +118,9 @@ export const SupportingTile = (props: SupportingTileProps) => {
     <Tile style={[styles.root, style]} onPress={handlePress}>
       <ImageBackground
         style={styles.backgroundImage}
-        source={{ uri: coverPhoto }}
+        source={{
+          uri: isDefaultImage ? `https://audius.co/${coverPhoto}` : coverPhoto
+        }}
       >
         <LinearGradient
           colors={['#0000001A', '#0000004D']}


### PR DESCRIPTION
### Description

Mimics https://github.com/AudiusProject/audius-client/blob/2be3701f9a1925435f913ef01e0da1a8d483c40e/packages/mobile/src/screens/profile-screen/CoverPhoto.tsx#L58

Might be worth wrapping the hook to do this for us?

After: (ignore gradient, fixed separately in #1496 )
![image](https://user-images.githubusercontent.com/3690498/175119864-59543b70-1927-4004-8f6a-3a1b32b153b3.png)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

iOS sim

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
