### PR TITLE
[PAY-400] Fix twitter button repeat share

### DIFF
--- a/packages/mobile/src/components/twitter-button/TwitterButton.tsx
+++ b/packages/mobile/src/components/twitter-button/TwitterButton.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
 
 import { getUser } from 'audius-client/src/common/store/cache/users/selectors'
 import { Nullable } from 'audius-client/src/common/utils/typeUtils'
+import { useTwitterButtonStatus } from 'common/hooks/useTwitterButtonStatus'
 import { fetchUserSocials } from 'common/store/cache/users/actions'
 
 import IconTwitterBird from 'app/assets/images/iconTwitterBird.svg'
@@ -21,8 +22,6 @@ const useStyles = makeStyles(({ palette }) => ({
     backgroundColor: palette.staticTwitterBlue
   }
 }))
-
-type ShareStatus = 'idle' | 'loading' | 'success'
 
 type StaticTwitterProps = {
   type: 'static'
@@ -49,14 +48,17 @@ export const TwitterButton = (props: TwitterButtonProps) => {
   const styles = useStyles()
   const openLink = useOnOpenLink()
   const dispatchWeb = useDispatchWeb()
-  const [shareTwitterStatus, setShareTwitterStatus] = useState<ShareStatus>(
-    'idle'
-  )
   const user = useSelectorWeb(state =>
     getUser(state, { handle: 'handle' in other ? other.handle : undefined })
   )
-  const userName = user?.name
-  const twitterHandle = user ? user.twitter_handle : null
+
+  const {
+    userName,
+    shareTwitterStatus,
+    twitterHandle,
+    setLoading,
+    setIdle
+  } = useTwitterButtonStatus(user)
 
   const handlePress = useCallback(() => {
     if (other.type === 'static' && other.analytics) {
@@ -64,28 +66,20 @@ export const TwitterButton = (props: TwitterButtonProps) => {
     }
     if (other.type === 'dynamic') {
       dispatchWeb(fetchUserSocials(other.handle))
-      setShareTwitterStatus('loading')
+      setLoading()
     }
-  }, [other, dispatchWeb])
+  }, [other, dispatchWeb, setLoading])
 
-  useEffect(() => {
-    if (shareTwitterStatus === 'loading' && twitterHandle !== null) {
-      setShareTwitterStatus('success')
+  if (other.type === 'dynamic' && shareTwitterStatus === 'success') {
+    const handle = twitterHandle ? `@${twitterHandle}` : userName
+    const twitterData = other.shareData(handle)
+    if (twitterData) {
+      const { shareText, analytics } = twitterData
+      openLink(getTwitterLink(url, shareText))
+      track(analytics)
+      setIdle()
     }
-  }, [shareTwitterStatus, twitterHandle])
-
-  useEffect(() => {
-    if (other.type === 'dynamic' && shareTwitterStatus === 'success') {
-      const handle = twitterHandle ? `@${twitterHandle}` : userName
-      const twitterData = other.shareData(handle)
-      if (twitterData) {
-        const { shareText, analytics } = twitterData
-        openLink(getTwitterLink(url, shareText))
-        track(analytics)
-        setShareTwitterStatus('idle')
-      }
-    }
-  }, [other, shareTwitterStatus, twitterHandle, userName, openLink, url])
+  }
 
   return (
     <Button

--- a/packages/web/src/common/hooks/useTwitterButtonStatus.ts
+++ b/packages/web/src/common/hooks/useTwitterButtonStatus.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react'
+
+import { User } from 'common/models/User'
+import { Nullable } from 'common/utils/typeUtils'
+
+type ShareStatus = 'idle' | 'loading' | 'success'
+
+export const useTwitterButtonStatus = (user: Nullable<User>) => {
+  const [shareTwitterStatus, setShareTwitterStatus] = useState<ShareStatus>(
+    'idle'
+  )
+
+  const userName = user?.name
+  const twitterHandle = user ? user.twitter_handle : null
+
+  // Initially twitter handle is undefined; after fetch it's
+  // set to either null or a value in `fetchUserSocials` sagas
+  const twitterHandleFetched = twitterHandle !== undefined
+
+  if (shareTwitterStatus === 'loading' && twitterHandleFetched) {
+    setShareTwitterStatus('success')
+  }
+
+  const setLoading = useCallback(() => setShareTwitterStatus('loading'), [])
+  const setIdle = useCallback(() => setShareTwitterStatus('idle'), [])
+  return { userName, shareTwitterStatus, twitterHandle, setLoading, setIdle }
+}

--- a/packages/web/src/components/notification/Notification/components/TwitterShareButton.tsx
+++ b/packages/web/src/components/notification/Notification/components/TwitterShareButton.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState } from 'react'
+import { MouseEventHandler, useCallback } from 'react'
 
 import { useDispatch, useSelector } from 'react-redux'
 
 import { ReactComponent as IconTwitterBird } from 'assets/img/iconTwitterBird.svg'
+import { useTwitterButtonStatus } from 'common/hooks/useTwitterButtonStatus'
 import { CommonState } from 'common/store'
 import { fetchUserSocials } from 'common/store/cache/users/actions'
 import { getUser } from 'common/store/cache/users/selectors'
@@ -15,8 +16,6 @@ import styles from './TwitterShareButton.module.css'
 const messages = {
   share: 'Share'
 }
-
-type ShareStatus = 'idle' | 'loading' | 'success'
 
 type StaticTwitterProps = {
   type: 'static'
@@ -41,52 +40,51 @@ export const TwitterShareButton = (props: TwitterShareButtonProps) => {
   const { url = null, ...other } = props
   const record = useRecord()
   const dispatch = useDispatch()
-  const [shareTwitterStatus, setShareTwitterStatus] = useState<ShareStatus>(
-    'idle'
-  )
   const user = useSelector((state: CommonState) =>
     getUser(state, { handle: 'handle' in other ? other.handle : undefined })
   )
-  const userName = user?.name
-  const twitterHandle = user ? user.twitter_handle : null
 
-  const handleClick = useCallback(() => {
-    if (other.type === 'static') {
-      openTwitterLink(url, other.shareText)
-      if (other.analytics) {
-        // @ts-ignore issues with record type
-        record(other.analytics)
+  const {
+    userName,
+    shareTwitterStatus,
+    twitterHandle,
+    setLoading,
+    setIdle
+  } = useTwitterButtonStatus(user)
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
+    e => {
+      e.stopPropagation()
+      if (other.type === 'static') {
+        openTwitterLink(url, other.shareText)
+        if (other.analytics) {
+          // @ts-ignore issues with record type
+          record(other.analytics)
+        }
       }
-    }
-    if (other.type === 'dynamic') {
-      dispatch(fetchUserSocials(other.handle))
-      setShareTwitterStatus('loading')
-    }
-  }, [url, other, dispatch, record])
-
-  useEffect(() => {
-    if (shareTwitterStatus === 'loading' && twitterHandle !== null) {
-      setShareTwitterStatus('success')
-    }
-  }, [shareTwitterStatus, twitterHandle])
-
-  useEffect(() => {
-    if (
-      other.type === 'dynamic' &&
-      shareTwitterStatus === 'success' &&
-      userName
-    ) {
-      const handle = twitterHandle ? `@${twitterHandle}` : userName
-      const twitterData = other.shareData(handle)
-      if (twitterData) {
-        const { shareText, analytics } = twitterData
-        openTwitterLink(url, shareText)
-        // @ts-ignore issues with record type
-        record(analytics)
-        setShareTwitterStatus('idle')
+      if (other.type === 'dynamic') {
+        dispatch(fetchUserSocials(other.handle))
+        setLoading()
       }
+    },
+    [url, other, dispatch, record, setLoading]
+  )
+
+  if (
+    other.type === 'dynamic' &&
+    shareTwitterStatus === 'success' &&
+    userName
+  ) {
+    const handle = twitterHandle ? `@${twitterHandle}` : userName
+    const twitterData = other.shareData(handle)
+    if (twitterData) {
+      const { shareText, analytics } = twitterData
+      openTwitterLink(url, shareText)
+      // @ts-ignore issues with record type
+      record(analytics)
+      setIdle()
     }
-  }, [other, shareTwitterStatus, twitterHandle, userName, url, record])
+  }
 
   return (
     <button className={styles.root} onClick={handleClick}>


### PR DESCRIPTION
### Description

This one requires some explanation!

**Problem**: The share to Twitter button doesn't let you click it twice

**Reason**:
The flow here was:
- Button starts in idle state, we haven't fetched social handles
- We click it, set button to loading, and wait for twitterHandle !== null before setting loading = succeeded

This doesn't work, because initially a user's social handles are undefined (unfetched), and in the saga layer once we fetch, if they are still empty, the saga sets them to null. But the Twitter button thinks that null means still fetching, so it never moves to success state.

**Solution**
- Loading state should be represented by `undefined` (unfetched), not null. Added some comments to make this more explicit.
- Also stop propagation on desktop, to prevent modal panel from closing after share
- Also refactor this into a hook to share behavior on desktop and mobile
- In the refactored hook, was able to drop two useEffect and use a regular conditional instead, making the flower easier to grok

### Dragons

None

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested on web, testing on mobile

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

