### PR TITLE
[PAY-353] Mobile: Update user list items

### DIFF
--- a/packages/mobile/src/screens/user-list-screen/SupporterInfo.tsx
+++ b/packages/mobile/src/screens/user-list-screen/SupporterInfo.tsx
@@ -55,8 +55,8 @@ export const SupporterInfo = (props: SupporterInfoProps) => {
       <View style={styles.rankContainer}>
         <RankIcon
           fill={isTopRank ? secondary : neutralLight4}
-          height={12}
-          width={12}
+          height={15}
+          width={15}
         />
         <Text
           style={styles.rankText}

--- a/packages/mobile/src/screens/user-list-screen/Tip.tsx
+++ b/packages/mobile/src/screens/user-list-screen/Tip.tsx
@@ -10,7 +10,8 @@ import { useThemeColors } from 'app/utils/theme'
 const useStyles = makeStyles(({ spacing, typography }) => ({
   root: {
     flexDirection: 'row',
-    alignItems: 'center'
+    alignItems: 'center',
+    marginVertical: spacing(1)
   },
   amount: {
     marginLeft: spacing(1.5),
@@ -33,7 +34,7 @@ export const Tip = (props: TipProps) => {
 
   return (
     <View style={styles.root}>
-      <IconTip fill={neutralLight4} height={14} width={14} />
+      <IconTip fill={neutralLight4} height={15} width={15} />
       <Text style={styles.amount} color='neutralLight4' weight='bold'>
         {formatWei(stringWeiToBN(amount))}
       </Text>

--- a/packages/mobile/src/screens/user-list-screen/UserListItem.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserListItem.tsx
@@ -34,15 +34,17 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
   },
   infoRoot: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     marginBottom: spacing(2)
   },
   photo: {
-    height: 72,
-    width: 72
+    height: 74,
+    width: 74,
+    borderColor: palette.neutralLight8,
+    borderWidth: 1
   },
   userInfo: {
-    marginLeft: spacing(1),
+    marginLeft: spacing(2),
     flex: 1
   },
   userStats: {
@@ -118,7 +120,7 @@ export const UserListItem = (props: UserListItemProps) => {
                 <IconUser height={15} width={15} fill={styles.userIcon.color} />
                 <Text variant='body' color='neutralLight4'>
                   {' '}
-                  <Text color='inherit' weight='bold'>
+                  <Text color='inherit' weight='bold' fontSize='small'>
                     {formatCount(follower_count)}{' '}
                   </Text>
                   {messages.followers(follower_count)}


### PR DESCRIPTION
### Description

- Updates user list items to have equally sized metric fonts, icons
- Updates the profile image to be 72x72 (with a 1px border instead of 2px)
- Aligns the profile image to the top

### How Has This Been Tested?

iOS sim: iPhone 13 iOS 15.0

(See Linear for before pic)

After:

![image](https://user-images.githubusercontent.com/3690498/175190336-e4a01871-0467-482f-bbba-b872b35497e9.png)
![image](https://user-images.githubusercontent.com/3690498/175190403-5ed11bf9-2013-45d2-a74f-6dd0ec8b34e4.png)


