### PR TITLE
[C-797] Fix track-remix-screen text color

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   },
   text: {
     ...typography.body,
+    color: palette.neutral,
     textAlign: 'center',
     lineHeight: 20
   },


### PR DESCRIPTION
### Description

Ensures header text in TrackRemixScreen is color is neutral

<img width="405" alt="image" src="https://user-images.githubusercontent.com/8230000/183995415-bdf3fbd6-188b-4035-960e-4c5a9cb6bf15.png">

