### PR TITLE
Pass entity through to milestone notif

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Notifications/MilestoneNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/MilestoneNotification.tsx
@@ -6,6 +6,7 @@ import {
 } from 'audius-client/src/common/store/notifications/selectors'
 import {
   Achievement,
+  EntityType,
   Milestone
 } from 'audius-client/src/common/store/notifications/types'
 import {
@@ -52,7 +53,7 @@ Check it out!`
   }
 }
 
-const getTwitterShareData = (notification: Milestone) => {
+const getTwitterShareData = (notification: Milestone, entity: EntityType) => {
   const { achievement, user, value } = notification
   switch (achievement) {
     case Achievement.Followers: {
@@ -63,7 +64,7 @@ const getTwitterShareData = (notification: Milestone) => {
     case Achievement.Favorites:
     case Achievement.Listens:
     case Achievement.Reposts: {
-      const { entity, entityType } = notification
+      const { entityType } = notification
       const link = getEntityRoute(entity, true)
       const text = messages.achievementText(
         entityType,
@@ -132,7 +133,7 @@ export const MilestoneNotification = (props: MilestoneNotificationProps) => {
     }
   }
 
-  const { link, text } = getTwitterShareData(notification)
+  const { link, text } = getTwitterShareData(notification, entity)
 
   return (
     <NotificationTile notification={notification} onPress={handlePress}>


### PR DESCRIPTION
### Description

As far as I understand, entity was never part of the notification itself, which comes from the makeGetAllNotifications selector and we have a separate selector to pull the entity.

This may not be the full solution, but this unblocks local build! @isaacsolo  & I discovered this

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally vs. staging w/ a listens milestone notification

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
