### PR TITLE
[PAY-369][PAY-349][PAY-331][PAY-376][PAY-389][PAY-219] Fix more tipping QA issues

### DIFF
--- a/packages/mobile/src/components/feed-tip-tile/SendTipButton.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/SendTipButton.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     marginTop: spacing(4)
   },
   sendTipButtonTitleContainer: {
+    paddingTop: spacing(0.5),
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',

--- a/packages/mobile/src/screens/notifications-screen/Notification/NotificationText.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/NotificationText.tsx
@@ -6,7 +6,17 @@ export const NotificationText = (props: NotificationTextProps) => {
   const { children, style, ...other } = props
 
   return (
-    <Text fontSize='large' style={[{ lineHeight: 27 }, style]} {...other}>
+    <Text
+      fontSize='large'
+      style={[
+        {
+          lineHeight: 27,
+          flex: 1
+        },
+        style
+      ]}
+      {...other}
+    >
       {children}
     </Text>
   )

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SocialLink.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/SocialLink.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useState } from 'react'
+
 import { StyleProp, View, ViewStyle } from 'react-native'
 
 import IconInstagram from 'app/assets/images/iconInstagram.svg'
@@ -46,6 +48,9 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   },
   hyperlinkLink: {
     fontSize: typography.fontSize.medium
+  },
+  active: {
+    color: palette.primary
   }
 }))
 
