### PR TITLE
[C-707] Remove extra search bar from the search results page

### DIFF
--- a/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
+++ b/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
@@ -472,8 +472,7 @@ class SearchPageContent extends Component {
         description={`Search results for ${searchText}`}
         canonicalUrl={fullSearchResultsPage(searchText)}
         contentClassName={styles.searchResults}
-        header={header}
-        scrollableSearch>
+        header={header}>
         {status === Status.ERROR ? (
           <p>Oh no! Something went wrong!</p>
         ) : status === Status.LOADING ? (


### PR DESCRIPTION
### Description
scrollableSearch seems to be used for pages that do not have a header rendered so the search results page was rendering two search bars. Removed the prop to allow the header to render the searchbar

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A


### Before
<img width="1053" alt="Screen Shot 2022-07-22 at 11 38 52 AM" src="https://user-images.githubusercontent.com/23732287/180474677-2abcac04-0364-4c8b-8092-921d4a7d73b6.png">


### After
<img width="1059" alt="Screen Shot 2022-07-22 at 11 39 14 AM" src="https://user-images.githubusercontent.com/23732287/180474691-6ff5b148-51cd-4de6-9876-0651570c7f8e.png">

