### PR TITLE
[PAY-379] Fix Twitter icon in referral challenge modal in matrix mode

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
@@ -375,6 +375,7 @@
 
 .twitterButton .twitterText {
   font-size: var(--font-m);
+  color: var(--static-white);
 }
 .twitterButton .twitterIcon {
   margin-right: 8px !important;
@@ -382,6 +383,7 @@
 .twitterButton .twitterIcon svg {
   width: 24px;
   height: 18px;
+  fill: var(--static-white);
 }
 
 .buttonSpacer {


### PR DESCRIPTION
### Description

In the referral challenge modal, in matrix mode, the Twitter icon
and text was gray. Switched to white.

### Dragons

None

### How Has This Been Tested?

Checked visually in web client.
<img width="711" alt="Screen Shot 2022-06-24 at 9 15 14 PM" src="https://user-images.githubusercontent.com/3893871/175757661-c5813b97-3754-4fb8-98ec-42b08f72d312.png">


### How will this change be monitored?
n/a

### Feature Flags ###
n/a
