### PR TITLE
Remove antd table shadow pseudoelements

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.module.css
+++ b/packages/web/src/components/tracks-table/TracksTable.module.css
@@ -2,6 +2,11 @@
   width: 100%;
 }
 
+.tracksTableContainer :global(.ant-table .ant-table-container:before),
+.tracksTableContainer :global(.ant-table .ant-table-container:after) {
+  display: none;
+}
+
 .table {
   overflow: hidden;
 }


### PR DESCRIPTION
### Description
Small issue when displaying antd table on smaller screens. Removing the pseudo elements to avoid unwanted shadows in the table

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

