### PR TITLE
[C-808] Don't show unnecessarily show profile option on overflow menu

### DIFF
--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -93,6 +93,10 @@ const TrackTileComponent = ({
     track_id
   } = track
 
+  const currentScreen = navigation.getState().history?.[0]
+  // @ts-expect-error
+  const isOnArtistsTracksTab = currentScreen?.key.includes('Tracks')
+
   const { user_id } = user
 
   const isOwner = user_id === currentUserId
@@ -141,7 +145,7 @@ const TrackTileComponent = ({
       OverflowAction.SHARE,
       OverflowAction.ADD_TO_PLAYLIST,
       OverflowAction.VIEW_TRACK_PAGE,
-      OverflowAction.VIEW_ARTIST_PAGE
+      isOnArtistsTracksTab ? null : OverflowAction.VIEW_ARTIST_PAGE
     ].filter(Boolean) as OverflowAction[]
 
     dispatchWeb(

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -94,7 +94,7 @@ const TrackTileComponent = ({
   } = track
 
   const currentScreen = navigation.getState().history?.[0]
-  // @ts-expect-error
+  // @ts-expect-error -- history returning unknown[]
   const isOnArtistsTracksTab = currentScreen?.key.includes('Tracks')
 
   const { user_id } = user

--- a/packages/mobile/src/components/track-list/TrackList.tsx
+++ b/packages/mobile/src/components/track-list/TrackList.tsx
@@ -86,7 +86,7 @@ export const TrackList = ({
   )
 
   const renderDraggableTrack: DraggableFlatListProps<TrackMetadata>['renderItem'] =
-    ({ item: track, index = -1, drag, isActive: isDragActive }) => {
+    ({ item: track, index = -1, drag }) => {
       const isActive = track.uid !== undefined && track.uid === playingUid
 
       // The dividers above and belove the active track should be hidden
@@ -108,7 +108,6 @@ export const TrackList = ({
             drag={drag}
             hideArt={hideArt}
             isActive={isActive}
-            isDragging={isDragActive}
             isPlaying={isPlaying}
             isReorderable={isReorderable}
             track={track}

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -89,10 +89,8 @@ export type TrackListItemProps = {
   hideArt?: boolean
   index: number
   isActive?: boolean
-  isDragging?: boolean
   isLoading?: boolean
   isPlaying?: boolean
-  isRemoveActive?: boolean
   isReorderable?: boolean
   onRemove?: (index: number) => void
   onSave?: (isSaved: boolean, trackId: ID) => void
@@ -106,8 +104,6 @@ export const TrackListItem = ({
   hideArt,
   index,
   isActive,
-  isDragging = false,
-  isRemoveActive = false,
   isReorderable = false,
   isLoading = false,
   isPlaying = false,

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -57,6 +57,7 @@ export const useNavigation = <
 
   return useMemo(
     () => ({
+      ...nativeNavigation,
       navigate: performNavigation(nativeNavigation.navigate),
       push:
         'push' in nativeNavigation


### PR DESCRIPTION
### Description

Fixes case where artist's track's overflow menu shows option to go to artist page, which doesn't make sense since we are already on the artist page

### Dragons

Definitely a bit hacky.

