### PR TITLE
Rj fix brave solana integration

### DIFF
--- a/packages/web/src/store/token-dashboard/sagas.ts
+++ b/packages/web/src/store/token-dashboard/sagas.ts
@@ -307,20 +307,12 @@ function* connectPhantomWallet(solana: any) {
   const disconnect = async () => {
     await solana.disconnect()
   }
-  yield connectSPLWallet(connectingWallet, solana.signMessage, disconnect)
+  yield connectSPLWallet(connectingWallet, solana, disconnect)
 }
-
-type SolanaSignMessage = (
-  encodedMessage: Uint8Array,
-  encoding: string
-) => Promise<{
-  publicKey: any
-  signature: any
-}>
 
 function* connectSPLWallet(
   connectingWallet: string,
-  solanaSignMessage: SolanaSignMessage,
+  solana: any,
   disconnect: () => Promise<void>
 ) {
   try {
@@ -377,7 +369,7 @@ function* connectSPLWallet(
     const signedResponse: {
       publicKey: any
       signature: any
-    } = yield solanaSignMessage(encodedMessage, 'utf8')
+    } = yield solana.signMessage(encodedMessage, 'utf8')
 
     const publicKey = signedResponse.publicKey.toString()
     const signature = signedResponse.signature.toString('hex')


### PR DESCRIPTION
### Description

Fixes integration with Brave browser on solana side. Brave does not let you invoke `signMessage` as a pure function, it must be called on the solana object itself.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally with brave. Connecting wallet now works.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

