### PR TITLE
[PAY-405] Fixed Claim Rewards Pill To Respect Optimizely Config

### DIFF
--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -46,11 +46,9 @@ const validRewardIds: Set<ChallengeRewardID> = new Set([
 const useActiveRewardIds = () => {
   const rewardsString = useRemoteVar(StringKeys.CHALLENGE_REWARD_IDS)
   if (rewardsString === null) return []
-  const activeRewards = rewardsString.split(',') as ChallengeRewardID[]
-  const filteredRewards = activeRewards.filter(reward =>
-    validRewardIds.has(reward)
-  )
-  return filteredRewards
+  const rewards = rewardsString.split(',') as ChallengeRewardID[]
+  const activeRewards = rewards.filter(reward => validRewardIds.has(reward))
+  return activeRewards
 }
 
 const NavAudio = () => {
@@ -73,7 +71,7 @@ const NavAudio = () => {
   const activeRewardIds = useActiveRewardIds()
   const activeUserChallenges = Object.values(
     optimisticUserChallenges
-  ).filter(challenge => activeRewardIds.includes(challenge?.challenge_id))
+  ).filter(challenge => activeRewardIds.includes(challenge.challenge_id))
   const hasClaimableTokens = activeUserChallenges.some(
     challenge => challenge.claimableAmount > 0
   )

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -43,14 +43,12 @@ const validRewardIds: Set<ChallengeRewardID> = new Set([
 ])
 
 /** Pulls rewards from remoteconfig */
-const useRewardIds = (
-  hideConfig: Partial<Record<ChallengeRewardID, boolean>>
-) => {
+const useActiveRewardIds = () => {
   const rewardsString = useRemoteVar(StringKeys.CHALLENGE_REWARD_IDS)
   if (rewardsString === null) return []
-  const rewards = rewardsString.split(',') as ChallengeRewardID[]
-  const filteredRewards: ChallengeRewardID[] = rewards.filter(
-    reward => validRewardIds.has(reward) && !hideConfig[reward]
+  const activeRewards = rewardsString.split(',') as ChallengeRewardID[]
+  const filteredRewards = activeRewards.filter(reward =>
+    validRewardIds.has(reward)
   )
   return filteredRewards
 }
@@ -72,12 +70,12 @@ const NavAudio = () => {
   const audioBadge = audioTierMapPng[tier as BadgeTier]
 
   const optimisticUserChallenges = useSelector(getOptimisticUserChallenges)
-  const rewardIds = useRewardIds({})
-  const filteredUserChallenges = Object.values(
+  const activeRewardIds = useActiveRewardIds()
+  const activeUserChallenges = Object.values(
     optimisticUserChallenges
-  ).filter(challenge => rewardIds.includes(challenge.challenge_id))
-  const hasClaimableTokens = filteredUserChallenges.some(
-    challenge => challenge && challenge.claimableAmount > 0
+  ).filter(challenge => activeRewardIds.includes(challenge?.challenge_id))
+  const hasClaimableTokens = activeUserChallenges.some(
+    challenge => challenge.claimableAmount > 0
   )
 
   const [bubbleType, setBubbleType] = useState<BubbleType>('none')

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -7,14 +7,17 @@ import { animated, Transition } from 'react-spring/renderprops'
 import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'
 import IconNoTierBadge from 'assets/img/tokenBadgeNoTier.png'
 import { useSelectTierInfo } from 'common/hooks/wallet'
+import { ChallengeRewardID } from 'common/models/AudioRewards'
 import { BadgeTier } from 'common/models/BadgeTier'
 import { BNWei } from 'common/models/Wallet'
+import { StringKeys } from 'common/services/remote-config'
 import { getAccountUser } from 'common/store/account/selectors'
 import { getOptimisticUserChallenges } from 'common/store/challenges/selectors/optimistic-challenges'
 import { getAccountTotalBalance } from 'common/store/wallet/selectors'
 import { formatWei } from 'common/utils/wallet'
 import { audioTierMapPng } from 'components/user-badges/UserBadges'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
+import { useRemoteVar } from 'hooks/useRemoteConfig'
 import { useSelector } from 'utils/reducer'
 import { AUDIO_PAGE } from 'utils/route'
 
@@ -25,6 +28,31 @@ type BubbleType = 'none' | 'claim' | 'earn'
 const messages = {
   earnAudio: 'EARN $AUDIO',
   claimRewards: 'Claim Rewards'
+}
+
+const validRewardIds: Set<ChallengeRewardID> = new Set([
+  'track-upload',
+  'referrals',
+  'ref-v',
+  'mobile-install',
+  'connect-verified',
+  'listen-streak',
+  'profile-completion',
+  'referred',
+  'send-first-tip'
+])
+
+/** Pulls rewards from remoteconfig */
+const useRewardIds = (
+  hideConfig: Partial<Record<ChallengeRewardID, boolean>>
+) => {
+  const rewardsString = useRemoteVar(StringKeys.CHALLENGE_REWARD_IDS)
+  if (rewardsString === null) return []
+  const rewards = rewardsString.split(',') as ChallengeRewardID[]
+  const filteredRewards: ChallengeRewardID[] = rewards.filter(
+    reward => validRewardIds.has(reward) && !hideConfig[reward]
+  )
+  return filteredRewards
 }
 
 const NavAudio = () => {
@@ -43,8 +71,12 @@ const NavAudio = () => {
   const { tier } = useSelectTierInfo(account?.user_id ?? 0)
   const audioBadge = audioTierMapPng[tier as BadgeTier]
 
-  const userChallenges = useSelector(getOptimisticUserChallenges)
-  const hasClaimableTokens = Object.values(userChallenges).some(
+  const optimisticUserChallenges = useSelector(getOptimisticUserChallenges)
+  const rewardIds = useRewardIds({})
+  const filteredUserChallenges = Object.values(
+    optimisticUserChallenges
+  ).filter(challenge => rewardIds.includes(challenge.challenge_id))
+  const hasClaimableTokens = filteredUserChallenges.some(
     challenge => challenge && challenge.claimableAmount > 0
   )
 


### PR DESCRIPTION
### Description
Fixes a bug where the "Claim Rewards" Pill in the left navbar on web client would turn green whenever the user completed a challenge - even if the challenge wasn't enabled in Optimizely.

The useRewardIds hook is ripe for refactoring but I can open a separate ticket for that.

### Dragons

### How Has This Been Tested?
* Uploaded 3 tracks to complete the upload challenge
* De-whitelisted the upload challenge in Optimizely
* Confirmed that the pill does not turn green.
* Confirmed that it does when the upload challenge is re-enabled.
![Screen Shot 2022-07-07 at 7 46 14 PM](https://user-images.githubusercontent.com/3893871/177889698-80de2d3a-07ff-4726-b7b8-d7a9040abb42.png)
![Screen Shot 2022-07-07 at 7 48 13 PM](https://user-images.githubusercontent.com/3893871/177889700-13498c55-7252-48a9-94c0-cea57291c9bc.png)

### How will this change be monitored?

### Feature Flags ###

