### PR TITLE
Fix challenge confetti re-render

### DIFF
--- a/packages/web/src/common/store/pages/audio-rewards/selectors.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/selectors.ts
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect'
+
 import { ChallengeRewardID } from 'common/models/AudioRewards'
 import { CommonState } from 'common/store'
 
@@ -7,8 +9,23 @@ export const getTrendingRewardsModalType = (state: CommonState) =>
 export const getChallengeRewardsModalType = (state: CommonState) =>
   state.pages.audioRewards.challengeRewardsModalType
 
-export const getUserChallenges = (state: CommonState) =>
+export const getUserChallengeSpecifierMap = (state: CommonState) =>
   state.pages.audioRewards.userChallenges
+
+// Returns just a single challenge per challengeId
+export const getUserChallenges = createSelector(
+  [getUserChallengeSpecifierMap],
+  challenges => {
+    return Object.values(challenges).reduce((acc, cur) => {
+      const challenge = Object.values(cur)[0]
+      if (!challenge) return acc // Shouldn't happen
+      return {
+        ...acc,
+        [challenge.challenge_id]: challenge
+      }
+    }, {})
+  }
+)
 
 export const getUndisbursedUserChallenges = (state: CommonState) =>
   state.pages.audioRewards.undisbursedChallenges.filter(challenge => {
@@ -20,7 +37,10 @@ export const getUndisbursedUserChallenges = (state: CommonState) =>
 export const getUserChallenge = (
   state: CommonState,
   props: { challengeId: ChallengeRewardID }
-) => state.pages.audioRewards.userChallenges[props.challengeId]
+) =>
+  Object.values(
+    state.pages.audioRewards.userChallenges[props.challengeId] || {}
+  )[0]
 
 export const getUserChallengesOverrides = (state: CommonState) =>
   state.pages.audioRewards.userChallengesOverrides

--- a/packages/web/src/common/store/pages/audio-rewards/slice.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/slice.ts
@@ -55,7 +55,9 @@ type RewardsUIState = {
   loading: boolean
   trendingRewardsModalType: TrendingRewardsModalType
   challengeRewardsModalType: ChallengeRewardsModalType
-  userChallenges: Partial<Record<ChallengeRewardID, UserChallenge>>
+  userChallenges: Partial<
+    Record<ChallengeRewardID, Record<Specifier, UserChallenge>>
+  >
   undisbursedChallenges: UndisbursedUserChallenge[]
   userChallengesOverrides: Partial<
     Record<ChallengeRewardID, Partial<UserChallenge>>
@@ -98,11 +100,14 @@ const slice = createSlice({
         state.userChallenges = {}
       } else {
         state.userChallenges = userChallenges.reduce<
-          Partial<Record<ChallengeRewardID, UserChallenge>>
+          Partial<Record<ChallengeRewardID, Record<Specifier, UserChallenge>>>
         >(
           (acc, challenge) => ({
             ...acc,
-            [challenge.challenge_id]: challenge
+            [challenge.challenge_id]: {
+              ...(acc[challenge.challenge_id] || {}),
+              [challenge.specifier]: challenge
+            }
           }),
           {}
         )
@@ -128,9 +133,13 @@ const slice = createSlice({
       }>
     ) => {
       const { challengeId, specifiers } = action.payload
-      const userChallenge = state.userChallenges[challengeId]
+
+      const userChallenge = Object.values(
+        state.userChallenges[challengeId] || {}
+      )[0]
+
       // Keep track of individual challenges for rolled up aggregates
-      if (userChallenge?.challenge_type === 'aggregate') {
+      if (userChallenge.challenge_type === 'aggregate') {
         state.disbursedChallenges[challengeId] = ([] as string[]).concat(
           state.disbursedChallenges[challengeId] ?? [],
           specifiers

--- a/packages/web/src/common/store/pages/audio-rewards/slice.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/slice.ts
@@ -138,6 +138,8 @@ const slice = createSlice({
         state.userChallenges[challengeId] || {}
       )[0]
 
+      if (!userChallenge) return
+
       // Keep track of individual challenges for rolled up aggregates
       if (userChallenge.challenge_type === 'aggregate') {
         state.disbursedChallenges[challengeId] = ([] as string[]).concat(

--- a/packages/web/src/pages/audio-rewards-page/store/sagas.ts
+++ b/packages/web/src/pages/audio-rewards-page/store/sagas.ts
@@ -1,4 +1,3 @@
-import { User } from '@sentry/browser'
 import {
   call,
   fork,
@@ -9,7 +8,7 @@ import {
   takeEvery,
   takeLatest,
   delay
-} from 'redux-saga/effects'
+} from 'typed-redux-saga/macro'
 
 import {
   ChallengeRewardID,
@@ -32,7 +31,6 @@ import {
   getUserChallengesOverrides
 } from 'common/store/pages/audio-rewards/selectors'
 import {
-  Claim,
   resetAndCancelClaimReward,
   claimChallengeReward,
   claimChallengeRewardFailed,
@@ -112,8 +110,9 @@ function* retryClaimChallengeReward({
   errorResolved: boolean
   retryOnFailure: boolean
 }) {
-  const claimStatus: ClaimStatus = yield select(getClaimStatus)
-  const claim: Claim = yield select(getClaimToRetry)
+  const claimStatus = yield* select(getClaimStatus)
+  const claim = yield* select(getClaimToRetry)
+  if (!claim) return
   if (claimStatus === ClaimStatus.WAITING_FOR_RETRY) {
     // Restore the challenge rewards modal if necessary
     yield put(
@@ -187,12 +186,12 @@ function* claimChallengeRewardAsync(
   // This is possible because the client may optimistically set a challenge as complete
   // even though the DN has not yet indexed the change that would mark the challenge as complete.
   // In this case, we wait until the challenge is complete in the DN before claiming
-  const challenge: UserChallenge = yield select(getUserChallenge, {
+  const challenge = yield* select(getUserChallenge, {
     challengeId
   })
   if (challenge.challenge_type !== 'aggregate' && !challenge.is_complete) {
     console.log('Waiting for challenge completion...')
-    const raceResult: { isComplete?: boolean } = yield race({
+    const raceResult: { isComplete?: boolean } = yield* race({
       isComplete: call(
         waitForValue,
         getUserChallenge,
@@ -209,8 +208,10 @@ function* claimChallengeRewardAsync(
     }
   }
 
-  const currentUser: User = yield select(getAccountUser)
-  const feePayerOverride: string = yield select(getFeePayer)
+  const currentUser = yield* select(getAccountUser)
+  const feePayerOverride = yield* select(getFeePayer)
+
+  if (!currentUser) return
 
   // When endpoints is unset, `submitAndEvaluateAttestations` picks for us
   const endpoints =
@@ -234,7 +235,7 @@ function* claimChallengeRewardAsync(
       challenge_id: challengeId,
       specifier
     }))
-    const response: { error?: string } = yield call(
+    const response: { error?: string } = yield* call(
       AudiusBackend.submitAndEvaluateAttestations,
       {
         challenges,
@@ -324,11 +325,11 @@ function* claimChallengeRewardAsync(
 }
 
 function* watchSetHCaptchaStatus() {
-  yield takeLatest(setHCaptchaStatus.type, function* (
+  yield* takeLatest(setHCaptchaStatus.type, function* (
     action: ReturnType<typeof setHCaptchaStatus>
   ) {
     const { status } = action.payload
-    yield call(retryClaimChallengeReward, {
+    yield* call(retryClaimChallengeReward, {
       errorResolved: status === HCaptchaStatus.SUCCESS,
       retryOnFailure: true
     })
@@ -336,7 +337,7 @@ function* watchSetHCaptchaStatus() {
 }
 
 function* watchSetCognitoFlowStatus() {
-  yield takeLatest(setCognitoFlowStatus.type, function* (
+  yield* takeLatest(setCognitoFlowStatus.type, function* (
     action: ReturnType<typeof setCognitoFlowStatus>
   ) {
     const { status } = action.payload
@@ -347,12 +348,13 @@ function* watchSetCognitoFlowStatus() {
       // otherwise may get failure reason that says cognito
       // even though user completed the cognito flow
       let numRetries = 0
-      const handle: string = yield select(getUserHandle)
+      const handle = yield* select(getUserHandle)
+      if (!handle) return
       do {
         try {
-          const { exists } = yield call(getCognitoExists, handle)
+          const { exists } = yield* call(getCognitoExists, handle)
           if (exists) {
-            yield call(retryClaimChallengeReward, {
+            yield* call(retryClaimChallengeReward, {
               errorResolved: true,
               retryOnFailure: false
             })
@@ -370,7 +372,7 @@ function* watchSetCognitoFlowStatus() {
       } while (numRetries++ < COGNITO_CHECK_MAX_RETRIES)
 
       if (numRetries === COGNITO_CHECK_MAX_RETRIES) {
-        yield call(retryClaimChallengeReward, {
+        yield* call(retryClaimChallengeReward, {
           errorResolved: false,
           retryOnFailure: false
         })
@@ -380,12 +382,12 @@ function* watchSetCognitoFlowStatus() {
 }
 
 function* watchClaimChallengeReward() {
-  yield takeLatest(claimChallengeReward.type, function* (
+  yield* takeLatest(claimChallengeReward.type, function* (
     args: ReturnType<typeof claimChallengeReward>
   ) {
     // Race the claim against the user clicking "close" on the modal,
     // so that the claim saga gets canceled if the modal is closed
-    yield race({
+    yield* race({
       task: call(claimChallengeRewardAsync, args),
       cancel: take(resetAndCancelClaimReward.type)
     })
@@ -393,8 +395,9 @@ function* watchClaimChallengeReward() {
 }
 
 function* fetchUserChallengesAsync() {
-  yield call(waitForBackendSetup)
-  const currentUserId: number = yield select(getUserId)
+  yield* call(waitForBackendSetup)
+  const currentUserId = yield* select(getUserId)
+  if (!currentUserId) return
 
   try {
     const userChallenges: UserChallenge[] = yield call(
@@ -422,10 +425,7 @@ function* checkForNewDisbursements(
   if (!userChallenges) {
     return
   }
-  const prevChallenges: Partial<Record<
-    ChallengeRewardID,
-    UserChallenge
-  >> = yield select(getUserChallenges)
+  const prevChallenges = yield* select(getUserChallenges)
   const challengesOverrides: Partial<Record<
     ChallengeRewardID,
     UserChallenge
@@ -434,12 +434,16 @@ function* checkForNewDisbursements(
   for (const challenge of userChallenges) {
     const prevChallenge = prevChallenges[challenge.challenge_id]
     const challengeOverrides = challengesOverrides[challenge.challenge_id]
+
     // Check for new disbursements
+    const wasNotPreviouslyDisbursed =
+      prevChallenge && !prevChallenge.is_disbursed
+    const wasNotDisbursedThisSession =
+      !challengeOverrides || !challengeOverrides.is_disbursed
     if (
       challenge.is_disbursed &&
-      prevChallenge &&
-      !prevChallenge.is_disbursed && // it wasn't already claimed
-      (!challengeOverrides || !challengeOverrides.is_disbursed) // we didn't claim this session
+      wasNotPreviouslyDisbursed &&
+      wasNotDisbursedThisSession
     ) {
       newDisbursement = true
     }
@@ -452,17 +456,17 @@ function* checkForNewDisbursements(
 }
 
 function* watchFetchUserChallengesSucceeded() {
-  yield takeEvery(fetchUserChallengesSucceeded.type, function* (
+  yield* takeEvery(fetchUserChallengesSucceeded.type, function* (
     action: ReturnType<typeof fetchUserChallengesSucceeded>
   ) {
-    yield call(checkForNewDisbursements, action)
-    yield call(handleOptimisticChallengesOnUpdate, action)
+    yield* call(checkForNewDisbursements, action)
+    yield* call(handleOptimisticChallengesOnUpdate, action)
   })
 }
 
 function* watchFetchUserChallenges() {
-  yield takeEvery(fetchUserChallenges.type, function* () {
-    yield call(fetchUserChallengesAsync)
+  yield* takeEvery(fetchUserChallenges.type, function* () {
+    yield* call(fetchUserChallengesAsync)
   })
 }
 
@@ -472,7 +476,7 @@ function* watchFetchUserChallenges() {
  */
 function* handleOptimisticListenStreakUpdate(
   challenge: UserChallenge,
-  challengeOverrides?: UserChallenge
+  challengeOverrides?: Partial<UserChallenge>
 ) {
   if (
     (challengeOverrides?.current_step_count ?? 0) > 0 &&
@@ -497,14 +501,11 @@ function* handleOptimisticChallengesOnUpdate(
     return
   }
 
-  const challengesOverrides: Partial<Record<
-    ChallengeRewardID,
-    UserChallenge
-  >> = yield select(getUserChallengesOverrides)
+  const challengesOverrides = yield* select(getUserChallengesOverrides)
 
   for (const challenge of userChallenges) {
     if (challenge.challenge_id === 'listen-streak') {
-      yield call(
+      yield* call(
         handleOptimisticListenStreakUpdate,
         challenge,
         challengesOverrides[challenge.challenge_id]
@@ -517,13 +518,10 @@ function* handleOptimisticChallengesOnUpdate(
  * Updates the listen streak optimistically if current_step_count is zero and a track is played
  */
 function* watchUpdateOptimisticListenStreak() {
-  yield takeEvery(updateOptimisticListenStreak.type, function* () {
-    const listenStreakChallenge: ReturnType<typeof getUserChallenge> = yield select(
-      getUserChallenge,
-      {
-        challengeId: 'listen-streak'
-      }
-    )
+  yield* takeEvery(updateOptimisticListenStreak.type, function* () {
+    const listenStreakChallenge = yield* select(getUserChallenge, {
+      challengeId: 'listen-streak'
+    })
     if (listenStreakChallenge?.current_step_count === 0) {
       yield put(
         setUserChallengeCurrentStepCount({
@@ -536,11 +534,11 @@ function* watchUpdateOptimisticListenStreak() {
 }
 
 function* watchUpdateHCaptchaScore() {
-  yield takeEvery(updateHCaptchaScore.type, function* (
+  yield* takeEvery(updateHCaptchaScore.type, function* (
     action: ReturnType<typeof updateHCaptchaScore>
   ): any {
     const { token } = action.payload
-    const result = yield call(AudiusBackend.updateHCaptchaScore, token)
+    const result = yield* call(AudiusBackend.updateHCaptchaScore, token)
     if (result.error) {
       yield put(setHCaptchaStatus({ status: HCaptchaStatus.ERROR }))
     } else {
@@ -557,7 +555,7 @@ function* pollUserChallenges(frequency: number) {
 }
 
 function* userChallengePollingDaemon() {
-  yield call(remoteConfigInstance.waitForRemoteConfig)
+  yield* call(remoteConfigInstance.waitForRemoteConfig)
   const defaultChallengePollingTimeout = remoteConfigInstance.getRemoteVar(
     IntKeys.CHALLENGE_REFRESH_INTERVAL_MS
   )!
@@ -567,9 +565,9 @@ function* userChallengePollingDaemon() {
 
   yield take(fetchAccountSucceeded.type)
   yield fork(function* () {
-    yield call(visibilityPollingDaemon, fetchUserChallenges())
+    yield* call(visibilityPollingDaemon, fetchUserChallenges())
   })
-  yield call(
+  yield* call(
     foregroundPollingDaemon,
     fetchUserChallenges(),
     defaultChallengePollingTimeout,

--- a/packages/web/src/pages/audio-rewards-page/store/sagas.ts
+++ b/packages/web/src/pages/audio-rewards-page/store/sagas.ts
@@ -10,11 +10,7 @@ import {
   delay
 } from 'typed-redux-saga/macro'
 
-import {
-  ChallengeRewardID,
-  FailureReason,
-  UserChallenge
-} from 'common/models/AudioRewards'
+import { FailureReason, UserChallenge } from 'common/models/AudioRewards'
 import { StringAudio } from 'common/models/Wallet'
 import { IntKeys, StringKeys } from 'common/services/remote-config'
 import { fetchAccountSucceeded } from 'common/store/account/reducer'
@@ -27,8 +23,8 @@ import {
   getClaimStatus,
   getClaimToRetry,
   getUserChallenge,
-  getUserChallenges,
-  getUserChallengesOverrides
+  getUserChallengesOverrides,
+  getUserChallengeSpecifierMap
 } from 'common/store/pages/audio-rewards/selectors'
 import {
   resetAndCancelClaimReward,
@@ -425,14 +421,13 @@ function* checkForNewDisbursements(
   if (!userChallenges) {
     return
   }
-  const prevChallenges = yield* select(getUserChallenges)
-  const challengesOverrides: Partial<Record<
-    ChallengeRewardID,
-    UserChallenge
-  >> = yield select(getUserChallengesOverrides)
+  const prevChallenges = yield* select(getUserChallengeSpecifierMap)
+  const challengesOverrides = yield* select(getUserChallengesOverrides)
   let newDisbursement = false
+
   for (const challenge of userChallenges) {
-    const prevChallenge = prevChallenges[challenge.challenge_id]
+    const prevChallenge =
+      prevChallenges[challenge.challenge_id]?.[challenge.specifier]
     const challengeOverrides = challengesOverrides[challenge.challenge_id]
 
     // Check for new disbursements

--- a/packages/web/src/pages/audio-rewards-page/store/store.test.ts
+++ b/packages/web/src/pages/audio-rewards-page/store/store.test.ts
@@ -21,7 +21,8 @@ import {
   getClaimToRetry,
   getUserChallenge,
   getUserChallenges,
-  getUserChallengesOverrides
+  getUserChallengesOverrides,
+  getUserChallengeSpecifierMap
 } from 'common/store/pages/audio-rewards/selectors'
 import {
   Claim,
@@ -563,11 +564,13 @@ describe('Rewards Page Sagas', () => {
         .provide([
           ...fetchUserChallengesProvisions,
           [
-            select(getUserChallenges),
+            select(getUserChallengeSpecifierMap),
             {
               'profile-completion': {
-                is_complete: true,
-                is_disbursed: false
+                [testUser.user_id]: {
+                  is_complete: true,
+                  is_disbursed: false
+                }
               }
             }
           ],
@@ -589,11 +592,13 @@ describe('Rewards Page Sagas', () => {
         .provide([
           ...fetchUserChallengesProvisions,
           [
-            select(getUserChallenges),
+            select(getUserChallengeSpecifierMap),
             {
               'profile-completion': {
-                is_complete: true,
-                is_disbursed: true
+                [testUser.user_id]: {
+                  is_complete: true,
+                  is_disbursed: true
+                }
               }
             }
           ],
@@ -614,11 +619,13 @@ describe('Rewards Page Sagas', () => {
         .provide([
           ...fetchUserChallengesProvisions,
           [
-            select(getUserChallenges),
+            select(getUserChallengeSpecifierMap),
             {
-              referrals: {
-                is_complete: true,
-                is_disbursed: false
+              [testUser.user_id]: {
+                referrals: {
+                  is_complete: true,
+                  is_disbursed: false
+                }
               }
             }
           ],
@@ -664,12 +671,14 @@ describe('Rewards Page Sagas', () => {
         )
         .provide([
           [
-            select(getUserChallenges),
+            select(getUserChallengeSpecifierMap),
             {
               'listen-streak': {
-                current_step_count: 0,
-                is_complete: false,
-                is_disbursed: false
+                [testUser.user_id]: {
+                  current_step_count: 0,
+                  is_complete: false,
+                  is_disbursed: false
+                }
               }
             }
           ],
@@ -714,12 +723,14 @@ describe('Rewards Page Sagas', () => {
         )
         .provide([
           [
-            select(getUserChallenges),
+            select(getUserChallengeSpecifierMap),
             {
               'listen-streak': {
-                current_step_count: 0,
-                is_complete: false,
-                is_disbursed: false
+                [testUser.user_id]: {
+                  current_step_count: 0,
+                  is_complete: false,
+                  is_disbursed: false
+                }
               }
             }
           ],


### PR DESCRIPTION
### Description

Can be reviewed per commit to cut down on some of the type fixing noise.

- Set state.userChallenges to be a mapping of challengeId -> specifier -> user_challenge, and then adapt the selectors and calling code as necessary

### Dragons

None

### How Has This Been Tested?

Tested challenge completion locally. Also no longer see confetti spam

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

