### PR TITLE
[PAY-440] Fix descenders in artist name on tip modal cut off

### DIFF
--- a/packages/web/src/components/profile-info/ProfileInfo.module.css
+++ b/packages/web/src/components/profile-info/ProfileInfo.module.css
@@ -72,7 +72,7 @@
 .accountWrapper .userInfoWrapper .handleContainer {
   display: inline-flex;
   overflow: hidden;
-  line-height: 14px;
+  line-height: 18px;
   padding-right: 4px;
 }
 


### PR DESCRIPTION
### Description

Descenders in tip receiver profile names were cut off in the tipping modal.

Before:
<img width="487" alt="Screen Shot 2022-07-19 at 1 07 04 PM" src="https://user-images.githubusercontent.com/3893871/179809039-2c029127-8740-4da8-9469-f76b055f2e13.png">
After:
<img width="486" alt="Screen Shot 2022-07-19 at 1 07 38 PM" src="https://user-images.githubusercontent.com/3893871/179809058-044848dd-a7ef-477a-bea0-8c88dd452c8a.png">

