### PR TITLE
[C-632] Fix lint error in feature flag modal and update loader styles

### DIFF
--- a/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.module.css
+++ b/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.module.css
@@ -10,3 +10,9 @@
   justify-content: space-between;
   gap: 16px;
 }
+
+.loader {
+  height: 40px;
+  width: 40px;
+  margin: 0 auto;
+}

--- a/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.tsx
+++ b/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
   Modal,
@@ -39,8 +39,10 @@ const setOverrideSetting = (flag: string, val: OverrideSetting) => {
 
 export const FeatureFlagOverrideModal = () => {
   const hotkeyToggle = useDevModeHotkey(70 /* f */)
+  // Ref to handle modal toggle from the hotkey
+  // Needed to avoid it getting out of sync when using closeModal function
+  const hotkeyRef = useRef<boolean | null>(null)
   const [remoteInstanceLoaded, setRemoteInstanceLoaded] = useState(false)
-  const [hotkeyLoaded, setHotkeyLoaded] = useState(false)
   const [isOpen, setIsOpen] = useModalState('FeatureFlagOverride')
   const defaultSettings = useRef<Record<string, boolean>>({})
   const [overrideSettings, setOverrideSettings] = useState(
@@ -65,16 +67,20 @@ export const FeatureFlagOverrideModal = () => {
     remoteConfigInstance.waitForUserRemoteConfig().then(updateDefaultSettings)
   }, [])
 
-  const openModal = () => setIsOpen(true)
-  const closeModal = () => setIsOpen(false)
+  const closeModal = useCallback(() => {
+    hotkeyRef.current = false
+    setIsOpen(false)
+  }, [hotkeyRef, setIsOpen])
 
   useEffect(() => {
-    if (hotkeyLoaded) {
-      isOpen ? closeModal() : openModal()
-    } else {
-      setHotkeyLoaded(true)
+    if (hotkeyRef.current === null) {
+      hotkeyRef.current = false
+      return
     }
-  }, [hotkeyToggle])
+
+    hotkeyRef.current = !hotkeyRef.current
+    setIsOpen(hotkeyRef.current)
+  }, [hotkeyToggle, setIsOpen])
 
   return (
     <Modal
@@ -115,7 +121,7 @@ export const FeatureFlagOverrideModal = () => {
             ))}
           </div>
         ) : (
-          <LoadingSpinner />
+          <LoadingSpinner className={styles.loader} />
         )}
       </ModalContent>
     </Modal>

--- a/packages/web/src/utils/hotkeyUtil.js
+++ b/packages/web/src/utils/hotkeyUtil.js
@@ -50,6 +50,7 @@ function fireHotkey(e, mapping, preventDefault) {
         cb(e)
       }
     } else {
+      if (e.metaKey || e.ctrlKey || e.altKey) return
       // If no modifier keys are required, fire the callback.
       if (preventDefault) e.preventDefault()
       mapping[e.keyCode](e)


### PR DESCRIPTION
### Description

* Update FeatureFlagOverrideModal deps for hotkey toggle callback to remove warning and not have infinite renders
* Small update for loader style
* Small addition to prevent hot keys from blocking default browser actions like Cmd+F

### Dragons

N/a

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/a

### Feature Flags ###

N/a

