### PR TITLE
[PAY-442] Web: Don't propagate clicks on the reactions to prevent navigation to profile

### DIFF
--- a/packages/web/src/components/notification/Notification/TipReceivedNotification.tsx
+++ b/packages/web/src/components/notification/Notification/TipReceivedNotification.tsx
@@ -121,7 +121,10 @@ export const TipReceivedNotification = (
           {reactionList.map(([reactionType, Reaction]) => (
             <Reaction
               key={reactionType}
-              onClick={() => setReaction(reactionType)}
+              onClick={(e) => {
+                e.stopPropagation()
+                setReaction(reactionType)
+              }}
               isActive={
                 reactionValue // treat 0 and null equivalently here
                   ? reactionType === reactionValue


### PR DESCRIPTION
### Description

Clicking a reaction currently redirects to a profile. We don't want this behavior.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested against stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

