### PR TITLE
Update explore endpoints in libs to use v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2010,7 +2010,7 @@
     "add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+      "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
       "dev": true
     },
     "agent-base": {
@@ -2121,7 +2121,7 @@
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
     "array-includes": {
@@ -2443,7 +2443,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -2557,7 +2557,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "contains-path": {
@@ -2736,7 +2736,7 @@
     "debuglog": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
     "decamelize": {
@@ -2758,7 +2758,7 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
       }
@@ -2778,7 +2778,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "requires": {
         "clone": "^1.0.2"
       }
@@ -2796,7 +2796,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
@@ -2814,7 +2814,7 @@
     "detect-indent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true
     },
     "dezalgo": {
@@ -3629,7 +3629,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
@@ -3793,7 +3793,7 @@
     "git-remote-origin-url": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
+      "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
       "dev": true,
       "requires": {
         "gitconfiglocal": "^1.0.0",
@@ -3803,7 +3803,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -3848,7 +3848,7 @@
     "gitconfiglocal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
+      "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
       "dev": true,
       "requires": {
         "ini": "^1.3.2"
@@ -3972,7 +3972,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "hosted-git-info": {
@@ -4020,7 +4020,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
@@ -4099,7 +4099,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
@@ -4117,7 +4117,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -4217,7 +4217,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bigint": {
@@ -4275,7 +4275,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -4301,7 +4301,7 @@
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
     },
     "is-negative-zero": {
@@ -4401,7 +4401,7 @@
     "is-text-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
+      "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
@@ -4430,13 +4430,13 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
@@ -5159,19 +5159,19 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
           "dev": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
           "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
           "dev": true,
           "requires": {
             "tr46": "~0.0.3",
@@ -5599,7 +5599,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-inspect": {
@@ -5672,7 +5672,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -6133,7 +6133,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
@@ -6386,7 +6386,7 @@
     "promzard": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-      "integrity": "sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "requires": {
         "read": "1"
@@ -6448,7 +6448,7 @@
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
         "mute-stream": "~0.0.4"
@@ -6518,7 +6518,7 @@
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
         "load-json-file": "^4.0.0",
@@ -6535,7 +6535,7 @@
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -6559,7 +6559,7 @@
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
@@ -6578,7 +6578,7 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "semver": {
@@ -6592,7 +6592,7 @@
     "read-pkg-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "dev": true,
       "requires": {
         "find-up": "^2.0.0",
@@ -6886,7 +6886,7 @@
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
@@ -7763,7 +7763,7 @@
     "validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
@@ -7786,7 +7786,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "requires": {
         "defaults": "^1.0.3"
       }
@@ -7853,7 +7853,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
@@ -7899,7 +7899,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -10620,7 +10620,7 @@
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -11657,7 +11657,7 @@
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -12200,7 +12200,7 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA=="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "earcut": {
       "version": "2.2.3",
@@ -15186,12 +15186,12 @@
         "Base64": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-          "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw=="
+          "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
         },
         "JSONStream": {
           "version": "0.8.4",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-          "integrity": "sha512-l0NN3IcqrZfZBJp7JWDJIHsnPV7yzJWqsYxQzL8Fwdx1BmEMjLuvtYkv+P9pbvpyfP75/f4MeDZhWNU4is32uA==",
+          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
           "requires": {
             "jsonparse": "0.0.5",
             "through": ">=2.2.7 <3"
@@ -15200,7 +15200,7 @@
         "acorn": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug=="
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         },
         "acorn-node": {
           "version": "1.8.2",
@@ -15232,7 +15232,7 @@
         "align-text": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -15242,7 +15242,7 @@
         "amdefine": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "asn1.js": {
           "version": "5.4.1",
@@ -15265,7 +15265,7 @@
         "assert": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
-          "integrity": "sha512-pSLN/C6u6JFR8L+0TzQ0Elc+VboxUXFtNw11RI1UcTcHEktQqIKIKK5S4nAZX4j8mpTpnCtmqpR+thPfqT11Kg==",
+          "integrity": "sha1-raoExGu1jG3R8pTaPrJuYijrbkQ=",
           "requires": {
             "util": "0.10.3"
           },
@@ -15273,12 +15273,12 @@
             "inherits": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             },
             "util": {
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
+              "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
               "requires": {
                 "inherits": "2.0.1"
               }
@@ -15288,7 +15288,7 @@
         "astw": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-          "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
+          "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
           "requires": {
             "acorn": "^4.0.3"
           }
@@ -15296,7 +15296,7 @@
         "async": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "balanced-match": {
           "version": "1.0.2",
@@ -15306,7 +15306,7 @@
         "base64-js": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
         },
         "bn.js": {
           "version": "5.2.1",
@@ -15325,12 +15325,12 @@
         "brorand": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browser-pack": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
-          "integrity": "sha512-BHla5EbbxjNyLMFUMamVjeTY+q1QwHbrYNXlWOkw71QcBqAQF7maJyNh3OI/V0d5YyNdMYD6tiPhJB9ukBo99Q==",
+          "integrity": "sha1-+qHLxBSHsazEdH43PhFIrf/Q4tk=",
           "requires": {
             "JSONStream": "~0.8.4",
             "combine-source-map": "~0.3.0",
@@ -15343,7 +15343,7 @@
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -15354,7 +15354,7 @@
             "through2": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "requires": {
                 "readable-stream": "~1.0.17",
                 "xtend": "~3.0.0"
@@ -15373,14 +15373,14 @@
             "resolve": {
               "version": "1.1.7",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
             }
           }
         },
         "browserify": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-7.1.0.tgz",
-          "integrity": "sha512-BHHshSNeACBbVMAo/QCeJ4chEVOfrF1S4/8YTdNPnmP4GmuyS+RmZKHcKD0SmjJjvjBiHsT4eYuv/VUA0/9XnA==",
+          "integrity": "sha1-FmB3XJPD7+rrQvPGY4psTCtBTxQ=",
           "requires": {
             "JSONStream": "~0.8.3",
             "assert": "~1.1.0",
@@ -15515,7 +15515,7 @@
         "browserify-zlib": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
             "pako": "~0.2.0"
           }
@@ -15533,34 +15533,34 @@
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             }
           }
         },
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "builtins": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-          "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw=="
+          "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo="
         },
         "callsite": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-          "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ=="
+          "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
         },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g=="
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
         },
         "center-align": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "requires": {
             "align-text": "^0.1.3",
             "lazy-cache": "^1.0.3"
@@ -15578,7 +15578,7 @@
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
             "center-align": "^0.1.1",
             "right-align": "^0.1.1",
@@ -15588,14 +15588,14 @@
             "wordwrap": {
               "version": "0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
             }
           }
         },
         "combine-source-map": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
-          "integrity": "sha512-HRKa6g9SC1xd6ifto8ay6SxvyHaaQ50/8NO1ZONXx2hsIF9t/52qXa7Eeivaf5KFOSowK7Nm8TkIL/VC4khdBA==",
+          "integrity": "sha1-2edPWT2c1DgHMSy12EbUUe+qnrc=",
           "requires": {
             "convert-source-map": "~0.3.0",
             "inline-source-map": "~0.3.0",
@@ -15605,12 +15605,12 @@
         "commondir": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-          "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg=="
+          "integrity": "sha1-ifAP3NUbUZxXhzP+xWPmptp/W+I="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
           "version": "1.4.11",
@@ -15630,12 +15630,12 @@
         "constants-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-          "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA=="
+          "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI="
         },
         "convert-source-map": {
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-          "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg=="
+          "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
         },
         "core-util-is": {
           "version": "1.0.3",
@@ -15704,22 +15704,22 @@
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "deep-equal": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-          "integrity": "sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ=="
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
         },
         "defined": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-          "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg=="
+          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
         },
         "deps-sort": {
           "version": "1.3.9",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
-          "integrity": "sha512-aEnmQuu/Hf5h8akL8QshYWzk9MVBg/JYMyNq/Lz68i69nR17tunjP6o/AC6Tn48c8ayzG6aeKs6OoFOtVCtvrQ==",
+          "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
           "requires": {
             "JSONStream": "^1.0.3",
             "shasum": "^1.0.0",
@@ -15739,7 +15739,7 @@
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             }
           }
         },
@@ -15769,7 +15769,7 @@
             "defined": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             }
           }
         },
