### PR TITLE
[PAY-416] Early access mode & feature flag refactor

### DIFF
--- a/packages/common/src/hooks/index.ts
+++ b/packages/common/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useFeatureFlag'
+export * from './useRemoteVar'

--- a/packages/common/src/hooks/useFeatureFlag.ts
+++ b/packages/common/src/hooks/useFeatureFlag.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { FeatureFlags, RemoteConfigInstance } from '@audius/common'
+import { FeatureFlags, RemoteConfigInstance } from '../services'
 
 export const FEATURE_FLAG_OVERRIDE_KEY = 'FeatureFlagOverride'
 

--- a/packages/common/src/hooks/useRemoteVar.ts
+++ b/packages/common/src/hooks/useRemoteVar.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 
-import { useRecomputeToggle } from 'common/hooks/useFeatureFlag'
 import {
   AllRemoteConfigKeys,
   BooleanKeys,
@@ -8,7 +7,9 @@ import {
   DoubleKeys,
   StringKeys,
   RemoteConfigInstance
-} from '@audius/common'
+} from '../services'
+
+import { useRecomputeToggle } from './useFeatureFlag'
 
 export const createUseRemoteVarHook = ({
   remoteConfigInstance,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,3 +1,4 @@
 export * from './models'
 export * from './utils'
 export * from './services'
+export * from './hooks'

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -12,7 +12,8 @@ export enum FeatureFlags {
   PLAYLIST_FOLDERS = 'playlist_folders',
   DISABLE_SIGN_UP_CONFIRMATION = 'disable_sign_up_confirmation',
   TIPPING_ENABLED = 'tipping_enabled',
-  WRITE_QUORUM_ENABLED = 'write_quorum_enabled'
+  WRITE_QUORUM_ENABLED = 'write_quorum_enabled',
+  EARLY_ACCESS = 'early_access'
 }
 
 /**
@@ -31,38 +32,6 @@ export const flagDefaults: { [key in FeatureFlags]: boolean } = {
   [FeatureFlags.PLAYLIST_FOLDERS]: false,
   [FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION]: false,
   [FeatureFlags.TIPPING_ENABLED]: false,
-  [FeatureFlags.WRITE_QUORUM_ENABLED]: false
-}
-
-export enum FeatureFlagCohortType {
-  /**
-   * Segments feature experiments by a user's id. If userId is not present,
-   * the feature is off.
-   */
-  USER_ID = 'user_id',
-  /**
-   * Segments feature experiments by a random uuid set in local storage defined by FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY.
-   * There should always be a value for sessionId. This is managed in Provider.ts
-   */
-  SESSION_ID = 'session_id'
-}
-
-export const flagCohortType: {
-  [key in FeatureFlags]: FeatureFlagCohortType
-} = {
-  [FeatureFlags.SOLANA_LISTEN_ENABLED]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.PLAYLIST_UPDATES_ENABLED]: FeatureFlagCohortType.USER_ID,
-  [FeatureFlags.SHARE_SOUND_TO_TIKTOK]: FeatureFlagCohortType.USER_ID,
-  [FeatureFlags.CHALLENGE_REWARDS_UI]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.SOL_WALLET_AUDIO_ENABLED]: FeatureFlagCohortType.USER_ID,
-  [FeatureFlags.SURFACE_AUDIO_ENABLED]: FeatureFlagCohortType.USER_ID,
-  [FeatureFlags.PREFER_HIGHER_PATCH_FOR_PRIMARY]:
-    FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.PREFER_HIGHER_PATCH_FOR_SECONDARIES]:
-    FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.ENABLE_SPL_AUDIO]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.PLAYLIST_FOLDERS]: FeatureFlagCohortType.USER_ID,
-  [FeatureFlags.DISABLE_SIGN_UP_CONFIRMATION]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.TIPPING_ENABLED]: FeatureFlagCohortType.SESSION_ID,
-  [FeatureFlags.WRITE_QUORUM_ENABLED]: FeatureFlagCohortType.SESSION_ID
+  [FeatureFlags.WRITE_QUORUM_ENABLED]: false,
+  [FeatureFlags.EARLY_ACCESS]: false
 }

--- a/packages/common/src/services/remote-config/index.ts
+++ b/packages/common/src/services/remote-config/index.ts
@@ -1,10 +1,6 @@
 export { IntKeys, StringKeys, DoubleKeys, BooleanKeys } from './types'
 export { AllRemoteConfigKeys } from './types'
