### PR TITLE
[C-608] Fix tooltip bugs

### DIFF
--- a/packages/web/src/components/actions-tab/ActionsTab.js
+++ b/packages/web/src/components/actions-tab/ActionsTab.js
@@ -74,7 +74,8 @@ const ExpandedActionsTab = (props) => {
       <Tooltip
         text={currentUserReposted ? 'Unrepost' : 'Repost'}
         disabled={isHidden || isDisabled || isOwner}
-        placement={direction === 'horizontal' ? 'bottom' : 'right'}
+        placement={direction === 'horizontal' ? 'top' : 'right'}
+        mount='page'
       >
         <div
           className={cn(styles.actionButton, {
@@ -87,7 +88,7 @@ const ExpandedActionsTab = (props) => {
             disabled={currentUserReposted || isHidden || isDisabled || isOwner}
             delay={REPOST_TOAST_TIMEOUT_MILLIS}
             containerClassName={styles.actionIconContainer}
-            placement={direction === 'horizontal' ? 'bottom' : 'right'}
+            placement={direction === 'horizontal' ? 'top' : 'right'}
           >
             <IconRepost
               className={cn(styles.iconRepost, {
@@ -100,7 +101,8 @@ const ExpandedActionsTab = (props) => {
       <Tooltip
         text='Share'
         disabled={isHidden || isDisabled}
-        placement={direction === 'horizontal' ? 'bottom' : 'right'}
+        placement={direction === 'horizontal' ? 'top' : 'right'}
+        mount='page'
       >
         <div
           className={styles.actionButton}

--- a/packages/web/src/components/card/desktop/Card.module.css
+++ b/packages/web/src/components/card/desktop/Card.module.css
@@ -16,7 +16,7 @@
   background-color: var(--neutral-light-10);
   box-shadow: 0 1px 5px 1px var(--tile-shadow-1-alt),
     0 1px 0 0 var(--tile-shadow-2), 0 2px 10px -2px var(--tile-shadow-3);
-  transform: scale(1.02);
+  transform: scale3d(1.01, 1.01, 1.01);
 }
 
 .cardContainer:active {

--- a/packages/web/src/components/nav/desktop/NavColumn.tsx
+++ b/packages/web/src/components/nav/desktop/NavColumn.tsx
@@ -469,7 +469,9 @@ const NavColumn = ({
                             ? messages.newPlaylistOrFolderTooltip
                             : messages.newPlaylistTooltip
                         }
-                        mount='parent'
+                        getPopupContainer={() =>
+                          scrollbarRef.current?.parentNode
+                        }
                       >
                         <span>
                           <Pill

--- a/packages/web/src/components/tooltip/Tooltip.tsx
+++ b/packages/web/src/components/tooltip/Tooltip.tsx
@@ -24,7 +24,7 @@ export const Tooltip = ({
   text = ''
 }: TooltipProps) => {
   // Keep track of a hidden state ourselves so we can dismiss the tooltip on click
-  const [isHidden, setIsHidden] = useState(false)
+  const [isHiddenOverride, setIsHiddenOverride] = useState(false)
 
   // Keep track of whether we are hovering over the tooltip to know when to
   // allow it to become visible again
@@ -32,14 +32,17 @@ export const Tooltip = ({
 
   const onClick = useCallback(() => {
     if (shouldDismissOnClick) {
-      setIsHidden(true)
+      setIsHiddenOverride(true)
     }
-  }, [shouldDismissOnClick, setIsHidden])
+  }, [shouldDismissOnClick, setIsHiddenOverride])
 
   const onMouseOut = useCallback(() => {
     mousedOver.current = false
-    setIsHidden(false)
-  }, [mousedOver, setIsHidden])
+    // Reset the hidden override if we are mousing
+    // out from the tooltip so that it can be used to
+    // hide the tooltip on the next hover.
+    setIsHiddenOverride(false)
+  }, [mousedOver, setIsHiddenOverride])
 
   const onMouseOver = useCallback(() => {
     mousedOver.current = true
@@ -50,10 +53,10 @@ export const Tooltip = ({
       // Reset the hidden override if we are becoming invisible or
       // the mouse is not overtop the tooltip
       if (!visible || !mousedOver.current) {
-        setIsHidden(false)
+        setIsHiddenOverride(false)
       }
     },
-    [setIsHidden]
+    [setIsHiddenOverride]
   )
 
   let popupContainer
@@ -71,11 +74,11 @@ export const Tooltip = ({
 
   // Keep track of visibility to override antd's native visibility.
   // Use an empty object when visible as to not trigger the antd component to update
-  const visibleProps = disabled || isHidden ? { visible: false } : {}
+  const visibleProps = disabled || isHiddenOverride ? { visible: false } : {}
   // Use a css property so that when we change visibility on click the tooltip
   // immediately disappears instead of animating out.
   const overlayStyle = {
-    visibility: isHidden ? 'hidden' : 'visible'
+    visibility: isHiddenOverride ? 'hidden' : 'visible'
   } as CSSProperties
 
   return (

--- a/packages/web/src/components/tooltip/Tooltip.tsx
+++ b/packages/web/src/components/tooltip/Tooltip.tsx
@@ -16,6 +16,7 @@ export const Tooltip = ({
   color = themeColors['--secondary-transparent'],
   disabled = false,
   mount = 'parent',
+  getPopupContainer,
   mouseEnterDelay = 0.5,
   mouseLeaveDelay = 0,
   placement = 'top',
@@ -89,7 +90,7 @@ export const Tooltip = ({
       title={text}
       color={color}
       // @ts-ignore
-      getPopupContainer={popupContainer}
+      getPopupContainer={getPopupContainer || popupContainer}
       overlayClassName={cn(styles.tooltip, className, {
         [styles.nonWrappingTooltip]: !shouldWrapContent
       })}

--- a/packages/web/src/components/tooltip/types.ts
+++ b/packages/web/src/components/tooltip/types.ts
@@ -17,6 +17,7 @@ export type TooltipProps = {
   mouseEnterDelay?: number
   mouseLeaveDelay?: number
   placement?: TooltipPlacement
+  // Should the tooltip go away when clicking on the underlying element?
   shouldDismissOnClick?: boolean
   // Whether there is a fixed max width, causing content to wrap onto the next line.
   shouldWrapContent?: boolean

--- a/packages/web/src/components/tooltip/types.ts
+++ b/packages/web/src/components/tooltip/types.ts
@@ -12,8 +12,11 @@ export type TooltipProps = {
   color?: string
   // determines if it should display.
   disabled?: boolean
-  // Whether the tooltip gets mounted.
+  // Where the tooltip gets mounted.
   mount?: 'parent' | 'page' | 'body'
+  // Whether the tooltip should have a custom container/mount.
+  // Takes precedence over `mount`
+  getPopupContainer?: () => React.ReactNode
   mouseEnterDelay?: number
   mouseLeaveDelay?: number
   placement?: TooltipPlacement

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -108,6 +108,7 @@ const TrackTile = memo(
           text={'Share'}
           disabled={isDisabled || hideShare}
           placement={'bottom'}
+          mount='page'
         >
           <div
             className={cn(styles.iconButtonContainer, {
@@ -257,6 +258,7 @@ const TrackTile = memo(
                   text={repostLabel}
                   disabled={isDisabled || isOwner}
                   placement={'bottom'}
+                  mount='page'
                 >
                   <div
                     className={cn(styles.iconButtonContainer, {
@@ -279,6 +281,7 @@ const TrackTile = memo(
                   text={isFavorited ? 'Unfavorite' : 'Favorite'}
                   disabled={isDisabled || isOwner}
                   placement={'bottom'}
+                  mount='page'
                 >
                   <div
                     className={cn(styles.iconButtonContainer, {

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -107,7 +107,7 @@ const TrackTile = memo(
         <Tooltip
           text={'Share'}
           disabled={isDisabled || hideShare}
-          placement={'bottom'}
+          placement='top'
           mount='page'
         >
           <div
@@ -257,7 +257,7 @@ const TrackTile = memo(
                 <Tooltip
                   text={repostLabel}
                   disabled={isDisabled || isOwner}
-                  placement={'bottom'}
+                  placement='top'
                   mount='page'
                 >
                   <div
@@ -280,7 +280,7 @@ const TrackTile = memo(
                 <Tooltip
                   text={isFavorited ? 'Unfavorite' : 'Favorite'}
                   disabled={isDisabled || isOwner}
-                  placement={'bottom'}
+                  placement='top'
                   mount='page'
                 >
                   <div


### PR DESCRIPTION
### Description

Fix tooltip bugs. There were kind of a few things that were causing jankiness, primarily the timeout though, which is a blunt weapon to handle this kinda stuff. This is why I kinda dislike antd... Have to learn about the internals a little bit to get the behavior.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Focused on 3 places
- GiantTrackTile (track page): to test the bug in the linear issue -- tooltip appearing after clicking
- Receive $AUDIO modal -- to test that the tooltip goes away when you click, even if you're still hovering over the element
- Track tile on feed: to test that the tooltip goes away when you click, but also that you can summon it by hovering over again

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

