### PR TITLE
Change WRITE_QUORUM_ENABLED to session flag and set session before init

### DIFF
--- a/packages/web/src/common/services/remote-config/feature-flags.ts
+++ b/packages/web/src/common/services/remote-config/feature-flags.ts
@@ -64,5 +64,5 @@ export const flagCohortType: {
   [FeatureFlags.PLAYLIST_FOLDERS]: FeatureFlagCohortType.USER_ID,
   [FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION]: FeatureFlagCohortType.SESSION_ID,
   [FeatureFlags.TIPPING_ENABLED]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.WRITE_QUORUM_ENABLED]: FeatureFlagCohortType.USER_ID
+  [FeatureFlags.WRITE_QUORUM_ENABLED]: FeatureFlagCohortType.SESSION_ID
 }

--- a/packages/web/src/common/services/remote-config/remote-config.ts
+++ b/packages/web/src/common/services/remote-config/remote-config.ts
@@ -76,6 +76,16 @@ export const remoteConfig = <
   let client: Client | undefined
 
   async function init() {
+    // Set sessionId for feature flag bucketing
+    const savedSessionId = await getFeatureFlagSessionId()
+    if (!savedSessionId) {
+      const newSessionId = uuid()
+      setFeatureFlagSessionId(newSessionId)
+      state.sessionId = newSessionId
+    } else {
+      state.sessionId = savedSessionId
+    }
+
     client = await createOptimizelyClient()
 
     client.onReady().then(() => {
@@ -87,16 +97,6 @@ export const remoteConfig = <
 
       // console.timeEnd('remote-config')
     })
-
-    // Set sessionId for feature flag bucketing
-    const savedSessionId = await getFeatureFlagSessionId()
-    if (!savedSessionId) {
-      const newSessionId = uuid()
-      setFeatureFlagSessionId(newSessionId)
-      state.sessionId = newSessionId
-    } else {
-      state.sessionId = savedSessionId
-    }
   }
 
   // API


### PR DESCRIPTION
### Description
- Change `WRITE_QUORUM_ENABLED` feature flag to session based because there's no user_id for the user before they sign up (or is there?), and we want write quorum to replicate user metadata on sign up (also the flag has a deadlock condition that prevents it from enabling because the flag needs the client to get the user ID, but client also needs the flag to initialize SDK)
- `getFeatureEnabled()` uses sessionId for checking flags, but it could be called as soon as `waitForRemoteConfig()` finishes. So I changed it to make init not call its callbacks until sessionId is set

### Dragons
None -- I double-checked that the logic I moved to the top of init() doesn't rely on anything that comes after it.

### How Has This Been Tested?
Tested locally against staging (`npm run start:stage`) and verified that the write quorum flag is now true.

### How will this change be monitored?
I'll monitor logs for write quorum (logs starting with `issueAndWaitForSecondarySyncRequests`).

### Feature Flags ###
Changes [write quorum flag](https://app.optimizely.com/v2/projects/18140642080/features/21790311781/rules) from user id to session id.

