### PR TITLE
Don't propagate clicks inside modals to other content

### DIFF
--- a/packages/stems/src/components/Modal/Modal.tsx
+++ b/packages/stems/src/components/Modal/Modal.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, useCallback, useMemo, forwardRef } from 'react'
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  forwardRef,
+  MouseEventHandler
+} from 'react'
 
 import cn from 'classnames'
 import uniqueId from 'lodash/uniqueId'
@@ -275,6 +282,10 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
   }, [setHeight])
 
   const bodyOffset = getOffset(anchor, verticalAnchorOffset)
+
+  const handleModalContentClicked: MouseEventHandler = e => {
+    e.stopPropagation()
+  }
   return (
     <>
       {modalRoot &&
@@ -301,6 +312,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(function Modal(
                       role='dialog'
                       aria-labelledby={titleId}
                       aria-describedby={subtitleId}
+                      onClick={handleModalContentClicked}
                     >
                       <>
                         {/** Begin @deprecated section (moved to ModalHeader and ModalTitle sub-components)  */}


### PR DESCRIPTION
### Description

Clicking the modal content and changing out the content based on the click will unmount the modal content, causing the `useClickOutside` handler to not be able to find the parent ref when doing the `ignore` checks. Instead of relying on parent elements and refs, simply stop the propagation of the event from the parent modal container. Everything else is then going to trigger the click outside (we can probably remove the ignore handler later).

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Affects ALL MODALS. No clicks inside will be propagated to the root!

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Did a smoke test of existing modals inc supporting to supporting and notifs

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
