### PR TITLE
[PAY-466] Display AAO emoji errors for failed reward claims

### DIFF
--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawer.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawer.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import type { UserChallengeState } from '@audius/common'
 import { ClaimStatus } from 'audius-client/src/common/store/pages/audio-rewards/slice'
+import { getAAOErrorEmojis } from 'audius-client/src/common/utils/aaoErrorCodes'
 import { fillString } from 'audius-client/src/common/utils/fillString'
 import { formatNumberCommas } from 'audius-client/src/common/utils/formatUtil'
 import type { ImageSourcePropType } from 'react-native'
@@ -30,6 +31,8 @@ const messages = {
   claim: 'Claim Your Reward',
   claimErrorMessage:
     'Something has gone wrong, not all your rewards were claimed. Please try again.',
+  claimErrorMessageAAO:
+    'Your account is unable to claim rewards at this time. Please try again later or contact @support@audius.co. ',
   claimableLabel: '$AUDIO available to claim',
   claimedLabel: '$AUDIO claimed so far'
 }
@@ -165,6 +168,8 @@ type ChallengeRewardsDrawerProps = {
   claimedAmount: number
   /** The status of the rewards being claimed */
   claimStatus: ClaimStatus
+  /** Error code from AAO in the case of AAO rejection */
+  aaoErrorCode?: number
   /** Callback that runs on the claim rewards button being clicked */
   onClaim?: () => void
   /** Whether the challenge is for verified users only */
@@ -186,6 +191,7 @@ export const ChallengeRewardsDrawer = ({
   claimableAmount,
   claimedAmount,
   claimStatus,
+  aaoErrorCode,
   onClaim,
   isVerifiedChallenge,
   showProgressBar,
@@ -217,6 +223,21 @@ export const ChallengeRewardsDrawer = ({
     messages.claimableLabel
   }`
 
+  const getErrorMessage = () => {
+    if (aaoErrorCode === undefined) {
+      return (
+        <Text style={styles.claimRewardsError} weight='bold'>
+          {messages.claimErrorMessage}
+        </Text>
+      )
+    }
+    return (
+      <Text style={styles.claimRewardsError} weight='bold'>
+        {messages.claimErrorMessageAAO}
+        {getAAOErrorEmojis(aaoErrorCode)}
+      </Text>
+    )
+  }
   return (
     <AppDrawer
       modalName='ChallengeRewardsExplainer'
@@ -321,11 +342,7 @@ export const ChallengeRewardsDrawer = ({
               {claimedAmountText}
             </Text>
           ) : null}
-          {claimError ? (
-            <Text style={styles.claimRewardsError} weight='bold'>
-              {messages.claimErrorMessage}
-            </Text>
-          ) : null}
+          {claimError ? getErrorMessage() : null}
         </View>
       </View>
     </AppDrawer>

--- a/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
+++ b/packages/mobile/src/components/challenge-rewards-drawer/ChallengeRewardsDrawerProvider.tsx
@@ -4,6 +4,7 @@ import type { Maybe } from '@audius/common'
 import { IntKeys, StringKeys } from '@audius/common'
 import { getOptimisticUserChallenges } from 'audius-client/src/common/store/challenges/selectors/optimistic-challenges'
 import {
+  getAAOErrorCode,
   getChallengeRewardsModalType,
   getClaimStatus
 } from 'audius-client/src/common/store/pages/audio-rewards/selectors'
@@ -54,6 +55,7 @@ export const ChallengeRewardsDrawerProvider = () => {
   }, [dispatchWeb, onClose])
 
   const claimStatus = useSelectorWeb(getClaimStatus)
+  const aaoErrorCode = useSelectorWeb(getAAOErrorCode)
 
   const { toast } = useContext(ToastContext)
 
@@ -182,6 +184,7 @@ export const ChallengeRewardsDrawerProvider = () => {
       claimableAmount={audioToClaim}
       claimedAmount={audioClaimedSoFar}
       claimStatus={claimStatus}
+      aaoErrorCode={aaoErrorCode}
       onClaim={hasConfig ? onClaim : undefined}
       isVerifiedChallenge={!!config.isVerifiedChallenge}
       showProgressBar={

--- a/packages/web/src/common/services/audius-backend/AudiusBackend.ts
+++ b/packages/web/src/common/services/audius-backend/AudiusBackend.ts
@@ -2950,7 +2950,9 @@ export const audiusBackend = ({
         const error = hcaptchaOrCognito
           ? hcaptchaOrCognito.error
           : res.errors[0].error
-        return { error }
+        const aaoErrorCode = res.errors[0].aaoErrorCode
+
+        return { error, aaoErrorCode }
       }
       return res
     } catch (e) {

--- a/packages/web/src/common/store/pages/audio-rewards/selectors.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/selectors.ts
@@ -3,6 +3,8 @@ import { createSelector } from 'reselect'
 
 import { CommonState } from 'common/store'
 
+import { ClaimStatus } from './slice'
+
 export const getTrendingRewardsModalType = (state: CommonState) =>
   state.pages.audioRewards.trendingRewardsModalType
 
@@ -49,10 +51,10 @@ export const getUserChallengesLoading = (state: CommonState) =>
   state.pages.audioRewards.loading
 
 export const getClaimStatus = (state: CommonState) =>
-  state.pages.audioRewards.claimStatus
+  state.pages.audioRewards.claimState.status
 
 export const getClaimToRetry = (state: CommonState) =>
-  state.pages.audioRewards.claimToRetry
+  state.pages.audioRewards.claimState.status
 
 export const getHCaptchaStatus = (state: CommonState) =>
   state.pages.audioRewards.hCaptchaStatus
@@ -68,3 +70,11 @@ export const getCognitoFlowUrlStatus = (state: CommonState) =>
 
 export const getShowRewardClaimedToast = (state: CommonState) =>
   state.pages.audioRewards.showRewardClaimedToast
+
+export const getAAOErrorCode = (state: CommonState) => {
+  const claimState = state.pages.audioRewards.claimState
+  if (claimState.status !== ClaimStatus.ERROR) {
+    return undefined
+  }
+  return claimState.aaoErrorCode
+}

--- a/packages/web/src/common/store/pages/audio-rewards/selectors.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/selectors.ts
@@ -54,7 +54,7 @@ export const getClaimStatus = (state: CommonState) =>
   state.pages.audioRewards.claimState.status
 
 export const getClaimToRetry = (state: CommonState) =>
-  state.pages.audioRewards.claimState.status
+  state.pages.audioRewards.claimToRetry
 
 export const getHCaptchaStatus = (state: CommonState) =>
   state.pages.audioRewards.hCaptchaStatus

--- a/packages/web/src/common/store/pages/audio-rewards/slice.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/slice.ts
@@ -18,38 +18,13 @@ export enum ClaimStatus {
   ERROR = 'error'
 }
 
-type ClaimNone = {
-  status: ClaimStatus.NONE
-}
-
-type ClaimClaiming = {
-  status: ClaimStatus.CLAIMING
-}
-
-type ClaimWaitingForRetry = {
-  status: ClaimStatus.WAITING_FOR_RETRY
-}
-
-type ClaimAlreadyClaimed = {
-  status: ClaimStatus.ALREADY_CLAIMED
-}
-
-type ClaimSuccess = {
-  status: ClaimStatus.SUCCESS
-}
-
-type ClaimError = {
-  status: ClaimStatus.ERROR
-  aaoErrorCode: number | undefined
-}
-
 export type ClaimState =
-  | ClaimNone
-  | ClaimClaiming
-  | ClaimWaitingForRetry
-  | ClaimAlreadyClaimed
-  | ClaimSuccess
-  | ClaimError
+  | { status: ClaimStatus.NONE }
+  | { status: ClaimStatus.CLAIMING }
+  | { status: ClaimStatus.WAITING_FOR_RETRY }
+  | { status: ClaimStatus.ALREADY_CLAIMED }
+  | { status: ClaimStatus.SUCCESS }
+  | { status: ClaimStatus.ERROR; aaoErrorCode: number | undefined }
 
 export type Claim = {
   challengeId: ChallengeRewardID

--- a/packages/web/src/common/utils/aaoErrorCodes.ts
+++ b/packages/web/src/common/utils/aaoErrorCodes.ts
@@ -1,4 +1,15 @@
-const aaoErrorEmojis = ['😓', '😭', '😥', '😮', '🤬', '😷', '😿', '😤', '🤨']
+const aaoErrorEmojis = [
+  '😓',
+  '😭',
+  '😥',
+  '😮',
+  '🤬',
+  '😷',
+  '😿',
+  '😤',
+  '🙁',
+  '🤨'
+]
 
 /**
  * Currently we have 7 error codes, please see this link:

--- a/packages/web/src/common/utils/aaoErrorCodes.ts
+++ b/packages/web/src/common/utils/aaoErrorCodes.ts
@@ -7,7 +7,8 @@ const aaoErrorEmojis = ['😓', '😭', '😥', '😮', '🤬', '😷', '😿', 
  * Error code mappings:
  * Negative numbers are unexpected but valid, return last emoji.
  * Positive numbers are expected, return emoji at index of error code.
- * Positive numbers larger than number of error codes are invalid, ignore.
+ * Positive numbers larger than number of error codes are technically invalid,
+ * but ignore them and return last emoji to prevent errors.
  **/
 export const getAAOErrorEmojis = (errorCode: number): string => {
   return aaoErrorEmojis[errorCode] ?? aaoErrorEmojis[aaoErrorEmojis.length - 1]

--- a/packages/web/src/common/utils/aaoErrorCodes.ts
+++ b/packages/web/src/common/utils/aaoErrorCodes.ts
@@ -12,14 +12,10 @@ const aaoErrorEmojis = [
 ]
 
 /**
- * Currently we have 7 error codes, please see this link:
- * https://www.notion.so/audiusproject/77229a671b564d97a7426ed98fe3c928?v=1b434faf2f7c4de19ea20f2d6c73ea9b
- *
- * Error code mappings:
  * Negative numbers are unexpected but valid, return last emoji.
  * Positive numbers are expected, return emoji at index of error code.
- * Positive numbers larger than number of error codes are technically invalid,
- * but ignore them and return last emoji to prevent errors.
+ * Positive numbers greater than total number of error codes are technically
+ * invalid, but ignore them and return last emoji to avoid errors.
  **/
 export const getAAOErrorEmojis = (errorCode: number): string => {
   return aaoErrorEmojis[errorCode] ?? aaoErrorEmojis[aaoErrorEmojis.length - 1]

--- a/packages/web/src/common/utils/aaoErrorCodes.ts
+++ b/packages/web/src/common/utils/aaoErrorCodes.ts
@@ -1,0 +1,14 @@
+const aaoErrorEmojis = ['😓', '😭', '😥', '😮', '🤬', '😷', '😿', '😤', '🤨']
+
+/**
+ * Currently we have 7 error codes, please see this link:
+ * https://www.notion.so/audiusproject/77229a671b564d97a7426ed98fe3c928?v=1b434faf2f7c4de19ea20f2d6c73ea9b
+ *
+ * Error code mappings:
+ * Negative numbers are unexpected but valid, return last emoji.
+ * Positive numbers are expected, return emoji at index of error code.
+ * Positive numbers larger than number of error codes are invalid, ignore.
+ **/
+export const getAAOErrorEmojis = (errorCode: number): string => {
+  return aaoErrorEmojis[errorCode] ?? aaoErrorEmojis[aaoErrorEmojis.length - 1]
+}

--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.tsx
@@ -20,6 +20,7 @@ import { getUserHandle } from 'common/store/account/selectors'
 import { getOptimisticUserChallenges } from 'common/store/challenges/selectors/optimistic-challenges'
 import { getCompletionStages } from 'common/store/challenges/selectors/profile-progress'
 import {
+  getAAOErrorCode,
   getChallengeRewardsModalType,
   getClaimStatus,
   getCognitoFlowStatus
@@ -32,6 +33,7 @@ import {
   CognitoFlowStatus,
   claimChallengeReward
 } from 'common/store/pages/audio-rewards/slice'
+import { getAAOErrorEmojis } from 'common/utils/aaoErrorCodes'
 import { fillString } from 'common/utils/fillString'
 import { formatNumberCommas } from 'common/utils/formatUtil'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
@@ -77,7 +79,9 @@ const messages = {
   rewardClaimed: 'Reward claimed successfully!',
   rewardAlreadyClaimed: 'Reward already claimed!',
   claimError:
-    'Something has gone wrong, not all your rewards were claimed. Please try again.',
+    'Something has gone wrong, not all your rewards were claimed. Please try again or contact support@audius.co.',
+  claimErrorAAO:
+    'Your account is unable to claim rewards at this time. Please try again later or contact support@audius.co. ',
   claimYourReward: 'Claim Your Reward',
   twitterShare: (modalType: 'referrals' | 'ref-v') =>
     `Share Invite With Your ${modalType === 'referrals' ? 'Friends' : 'Fans'}`,
@@ -277,6 +281,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
 
   const { toast } = useContext(ToastContext)
   const claimStatus = useSelector(getClaimStatus)
+  const aaoErrorCode = useSelector(getAAOErrorCode)
   const claimInProgress =
     claimStatus === ClaimStatus.CLAIMING ||
     claimStatus === ClaimStatus.WAITING_FOR_RETRY
@@ -335,6 +340,18 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
     () => (userHandle ? fillString(messages.inviteLink, userHandle) : ''),
     [userHandle]
   )
+
+  const getErrorMessage = () => {
+    if (aaoErrorCode !== undefined) {
+      return (
+        <>
+          {messages.claimErrorAAO}
+          {getAAOErrorEmojis(aaoErrorCode)}
+        </>
+      )
+    }
+    return <>{messages.claimError}</>
+  }
 
   return (
     <div className={wm(styles.container)}>
@@ -442,7 +459,7 @@ const ChallengeRewardsBody = ({ dismissModal }: BodyProps) => {
         ) : null}
       </div>
       {claimStatus === ClaimStatus.ERROR && (
-        <div className={styles.claimError}>{messages.claimError}</div>
+        <div className={styles.claimError}>{getErrorMessage()}</div>
       )}
     </div>
   )


### PR DESCRIPTION
### Description
When a user tries to claim a challenge reward and fails due to an AAO rejection, display an emoji that corresponds to error codes from the AAO.

### Dragons
Things get a bit hairy in sagas.ts - we switch on failure reasons, then throw an error in the BLOCKED case and in the case of an AAO_ATTESTATION_REJECTION we end up in the else statement after retries. I think these are the only paths an AAO rejection will follow but would like confirmation.

### How Has This Been Tested?

Tested manually on both web and mobile. Manually set selector to return all expected values and confirmed behavior.

### How will this change be monitored?

### Feature Flags ###
