### PR TITLE
[C-806] Prevent multiple overflow menus at a time

### DIFF
--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -69,8 +69,7 @@ import { isDarkMode, isMatrix } from 'utils/theme/theme'
 
 import {
   getCollectionWithFallback,
-  getUserWithFallback,
-  isDescendantElementOf
+  getUserWithFallback
 } from '../helpers'
 
 import styles from './ConnectedPlaylistTile.module.css'
@@ -78,6 +77,7 @@ import PlaylistTile from './PlaylistTile'
 import TrackListItem from './TrackListItem'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
+import { isDescendantElementOf } from 'utils/domUtils'
 
 type OwnProps = {
   uid: UID

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -67,7 +67,11 @@ import {
 } from 'utils/route'
 import { isDarkMode, isMatrix } from 'utils/theme/theme'
 
-import { getCollectionWithFallback, getUserWithFallback } from '../helpers'
+import {
+  getCollectionWithFallback,
+  getUserWithFallback,
+  isDescendantElementOf
+} from '../helpers'
 
 import styles from './ConnectedPlaylistTile.module.css'
 import PlaylistTile from './PlaylistTile'
@@ -162,12 +166,16 @@ const ConnectedPlaylistTile = memo(
     const onTogglePlay = useCallback(
       (e?: MouseEvent /* click event within TrackTile */) => {
         // Skip playing / pausing track if click event happened within track menu container
-        const element =
-          e?.target instanceof Element ? (e.target as Element) : null
-        const shouldSkipTogglePlay = menuRef.current?.contains(element)
-        if (shouldSkipTogglePlay) {
-          return
-        }
+        // because clicking on it should not affect corresponding playlist track.
+        // We have to do this instead of stopping the event propagation
+        // because we need it to bubble up to the document to allow
+        // the document click listener to close other track/playlist tile menus
+        // that are already open.
+        const shouldSkipTogglePlay = isDescendantElementOf(
+          e?.target,
+          menuRef.current
+        )
+        if (shouldSkipTogglePlay) return
         if (isUploading) return
         if (!isActive || !isPlaying) {
           if (isActive) {

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -57,6 +57,7 @@ import {
 } from 'store/application/ui/userListModal/types'
 import { getUid, getBuffering, getPlaying } from 'store/player/selectors'
 import { AppState } from 'store/types'
+import { isDescendantElementOf } from 'utils/domUtils'
 import {
   albumPage,
   fullAlbumPage,
@@ -67,17 +68,13 @@ import {
 } from 'utils/route'
 import { isDarkMode, isMatrix } from 'utils/theme/theme'
 
-import {
-  getCollectionWithFallback,
-  getUserWithFallback
-} from '../helpers'
+import { getCollectionWithFallback, getUserWithFallback } from '../helpers'
 
 import styles from './ConnectedPlaylistTile.module.css'
 import PlaylistTile from './PlaylistTile'
 import TrackListItem from './TrackListItem'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
-import { isDescendantElementOf } from 'utils/domUtils'
 
 type OwnProps = {
   uid: UID

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -51,8 +51,7 @@ import { isDarkMode, isMatrix } from 'utils/theme/theme'
 
 import {
   getTrackWithFallback,
-  getUserWithFallback,
-  isDescendantElementOf
+  getUserWithFallback
 } from '../helpers'
 import { TrackTileSize } from '../types'
 
@@ -60,6 +59,7 @@ import styles from './ConnectedTrackTile.module.css'
 import TrackTile from './TrackTile'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
+import { isDescendantElementOf } from 'utils/domUtils'
 
 type OwnProps = {
   uid: UID

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -49,7 +49,11 @@ import { AppState } from 'store/types'
 import { fullTrackPage, profilePage } from 'utils/route'
 import { isDarkMode, isMatrix } from 'utils/theme/theme'
 
-import { getTrackWithFallback, getUserWithFallback } from '../helpers'
+import {
+  getTrackWithFallback,
+  getUserWithFallback,
+  isDescendantElementOf
+} from '../helpers'
 import { TrackTileSize } from '../types'
 
 import styles from './ConnectedTrackTile.module.css'
@@ -304,12 +308,16 @@ const ConnectedTrackTile = memo(
     const onTogglePlay = useCallback(
       (e?: MouseEvent /* click event within TrackTile */) => {
         // Skip toggle play if click event happened within track menu container
-        const element =
-          e?.target instanceof Element ? (e.target as Element) : null
-        const shouldSkipTogglePlay = menuRef.current?.contains(element)
-        if (shouldSkipTogglePlay) {
-          return
-        }
+        // because clicking on it should not affect corresponding track.
+        // We have to do this instead of stopping the event propagation
+        // because we need it to bubble up to the document to allow
+        // the document click listener to close other track/playlist tile menus
+        // that are already open.
+        const shouldSkipTogglePlay = isDescendantElementOf(
+          e?.target,
+          menuRef.current
+        )
+        if (shouldSkipTogglePlay) return
         togglePlay(uid, trackId)
       },
       [togglePlay, uid, trackId]

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -1,4 +1,11 @@
-import { memo, useState, useCallback, useEffect } from 'react'
+import {
+  memo,
+  useState,
+  useCallback,
+  useEffect,
+  MouseEvent,
+  useRef
+} from 'react'
 
 import {
   UID,
@@ -130,6 +137,8 @@ const ConnectedTrackTile = memo(
     const isOwner = handle === userHandle
     const isArtistPick = showArtistPick && _artist_pick === trackId
 
+    const menuRef = useRef<HTMLDivElement>(null)
+
     const onClickStatRepost = () => {
       setRepostUsers(trackId)
       setModalVisibility()
@@ -189,7 +198,7 @@ const ConnectedTrackTile = memo(
       return (
         <Menu menu={menu}>
           {(ref, triggerPopup) => (
-            <div className={styles.menuContainer}>
+            <div className={styles.menuContainer} ref={menuRef}>
               <div
                 className={cn(styles.menuKebabContainer, {
                   [styles.small]: size === TrackTileSize.SMALL,
@@ -292,9 +301,19 @@ const ConnectedTrackTile = memo(
       shareTrack(trackId)
     }, [shareTrack, trackId])
 
-    const onTogglePlay = useCallback(() => {
-      togglePlay(uid, trackId)
-    }, [togglePlay, uid, trackId])
+    const onTogglePlay = useCallback(
+      (e?: MouseEvent /* click event within TrackTile */) => {
+        // Skip toggle play if click event happened within track menu container
+        const element =
+          e?.target instanceof Element ? (e.target as Element) : null
+        const shouldSkipTogglePlay = menuRef.current?.contains(element)
+        if (shouldSkipTogglePlay) {
+          return
+        }
+        togglePlay(uid, trackId)
+      },
+      [togglePlay, uid, trackId]
+    )
 
     if (is_delete || user?.is_deactivated) return null
 

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -46,20 +46,17 @@ import {
 } from 'store/application/ui/userListModal/types'
 import { getUid, getPlaying, getBuffering } from 'store/player/selectors'
 import { AppState } from 'store/types'
+import { isDescendantElementOf } from 'utils/domUtils'
 import { fullTrackPage, profilePage } from 'utils/route'
 import { isDarkMode, isMatrix } from 'utils/theme/theme'
 
-import {
-  getTrackWithFallback,
-  getUserWithFallback
-} from '../helpers'
+import { getTrackWithFallback, getUserWithFallback } from '../helpers'
 import { TrackTileSize } from '../types'
 
 import styles from './ConnectedTrackTile.module.css'
 import TrackTile from './TrackTile'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
-import { isDescendantElementOf } from 'utils/domUtils'
 
 type OwnProps = {
   uid: UID

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -1,4 +1,4 @@
-import { memo, MouseEvent } from 'react'
+import { memo, MouseEvent, useRef } from 'react'
 
 import { UID, ID } from '@audius/common'
 import cn from 'classnames'
@@ -48,6 +48,8 @@ const TrackListItem = ({
   isLoading,
   forceSkeleton = false
 }: TrackListItemProps) => {
+  const menuRef = useRef<HTMLDivElement>(null)
+
   if (forceSkeleton) {
     return (
       <div
@@ -79,12 +81,14 @@ const TrackListItem = ({
   }
 
   const onMoreClick = (triggerPopup: () => void) => (e: MouseEvent) => {
-    e.stopPropagation()
     triggerPopup()
   }
 
-  const onPlayTrack = () => {
-    if (!deleted && togglePlay) togglePlay(track.uid, track.track_id)
+  const onPlayTrack = (e?: MouseEvent) => {
+    const element = e?.target instanceof Element ? (e.target as Element) : null
+    const shouldSkipTogglePlay = menuRef.current?.contains(element)
+    if (!deleted && togglePlay && !shouldSkipTogglePlay)
+      togglePlay(track.uid, track.track_id)
   }
 
   const hideShow = cn({
@@ -165,7 +169,7 @@ const TrackListItem = ({
         {!disableActions && !deleted ? (
           <Menu menu={menu}>
             {(ref, triggerPopup) => (
-              <div className={cn(styles.menuContainer)}>
+              <div className={cn(styles.menuContainer)} ref={menuRef}>
                 <IconKebabHorizontal
                   className={styles.iconKebabHorizontal}
                   ref={ref}

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -13,10 +13,10 @@ import Skeleton from 'components/skeleton/Skeleton'
 import TablePlayButton from 'components/tracks-table/TablePlayButton'
 import { profilePage } from 'utils/route'
 
-import { isDescendantElementOf } from '../helpers'
 import { TrackTileSize } from '../types'
 
 import styles from './TrackListItem.module.css'
+import { isDescendantElementOf } from 'utils/domUtils'
 
 const makeStrings = ({ deleted }: { deleted: boolean }) => ({
   deleted: deleted ? ` [Deleted By Artist]` : '',

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -11,12 +11,12 @@ import Menu from 'components/menu/Menu'
 import { OwnProps as TrackMenuProps } from 'components/menu/TrackMenu'
 import Skeleton from 'components/skeleton/Skeleton'
 import TablePlayButton from 'components/tracks-table/TablePlayButton'
+import { isDescendantElementOf } from 'utils/domUtils'
 import { profilePage } from 'utils/route'
 
 import { TrackTileSize } from '../types'
 
 import styles from './TrackListItem.module.css'
-import { isDescendantElementOf } from 'utils/domUtils'
 
 const makeStrings = ({ deleted }: { deleted: boolean }) => ({
   deleted: deleted ? ` [Deleted By Artist]` : '',

--- a/packages/web/src/components/track/desktop/TrackListItem.tsx
+++ b/packages/web/src/components/track/desktop/TrackListItem.tsx
@@ -13,6 +13,7 @@ import Skeleton from 'components/skeleton/Skeleton'
 import TablePlayButton from 'components/tracks-table/TablePlayButton'
 import { profilePage } from 'utils/route'
 
+import { isDescendantElementOf } from '../helpers'
 import { TrackTileSize } from '../types'
 
 import styles from './TrackListItem.module.css'
@@ -85,8 +86,16 @@ const TrackListItem = ({
   }
 
   const onPlayTrack = (e?: MouseEvent) => {
-    const element = e?.target instanceof Element ? (e.target as Element) : null
-    const shouldSkipTogglePlay = menuRef.current?.contains(element)
+    // Skip toggle play if click event happened within track menu container
+    // because clicking on it should not affect corresponding track.
+    // We have to do this instead of stopping the event propagation
+    // because we need it to bubble up to the document to allow
+    // the document click listener to close other track/playlist tile menus
+    // that are already open.
+    const shouldSkipTogglePlay = isDescendantElementOf(
+      e?.target,
+      menuRef.current
+    )
     if (!deleted && togglePlay && !shouldSkipTogglePlay)
       togglePlay(track.uid, track.track_id)
   }

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -299,9 +299,7 @@ const TrackTile = memo(
                 {renderShareButton()}
               </div>
             )}
-            {!isLoading && (
-              <div onClick={onStopPropagation}>{rightActions}</div>
-            )}
+            {!isLoading && <div>{rightActions}</div>}
           </div>
         </div>
       </div>

--- a/packages/web/src/components/track/helpers.ts
+++ b/packages/web/src/components/track/helpers.ts
@@ -85,12 +85,3 @@ export const getUserWithFallback = (user: User | null) => {
     }
   )
 }
-
-export const isDescendantElementOf = (
-  descendant: any,
-  ancestor: Nullable<HTMLElement>
-) => {
-  const descendantElement =
-    descendant instanceof Element ? (descendant as Element) : null
-  return ancestor?.contains(descendantElement)
-}

--- a/packages/web/src/components/track/helpers.ts
+++ b/packages/web/src/components/track/helpers.ts
@@ -1,4 +1,10 @@
-import { Collection, FieldVisibility, Track, User } from '@audius/common'
+import {
+  Nullable,
+  Collection,
+  FieldVisibility,
+  Track,
+  User
+} from '@audius/common'
 
 const defaultFieldVisibility: FieldVisibility = {
   genre: true,
@@ -78,4 +84,13 @@ export const getUserWithFallback = (user: User | null) => {
       user_id: -1
     }
   )
+}
+
+export const isDescendantElementOf = (
+  descendant: any,
+  ancestor: Nullable<HTMLElement>
+) => {
+  const descendantElement =
+    descendant instanceof Element ? (descendant as Element) : null
+  return ancestor?.contains(descendantElement)
 }

--- a/packages/web/src/components/track/helpers.ts
+++ b/packages/web/src/components/track/helpers.ts
@@ -1,10 +1,4 @@
-import {
-  Nullable,
-  Collection,
-  FieldVisibility,
-  Track,
-  User
-} from '@audius/common'
+import { Collection, FieldVisibility, Track, User } from '@audius/common'
 
 const defaultFieldVisibility: FieldVisibility = {
   genre: true,

--- a/packages/web/src/utils/domUtils.ts
+++ b/packages/web/src/utils/domUtils.ts
@@ -1,3 +1,5 @@
+import { Nullable } from "@audius/common"
+
 export const findAncestor = (el: Element, selector: string) => {
   if (el.closest) {
     return el.closest(selector)
@@ -14,4 +16,13 @@ export const findAncestor = (el: Element, selector: string) => {
     el = el.parentElement
   }
   return el
+}
+
+export const isDescendantElementOf = (
+  descendant: any,
+  ancestor: Nullable<HTMLElement>
+) => {
+  const descendantElement =
+    descendant instanceof Element ? (descendant as Element) : null
+  return ancestor?.contains(descendantElement)
 }

--- a/packages/web/src/utils/domUtils.ts
+++ b/packages/web/src/utils/domUtils.ts
@@ -1,4 +1,4 @@
-import { Nullable } from "@audius/common"
+import { Nullable } from '@audius/common'
 
 export const findAncestor = (el: Element, selector: string) => {
   if (el.closest) {


### PR DESCRIPTION
### Description

Prevent multiple overflow menus at a time.

The issue was that there was an event.stopPropagation as the click event from the the kebab menu in the track/playlist was bubbling up. This was there so that the underlying track does not play/pause on kebab menu click. However, because the click event stopped bubbling up, the logic for the click outside of already open menus would not trigger, leaving those menus open.
This PR does not stop the click event from bubbling up to the document, and it prevents the play/pause track if the click target is from the kebab menu.

### Dragons

Other menu overflow behavior should still work as expected.

### How Has This Been Tested?

local vs stage

https://www.loom.com/share/034b9e3fb52e4ac09fdd2b975cd2ad08

### How will this change be monitored?

n/a

### Feature Flags ###

none

