### PR TITLE
[PAY-380] Web: Make trophy icon neutral fill

### DIFF
--- a/packages/web/src/components/tipping/support/TopSupporters.module.css
+++ b/packages/web/src/components/tipping/support/TopSupporters.module.css
@@ -6,3 +6,7 @@
   width: 18px;
   height: 18px;
 }
+
+.trophyIcon path {
+  fill: var(--neutral);
+}


### PR DESCRIPTION
### Description
Before:
![image](https://user-images.githubusercontent.com/3690498/176046300-04a0cc2e-8270-4a6b-8d3f-7ee6fb0e291d.png)

After:
![image](https://user-images.githubusercontent.com/3690498/176046014-f32bdba4-595b-43f6-a32f-ed4fb0c99908.png)

### How Has This Been Tested?

Locally against stage

