### PR TITLE
[PAY-432] Freeze balance briefly after sending a tip

### DIFF
--- a/packages/web/src/common/store/wallet/selectors.ts
+++ b/packages/web/src/common/store/wallet/selectors.ts
@@ -19,14 +19,16 @@ export const getAccountBalance = createSelector(
   (balance) => (balance ? stringWeiToBN(balance) : null)
 )
 
-const getAccountTotalBalanceStr = (state: CommonState): Nullable<StringWei> => {
-  return state.wallet.totalBalance ?? null
-}
+const getAccountTotalBalanceStr = (state: CommonState): Nullable<StringWei> =>
+  state.wallet.totalBalance ?? null
+
 export const getAccountTotalBalance = createSelector(
   getAccountTotalBalanceStr,
   (totalBalance) => (totalBalance ? stringWeiToBN(totalBalance) : null)
 )
 
-export const getLocalBalanceDidChange = (state: CommonState): boolean => {
-  return state.wallet.localBalanceDidChange
-}
+export const getLocalBalanceDidChange = (state: CommonState): boolean =>
+  state.wallet.localBalanceDidChange
+
+export const getFreezeUntilTime = (state: CommonState): Nullable<number> =>
+  state.wallet.freezeBalanceUntil

--- a/packages/web/src/common/store/wallet/slice.ts
+++ b/packages/web/src/common/store/wallet/slice.ts
@@ -10,13 +10,20 @@ type WalletState = {
   balance: Nullable<StringWei>
   totalBalance: Nullable<StringWei>
   localBalanceDidChange: boolean
+  freezeBalanceUntil: Nullable<number>
 }
 
 const initialState: WalletState = {
   balance: null,
   totalBalance: null,
-  localBalanceDidChange: false
+  localBalanceDidChange: false,
+  freezeBalanceUntil: null
 }
+
+// After optimistically updating the balance, it can be useful
+// to briefly freeze the value so fetching an outdated
+// value from chain doesn't overwrite the state.
+const BALANCE_FREEZE_DURATION_SEC = 15
 
 const slice = createSlice({
   name: 'wallet',
@@ -47,6 +54,7 @@ const slice = createSlice({
           .toString() as StringWei
       }
       state.localBalanceDidChange = true
+      state.freezeBalanceUntil = Date.now() + BALANCE_FREEZE_DURATION_SEC * 1000
     },
     decreaseBalance: (
       state,
@@ -63,6 +71,7 @@ const slice = createSlice({
           .toString() as StringWei
       }
       state.localBalanceDidChange = true
+      state.freezeBalanceUntil = Date.now() + BALANCE_FREEZE_DURATION_SEC * 1000
     },
     // Saga Actions
     getBalance: () => {},

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -13,6 +13,7 @@ import {
 } from 'common/store/pages/token-dashboard/slice'
 import {
   getAccountBalance,
+  getFreezeUntilTime,
   getLocalBalanceDidChange
 } from 'common/store/wallet/selectors'
 import {
@@ -33,6 +34,11 @@ import { getErrorMessage } from 'utils/error'
 // TODO: handle errors
 const errors = {
   rateLimitError: 'Please wait before trying again'
+}
+
+function* getIsBalanceFrozen() {
+  const freezeUntil = yield* select(getFreezeUntilTime)
+  return freezeUntil && Date.now() < freezeUntil
 }
 
 /**
@@ -145,6 +151,11 @@ function* getWalletBalanceAndWallets() {
 function* fetchBalanceAsync() {
   const account = yield* select(getAccountUser)
   if (!account) return
+
+  // Opt out of balance refreshes if the balance
+  // is frozen due to a recent optimistic update
+  const isBalanceFrozen = yield* call(getIsBalanceFrozen)
+  if (isBalanceFrozen) return
 
   const localBalanceChange: ReturnType<typeof getLocalBalanceDidChange> =
     yield* select(getLocalBalanceDidChange)


### PR DESCRIPTION
### Description

There is a bug (exercised by @dharit-tan) where after sending a tip and optimistically updating the balance, some balance polling rewrites the balance before Solana has returns the correct value. This is easily seen by sending a tip and going to the artist-dashboard, which triggers a polling interval.

This definitely isn't the *best* way to handle this – the proper way would be to look up the tx referenced by the signature returned from identity relay, store the slot, and then when fetching balance, compare the stored slot to the current on chain slot. But too much effort for a small bug like this.

### Dragons

Not really.

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested on stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

