### PR TITLE
CON-321 Remove rolloverNodes remote flag

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -75,6 +75,5 @@ export const remoteConfigBooleanDefaults: {
   [BooleanKeys.DISPLAY_WEB3_PROVIDER_BITSKI]: true,
   [BooleanKeys.DISPLAY_WEB3_PROVIDER_WALLET_LINK]: true,
   [BooleanKeys.DISPLAY_SOLANA_WEB3_PROVIDER_PHANTOM]: true,
-  [BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK]: false,
   [BooleanKeys.USE_AMPLITUDE]: true
 }

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -147,11 +147,6 @@ export enum BooleanKeys {
   DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP = 'DISPLAY_INSTAGRAM_VERIFICATION_WEB_AND_DESKTOP',
 
   /**
-   * Boolean to skip the rollover nodes sanity check.
-   */
-  SKIP_ROLLOVER_NODES_SANITY_CHECK = 'SKIP_ROLLOVER_NODES_SANITY_CHECK',
-
-  /**
    * Boolean to use amplitude as the metrics tracking.
    */
   USE_AMPLITUDE = 'USE_AMPLITUDE'

--- a/packages/web/src/common/services/audius-backend/AudiusBackend.ts
+++ b/packages/web/src/common/services/audius-backend/AudiusBackend.ts
@@ -551,10 +551,7 @@ export const audiusBackend = ({
 
   async function sanityChecks(audiusLibs: any) {
     try {
-      const sanityCheckOptions = {
-        skipRollover: getRemoteVar(BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK)
-      }
-      const sanityChecks = new SanityChecks(audiusLibs, sanityCheckOptions)
+      const sanityChecks = new SanityChecks(audiusLibs)
       await sanityChecks.run()
     } catch (e) {
       console.error(`Sanity checks failed: ${e}`)

--- a/packages/web/src/common/services/audius-backend/AudiusBackend.ts
+++ b/packages/web/src/common/services/audius-backend/AudiusBackend.ts
@@ -1,6 +1,5 @@
 import {
   BNWei,
-  BooleanKeys,
   ChallengeRewardID,
   CID,
   Collection,


### PR DESCRIPTION
### Description
Related to cleaning up sanity checks in SDK and removing the rolloverNodes check in https://github.com/AudiusProject/audius-protocol/pull/3658. This PR just removes references to the soon to be unused rolloverNodes.

Note - the plan here is to merge this and the libs PR once the content node side feature is ready to rollout. Making this PR a week or so ahead of schedule just so we have it ready to go.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*
Should be none, isolated to just sanityChecks in libs.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*
Tested client locally running against stage with sdk linked and everything seems to work as intended.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*
This removes features, as long as other feature flags continue to work as intended this should have no impact.

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*
Feature flags are removed 🙂 
