### PR TITLE
[PAY-391] Redirect user to signup page when click on tip audio button and not signed in

### DIFF
--- a/packages/web/src/common/services/remote-config/feature-flags.ts
+++ b/packages/web/src/common/services/remote-config/feature-flags.ts
@@ -61,5 +61,5 @@ export const flagCohortType: {
   [FeatureFlags.ENABLE_SPL_AUDIO]: FeatureFlagCohortType.SESSION_ID,
   [FeatureFlags.PLAYLIST_FOLDERS]: FeatureFlagCohortType.USER_ID,
   [FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.TIPPING_ENABLED]: FeatureFlagCohortType.USER_ID
+  [FeatureFlags.TIPPING_ENABLED]: FeatureFlagCohortType.SESSION_ID
 }

--- a/packages/web/src/components/tipping/tip-audio/TipAudioButton.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioButton.tsx
@@ -2,12 +2,15 @@ import { useCallback } from 'react'
 
 import { Button, ButtonType } from '@audius/stems'
 import cn from 'classnames'
+import { push as pushRoute } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 
 import IconGoldBadge from 'assets/img/tokenBadgeGold40@2x.png'
 import { useSelector } from 'common/hooks/useSelector'
+import { getAccountUser } from 'common/store/account/selectors'
 import { getProfileUser } from 'common/store/pages/profile/selectors'
 import { beginTip } from 'common/store/tipping/slice'
+import { SIGN_UP_PAGE } from 'utils/route'
 
 import styles from './TipAudio.module.css'
 
@@ -18,10 +21,15 @@ const messages = {
 export const TipAudioButton = () => {
   const dispatch = useDispatch()
   const profile = useSelector(getProfileUser)
+  const account = useSelector(getAccountUser)
 
   const handleClick = useCallback(() => {
-    dispatch(beginTip({ user: profile, source: 'profile' }))
-  }, [dispatch, profile])
+    if (account) {
+      dispatch(beginTip({ user: profile, source: 'profile' }))
+    } else {
+      dispatch(pushRoute(SIGN_UP_PAGE))
+    }
+  }, [dispatch, profile, account])
 
   return (
     <Button

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -203,7 +203,8 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
           instagramHandle={instagramHandle}
           tikTokHandle={tikTokHandle}
         />
-        {isTippingEnabled && accountUser && accountUser.user_id !== userId ? (
+        {isTippingEnabled &&
+        (!accountUser || accountUser.user_id !== userId) ? (
           <OpacityTransition render={renderTipAudioButton} />
         ) : null}
         {isTippingEnabled && <SupportingList />}


### PR DESCRIPTION
### Description

So that the tip audio button will always be there and prompt the user to take an action.

### Dragons

no dangerous changes really.

### How Has This Been Tested?

local dapp against stage

https://user-images.githubusercontent.com/9600175/176057246-f791fb18-313a-4fb5-af4a-042a25de0486.mp4

### How will this change be monitored?

n/a

### Feature Flags ###

already exisiting tipping feature flag.