@@ -15793,12 +15793,12 @@
         "domain-browser": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-          "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q=="
+          "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
         },
         "duplexer2": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "requires": {
             "readable-stream": "~1.1.9"
           }
@@ -15827,7 +15827,7 @@
         "events": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
-          "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ=="
+          "integrity": "sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ="
         },
         "evp_bytestokey": {
           "version": "1.0.3",
@@ -15846,7 +15846,7 @@
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -15904,7 +15904,7 @@
         "hmac-drbg": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-          "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -15914,7 +15914,7 @@
         "http-browserify": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
+          "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
           "requires": {
             "Base64": "~0.2.0",
             "inherits": "~2.0.1"
@@ -15923,7 +15923,7 @@
         "https-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-          "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ=="
+          "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
         },
         "ieee754": {
           "version": "1.2.1",
@@ -15933,12 +15933,12 @@
         "indexof": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-          "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
+          "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -15952,7 +15952,7 @@
         "inline-source-map": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-          "integrity": "sha512-RNlldBXZ7BBcVm3HjXIXiwKxih1lnuKbzeLBRDSB/qaqk8/g4JEZBjxpBQMhqEthQyGv7ycu8r/8PKGgBdIqrA==",
+          "integrity": "sha1-pSi1FOaJ/OkNswiehw2S9Sestes=",
           "requires": {
             "source-map": "~0.3.0"
           },
@@ -15960,7 +15960,7 @@
             "source-map": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-              "integrity": "sha512-jz8leTIGS8+qJywWiO9mKza0hJxexdeIYXhDHw9avTQcXSNAGk3hiiRMpmI2Qf9dOrZDrDpgH9VNefzuacWC9A==",
+              "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -15970,7 +15970,7 @@
         "insert-module-globals": {
           "version": "6.6.3",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
-          "integrity": "sha512-ryk8hTKUZCc300SPOOwx30WhE5oRUssPDVlIoO8vtoMNBy5HGeesVRl3HF7ra4ll42T0IdnwD9XR9svh6+RRhg==",
+          "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
           "requires": {
             "JSONStream": "^1.0.3",
             "combine-source-map": "~0.6.1",
@@ -15994,7 +15994,7 @@
             "combine-source-map": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
-              "integrity": "sha512-XKRNtuZRlVDTuSGKsfZpXYz80y0XDbYS4a+FzafTgmYHy/ckruFBx7Nd6WaQnFHVI3O6IseWVdXUvZutMpjSkQ==",
+              "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
               "requires": {
                 "convert-source-map": "~1.1.0",
                 "inline-source-map": "~0.5.0",
@@ -16005,12 +16005,12 @@
             "convert-source-map": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-              "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg=="
+              "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
             },
             "inline-source-map": {
               "version": "0.5.0",
               "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
-              "integrity": "sha512-2WtHG0qX9OH9TVcxsLVfq3Tzr+qtL6PtWgoh0XAAKe4KkdA/57Q+OGJuRJHA4mZ2OZnkJ/ZAaXf9krLB12/nIg==",
+              "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
               "requires": {
                 "source-map": "~0.4.0"
               }
@@ -16018,17 +16018,17 @@
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             },
             "process": {
               "version": "0.11.10",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
             },
             "source-map": {
               "version": "0.4.4",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -16056,12 +16056,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "json-stable-stringify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-          "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
+          "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
           "requires": {
             "jsonify": "~0.0.0"
           }
@@ -16069,17 +16069,17 @@
         "jsonify": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA=="
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsonparse": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
-          "integrity": "sha512-fw7Q/8gFR8iSekUi9I+HqWIap6mywuoe7hQIg3buTVjuZgALKj4HAmm0X6f+TaL4c9NJbvyFQdaI2ppr5p6dnQ=="
+          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
         },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -16087,7 +16087,7 @@
         "labeled-stream-splicer": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
-          "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
+          "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
           "requires": {
             "inherits": "^2.0.1",
             "isarray": "~0.0.1",
@@ -16097,12 +16097,12 @@
         "lazy-cache": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
         },
         "lexical-scope": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-          "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
+          "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
           "requires": {
             "astw": "^2.0.0"
           }
@@ -16110,12 +16110,12 @@
         "lodash.memoize": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-          "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A=="
+          "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
         },
         "longest": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg=="
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "md5.js": {
           "version": "1.3.5",
@@ -16151,12 +16151,12 @@
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
             "brace-expansion": "^1.0.0"
           }
@@ -16169,7 +16169,7 @@
         "module-deps": {
           "version": "3.9.1",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
-          "integrity": "sha512-EbWWlSGaCVidEsLsSzkY6l/jm0IcGDSQ8tGwtjM8joTrxqxP0om02Px9Np8D7FMZ/vZFdsOGbio+WqkKQxYuTA==",
+          "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
           "requires": {
             "JSONStream": "^1.0.3",
             "browser-resolve": "^1.7.0",
@@ -16199,17 +16199,17 @@
             "defined": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             },
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             },
             "parents": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-              "integrity": "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==",
+              "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
               "requires": {
                 "path-platform": "~0.11.15"
               }
@@ -16234,7 +16234,7 @@
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
@@ -16242,7 +16242,7 @@
         "optimist": {
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "requires": {
             "wordwrap": "~0.0.2"
           }
@@ -16250,17 +16250,17 @@
         "os-browserify": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-          "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA=="
+          "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
         },
         "pako": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
         },
         "parents": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
-          "integrity": "sha512-ASkdjFPS2nrxujzSBZGt8ZCKeG0/K2ZZVKveqXt7XGtXfu+ssnk4DQhnK91KRvt83f36LjfxOfwi0cv1+Re0eA==",
+          "integrity": "sha1-+iEvAk2fpjGNu2tM5nbIvkk7nEM=",
           "requires": {
             "path-platform": "^0.0.1"
           },
@@ -16268,7 +16268,7 @@
             "path-platform": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
-              "integrity": "sha512-ydK1VKZFYwy0mT2JvimJfxt5z6Z6sjBbLfsFMoJczbwZ/ul0AjgpXLHinUzclf4/XYC8mtsWGuFERZ95Rnm8wA=="
+              "integrity": "sha1-tVhdfDxGPYmqAGDYZhHPGv1hfio="
             }
           }
         },
