### PR TITLE
Close user-list when navigating to sign-in page

### DIFF
--- a/packages/web/src/components/user-list-modal/components/UserListModal.tsx
+++ b/packages/web/src/components/user-list-modal/components/UserListModal.tsx
@@ -180,6 +180,8 @@ const UserListModal = ({
           getScrollParent={() => scrollParentRef.current || null}
           beforeClickArtistName={onClose}
           onNavigateAway={onClose}
+          afterFollow={onClose}
+          afterUnfollow={onClose}
         />
       </Scrollbar>
     </Modal>


### PR DESCRIPTION
### Description

Closes user-list-modal when trying to follow a user while logged out