-export {
-  FeatureFlags,
-  FeatureFlagCohortType,
-  flagCohortType
-} from './feature-flags'
+export { FeatureFlags } from './feature-flags'
 export { remoteConfig, USER_ID_AVAILABLE_EVENT } from './remote-config'
 export { RemoteConfigInstance } from './remote-config'
 export {

--- a/packages/common/src/services/remote-config/remote-config.ts
+++ b/packages/common/src/services/remote-config/remote-config.ts
@@ -120,15 +120,15 @@ export const remoteConfig = <
   /**
    * API for listening to setUser events
    */
-  function listenForUserId(fn: () => void | Promise<void>) {
-    emitter.addListener('setUserId', fn)
+  function listenForUserId(cb: () => void | Promise<void>) {
+    emitter.addListener('setUserId', cb)
   }
 
   /**
    * API to unlisten to setUser events
    */
-  function unlistenForUserId(fn: () => void | Promise<void>) {
-    emitter.removeListener('setUserId', fn)
+  function unlistenForUserId(cb: () => void | Promise<void>) {
+    emitter.removeListener('setUserId', cb)
   }
 
   /**

--- a/packages/common/src/services/remote-config/remote-config.ts
+++ b/packages/common/src/services/remote-config/remote-config.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events'
 
-import { ID, Nullable } from '@audius/common'
 import optimizely from '@optimizely/optimizely-sdk'
 
+import { ID } from 'models'
 import {
   remoteConfigIntDefaults,
   remoteConfigStringDefaults,
@@ -20,6 +20,7 @@ import {
   BooleanKeys,
   AllRemoteConfigKeys
 } from 'services/remote-config/types'
+import { Nullable } from 'utils'
 
 export const USER_ID_AVAILABLE_EVENT = 'USER_ID_AVAILABLE_EVENT'
 
@@ -34,7 +35,7 @@ type State = {
   initializationCallbacks: (() => void)[]
 }
 
-type RemoteConfigOptions<Client> = {
+export type RemoteConfigOptions<Client> = {
   createOptimizelyClient: () => Promise<Client>
   getFeatureFlagSessionId: () => Promise<Nullable<number>>
   setFeatureFlagSessionId: (id: number) => Promise<void>

--- a/packages/common/src/services/remote-config/remote-config.ts
+++ b/packages/common/src/services/remote-config/remote-config.ts
@@ -1,6 +1,8 @@
+import { EventEmitter } from 'events'
+
+import { ID, Nullable } from '@audius/common'
 import optimizely from '@optimizely/optimizely-sdk'
 
-import { ID } from 'models/Identifiers'
 import {
   remoteConfigIntDefaults,
   remoteConfigStringDefaults,
@@ -9,9 +11,7 @@ import {
 } from 'services/remote-config/defaults'
 import {
   FeatureFlags,
-  flagDefaults,
-  flagCohortType,
-  FeatureFlagCohortType
+  flagDefaults
 } from 'services/remote-config/feature-flags'
 import {
   IntKeys,
@@ -20,8 +20,6 @@ import {
   BooleanKeys,
   AllRemoteConfigKeys
 } from 'services/remote-config/types'
-import { Nullable } from 'utils/typeUtils'
-import { uuid } from 'utils/uid'
 
 export const USER_ID_AVAILABLE_EVENT = 'USER_ID_AVAILABLE_EVENT'
 
@@ -32,15 +30,14 @@ const REMOTE_CONFIG_FEATURE_KEY = 'remote_config'
 // Internal State
 type State = {
   didInitialize: boolean
-  userId: Nullable<string>
-  sessionId: Nullable<string>
+  id: Nullable<number>
   initializationCallbacks: (() => void)[]
 }
 
 type RemoteConfigOptions<Client> = {
   createOptimizelyClient: () => Promise<Client>
-  getFeatureFlagSessionId: () => Promise<string | null>
-  setFeatureFlagSessionId: (id: string) => Promise<void>
+  getFeatureFlagSessionId: () => Promise<Nullable<number>>
+  setFeatureFlagSessionId: (id: number) => Promise<void>
   setLogLevel: () => void
 }
 
@@ -60,13 +57,9 @@ export const remoteConfig = <
   setFeatureFlagSessionId,
   setLogLevel
 }: RemoteConfigOptions<Client>) => {
-  // Uncomment to time remote config
-  // console.time('remote-config')
-
   const state: State = {
     didInitialize: false,
-    userId: null,
-    sessionId: null,
+    id: null,
     initializationCallbacks: []
   }
 
@@ -79,11 +72,11 @@ export const remoteConfig = <
     // Set sessionId for feature flag bucketing
     const savedSessionId = await getFeatureFlagSessionId()
     if (!savedSessionId) {
-      const newSessionId = uuid()
+      const newSessionId = generateSessionId()
       setFeatureFlagSessionId(newSessionId)
-      state.sessionId = newSessionId
+      state.id = newSessionId
     } else {
-      state.sessionId = savedSessionId
+      state.id = savedSessionId
     }
 
     client = await createOptimizelyClient()
@@ -94,8 +87,6 @@ export const remoteConfig = <
       // Call initializationCallbacks
       state.initializationCallbacks.forEach((cb) => cb())
       state.initializationCallbacks = []
-
-      // console.timeEnd('remote-config')
     })
   }
 
@@ -113,13 +104,31 @@ export const remoteConfig = <
     }
   }
 
+  // Use event emission to track setUser events
+  const emitter = new EventEmitter()
+
   /**
    * Set the userId for calls to Optimizely.
    * Prior to calling, uses the ANONYMOUS_USER_ID constant.
    * @param userId
    */
   function setUserId(userId: ID) {
-    state.userId = userId.toString()
+    state.id = userId
+    emitter.emit('setUserId')
+  }
+
+  /**
+   * API for listening to setUser events
+   */
+  function listenForUserId(fn: () => void | Promise<void>) {
+    emitter.addListener('setUserId', fn)
+  }
+
+  /**
+   * API to unlisten to setUser events
+   */
+  function unlistenForUserId(fn: () => void | Promise<void>) {
+    emitter.removeListener('setUserId', fn)
   }
 
   /**
@@ -137,10 +146,9 @@ export const remoteConfig = <
     key: AllRemoteConfigKeys
   ): number | string | boolean | null {
     // If the client is not ready yet, return early with `null`
-    if (!client) return null
+    if (!client || !state.id) return null
 
-    // If userId is null, set to string default. This will effectively capture all users as intended for remote config
-    const id = state.userId || 'ANONYMOUS_USER'
+    const id = state.id
 
     if (isIntKey(key)) {
       return getValue(
@@ -151,12 +159,10 @@ export const remoteConfig = <
       )
     }
 
-    // TODO: We can take out the keyof typeof garbage
-    // once all the enums have keys.
     if (isStringKey(key)) {
       return getValue(
         remoteConfigStringDefaults,
-        key as unknown as string,
+        key,
         id,
         client.getFeatureVariableString.bind(client)
       )
@@ -165,7 +171,7 @@ export const remoteConfig = <
     if (isDoubleKey(key)) {
       return getValue(
         remoteConfigDoubleDefaults,
-        key as unknown as string,
+        key,
         id,
         client.getFeatureVariableDouble.bind(client)
       )
@@ -173,7 +179,7 @@ export const remoteConfig = <
 
     return getValue(
       remoteConfigBooleanDefaults,
-      key as unknown as string,
+      key,
       id,
       client.getFeatureVariableBoolean.bind(client)
     )
@@ -185,30 +191,16 @@ export const remoteConfig = <
    */
   function getFeatureEnabled(flag: FeatureFlags) {
     // If the client is not ready yet, return early with `null`
-    if (!client) return null
+    if (!client || !state.id) return null
 
     const defaultVal = flagDefaults[flag]
 
-    // Set the unique identifier as the userId or sessionId
-    // depending on the feature flag
-    let id: string
-    const cohortType = flagCohortType[flag]
-    switch (cohortType) {
-      case FeatureFlagCohortType.USER_ID: {
-        // If the id is anonymous, do not enable feature
-        if (!state.userId) return false
-        id = state.userId
-        break
-      }
-      case FeatureFlagCohortType.SESSION_ID: {
-        id = state.sessionId!
-        break
-      }
-    }
+    const id = state.id
 
     try {
       const enabled = state.didInitialize
-        ? client.isFeatureEnabled(flag as unknown as string, id) ?? defaultVal
+        ? client.isFeatureEnabled(flag, id.toString(), { userId: id }) ??
+          defaultVal
         : defaultVal
       return enabled
     } catch (err) {
@@ -228,12 +220,12 @@ export const remoteConfig = <
    * that is enabled and supposed to return true.
    */
   const waitForUserRemoteConfig = async () => {
-    if (state.userId) {
+    if (state.id && state.id > 0) {
       await new Promise<void>((resolve) => onClientReady(resolve))
       return
     }
     await new Promise<void>((resolve) => {
-      if (state.userId) {
+      if (state.id && state.id > 0) {
         onClientReady(resolve)
       } else {
         window.addEventListener(USER_ID_AVAILABLE_EVENT, () =>
@@ -259,12 +251,21 @@ export const remoteConfig = <
   function getValue<T>(
     defaults: { [id: string]: T },
     varKey: string,
-    userId: string,
-    getFn: (featureKey: string, variableKey: string, userId: string) => T | null
+    userId: number,
+    getFn: (
+      featureKey: string,
+      variableKey: string,
+      userId: string,
+      attributes?: { [key: string]: string | number | boolean }
+    ) => T | null
   ): T {
     const defaultVal = defaults[varKey]
     if (!state.didInitialize) return defaultVal
-    return getFn(REMOTE_CONFIG_FEATURE_KEY, varKey, userId) ?? defaultVal
+    return (
+      getFn(REMOTE_CONFIG_FEATURE_KEY, varKey, userId.toString(), {
+        userId
+      }) ?? defaultVal
+    )
   }
 
   return {
@@ -274,7 +275,14 @@ export const remoteConfig = <
     onClientReady,
     setUserId,
     waitForRemoteConfig,
-    waitForUserRemoteConfig
+    waitForUserRemoteConfig,
+    listenForUserId,
+    unlistenForUserId
+  }
+
+  // Generate negative ints for session IDs
+  function generateSessionId() {
+    return Math.floor(Math.random() * Number.MIN_SAFE_INTEGER)
   }
 }
 

--- a/packages/mobile/src/hooks/useRemoteConfig.ts
+++ b/packages/mobile/src/hooks/useRemoteConfig.ts
@@ -11,11 +11,12 @@ import { remoteConfigInstance } from 'app/services/remote-config/remote-config-i
 
 export const useFeatureFlag = createUseFeatureFlagHook({
   remoteConfigInstance,
-  useAccountProvider: () => !!useSelectorWeb(getAccountUser),
-  useConfigLoadedProvider: () => !!useSelector(isRemoteConfigLoaded)
+  useHasAccount: () => !!useSelectorWeb(getAccountUser),
+  useHasConfigLoaded: () => !!useSelector(isRemoteConfigLoaded)
 })
 
-export const useRemoteVar = createUseRemoteVarHook(
+export const useRemoteVar = createUseRemoteVarHook({
   remoteConfigInstance,
-  () => !!useSelector(isRemoteConfigLoaded)
-)
+  useHasAccount: () => !!useSelectorWeb(getAccountUser),
+  useHasConfigLoaded: () => !!useSelector(isRemoteConfigLoaded)
+})

--- a/packages/mobile/src/hooks/useRemoteConfig.ts
+++ b/packages/mobile/src/hooks/useRemoteConfig.ts
@@ -1,16 +1,6 @@
-import { useMemo } from 'react'
-
-// import { createUseFeatureFlagHook } from 'audius-client/src/common/hooks/useFeatureFlag'
-// import { createUseRemoteVarHook } from 'audius-client/src/common/hooks/useRemoteVar'
-
-import { FeatureFlagCohortType, flagCohortType } from '@audius/common'
-import type {
-  AllRemoteConfigKeys,
-  BooleanKeys,
-  DoubleKeys,
-  IntKeys,
-  StringKeys,
-  FeatureFlags
+import {
+  createUseFeatureFlagHook,
+  createUseRemoteVarHook
 } from '@audius/common'
 import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
 import { isRemoteConfigLoaded } from 'audius-client/src/common/store/remote-config/selectors'
@@ -19,41 +9,13 @@ import { useSelector } from 'react-redux'
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { remoteConfigInstance } from 'app/services/remote-config/remote-config-instance'
 
-// Duplicating these hooks here instead of using `createUseFeatureFlagHook` and `createUseRemoteVarHook`
-// because the react version mismatch between audius-mobile-client and audius-client is causing
-// any hooks imported from audius-client to throw an "Invalid hook call" error.
-// When the react versions are matched, this can be updated
+export const useFeatureFlag = createUseFeatureFlagHook({
+  remoteConfigInstance,
+  useAccountProvider: () => !!useSelectorWeb(getAccountUser),
+  useConfigLoadedProvider: () => !!useSelector(isRemoteConfigLoaded)
+})
 
-// export const useFlag = createUseFeatureFlagHook(remoteConfigInstance)
-// export const useRemoteVar = createUseRemoteVarHook(remoteConfigInstance)
-
-export const useFeatureFlag = (flag: FeatureFlags) => {
-  const configLoaded = useSelector(isRemoteConfigLoaded)
-  const userIdFlag = flagCohortType[flag] === FeatureFlagCohortType.USER_ID
-  const hasAccount = useSelectorWeb(getAccountUser)
-  const shouldRecompute = userIdFlag ? hasAccount : true
-  const isEnabled = useMemo(
-    () => remoteConfigInstance.getFeatureEnabled(flag),
-    // We want configLoaded and shouldRecompute to trigger refreshes of the memo
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [flag, configLoaded, shouldRecompute]
-  )
-  return { isLoaded: configLoaded, isEnabled }
-}
-
-export function useRemoteVar(key: IntKeys): number
-export function useRemoteVar(key: DoubleKeys): number
-export function useRemoteVar(key: StringKeys): string
-export function useRemoteVar(key: BooleanKeys): boolean
-export function useRemoteVar(
-  key: AllRemoteConfigKeys
-): boolean | string | number | null {
-  const configLoaded = useSelector(isRemoteConfigLoaded)
-  // eslint complains about configLoaded as part of the deps array
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const remoteVar = useMemo(
-    () => remoteConfigInstance.getRemoteVar(key),
-    [key, configLoaded, remoteConfigInstance]
-  )
-  return remoteVar
-}
+export const useRemoteVar = createUseRemoteVarHook(
+  remoteConfigInstance,
+  () => !!useSelector(isRemoteConfigLoaded)
+)

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -17,13 +17,9 @@ import IconNotification from 'app/assets/images/iconNotification.svg'
 import IconSearch from 'app/assets/images/iconSearch.svg'
 import { IconButton } from 'app/components/core'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
-<<<<<<< HEAD
 import type { ContextualParams } from 'app/hooks/useNavigation'
 import { useNavigation } from 'app/hooks/useNavigation'
-=======
-import { ContextualParams, useNavigation } from 'app/hooks/useNavigation'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
->>>>>>> d8b69761d (Early Access Mode)
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { NotificationsDrawerNavigationContext } from 'app/screens/notifications-screen/NotificationsDrawerNavigationContext'
 import { makeStyles } from 'app/styles'

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -6,6 +6,7 @@ import type {
   NativeStackNavigationProp
 } from '@react-navigation/native-stack'
 import { CardStyleInterpolators } from '@react-navigation/stack'
+import { FeatureFlags } from 'audius-client/src/common/services/remote-config'
 import { markAllAsViewed } from 'audius-client/src/common/store/notifications/actions'
 import { getNotificationUnviewedCount } from 'audius-client/src/common/store/notifications/selectors'
 import { Text, View } from 'react-native'
@@ -16,8 +17,13 @@ import IconNotification from 'app/assets/images/iconNotification.svg'
 import IconSearch from 'app/assets/images/iconSearch.svg'
 import { IconButton } from 'app/components/core'
 import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+<<<<<<< HEAD
 import type { ContextualParams } from 'app/hooks/useNavigation'
 import { useNavigation } from 'app/hooks/useNavigation'
+=======
+import { ContextualParams, useNavigation } from 'app/hooks/useNavigation'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
+>>>>>>> d8b69761d (Early Access Mode)
 import { useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { NotificationsDrawerNavigationContext } from 'app/screens/notifications-screen/NotificationsDrawerNavigationContext'
 import { makeStyles } from 'app/styles'
@@ -66,8 +72,22 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   iconSearch: {
     height: 18,
     width: 18
+  },
+  earlyAccess: {
+    fontSize: 10,
+    position: 'absolute',
+    fontFamily: typography.fontByWeight.bold,
+    color: palette.primary,
+    letterSpacing: 0.5,
+    left: 30,
+    top: 18,
+    width: 72
   }
 }))
+
+const messages = {
+  earlyAccess: 'Early Access'
+}
 
 export const useAppScreenOptions = (
   overrides?: Partial<NativeStackNavigationOptions>
@@ -98,6 +118,8 @@ export const useAppScreenOptions = (
       native: { screen: 'Search' }
     })
   }, [navigation])
+
+  const { isEnabled: isEarlyAccess } = useFeatureFlag(FeatureFlags.EARLY_ACCESS)
 
   const screenOptions: (options: {
     navigation: NativeStackNavigationProp<AppScreenParamList>
@@ -178,12 +200,17 @@ export const useAppScreenOptions = (
             )
           }
           return (
-            <IconButton
-              icon={AudiusLogo}
-              fill={neutralLight4}
-              styles={{ icon: styles.audiusLogo }}
-              onPress={handlePressHome}
-            />
+            <View>
+              <IconButton
+                icon={AudiusLogo}
+                fill={neutralLight4}
+                styles={{ icon: styles.audiusLogo }}
+                onPress={handlePressHome}
+              />
+              {isEarlyAccess ? (
+                <Text style={styles.earlyAccess}>{messages.earlyAccess}</Text>
+              ) : null}
+            </View>
           )
         },
         headerRightContainerStyle: styles.headerRight,
@@ -211,7 +238,8 @@ export const useAppScreenOptions = (
       neutralLight4,
       accentOrangeLight1,
       notificationCount,
-      overrides
+      overrides,
+      isEarlyAccess
     ]
   )
 

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useContext } from 'react'
 
+import { FeatureFlags } from '@audius/common'
 import type { ParamListBase, RouteProp } from '@react-navigation/core'
 import type {
   NativeStackNavigationOptions,
   NativeStackNavigationProp
 } from '@react-navigation/native-stack'
 import { CardStyleInterpolators } from '@react-navigation/stack'
-import { FeatureFlags } from 'audius-client/src/common/services/remote-config'
 import { markAllAsViewed } from 'audius-client/src/common/store/notifications/actions'
 import { getNotificationUnviewedCount } from 'audius-client/src/common/store/notifications/selectors'
 import { Text, View } from 'react-native'

--- a/packages/mobile/src/services/remote-config/remote-config-instance.ts
+++ b/packages/mobile/src/services/remote-config/remote-config-instance.ts
@@ -12,10 +12,10 @@ export const remoteConfigInstance = remoteConfig({
     })
   },
   getFeatureFlagSessionId: async () => {
-    const item = await AsyncStorage.getItem(
+    const sessionId = await AsyncStorage.getItem(
       FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY
     )
-    return item ? parseInt(item) : null
+    return sessionId ? parseInt(sessionId) : null
   },
   setFeatureFlagSessionId: async (id) =>
     AsyncStorage.setItem(FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY, id.toString()),

--- a/packages/mobile/src/services/remote-config/remote-config-instance.ts
+++ b/packages/mobile/src/services/remote-config/remote-config-instance.ts
@@ -3,7 +3,7 @@ import * as optimizely from '@optimizely/react-sdk'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import Config from 'react-native-config'
 
-export const FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY = 'featureFlagSessionId'
+export const FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY = 'featureFlagSessionId-2'
 
 export const remoteConfigInstance = remoteConfig({
   createOptimizelyClient: async () => {
@@ -11,10 +11,14 @@ export const remoteConfigInstance = remoteConfig({
       sdkKey: Config.OPTIMIZELY_KEY
     })
   },
-  getFeatureFlagSessionId: async () =>
-    AsyncStorage.getItem(FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY),
+  getFeatureFlagSessionId: async () => {
+    const item = await AsyncStorage.getItem(
+      FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY
+    )
+    return item ? parseInt(item) : null
+  },
   setFeatureFlagSessionId: async (id) =>
-    AsyncStorage.setItem(FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY, id),
+    AsyncStorage.setItem(FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY, id.toString()),
   setLogLevel: () => optimizely.setLogLevel('warn')
 })
 

--- a/packages/web/src/common/hooks/useRemoteVar.ts
+++ b/packages/web/src/common/hooks/useRemoteVar.ts
@@ -8,13 +8,10 @@ import {
   StringKeys,
   RemoteConfigInstance
 } from '@audius/common'
-import { useSelector } from 'react-redux'
 
-import { isRemoteConfigLoaded } from 'common/store/remote-config/selectors'
-import { StateWithRemoteConfig } from 'common/store/remote-config/slice'
-
-export const createUseRemoteVarHook = <State extends StateWithRemoteConfig>(
-  remoteConfigInstance: RemoteConfigInstance
+export const createUseRemoteVarHook = (
+  remoteConfigInstance: RemoteConfigInstance,
+  configLoadedProvider: () => boolean
 ) => {
   function useRemoteVar(key: IntKeys): number
   function useRemoteVar(key: DoubleKeys): number
@@ -23,9 +20,7 @@ export const createUseRemoteVarHook = <State extends StateWithRemoteConfig>(
   function useRemoteVar(
     key: AllRemoteConfigKeys
   ): boolean | string | number | null {
-    const configLoaded = useSelector((state: State) =>
-      isRemoteConfigLoaded<State>(state)
-    )
+    const configLoaded = configLoadedProvider()
 
     const remoteVar = useMemo(
       () => remoteConfigInstance.getRemoteVar(key),

--- a/packages/web/src/common/hooks/useRemoteVar.ts
+++ b/packages/web/src/common/hooks/useRemoteVar.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { useRecomputeToggle } from 'common/hooks/useFeatureFlag'
 import {
   AllRemoteConfigKeys,
   BooleanKeys,
@@ -9,10 +10,15 @@ import {
   RemoteConfigInstance
 } from '@audius/common'
 
-export const createUseRemoteVarHook = (
-  remoteConfigInstance: RemoteConfigInstance,
-  configLoadedProvider: () => boolean
-) => {
+export const createUseRemoteVarHook = ({
+  remoteConfigInstance,
+  useHasAccount,
+  useHasConfigLoaded
+}: {
+  remoteConfigInstance: RemoteConfigInstance
+  useHasAccount: () => boolean
+  useHasConfigLoaded: () => boolean
+}) => {
   function useRemoteVar(key: IntKeys): number
   function useRemoteVar(key: DoubleKeys): number
   function useRemoteVar(key: StringKeys): string
@@ -20,12 +26,17 @@ export const createUseRemoteVarHook = (
   function useRemoteVar(
     key: AllRemoteConfigKeys
   ): boolean | string | number | null {
-    const configLoaded = configLoadedProvider()
+    const configLoaded = useHasConfigLoaded()
+    const shouldRecompute = useRecomputeToggle(
+      useHasAccount,
+      configLoaded,
+      remoteConfigInstance
+    )
 
     const remoteVar = useMemo(
       () => remoteConfigInstance.getRemoteVar(key),
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [key, configLoaded, remoteConfigInstance]
+      [key, shouldRecompute, remoteConfigInstance]
     )
     return remoteVar
   }

--- a/packages/web/src/common/services/remote-config/index.ts
+++ b/packages/web/src/common/services/remote-config/index.ts
@@ -1,5 +1,0 @@
-export { IntKeys, StringKeys, DoubleKeys, BooleanKeys } from './types'
-export type { AllRemoteConfigKeys } from './types'
-export { FeatureFlags } from './feature-flags'
-export { remoteConfig } from './remote-config'
-export type { RemoteConfigInstance } from './remote-config'

--- a/packages/web/src/common/services/remote-config/index.ts
+++ b/packages/web/src/common/services/remote-config/index.ts
@@ -1,0 +1,5 @@
+export { IntKeys, StringKeys, DoubleKeys, BooleanKeys } from './types'
+export type { AllRemoteConfigKeys } from './types'
+export { FeatureFlags } from './feature-flags'
+export { remoteConfig } from './remote-config'
+export type { RemoteConfigInstance } from './remote-config'

--- a/packages/web/src/common/store/remote-config/selectors.ts
+++ b/packages/web/src/common/store/remote-config/selectors.ts
@@ -1,5 +1,4 @@
-export const isRemoteConfigLoaded = <
-  State extends { remoteConfig: { remoteConfigLoaded: boolean } }
->(
-  state: State
-) => state.remoteConfig.remoteConfigLoaded
+type StateWithRemoteConfig = { remoteConfig: { remoteConfigLoaded: boolean } }
+
+export const isRemoteConfigLoaded = (state: StateWithRemoteConfig) =>
+  state.remoteConfig.remoteConfigLoaded

--- a/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.tsx
+++ b/packages/web/src/components/feature-flag-override-modal/FeatureFlagOverrideModal.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { FeatureFlags } from '@audius/common'
+import {
+  FeatureFlags,
+  FEATURE_FLAG_OVERRIDE_KEY,
+  OverrideSetting
+} from '@audius/common'
 import {
   Modal,
   ModalContent,
@@ -9,10 +13,6 @@ import {
   SegmentedControl
 } from '@audius/stems'
 
-import {
-  FEATURE_FLAG_OVERRIDE_KEY,
-  OverrideSetting
-} from 'common/hooks/useFeatureFlag'
 import { useModalState } from 'common/hooks/useModalState'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useDevModeHotkey } from 'hooks/useHotkey'

--- a/packages/web/src/components/nav/desktop/NavHeader.js
+++ b/packages/web/src/components/nav/desktop/NavHeader.js
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react'
 
-import { Theme, StringKeys } from '@audius/common'
+import { Theme, StringKeys, FeatureFlags } from '@audius/common'
 import cn from 'classnames'
 import PropTypes from 'prop-types'
 
@@ -10,11 +10,15 @@ import { formatCount } from 'common/utils/formatUtil'
 import NavButton from 'components/nav/desktop/NavButton'
 import NavPopupMenu from 'components/nav/desktop/NavPopupMenu'
 import { NotificationPanel } from 'components/notification'
-import { useRemoteVar } from 'hooks/useRemoteConfig'
+import { useFlag, useRemoteVar } from 'hooks/useRemoteConfig'
 import { HOME_PAGE, BASE_URL, stripBaseUrl } from 'utils/route'
 import { getTheme } from 'utils/theme/theme'
 
 import styles from './NavHeader.module.css'
+
+const messages = {
+  earlyAccess: 'Early Access'
+}
 
 const NavHeader = ({
   account,
@@ -44,6 +48,8 @@ const NavHeader = ({
     }
   }, [logoVariantClickTarget, goToRoute])
 
+  const { isEnabled: isEarlyAccess } = useFlag(FeatureFlags.EARLY_ACCESS)
+
   return (
     <div className={styles.header}>
       <div className={styles.logoWrapper} onClick={onClickLogo}>
@@ -55,6 +61,9 @@ const NavHeader = ({
           />
         )}
       </div>
+      {isEarlyAccess ? (
+        <div className={styles.earlyAccess}>{messages.earlyAccess}</div>
+      ) : null}
       {account ? (
         <div className={styles.headerIconContainer}>
           <NavPopupMenu />

--- a/packages/web/src/components/nav/desktop/NavHeader.module.css
+++ b/packages/web/src/components/nav/desktop/NavHeader.module.css
@@ -122,3 +122,13 @@ svg.logo.matrixLogo path {
   text-transform: uppercase;
   padding: 0px 6px;
 }
+
+.earlyAccess {
+  font-size: 10px;
+  position: absolute;
+  font-weight: var(--font-bold);
+  top: 34px;
+  color: var(--primary);
+  left: 58px;
+  letter-spacing: 0.5px;
+}

--- a/packages/web/src/components/nav/mobile/NavBar.module.css
+++ b/packages/web/src/components/nav/mobile/NavBar.module.css
@@ -216,3 +216,14 @@
 .crownButton svg path {
   fill: var(--accent-orange);
 }
+
+.earlyAccess {
+  font-size: 10px;
+  position: absolute;
+  font-weight: var(--font-bold);
+  color: var(--primary);
+  letter-spacing: 0.5px;
+  left: 30px;
+  top: 18px;
+  width: 72px;
+}

--- a/packages/web/src/components/nav/mobile/NavBar.tsx
+++ b/packages/web/src/components/nav/mobile/NavBar.tsx
@@ -15,6 +15,7 @@ import { useHistory } from 'react-router-dom'
 import { useTransition, animated } from 'react-spring'
 
 import { ReactComponent as AudiusLogo } from 'assets/img/audiusLogoHorizontal.svg'
+import { FeatureFlags } from 'common/services/remote-config'
 import { formatCount } from 'common/utils/formatUtil'
 import {
   RouterContext,
@@ -26,6 +27,7 @@ import NavContext, {
   RightPreset
 } from 'components/nav/store/context'
 import SearchBar from 'components/search-bar/SearchBar'
+import { useFlag } from 'hooks/useRemoteConfig'
 import { OpenNotificationsMessage } from 'services/native-mobile-interface/notifications'
 import { getIsIOS } from 'utils/browser'
 import { onNativeBack } from 'utils/nativeRoute'
@@ -52,7 +54,8 @@ interface NavBarProps {
 
 const messages = {
   signUp: 'Sign Up',
-  searchPlaceholder: 'Search Audius'
+  searchPlaceholder: 'Search Audius',
+  earlyAccess: 'Early Access'
 }
 
 const NavBar = ({
@@ -217,6 +220,8 @@ const NavBar = ({
 
   const matrix = isMatrix()
 
+  const { isEnabled: isEarlyAccess } = useFlag(FeatureFlags.EARLY_ACCESS)
+
   return (
     <div className={styles.container}>
       <div
@@ -236,6 +241,11 @@ const NavBar = ({
               item && (
                 <animated.div style={props} key={key}>
                   <AudiusLogo />
+                  {isEarlyAccess ? (
+                    <div className={styles.earlyAccess}>
+                      {messages.earlyAccess}
+                    </div>
+                  ) : null}
                 </animated.div>
               )
           )}

--- a/packages/web/src/components/nav/mobile/NavBar.tsx
+++ b/packages/web/src/components/nav/mobile/NavBar.tsx
@@ -1,6 +1,6 @@
 import { useState, useContext, useCallback, useEffect } from 'react'
 
-import { Status } from '@audius/common'
+import { Status, FeatureFlags } from '@audius/common'
 import {
   IconCaretRight,
   IconRemove,
@@ -15,7 +15,6 @@ import { useHistory } from 'react-router-dom'
 import { useTransition, animated } from 'react-spring'
 
 import { ReactComponent as AudiusLogo } from 'assets/img/audiusLogoHorizontal.svg'
-import { FeatureFlags } from 'common/services/remote-config'
 import { formatCount } from 'common/utils/formatUtil'
 import {
   RouterContext,

--- a/packages/web/src/hooks/useRemoteConfig.ts
+++ b/packages/web/src/hooks/useRemoteConfig.ts
@@ -1,6 +1,9 @@
 import { createUseFeatureFlagHook } from 'common/hooks/useFeatureFlag'
 import { createUseRemoteVarHook } from 'common/hooks/useRemoteVar'
+import { getAccountUser } from 'common/store/account/selectors'
+import { isRemoteConfigLoaded } from 'common/store/remote-config/selectors'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+import { useSelector } from 'utils/reducer'
 
 export const useFlag = createUseFeatureFlagHook({
   remoteConfigInstance,
@@ -8,6 +11,11 @@ export const useFlag = createUseFeatureFlagHook({
   setLocalStorageItem: (key: string, value: string | null) => {
     if (value === null) return window.localStorage.removeItem(key)
     window.localStorage.setItem(key, value)
-  }
+  },
+  useAccountProvider: () => !!useSelector(getAccountUser),
+  useConfigLoadedProvider: () => !!useSelector(isRemoteConfigLoaded)
 })
-export const useRemoteVar = createUseRemoteVarHook(remoteConfigInstance)
+export const useRemoteVar = createUseRemoteVarHook(
+  remoteConfigInstance,
+  () => !!useSelector(isRemoteConfigLoaded)
+)

--- a/packages/web/src/hooks/useRemoteConfig.ts
+++ b/packages/web/src/hooks/useRemoteConfig.ts
@@ -12,10 +12,11 @@ export const useFlag = createUseFeatureFlagHook({
     if (value === null) return window.localStorage.removeItem(key)
     window.localStorage.setItem(key, value)
   },
-  useAccountProvider: () => !!useSelector(getAccountUser),
-  useConfigLoadedProvider: () => !!useSelector(isRemoteConfigLoaded)
+  useHasAccount: () => !!useSelector(getAccountUser),
+  useHasConfigLoaded: () => !!useSelector(isRemoteConfigLoaded)
 })
-export const useRemoteVar = createUseRemoteVarHook(
+export const useRemoteVar = createUseRemoteVarHook({
   remoteConfigInstance,
-  () => !!useSelector(isRemoteConfigLoaded)
-)
+  useHasAccount: () => !!useSelector(getAccountUser),
+  useHasConfigLoaded: () => !!useSelector(isRemoteConfigLoaded)
+})

--- a/packages/web/src/hooks/useRemoteConfig.ts
+++ b/packages/web/src/hooks/useRemoteConfig.ts
@@ -1,5 +1,8 @@
-import { createUseFeatureFlagHook } from 'common/hooks/useFeatureFlag'
-import { createUseRemoteVarHook } from 'common/hooks/useRemoteVar'
+import {
+  createUseFeatureFlagHook,
+  createUseRemoteVarHook
+} from '@audius/common'
+
 import { getAccountUser } from 'common/store/account/selectors'
 import { isRemoteConfigLoaded } from 'common/store/remote-config/selectors'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'

--- a/packages/web/src/pages/explore-page/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/ExplorePage.tsx
@@ -17,9 +17,7 @@ const ExplorePage = ({ isMobile }: ExplorePageContentProps) => {
   // Do not render content until remote config is loaded so
   // that tiling layout does not change.
   // TODO: Remove this when Remixables feature flag is removed
-  const remoteConfigLoaded = useSelector((state: AppState) =>
-    isRemoteConfigLoaded<AppState>(state)
-  )
+  const remoteConfigLoaded = useSelector(isRemoteConfigLoaded)
   if (!remoteConfigLoaded) return null
 
   return <ExplorePageProvider>{content}</ExplorePageProvider>

--- a/packages/web/src/services/remote-config/featureFlagHelpers.ts
+++ b/packages/web/src/services/remote-config/featureFlagHelpers.ts
@@ -1,9 +1,8 @@
-import { FeatureFlags } from '@audius/common'
-
 import {
+  FeatureFlags,
   FEATURE_FLAG_OVERRIDE_KEY,
   OverrideSetting
-} from 'common/hooks/useFeatureFlag'
+} from '@audius/common'
 
 import { remoteConfigInstance } from './remote-config-instance'
 

--- a/packages/web/src/services/remote-config/remote-config-instance.ts
+++ b/packages/web/src/services/remote-config/remote-config-instance.ts
@@ -1,7 +1,7 @@
 import { remoteConfig } from '@audius/common'
 import optimizely from '@optimizely/optimizely-sdk'
 
-export const FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY = 'featureFlagSessionId'
+export const FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY = 'featureFlagSessionId-2'
 
 export const remoteConfigInstance = remoteConfig({
   createOptimizelyClient: async () => {
@@ -21,10 +21,17 @@ export const remoteConfigInstance = remoteConfig({
       datafile: window.optimizelyDatafile
     })
   },
-  getFeatureFlagSessionId: async () =>
-    window.localStorage.getItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY),
-  setFeatureFlagSessionId: async (id: string) =>
-    window.localStorage?.setItem(FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY, id),
+  getFeatureFlagSessionId: async () => {
+    const item = window.localStorage.getItem(
+      FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY
+    )
+    return item ? parseInt(item) : null
+  },
+  setFeatureFlagSessionId: async (id) =>
+    window.localStorage?.setItem(
+      FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY,
+      id.toString()
+    ),
   setLogLevel: () => optimizely.setLogLevel('warn')
 })
 

--- a/packages/web/src/services/remote-config/remote-config-instance.ts
+++ b/packages/web/src/services/remote-config/remote-config-instance.ts
@@ -27,7 +27,7 @@ export const remoteConfigInstance = remoteConfig({
     )
     return item ? parseInt(item) : null
   },
-  setFeatureFlagSessionId: async (id) =>
+  setFeatureFlagSessionId: async (id: number) =>
     window.localStorage?.setItem(
       FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY,
       id.toString()


### PR DESCRIPTION
### Description

This PR does 3 things:
- Changes the feature flag logic to remove the session + user based feature flag distinction. We always prefer a user ID now if it's available, opting for a session if not - sessions are negative integers, so you can group them differently on Optimizely.
- Consolidates the mobile and desktop implementation of feature flags, using an 'injected selectors' pattern. Also made this logic less brittle. 
- Adds new UI to indicate when you're in the 'early access mode' group, with access to features on prod that normal users don't have. 
<img width="250" alt="Screen Shot 2022-07-27 at 6 14 40 PM" src="https://user-images.githubusercontent.com/6780028/181382321-f72aff74-8d4f-45f2-9f93-9233b88f051e.png">
<img width="445" alt="Screen Shot 2022-07-27 at 6 14 28 PM" src="https://user-images.githubusercontent.com/6780028/181382327-cde04b06-68a3-4b25-b171-d087a0b757a2.png">


### Dragons

Touches feature flags, so it's a bit scary. 

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested on prod with different accounts belonging to different groups. Added a bunch of logs and saw potential race conditions in the logic to recompute the feature flags, so made this more robust. 

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

Yes :))

*Are all new features properly feature flagged? Describe added feature flags.*

