### PR TITLE
[C-634] Add Lightbox for profile page profile and cover photos

### DIFF
--- a/packages/web/src/components/cover-photo/CoverPhoto.tsx
+++ b/packages/web/src/components/cover-photo/CoverPhoto.tsx
@@ -27,6 +27,7 @@ type CoverPhotoProps = {
   error?: boolean
   edit?: boolean
   darken?: boolean
+  onClick?: () => void
   onDrop?: (
     file: FileWithPreview[],
     source: 'original' | 'unsplash' | 'url'
@@ -41,6 +42,7 @@ const CoverPhoto = ({
   error,
   edit = false,
   darken = false,
+  onClick,
   onDrop
 }: CoverPhotoProps) => {
   const [processing, setProcessing] = useState(false)
@@ -48,6 +50,10 @@ const CoverPhoto = ({
     ? 'linear-gradient(180deg, rgba(0,0,0,0.25) 0%, rgba(0,0,0,0.75) 100%)'
     : 'linear-gradient(rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.05) 70%, rgba(0, 0, 0, 0.2) 100%)'
 
+  const hasCoverPhoto = Boolean(
+    coverPhotoSizes?.[WidthSizes.SIZE_2000] ||
+      coverPhotoSizes?.[WidthSizes.SIZE_640]
+  )
   const image = useUserCoverPhoto(userId, coverPhotoSizes, WidthSizes.SIZE_2000)
   let backgroundImage = ''
   let backgroundStyle = {}
@@ -90,7 +96,10 @@ const CoverPhoto = ({
   )
 
   return (
-    <div className={cn(styles.coverPhoto, className)}>
+    <div
+      className={cn(styles.coverPhoto, className)}
+      style={{ cursor: hasCoverPhoto ? 'pointer' : 'default' }}
+      onClick={onClick}>
       <DynamicImage
         image={backgroundImage}
         isUrl={false}

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.module.css
@@ -274,3 +274,37 @@
 .tipAudioButtonContainer {
   margin-top: 32px;
 }
+
+.lightbox {
+  z-index: 10000;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+}
+
+.lightboxImgContainer {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: 60vh;
+  width: 80vw;
+}
+.lightboxImgContainer.profileImg {
+  max-height: 30rem;
+  max-width: 30rem;
+}
+.lightboxImgContainer.profileImg .lightboxImg {
+  border-radius: 50%;
+}
+
+.lightboxImg {
+  position: relative;
+  object-fit: contain;
+  height: 100%;
+  width: 100%;
+  filter: drop-shadow(0 8px 20px rgba(0, 0, 0, 0.2));
+}

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileWrapping.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileWrapping.tsx
@@ -36,6 +36,7 @@ type ProfileWrappingProps = {
   donation: string
   created: string
   tags: string[]
+  onClickProfilePicture: () => void
   onUpdateName: (name: string) => void
   onUpdateProfilePicture: (
     selectedFiles: any,
@@ -77,6 +78,7 @@ const ProfileWrapping = (props: ProfileWrappingProps) => {
     donation,
     created,
     tags,
+    onClickProfilePicture,
     onUpdateName,
     onUpdateProfilePicture,
     onUpdateBio,
@@ -92,18 +94,22 @@ const ProfileWrapping = (props: ProfileWrappingProps) => {
   return (
     <div className={styles.profileWrapping}>
       <div className={styles.header}>
-        <ProfilePicture
-          userId={userId}
-          updatedProfilePicture={
-            updatedProfilePicture ? updatedProfilePicture.url : ''
-          }
-          error={updatedProfilePicture ? updatedProfilePicture.error : false}
-          profilePictureSizes={isDeactivated ? null : profilePictureSizes}
-          loading={loading}
-          editMode={editMode}
-          hasProfilePicture={hasProfilePicture}
-          onDrop={onUpdateProfilePicture}
-        />
+        <div
+          style={{ cursor: hasProfilePicture ? 'pointer' : 'default' }}
+          onClick={onClickProfilePicture}>
+          <ProfilePicture
+            userId={userId}
+            updatedProfilePicture={
+              updatedProfilePicture ? updatedProfilePicture.url : ''
+            }
+            error={updatedProfilePicture ? updatedProfilePicture.error : false}
+            profilePictureSizes={isDeactivated ? null : profilePictureSizes}
+            loading={loading}
+            editMode={editMode}
+            hasProfilePicture={hasProfilePicture}
+            onDrop={onUpdateProfilePicture}
+          />
+        </div>
         <div className={styles.nameWrapper}>
           <BadgeArtist
             className={cn(styles.badgeArtist, {


### PR DESCRIPTION
### Description

Add the lightbox for the profile page profile and cover photos. Not too much logic here, but some repetition for checking if the photos exist so open to refactor things.

Will get feedback from Julian and Forrest before pushing anything

### How Has This Been Tested?

Manually tested, photo, no photo, and photos of different sizes appear to be working

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

