### PR TITLE
Update explore endpoints in libs to use v1

### DIFF
--- a/packages/web/src/services/audius-backend/Explore.ts
+++ b/packages/web/src/services/audius-backend/Explore.ts
@@ -168,13 +168,13 @@ class Explore {
     limit = 20
   ): Promise<Collection[]> {
     try {
-      const playlists = await libs().discoveryProvider.getTrendingPlaylists(
+      const playlists = await libs().discoveryProvider.getTopFullPlaylists({
         type,
         limit,
-        undefined,
-        followeesOnly ? 'followees' : undefined,
-        true
-      )
+        mood: undefined,
+        filter: followeesOnly ? 'followees' : undefined,
+        withUsers: true
+      })
       const adapted = playlists.map(adapter.makePlaylist)
       return adapted
     } catch (e) {
@@ -189,13 +189,13 @@ class Explore {
   ): Promise<UserCollectionMetadata[]> {
     try {
       const requests = moods.map((mood) => {
-        return libs().discoveryProvider.getTrendingPlaylists(
-          'playlist',
+        return libs().discoveryProvider.getTopFullPlaylists({
+          type: 'playlist',
           limit,
           mood,
-          undefined,
-          true
-        )
+          filter: undefined,
+          withUsers: true
+        })
       })
       const playlistsByMood: CollectionWithScore[] = await Promise.all(requests)
       let allPlaylists: CollectionWithScore[] = []

--- a/packages/web/src/services/audius-backend/Explore.ts
+++ b/packages/web/src/services/audius-backend/Explore.ts
@@ -139,11 +139,12 @@ class Explore {
   static async getMostLovedTracks(userId: ID, limit = 25) {
     try {
       const encodedUserId = encodeHashId(userId)
-      const tracks: APITrack[] = await libs().discoveryProvider.getMostLovedTracks(
-        encodedUserId,
-        limit,
-        true
-      )
+      const tracks: APITrack[] =
+        await libs().discoveryProvider.getMostLovedTracks(
+          encodedUserId,
+          limit,
+          true
+        )
       return tracks.map(adapter.makeTrack).filter(removeNullable)
     } catch (e) {
       console.error(e)

--- a/packages/web/src/services/audius-backend/Explore.ts
+++ b/packages/web/src/services/audius-backend/Explore.ts
@@ -1,15 +1,19 @@
 import { ID } from '@audius/common'
 
-import { Collection } from 'common/models/Collection'
+import { Collection, UserCollectionMetadata } from 'common/models/Collection'
 import FeedFilter from 'common/models/FeedFilter'
 import { Track, UserTrack } from 'common/models/Track'
+import { removeNullable } from 'common/utils/typeUtils'
 import AudiusBackend, {
   IDENTITY_SERVICE,
   AuthHeaders
 } from 'services/AudiusBackend'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
+import * as adapter from 'services/audius-api-client/ResponseAdapter'
+import { APIPlaylist, APITrack } from 'services/audius-api-client/types'
+import { encodeHashId } from 'utils/route/hashIds'
 
-type CollectionWithScore = Collection & { score: number }
+type CollectionWithScore = APIPlaylist & { score: number }
 
 // @ts-ignore
 const libs = () => window.audiusLibs
@@ -64,17 +68,19 @@ class Explore {
   }
 
   static async getTopFolloweeTracksFromWindow(
+    userId: ID,
     window: string,
     limit = 25
   ): Promise<UserTrack[]> {
     try {
-      const tracks = await libs().discoveryProvider.getTopFolloweeWindowed(
-        'track',
+      const encodedUserId = encodeHashId(userId)
+      const tracks = await libs().discoveryProvider.getBestNewReleases(
+        encodedUserId,
         window,
         limit,
         true
       )
-      return tracks
+      return tracks.map(adapter.makeTrack).filter(removeNullable)
     } catch (e) {
       console.error(e)
       return []
@@ -130,6 +136,21 @@ class Explore {
     }
   }
 
+  static async getMostLovedTracks(userId: ID, limit = 25) {
+    try {
+      const encodedUserId = encodeHashId(userId)
+      const tracks: APITrack[] = await libs().discoveryProvider.getMostLovedTracks(
+        encodedUserId,
+        limit,
+        true
+      )
+      return tracks.map(adapter.makeTrack).filter(removeNullable)
+    } catch (e) {
+      console.error(e)
+      return []
+    }
+  }
+
   static async getLatestTrackID(): Promise<number> {
     try {
       const latestTrackID = await libs().discoveryProvider.getLatest('track')
@@ -147,14 +168,15 @@ class Explore {
     limit = 20
   ): Promise<Collection[]> {
     try {
-      const playlists = await libs().discoveryProvider.getTopPlaylists(
+      const playlists = await libs().discoveryProvider.getTrendingPlaylists(
         type,
         limit,
         undefined,
         followeesOnly ? 'followees' : undefined,
         true
       )
-      return playlists
+      const adapted = playlists.map(adapter.makePlaylist)
+      return adapted
     } catch (e) {
       console.error(e)
       return []
@@ -164,10 +186,10 @@ class Explore {
   static async getTopPlaylistsForMood(
     moods: string[],
     limit = 16
-  ): Promise<Collection[]> {
+  ): Promise<UserCollectionMetadata[]> {
     try {
       const requests = moods.map((mood) => {
-        return libs().discoveryProvider.getTopPlaylists(
+        return libs().discoveryProvider.getTrendingPlaylists(
           'playlist',
           limit,
           mood,
@@ -175,13 +197,15 @@ class Explore {
           true
         )
       })
-      const playlistsByMood = await Promise.all(requests)
-
+      const playlistsByMood: CollectionWithScore[] = await Promise.all(requests)
       let allPlaylists: CollectionWithScore[] = []
       playlistsByMood.forEach((playlists) => {
         allPlaylists = allPlaylists.concat(playlists)
       })
-      return allPlaylists.sort(scoreComparator).slice(0, 20)
+      const playlists: APIPlaylist[] = allPlaylists
+        .sort(scoreComparator)
+        .slice(0, 20)
+      return playlists.map(adapter.makePlaylist).filter(removeNullable)
     } catch (e) {
       console.error(e)
       return []


### PR DESCRIPTION
### Description
Update explore page to use new v1 endpoints

Relies on updated libs version
reference PRs: 
* https://github.com/AudiusProject/audius-protocol/pull/3353
* https://github.com/AudiusProject/audius-protocol/pull/3354

Fixes PLAT-233

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Ran locally against linked libs and discovery running against prod with (fixed) endpoint

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

