### PR TITLE
Mobile: Remove unnecessary padding from send tip button

### DIFF
--- a/packages/mobile/src/components/feed-tip-tile/SendTipButton.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/SendTipButton.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     marginTop: spacing(4)
   },
   sendTipButtonTitleContainer: {
-    paddingTop: spacing(0.5),
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',


### PR DESCRIPTION
### Description

Fixes bad merge between:
- #1514 
- #1516 

### How Has This Been Tested?

Tested on iOS Sim
![simulator_screenshot_1F357E46-FB0D-464E-AE16-BBDFFA5363EB](https://user-images.githubusercontent.com/3690498/176044771-af98f969-1f45-4608-99e0-59264f290167.png)