@@ -60,7 +65,16 @@ export type SocialLinkProps = LinkProps &
 export const SocialLink = (props: SocialLinkProps) => {
   const { text, showText, url, icon: Icon, hyperlink, style, ...other } = props
   const styles = useStyles()
-  const { neutral } = useThemeColors()
+  const { primary, neutral } = useThemeColors()
+  const [isActive, setIsActive] = useState(false)
+
+  const handlePressIn = useCallback(() => {
+    setIsActive(true)
+  }, [])
+
+  const handlePressOut = useCallback(() => {
+    setIsActive(false)
+  }, [])
 
   // undefined equates to "LOADING" from backend
   if (text === undefined) {
@@ -81,23 +95,38 @@ export const SocialLink = (props: SocialLinkProps) => {
 
   if (text === null || text === '') return null
 
-  const iconButtonElement = <Icon height={28} width={28} fill={neutral} />
+  const iconButtonElement = (
+    <Icon height={28} width={28} fill={isActive ? primary : neutral} />
+  )
 
   if (showText)
     return (
-      <Link url={url} style={[styles.withText, style]} {...other}>
+      <Link
+        url={url}
+        style={[styles.withText, style]}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        {...other}
+      >
         {iconButtonElement}
         {hyperlink ? (
           <Hyperlink
             source='profile page'
             text={squashNewLines(text)}
             styles={{
-              root: [styles.text, styles.hyperlinkText],
+              root: [
+                styles.text,
+                styles.hyperlinkText,
+                isActive && styles.active
+              ],
               link: styles.hyperlinkLink
             }}
           />
         ) : (
-          <Text numberOfLines={1} style={styles.text}>
+          <Text
+            numberOfLines={1}
+            style={[styles.text, isActive && styles.active]}
+          >
             {text}
           </Text>
         )}
@@ -105,7 +134,12 @@ export const SocialLink = (props: SocialLinkProps) => {
     )
 
   return (
-    <Link url={url} style={style}>
+    <Link
+      url={url}
+      style={style}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+    >
       {iconButtonElement}
     </Link>
   )

--- a/packages/mobile/src/screens/tip-artist-screen/TipInput.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/TipInput.tsx
@@ -60,7 +60,7 @@ export const TipInput = (props: TipInputProps) => {
         input: styles.input
       }}
       placeholder={messages.placeholder}
-      keyboardType='numeric'
+      keyboardType='number-pad'
       Icon={() => <AudioText weight='bold' fontSize='xl' />}
       onFocus={() => setIsFocused(true)}
       onBlur={() => setIsFocused(false)}

--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -72,8 +72,8 @@ export const ConfirmSendTip = () => {
   const [isConverting, setIsConverting] = useState(false)
 
   useEffect(() => {
-    setIsDisabled(isSending)
-  }, [isSending])
+    setIsDisabled(isSending || isConverting)
+  }, [isSending, isConverting])
 
   const handleConfirmSendClick = useCallback(() => {
     setHasError(false)
@@ -94,8 +94,12 @@ export const ConfirmSendTip = () => {
       setIsConverting(false)
     } else if (sendStatus === 'SENDING') {
       setIsSending(true)
+      setIsConverting(false)
+      setHasError(false)
     } else if (sendStatus === 'CONVERTING') {
       setIsConverting(true)
+      setIsSending(false)
+      setHasError(false)
     }
   }, [sendStatus, setHasError])
 
@@ -118,7 +122,17 @@ export const ConfirmSendTip = () => {
     <div className={styles.container}>
       {renderSendingAudio()}
       <TipProfilePicture user={receiver} />
-      <ConvertingInfo isVisible={isConverting} />
+      {/*
+      Even though the isVisible prop is being passed in, we
+      only render the converting message if is converting.
+      This will make it so that when we are converting, the
+      message will be animated/faded in, but when conversion
+      is done (whether successful or failed), we hide the
+      message without fading out. This is so that the UI
+      does not show both the large conversion message and the
+      error message at the same time.
+      */}
+      {isConverting ? <ConvertingInfo isVisible={isConverting} /> : null}
       {hasError ? <ErrorMessage /> : null}
       {!hasError && !isSending && !isConverting ? <ConfirmInfo /> : null}
       <div className={cn(styles.flexCenter, styles.buttonContainer)}>
@@ -127,7 +141,7 @@ export const ConfirmSendTip = () => {
           text={
             hasError
               ? messages.confirmAndTryAgain
-              : !isSending
+              : !isSending && !isConverting
               ? messages.confirmTip
               : ''
           }
@@ -147,9 +161,7 @@ export const ConfirmSendTip = () => {
       </div>
       {!isSending && !isConverting ? (
         <div
-          className={cn(styles.flexCenter, styles.goBackContainer, {
-            [styles.disabled]: isDisabled
-          })}
+          className={cn(styles.flexCenter, styles.goBackContainer)}
           onClick={handleGoBackClick}
         >
           <IconCaretLeft />

--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -26,6 +26,12 @@ const messages = {
   holdOn: 'Don’t close this window or refresh the page.'
 }
 
+const ErrorMessage = () => (
+  <div className={cn(styles.flexCenter, styles.error)}>
+    {messages.somethingWrong}
+  </div>
+)
+
 const ConfirmInfo = () => (
   <div className={cn(styles.flexCenter, styles.info)}>
     {messages.areYouSure}
@@ -44,7 +50,6 @@ const ConvertingInfo = ({ isVisible }: { isVisible: boolean }) => (
       item ? (
         <animated.div style={style} className={styles.info}>
           <p>{messages.maintenance}</p>
-          <p>{JSON.stringify(item)}</p>
           <br />
           <p>{messages.fewMinutes}</p>
           <p>{messages.holdOn}</p>
@@ -109,19 +114,13 @@ export const ConfirmSendTip = () => {
     </div>
   )
 
-  const renderError = () => (
-    <div className={cn(styles.flexCenter, styles.error)}>
-      {messages.somethingWrong}
-    </div>
-  )
-
   return receiver ? (
     <div className={styles.container}>
       {renderSendingAudio()}
       <TipProfilePicture user={receiver} />
       <ConvertingInfo isVisible={isConverting} />
-      {hasError ? renderError() : null}
-      {!isSending ? <ConfirmInfo /> : null}
+      {hasError ? <ErrorMessage /> : null}
+      {!hasError && !isSending && !isConverting ? <ConfirmInfo /> : null}
       <div className={cn(styles.flexCenter, styles.buttonContainer)}>
         <Button
           type={ButtonType.PRIMARY}

--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -68,6 +68,7 @@ export const ConfirmSendTip = () => {
   } = useSelector(getSendTipData)
   const [isDisabled, setIsDisabled] = useState(false)
   const [hasError, setHasError] = useState(false)
+  const [hasPreviouslyErrored, setHasPreviouslyErrored] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [isConverting, setIsConverting] = useState(false)
 
@@ -90,6 +91,7 @@ export const ConfirmSendTip = () => {
   useEffect(() => {
     if (sendStatus === 'ERROR') {
       setHasError(true)
+      setHasPreviouslyErrored(true)
       setIsSending(false)
       setIsConverting(false)
     } else if (sendStatus === 'SENDING') {
@@ -101,7 +103,13 @@ export const ConfirmSendTip = () => {
       setIsSending(false)
       setHasError(false)
     }
-  }, [sendStatus, setHasError])
+  }, [
+    sendStatus,
+    setHasError,
+    setHasPreviouslyErrored,
+    setIsSending,
+    setIsConverting
+  ])
 
   const renderSendingAudio = () => (
     <div className={styles.modalContentHeader}>
@@ -155,6 +163,7 @@ export const ConfirmSendTip = () => {
           }
           disabled={isDisabled}
           className={cn(styles.button, styles.confirmButton, {
+            [styles.errorConfirmButton]: hasPreviouslyErrored,
             [styles.disabled]: isDisabled
           })}
         />

--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -68,7 +68,6 @@ export const ConfirmSendTip = () => {
   } = useSelector(getSendTipData)
   const [isDisabled, setIsDisabled] = useState(false)
   const [hasError, setHasError] = useState(false)
-  const [hasPreviouslyErrored, setHasPreviouslyErrored] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [isConverting, setIsConverting] = useState(false)
 
@@ -91,7 +90,6 @@ export const ConfirmSendTip = () => {
   useEffect(() => {
     if (sendStatus === 'ERROR') {
       setHasError(true)
-      setHasPreviouslyErrored(true)
       setIsSending(false)
       setIsConverting(false)
     } else if (sendStatus === 'SENDING') {
@@ -103,13 +101,7 @@ export const ConfirmSendTip = () => {
       setIsSending(false)
       setHasError(false)
     }
-  }, [
-    sendStatus,
-    setHasError,
-    setHasPreviouslyErrored,
-    setIsSending,
-    setIsConverting
-  ])
+  }, [sendStatus, setHasError, setIsSending, setIsConverting])
 
   const renderSendingAudio = () => (
     <div className={styles.modalContentHeader}>
@@ -163,7 +155,6 @@ export const ConfirmSendTip = () => {
           }
           disabled={isDisabled}
           className={cn(styles.button, styles.confirmButton, {
-            [styles.errorConfirmButton]: hasPreviouslyErrored,
             [styles.disabled]: isDisabled
           })}
         />

--- a/packages/web/src/components/tipping/tip-audio/SendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/SendTip.tsx
@@ -147,7 +147,7 @@ export const SendTip = () => {
     </div>
   )
 
-  return (
+  return receiver ? (
     <div className={styles.container}>
       <TipProfilePicture user={receiver} />
       {!hasInsufficientBalance && isFirstSupporter
@@ -186,5 +186,5 @@ export const SendTip = () => {
         </div>
       )}
     </div>
-  )
+  ) : null
 }

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -350,7 +350,7 @@
 .button:hover {
   background: var(--primary-light-1) !important;
 }
-.button:active {
+.button:not(.disabled):active {
   background: var(--primary-dark-1) !important;
   transform: perspective(1px) scale3d(0.99, 0.99, 0.99);
 }

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -256,12 +256,6 @@
 .disabled {
   cursor: unset;
 }
-.confirmButton.disabled {
-  width: 186px;
-}
-.errorConfirmButton.disabled {
-  width: 260px;
-}
 
 .loadingSpinner {
   height: 24px;
@@ -350,6 +344,9 @@
   color: var(--accent-red);
 }
 
+.confirmButton {
+  width: 252px;
+}
 .button:hover {
   background: var(--primary-light-1) !important;
 }

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -259,6 +259,9 @@
 .confirmButton.disabled {
   width: 186px;
 }
+.errorConfirmButton.disabled {
+  width: 260px;
+}
 
 .loadingSpinner {
   height: 24px;

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -241,7 +241,7 @@
   cursor: pointer;
 }
 .goBack {
-  margin-left: 4px;
+  margin-left: 8px;
   font-weight: var(--font-bold);
   font-size: var(--font-l);
   color: var(--neutral-light-4);


### PR DESCRIPTION
### Description

Fix more tipping QA issues:

- fix mobile notification text wrapping
- add margin between go back button and chevron in confirm send tip screen
- vertically center send tip button text on mobile feed tip tile
- fix tipping conversion screen, error state, sending state, and converting state
- give profile bio links active state on mobile

### Dragons

n/a

### How Has This Been Tested?

- local dapp and local mobile app against stage.
- also tested eth<>spl audio conversion, which failed a few times and eventually succeeded when i kept retrying. the UI showed the expected states during sending, conversion, error, and success.

### How will this change be monitored?

n/a