@@ -16297,7 +16297,7 @@
         "path-platform": {
           "version": "0.11.15",
           "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-          "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg=="
+          "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
         },
         "pbkdf2": {
           "version": "3.1.2",
@@ -16314,7 +16314,7 @@
         "process": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz",
-          "integrity": "sha512-g7Lv2/7sZaS5oNElebRqsd40W/k0QCTmq8WeNZ/w3PVTqRsz0giER3sMsFQXobi+/Gmuy/qbnksrh76o21DEDA=="
+          "integrity": "sha1-e7r3GH/m3tP9W+DLYQP7qcrLl5g="
         },
         "public-encrypt": {
           "version": "4.0.3",
@@ -16339,17 +16339,17 @@
         "punycode": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
-          "integrity": "sha512-h/vscxLPvI2l7k/0dFUKZ5I5TgMCJ/Pl+J6rw77PDuQM6UApf/GaRVkjv/YSm2k+fbp7Yw8dxsoe29DolT7h7w=="
+          "integrity": "sha1-VACKyXKux0F13vnLpt9/qdORh0A="
         },
         "querystring": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "querystring-es3": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-          "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="
+          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
         },
         "randombytes": {
           "version": "2.1.0",
@@ -16371,7 +16371,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -16382,7 +16382,7 @@
         "readable-wrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-          "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
+          "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
           "requires": {
             "readable-stream": "^1.1.13-1"
           }
@@ -16390,17 +16390,17 @@
         "repeat-string": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "resolve": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-          "integrity": "sha512-zxmAcifDjKxmUbk7chQdKhDSn8ml08g+MYyU37xhEXBp+N81cfbYsm4e0Gn9jtLbAvbR8w8Ox09xqUZtPuCoeA=="
+          "integrity": "sha1-OVqe+ehz+/4SvRRAi9kbuTYAPWk="
         },
         "rfile": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-          "integrity": "sha512-aNeTpY8g6DYmqPvakau22B0SipQTskO8FtYXzn8qg4X4bN9ExIH8VAhq/L9w7N8HvESYeSSwk3e4GmW+rLLAxQ==",
