### PR TITLE
[C678] Limit prod mobile builds to main & release branches

### DIFF
--- a/.circleci/src/workflows/mobile.yml
+++ b/.circleci/src/workflows/mobile.yml
@@ -7,6 +7,9 @@ jobs:
       context: Audius Mobile Client
       requires:
         - mobile-init
+      filters:
+        branches:
+          only: /(^main|^release.*)$/
 
   - mobile-build-staging-web-app:
       context: Audius Mobile Client
@@ -27,8 +30,14 @@ jobs:
       context: Audius Mobile Client
       requires:
         - mobile-build-production-web-app
+      filters:
+        branches:
+          only: /(^main|^release.*)$/
 
   - mobile-build-upload-production-android:
       context: Audius Mobile Client
       requires:
         - mobile-build-production-web-app
+      filters:
+        branches:
+          only: /(^main|^release.*)$/


### PR DESCRIPTION
### Description

Currently, prod mobile is being built on all commits that touch mobile. This isn't really necessary because we only upload prod mobile from release branches. Also, the staging build passing should be enough of an indicator that the prod build will pass too.

Including prod mobile build on `main` as a kind of sanity check that everything is green on main

### Dragons

The branch filters on the `mobile-build-upload-production-ios` and `mobile-build-upload-production-android` aren't necessary because the one on `mobile-build-production-web-app` would short circuit, but I'm adding them for clarity

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

