### PR TITLE
Move TipProfilePic to top level ProfileInfo component

### DIFF
--- a/packages/web/src/components/profile-info/ProfileInfo.module.css
+++ b/packages/web/src/components/profile-info/ProfileInfo.module.css
@@ -1,0 +1,91 @@
+.accountWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+  flex-shrink: 0;
+  padding-bottom: 4px;
+  color: var(--neutral);
+  transition: all ease-in-out 0.18s;
+}
+
+.accountWrapperLeftAlign {
+  justify-content: start;
+}
+
+.dynamicPhoto {
+  height: 78px;
+  border-radius: 40px;
+  border: 1px solid var(--white);
+  box-shadow: 0 0 1px 0 rgba(133, 129, 153, 0.5);
+
+  text-align: center;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: var(--default-profile-picture-background);
+}
+
+.accountWrapper .photo {
+  position: relative;
+
+  overflow: hidden;
+  flex: 0 0 78px;
+  height: 78px;
+  border-radius: 30px;
+  border: 1px solid var(--white);
+  box-shadow: 0 0 1px 0 rgba(133, 129, 153, 0.5);
+
+  text-align: center;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: var(--default-profile-picture-background);
+}
+
+.accountWrapper .userInfoWrapper {
+  margin-left: 8px;
+  text-align: left;
+  white-space: nowrap;
+  word-break: keep-all;
+  overflow: hidden;
+}
+
+.name {
+  font-size: var(--font-s);
+  line-height: 17px;
+  font-weight: var(--font-bold);
+  padding-bottom: 4px;
+  padding-right: 4px;
+  color: var(--neutral);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+}
+
+.badge {
+  margin-left: 4px;
+}
+
+.accountWrapper .userInfoWrapper .handleContainer {
+  display: inline-flex;
+  overflow: hidden;
+  line-height: 14px;
+  padding-right: 4px;
+}
+
+.handle {
+  font-size: var(--font-s);
+  color: var(--neutral);
+  font-weight: var(--font-medium);
+  transition: all 0.07s ease-in-out;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.accountWrapper .userInfoWrapper .handleContainer svg {
+  transition: all 0.07s ease-in-out;
+}

--- a/packages/web/src/components/profile-info/ProfileInfo.tsx
+++ b/packages/web/src/components/profile-info/ProfileInfo.tsx
@@ -6,9 +6,9 @@ import { Nullable } from 'common/utils/typeUtils'
 import UserBadges from 'components/user-badges/UserBadges'
 import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
 
-import styles from './TipAudio.module.css'
+import styles from './ProfileInfo.module.css'
 
-type TipProfilePictureProps = {
+type ProfileInfoProps = {
   user: Nullable<User>
   className?: string
   imgClassName?: string
@@ -17,7 +17,7 @@ type TipProfilePictureProps = {
   displayNameClassName?: string
   handleClassName?: string
 }
-export const TipProfilePicture = ({
+export const ProfileInfo = ({
   user,
   className = '',
   imgClassName = '',
@@ -25,7 +25,7 @@ export const TipProfilePicture = ({
   badgeSize = 12,
   displayNameClassName,
   handleClassName
-}: TipProfilePictureProps) => {
+}: ProfileInfoProps) => {
   const image = useUserProfilePicture(
     user?.user_id ?? null,
     user?._profile_picture_sizes ?? null,

--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -11,8 +11,9 @@ import { getSendTipData } from 'common/store/tipping/selectors'
 import { confirmSendTip, beginTip } from 'common/store/tipping/slice'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 
+import { ProfileInfo } from '../../profile-info/ProfileInfo'
+
 import styles from './TipAudio.module.css'
-import { TipProfilePicture } from './TipProfilePicture'
 
 const messages = {
   sending: 'SENDING',
@@ -120,7 +121,7 @@ export const ConfirmSendTip = () => {
   return receiver ? (
     <div className={styles.container}>
       {renderSendingAudio()}
-      <TipProfilePicture user={receiver} />
+      <ProfileInfo user={receiver} />
       {/*
       Even though the isVisible prop is being passed in, we
       only render the converting message if is converting.

--- a/packages/web/src/components/tipping/tip-audio/SendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/SendTip.tsx
@@ -24,8 +24,9 @@ import { audioTierMapPng } from 'components/user-badges/UserBadges'
 import { useGetFirstOrTopSupporter } from 'hooks/useGetFirstOrTopSupporter'
 import ButtonWithArrow from 'pages/audio-rewards-page/components/ButtonWithArrow'
 
+import { ProfileInfo } from '../../profile-info/ProfileInfo'
+
 import styles from './TipAudio.module.css'
-import { TipProfilePicture } from './TipProfilePicture'
 
 const messages = {
   availableToSend: 'AVAILABLE TO SEND',
@@ -149,7 +150,7 @@ export const SendTip = () => {
 
   return receiver ? (
     <div className={styles.container}>
-      <TipProfilePicture user={receiver} />
+      <ProfileInfo user={receiver} />
       {!hasInsufficientBalance && isFirstSupporter
         ? renderBecomeFirstSupporter()
         : null}

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -125,21 +125,6 @@
   font-size: var(--font-l) !important;
 }
 
-.accountWrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: row;
-  flex-shrink: 0;
-  padding-bottom: 4px;
-  color: var(--neutral);
-  transition: all ease-in-out 0.18s;
-}
-
-.accountWrapperLeftAlign {
-  justify-content: start;
-}
-
 .wrapperPhoto {
   position: relative;
 
@@ -159,70 +144,6 @@
   background-position: center;
   background-repeat: no-repeat;
   background-color: var(--default-profile-picture-background);
-}
-
-.accountWrapper .photo {
-  position: relative;
-
-  overflow: hidden;
-  flex: 0 0 78px;
-  height: 78px;
-  border-radius: 30px;
-  border: 1px solid var(--white);
-  box-shadow: 0 0 1px 0 rgba(133, 129, 153, 0.5);
-
-  text-align: center;
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-color: var(--default-profile-picture-background);
-}
-
-.accountWrapper .userInfoWrapper {
-  margin-left: 8px;
-  text-align: left;
-  white-space: nowrap;
-  word-break: keep-all;
-  overflow: hidden;
-}
-
-.name {
-  font-size: var(--font-s);
-  line-height: 17px;
-  font-weight: var(--font-bold);
-  padding-bottom: 4px;
-  padding-right: 4px;
-  color: var(--neutral);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: flex;
-  align-items: center;
-}
-
-.badge {
-  margin-left: 4px;
-}
-
-.accountWrapper .userInfoWrapper .handleContainer {
-  display: inline-flex;
-  overflow: hidden;
-  line-height: 14px;
-  padding-right: 4px;
-}
-
-.handle {
-  font-size: var(--font-s);
-  color: var(--neutral);
-  font-weight: var(--font-medium);
-  transition: all 0.07s ease-in-out;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.accountWrapper .userInfoWrapper .handleContainer svg {
-  transition: all 0.07s ease-in-out;
 }
 
 .info {

--- a/packages/web/src/components/tipping/tip-audio/TipSent.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipSent.tsx
@@ -11,8 +11,9 @@ import { formatNumberCommas } from 'common/utils/formatUtil'
 import { useRecord, make } from 'store/analytics/actions'
 import { openTwitterLink } from 'utils/tweet'
 
+import { ProfileInfo } from '../../profile-info/ProfileInfo'
+
 import styles from './TipAudio.module.css'
-import { TipProfilePicture } from './TipProfilePicture'
 
 const messages = {
   sending: 'SENDING',
@@ -70,7 +71,7 @@ export const TipSent = () => {
   return recipient ? (
     <div className={styles.container}>
       {renderSentAudio()}
-      <TipProfilePicture
+      <ProfileInfo
         user={recipient}
         className={styles.confirmReceiver}
         imgClassName={styles.smallDynamicPhoto}

--- a/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
+++ b/packages/web/src/pages/oauth-login-page/OAuthLoginPage.tsx
@@ -20,7 +20,7 @@ import { User } from 'common/models/User'
 import { getAccountUser } from 'common/store/account/selectors'
 import Input from 'components/data-entry/Input'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
-import { TipProfilePicture } from 'components/tipping/tip-audio/TipProfilePicture'
+import { ProfileInfo } from 'components/profile-info/ProfileInfo'
 import AudiusBackend from 'services/AudiusBackend'
 import { make, useRecord } from 'store/analytics/actions'
 import { getCreatorNodeIPFSGateways } from 'utils/gatewayUtil'
@@ -511,7 +511,7 @@ export const OAuthLoginPage = () => {
               You&apos;re signed in as
             </h3>
             <div className={styles.tile}>
-              <TipProfilePicture
+              <ProfileInfo
                 displayNameClassName={styles.userInfoDisplayName}
                 handleClassName={styles.userInfoDisplayName}
                 centered={false}


### PR DESCRIPTION
### Description
Rebased and updated version of https://github.com/AudiusProject/audius-client/pull/1336

Change TipProfilePic to ProfileInfo component since we are using the same component on the Oauth page and may use it again elsewhere. We might want to move this into Stems if Julian plans to use this in more places.

No effective changes to the component/app.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