+          "integrity": "sha1-WXCM+Qyh50xUw8/Fw2/bmBBDUmE=",
           "requires": {
             "callsite": "~1.0.0",
             "resolve": "~0.3.0"
@@ -16409,14 +16409,14 @@
             "resolve": {
               "version": "0.3.1",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-              "integrity": "sha512-mxx/I/wLjxtryDBtrrb0ZNzaYERVWaHpJ0W0Arm8N4l8b+jiX/U5yKcsj0zQpF9UuKN1uz80EUTOudON6OPuaQ=="
+              "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ="
             }
           }
         },
         "right-align": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "requires": {
             "align-text": "^0.1.1"
           }
@@ -16433,7 +16433,7 @@
         "ruglify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-          "integrity": "sha512-XfRj1YJdm/gnZNvmpQ5L+2YGRHglDGMPgJRbitgCxC3GzKVQF/t+ij1aNcNg2AnEXGtLHJDwoSWrAq3TUm0EVg==",
+          "integrity": "sha1-3Ikw4qlUSidDAcyZcldMDQmGtnU=",
           "requires": {
             "rfile": "~1.0",
             "uglify-js": "~2.2"
@@ -16442,7 +16442,7 @@
             "uglify-js": {
               "version": "2.2.5",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-              "integrity": "sha512-viLk+/8G0zm2aKt1JJAVcz5J/5ytdiNaIsKgrre3yvSUjwVG6ZUujGH7E2TiPigZUwLYCe7eaIUEP2Zka2VJPA==",
+              "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
               "requires": {
                 "optimist": "~0.3.5",
                 "source-map": "~0.1.7"
@@ -16472,12 +16472,12 @@
         "shallow-copy": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-          "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
+          "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
         },
         "shasum": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-          "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
+          "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
           "requires": {
             "json-stable-stringify": "~0.0.0",
             "sha.js": "~2.4.4"
@@ -16486,12 +16486,12 @@
         "shell-quote": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
-          "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ=="
+          "integrity": "sha1-GkEZbzwDM8SCMjWT1ohuzxU92YY="
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -16499,7 +16499,7 @@
         "stream-browserify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
+          "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
           "requires": {
             "inherits": "~2.0.1",
             "readable-stream": "^1.0.27-1"
@@ -16508,7 +16508,7 @@
         "stream-combiner2": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
-          "integrity": "sha512-7DO1SfBVnyIyo9ytUjSyVojT5bp1ZY6h3pj7HUs6PwcRSd/r8mBOHbRwYC7nbHRakKzMKyNp5HWJRv4GgVherA==",
+          "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
           "requires": {
             "duplexer2": "~0.0.2",
             "through2": "~0.5.1"
@@ -16517,7 +16517,7 @@
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -16528,7 +16528,7 @@
             "through2": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "requires": {
                 "readable-stream": "~1.0.17",
                 "xtend": "~3.0.0"
@@ -16539,7 +16539,7 @@
         "stream-splicer": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-          "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
+          "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
           "requires": {
             "indexof": "0.0.1",
             "inherits": "^2.0.1",
@@ -16552,12 +16552,12 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "subarg": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-          "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+          "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
           "requires": {
             "minimist": "^1.1.0"
           }
@@ -16578,12 +16578,12 @@
         "through": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
+          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "requires": {
             "readable-stream": ">=1.1.13-1 <1.2.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -16599,7 +16599,7 @@
         "timers-browserify": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-          "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+          "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
           "requires": {
             "process": "~0.11.0"
           },
@@ -16607,7 +16607,7 @@
             "process": {
               "version": "0.11.10",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
             }
           }
         },
@@ -16619,12 +16619,12 @@
         "typedarray": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
             "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
@@ -16634,12 +16634,12 @@
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
             },
             "yargs": {
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "requires": {
                 "camelcase": "^1.0.2",
                 "cliui": "^2.1.0",
@@ -16652,12 +16652,12 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q=="
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
         },
         "umd": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-          "integrity": "sha512-mEAJeceExHnblcAwN3BQtDPYOrTy4ALeBh6nQ9KW0cUCd0UU714jAfil2jvq09b67IizwJIiTVFOjE+/52Dyvw==",
+          "integrity": "sha1-SmMHt2LxfwLSAbX6FU5nM5bCY88=",
           "requires": {
             "rfile": "~1.0.0",
             "ruglify": "~1.0.0",
@@ -16668,7 +16668,7 @@
             "source-map": {
               "version": "0.1.34",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-              "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+              "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -16676,7 +16676,7 @@
             "uglify-js": {
               "version": "2.4.24",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-              "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
+              "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
               "requires": {
                 "async": "~0.2.6",
                 "source-map": "0.1.34",
@@ -16689,7 +16689,7 @@
         "url": {
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
           "requires": {
             "punycode": "1.3.2",
             "querystring": "0.2.0"
@@ -16698,7 +16698,7 @@
             "punycode": {
               "version": "1.3.2",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-              "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
             }
           }
         },
@@ -16713,19 +16713,19 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vm-browserify": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
+          "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
           "requires": {
             "indexof": "0.0.1"
           }
@@ -16733,27 +16733,27 @@
         "window-size": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg=="
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
         },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xtend": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg=="
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
         },
         "yargs": {
           "version": "3.5.4",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
+          "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
           "requires": {
             "camelcase": "^1.0.2",
             "decamelize": "^1.0.0",
@@ -16764,7 +16764,7 @@
             "wordwrap": {
               "version": "0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
             }
           }
         }
@@ -21026,7 +21026,7 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ=="
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -21102,7 +21102,7 @@
     "json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
       "requires": {
         "string-convert": "^0.2.0"
       }
@@ -24555,7 +24555,7 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA=="
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -27397,7 +27397,7 @@
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -28715,7 +28715,7 @@
     "string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-length": {
       "version": "4.0.2",
@@ -30142,7 +30142,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.6.5",
@@ -30888,7 +30888,7 @@
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "requires": {
         "prepend-http": "^2.0.0"
       }

--- a/packages/web/src/pages/smart-collection/store/sagas.ts
+++ b/packages/web/src/pages/smart-collection/store/sagas.ts
@@ -3,7 +3,8 @@ import {
   SmartCollectionVariant,
   Status,
   Track,
-  UserTrack
+  UserTrack,
+  UserTrackMetadata
 } from '@audius/common'
 import { takeEvery, put, call, select } from 'typed-redux-saga/macro'
 
@@ -58,7 +59,15 @@ function* fetchHeavyRotation() {
 }
 
 function* fetchBestNewReleases() {
-  const tracks = yield* call(Explore.getTopFolloweeTracksFromWindow, 'month')
+  const currentUserId = yield* select(getUserId)
+  if (currentUserId == null) {
+    return
+  }
+  const tracks = yield* call(
+    Explore.getTopFolloweeTracksFromWindow,
+    currentUserId,
+    'month'
+  )
 
   const trackIds = tracks
     .filter((track) => !track.user.is_deactivated)
@@ -99,11 +108,14 @@ function* fetchUnderTheRadar() {
 }
 
 function* fetchMostLoved() {
-  const tracks = yield* call(Explore.getTopFolloweeSaves)
-
+  const currentUserId = yield* select(getUserId)
+  if (currentUserId == null) {
+    return
+  }
+  const tracks = yield* call(Explore.getMostLovedTracks, currentUserId)
   const trackIds = tracks
     .filter((track) => !track.user.is_deactivated)
-    .map((track: Track) => ({
+    .map((track: UserTrackMetadata) => ({
       time: track.created_at,
       track: track.track_id
     }))

--- a/packages/web/src/services/audius-backend/Explore.ts
+++ b/packages/web/src/services/audius-backend/Explore.ts
@@ -1,12 +1,22 @@
-import { ID, Collection, FeedFilter, UserTrack } from '@audius/common'
+import {
+  ID,
+  Collection,
+  FeedFilter,
+  UserCollectionMetadata,
+  UserTrack,
+  removeNullable
+} from '@audius/common'
 
 import AudiusBackend, {
   IDENTITY_SERVICE,
   AuthHeaders
 } from 'services/AudiusBackend'
 import apiClient from 'services/audius-api-client/AudiusAPIClient'
+import * as adapter from 'services/audius-api-client/ResponseAdapter'
+import { APIPlaylist, APITrack } from 'services/audius-api-client/types'
+import { encodeHashId } from 'utils/route/hashIds'
 
-type CollectionWithScore = Collection & { score: number }
+type CollectionWithScore = APIPlaylist & { score: number }
 
 // @ts-ignore
 const libs = () => window.audiusLibs
@@ -61,17 +71,19 @@ class Explore {
   }
 
   static async getTopFolloweeTracksFromWindow(
+    userId: ID,
     window: string,
     limit = 25
   ): Promise<UserTrack[]> {
     try {
-      const tracks = await libs().discoveryProvider.getTopFolloweeWindowed(
-        'track',
+      const encodedUserId = encodeHashId(userId)
+      const tracks = await libs().discoveryProvider.getBestNewReleases(
+        encodedUserId,
         window,
         limit,
         true
       )
-      return tracks
+      return tracks.map(adapter.makeTrack).filter(removeNullable)
     } catch (e) {
       console.error(e)
       return []
@@ -130,6 +142,22 @@ class Explore {
     }
   }
 
+  static async getMostLovedTracks(userId: ID, limit = 25) {
+    try {
+      const encodedUserId = encodeHashId(userId)
+      const tracks: APITrack[] =
+        await libs().discoveryProvider.getMostLovedTracks(
+          encodedUserId,
+          limit,
+          true
+        )
+      return tracks.map(adapter.makeTrack).filter(removeNullable)
+    } catch (e) {
+      console.error(e)
+      return []
+    }
+  }
+
   static async getLatestTrackID(): Promise<number> {
     try {
       const latestTrackID = await libs().discoveryProvider.getLatest('track')
@@ -147,14 +175,15 @@ class Explore {
     limit = 20
   ): Promise<Collection[]> {
     try {
-      const playlists = await libs().discoveryProvider.getTopPlaylists(
+      const playlists = await libs().discoveryProvider.getTopFullPlaylists({
         type,
         limit,
-        undefined,
-        followeesOnly ? 'followees' : undefined,
-        true
-      )
-      return playlists
+        mood: undefined,
+        filter: followeesOnly ? 'followees' : undefined,
+        withUsers: true
+      })
+      const adapted = playlists.map(adapter.makePlaylist)
+      return adapted
     } catch (e) {
       console.error(e)
       return []
@@ -164,24 +193,26 @@ class Explore {
   static async getTopPlaylistsForMood(
     moods: string[],
     limit = 16
-  ): Promise<Collection[]> {
+  ): Promise<UserCollectionMetadata[]> {
     try {
       const requests = moods.map((mood) => {
-        return libs().discoveryProvider.getTopPlaylists(
-          'playlist',
+        return libs().discoveryProvider.getTopFullPlaylists({
+          type: 'playlist',
           limit,
           mood,
-          undefined,
-          true
-        )
+          filter: undefined,
+          withUsers: true
+        })
       })
-      const playlistsByMood = await Promise.all(requests)
-
+      const playlistsByMood: CollectionWithScore[] = await Promise.all(requests)
       let allPlaylists: CollectionWithScore[] = []
       playlistsByMood.forEach((playlists) => {
         allPlaylists = allPlaylists.concat(playlists)
       })
-      return allPlaylists.sort(scoreComparator).slice(0, 20)
+      const playlists: APIPlaylist[] = allPlaylists
+        .sort(scoreComparator)
+        .slice(0, 20)
+      return playlists.map(adapter.makePlaylist).filter(removeNullable)
     } catch (e) {
       console.error(e)
       return []


### PR DESCRIPTION
### Description
This  was originally reverted because not all discovery nodes were updated to have the latest endpoints.

Revert "Revert "Update explore endpoints in libs to use v1 (#1539)" (#1609)"

This reverts commit 317e197990d01bfc9259ebc8705d0353e137fd7a.

### Dragons

### How Has This Been Tested?
All nodes have been updated and testing this against prod seems to load discovery and subsequent pages file

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

