### PR TITLE
[C-773] Prevent showing file explorer on pressing enter

### DIFF
--- a/packages/web/src/components/image-selection/ImageSelectionButton.js
+++ b/packages/web/src/components/image-selection/ImageSelectionButton.js
@@ -44,7 +44,13 @@ const ImageSelectionButton = ({
     if (onOpenPopup) onOpenPopup()
   }
 
-  const handleClick = () => {
+  const handleClick = (e) => {
+    // if it's a keyboard event, the event detail is 0
+    // ignore the default click event in that case
+    // note that trying "e instanceof KeyboardEvent" did not work here
+    if (e.detail === 0) {
+      e.preventDefault()
+    }
     if (!showModal) {
       onClick()
       openModal()


### PR DESCRIPTION
### Description

Prevent showing file explorer on pressing enter and file open button not on focus.
We still have the ability to not only show the explorer on button click, but also on pressing enter/space as long as the button is on focus.

### Dragons

n/a

### How Has This Been Tested?

local against stage

### How will this change be monitored?

n/a

### Feature Flags ###

none

