### PR TITLE
[PAY-425] Fix optimistic trophy icon for supporting

### DIFF
--- a/packages/web/src/components/tipping/support/SupportingTile.module.css
+++ b/packages/web/src/components/tipping/support/SupportingTile.module.css
@@ -76,6 +76,7 @@
   align-items: center;
   margin: 12px;
   gap: 4px;
+  margin-top: auto;
 }
 
 .profilePicture {

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -66,9 +66,7 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
           <span className={styles.rankNumberSymbol}>#</span>
           <span>{rank}</span>
         </div>
-      ) : (
-        <div></div>
-      )}
+      ) : null}
       <div className={styles.profilePictureContainer}>
         <img className={styles.profilePicture} src={profileImage} />
         <span className={styles.name}>{receiver.name}</span>

--- a/packages/web/src/components/tipping/support/SupportingTile.tsx
+++ b/packages/web/src/components/tipping/support/SupportingTile.tsx
@@ -66,7 +66,9 @@ export const SupportingTile = ({ supporting }: SupportingCardProps) => {
           <span className={styles.rankNumberSymbol}>#</span>
           <span>{rank}</span>
         </div>
-      ) : null}
+      ) : (
+        <div></div>
+      )}
       <div className={styles.profilePictureContainer}>
         <img className={styles.profilePicture} src={profileImage} />
         <span className={styles.name}>{receiver.name}</span>


### PR DESCRIPTION
### Description

The `getOptimisticSupporters` selector re-ranks supporters based on the amounts, ensuring the ranking of supporters in the "Top Supporters" modal is correct. However, it doesn't do the same for the _supporting_, which is set to -1 when applied optimistically. Rather than rewrite this to do reranking at the saga level, I added the `getOptimisticSupporters` selector to the `getOptimisticSupporting` selector as a dependency. That way we'll have the updated rankings already computed on the supporter side and can map the rankings over to the supporting side.

Additionally, includes a bugfix where the profile image/name weren't at the bottom of the tile for non-top supporters on web

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

This might slightly affect perf, as we now have to loop over all entries in the entire supportingMap to check rankings. Reselect should prevent recomputations

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested against staging

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

