### PR TITLE
[C-677] Fix profile-screen icon hit-slop and color

### DIFF
--- a/packages/mobile/src/components/core/IconButton.tsx
+++ b/packages/mobile/src/components/core/IconButton.tsx
@@ -1,5 +1,6 @@
 import {
   Animated,
+  Insets,
   StyleProp,
   TouchableOpacity,
   View,
@@ -22,6 +23,7 @@ export type IconButtonProps = {
   >
   isDisabled?: boolean
   onPress?: GestureResponderHandler
+  hitSlop?: Insets
 } & StylesProps<{ root?: StyleProp<ViewStyle>; icon?: StyleProp<ViewStyle> }>
 
 const useStyles = makeStyles(() => ({
@@ -30,6 +32,8 @@ const useStyles = makeStyles(() => ({
     width: 18
   }
 }))
+
+const defaultHitSlop = { top: 12, right: 12, bottom: 12, left: 12 }
 
 /**
  * A button with touchable feedback that is only an
@@ -44,7 +48,8 @@ export const IconButton = ({
   isDisabled,
   onPress,
   style,
-  styles: stylesProp
+  styles: stylesProp,
+  hitSlop
 }: IconButtonProps) => {
   const styles = useStyles()
   const { scale, handlePressIn, handlePressOut } = usePressScaleAnimation(0.9)
@@ -61,7 +66,7 @@ export const IconButton = ({
         onPressOut={handlePressOut}
         disabled={isDisabled}
         activeOpacity={0.95}
-        hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}>
+        hitSlop={{ ...defaultHitSlop, ...hitSlop }}>
         <View
           style={[
             styles.icon,

--- a/packages/mobile/src/components/core/TextInput.tsx
+++ b/packages/mobile/src/components/core/TextInput.tsx
@@ -38,6 +38,9 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
     fill: palette.neutralLight5,
     height: spacing(4),
     width: spacing(4)
+  },
+  placeholderText: {
+    color: palette.neutralLight4
   }
 }))
 
@@ -86,6 +89,7 @@ export const TextInput = forwardRef<RNTextInput, TextInputProps>(
           autoComplete='off'
           autoCorrect={false}
           returnKeyType='search'
+          placeholderTextColor={styles.placeholderText.color}
           {...other}
         />
         {clearable ? (

--- a/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeaderV2/TopSupporters.tsx
@@ -72,6 +72,7 @@ export const TopSupporters = () => {
   const supportersForProfile: SupportersMapForUser =
     useSelectorWeb((state) => getOptimisticSupportersForUser(state, user_id)) ||
     {}
+
   const rankedSupporterIds = Object.keys(supportersForProfile)
     .sort((k1, k2) => {
       return (
@@ -81,6 +82,7 @@ export const TopSupporters = () => {
     })
     .map((k) => supportersForProfile[k as unknown as ID])
     .map((s) => s.sender_id)
+
   const rankedSupporters = useSelectorWeb((state) => {
     const usersMap = getUsers(state, { ids: rankedSupporterIds })
     return rankedSupporterIds.map((id) => usersMap[id]).filter(Boolean)

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -106,12 +106,17 @@ export const ProfileScreen = () => {
 
   const topbarLeft = isOwner ? (
     <View style={styles.topBarIcons}>
-      <TopBarIconButton icon={IconSettings} onPress={handlePressSettings} />
+      <TopBarIconButton
+        icon={IconSettings}
+        onPress={handlePressSettings}
+        hitSlop={{ right: 2 }}
+      />
       <TopBarIconButton
         styles={{ root: styles.iconCrownRoot, icon: styles.iconCrown }}
         fill={accentOrange}
         icon={IconCrown}
         onPress={handlePressAudio}
+        hitSlop={{ left: 2 }}
       />
     </View>
   ) : undefined

--- a/packages/mobile/src/utils/theme.ts
+++ b/packages/mobile/src/utils/theme.ts
@@ -174,7 +174,7 @@ export const matrixTheme = {
   pageHeaderGradientColor2: '#09BD51',
   actionSheetText: '#21B404',
   accentRed: '#D0021B',
-  accentOrange: '#D0021B',
+  accentOrange: '#EFA947',
   skeleton: '#1B3714',
   statTileText: '#184F17'
 }


### PR DESCRIPTION
### Description

- Improves touch targets for profile screen settings and rewards icons.
- Fixes rewards icon matrix color
- Fixes text-input placeholder color