### PR TITLE
Bump @audius/sdk version used to v0.0.17

### DIFF
--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -106,9 +106,9 @@
       }
     },
     "@audius/hedgehog": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@audius/hedgehog/-/hedgehog-1.0.12.tgz",
-      "integrity": "sha512-a8fsNacrdiNFq4Lh0be8djhgAS/C/sG4Lf6Dd4iucOrfxXJeNYY0qmIBYuakNpddaB4qzplCse7CWYJTGS/vng==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@audius/hedgehog/-/hedgehog-2.0.0.tgz",
+      "integrity": "sha512-0Oe4HIV7vACWD6IWci9sVWaSBzYZ77YiavWA6L1MikS/AF5+r06lwqKBmd0yGHXm5zNqZ80Skz4x7B5j0M0MSA==",
       "requires": {
         "bip39": "^2.5.0",
         "browserify-cipher": "^1.0.1",
@@ -137,12 +137,12 @@
       }
     },
     "@audius/sdk": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-0.0.12.tgz",
-      "integrity": "sha512-akIDY/f8qo37wovNLE7KfpA1JQ58aNfUPLKC73SAF8xwBS0t0YTVxlNeocAqy5mlxjoZMUI6qfr3E9V/wn2R2g==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-0.0.16.tgz",
+      "integrity": "sha512-CvDyrfMcBxeKudN9rD4mSGLCPc6jZWIYpXkybZeibhx6B9magR8KUEhxzEbkpce6sc6W4zk8AWO9suZdkGhPtw==",
       "requires": {
         "@audius/anchor-audius-data": "0.0.2",
-        "@audius/hedgehog": "1.0.12",
+        "@audius/hedgehog": "2.0.0",
         "@babel/runtime": "^7.18.3",
         "@certusone/wormhole-sdk": "0.1.1",
         "@ethersproject/solidity": "5.0.5",
@@ -4302,17 +4302,17 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -24697,9 +24697,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.0.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
-          "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ=="
+          "version": "18.0.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.4.tgz",
+          "integrity": "sha512-M0+G6V0Y4YV8cqzHssZpaNCqvYwlCiulmm0PwpNLF55r/+cT8Ol42CHRU1SEaYFH2rTwiiE1aYg/2g2rrtGdPA=="
         }
       }
     },
@@ -29009,7 +29009,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true
     },
     "style-loader": {
@@ -29789,7 +29789,7 @@
         "is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
         },
         "minimist": {
           "version": "1.2.6",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "@audius/sdk": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-0.0.16.tgz",
-      "integrity": "sha512-CvDyrfMcBxeKudN9rD4mSGLCPc6jZWIYpXkybZeibhx6B9magR8KUEhxzEbkpce6sc6W4zk8AWO9suZdkGhPtw==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-0.0.17.tgz",
+      "integrity": "sha512-S+wBFsGVjAMIqJZ/UIlU48r9gQ4A6Ts+G2HkvtL4qJLgjM61/3X92jeBJA9HG9W++jYGfN/pF7+2nfekeYgNHQ==",
       "requires": {
         "@audius/anchor-audius-data": "0.0.2",
         "@audius/hedgehog": "2.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@audius/common": "0.0.0",
-    "@audius/sdk": "0.0.16",
+    "@audius/sdk": "0.0.17",
     "@audius/stems": "1.1.12",
     "@craco/craco": "7.0.0-alpha.3",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@audius/common": "0.0.0",
-    "@audius/sdk": "0.0.12",
+    "@audius/sdk": "0.0.16",
     "@audius/stems": "1.1.12",
     "@craco/craco": "7.0.0-alpha.3",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",


### PR DESCRIPTION
### Description
Bumping the SDK version used by web.

### Dragons
I'm mainly doing this to test write quorum (SDK v0.0.14+ accepts a new write quorum param that the client is already passing), but I haven't tested any other libs changes. It doesn't look like any breaking changes were added, but I assigned some extra people who have made SDK changes recently just in case there's anything they want to flag.

### How Has This Been Tested?
Haven't tested -- see dragons above

### How will this change be monitored?
No new features

### Feature Flags ###
None

