### PR TITLE
[C-815] Fix electron update

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -109,6 +109,9 @@
     "webpack-bundle-analyzer": "4.5.0"
   },
   "main": "src/electron.js",
+  "build": {
+    "extends": null
+  },
   "scripts": {
     "configure-local-env": "node ./scripts/configureLocalEnv.js",
     "configure-local-env-cloud": "node ./scripts/configureLocalEnv.js --remote-host",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -109,9 +109,6 @@
     "webpack-bundle-analyzer": "4.5.0"
   },
   "main": "src/electron.js",
-  "build": {
-    "extends": null
-  },
   "scripts": {
     "configure-local-env": "node ./scripts/configureLocalEnv.js",
     "configure-local-env-cloud": "node ./scripts/configureLocalEnv.js --remote-host",

--- a/packages/web/src/electron.js
+++ b/packages/web/src/electron.js
@@ -31,6 +31,10 @@ const Environment = Object.freeze({
 const args = process.argv.slice(2)
 const appVersion = require('../package.json').version
 
+const appDataPath = (relativePath) => {
+  return path.resolve(app.getPath('appData'), app.getName(), relativePath)
+}
+
 let appEnvironment,
   buildName,
   localhostPort,
@@ -141,8 +145,8 @@ const registerBuild = (directory) => {
 }
 
 const downloadWebUpdateAndNotify = async (newVersion) => {
-  const newBuildPath = path.resolve(app.getAppPath(), `${buildName}.tar.gz`)
-  const webUpdateDir = path.resolve(app.getAppPath(), `web-update`)
+  const newBuildPath = appDataPath(`${buildName}.tar.gz`)
+  const webUpdateDir = appDataPath('web-update')
   const fileStream = fs.createWriteStream(newBuildPath)
 
   // Fetch the build tar.gz file and write to file
@@ -158,7 +162,7 @@ const downloadWebUpdateAndNotify = async (newVersion) => {
   // Create web-update directory and untar the build inside
   if (!fs.existsSync(webUpdateDir)) fs.mkdirSync(webUpdateDir)
   tar.x({
-    cwd: path.resolve(app.getAppPath(), `web-update`),
+    cwd: webUpdateDir,
     file: newBuildPath
   })
 
@@ -178,18 +182,12 @@ const checkForWebUpdate = () => {
     const newVersion = packageJson.version
 
     let currentVersion = appVersion
+    const packageJsonPath = appDataPath(`${buildName}/package.json`)
 
     // Additional check for the version from the build package.json
     // Needed after web updates because the local package.json version is not updated
-    if (
-      fs.existsSync(path.resolve(app.getAppPath(), `${buildName}/package.json`))
-    ) {
-      const buidlPackageJson = JSON.parse(
-        fs.readFileSync(
-          path.resolve(app.getAppPath(), `${buildName}/package.json`)
-        )
-      )
-
+    if (fs.existsSync(packageJsonPath)) {
+      const buidlPackageJson = JSON.parse(fs.readFileSync(packageJsonPath))
       currentVersion = buidlPackageJson.version
     }
 
@@ -258,7 +256,14 @@ const createWindow = () => {
     mainWindow.loadURL(`http://localhost:${localhostPort}`)
   } else {
     const buildDirectory = path.resolve(app.getAppPath(), buildName)
-    registerBuild(buildDirectory)
+    const updateBuildDirectory = appDataPath(buildName)
+
+    // Register the updated build if it exists, otherwise use the default build found via `getAppPath`
+    registerBuild(
+      fs.existsSync(updateBuildDirectory)
+        ? updateBuildDirectory
+        : buildDirectory
+    )
     checkForWebUpdate()
 
     // Win protocol handler
@@ -431,34 +436,25 @@ ipcMain.on('update', async (event, arg) => {
 })
 
 ipcMain.on('web-update', async (event, arg) => {
-  if (
-    fs.existsSync(path.resolve(app.getAppPath(), `web-update/${buildName}`))
-  ) {
+  const buildPath = appDataPath(`web-update/packages/web/${buildName}`)
+  if (fs.existsSync(buildPath)) {
     try {
-      // Rename web-update dir and move to base folder
-      fs.renameSync(
-        path.resolve(app.getAppPath(), `web-update/${buildName}`),
-        path.resolve(app.getAppPath(), `${buildName}-new`)
-      )
-      // Remove the web-update dir
-      fs.rmdirSync(path.resolve(app.getAppPath(), 'web-update'))
-      // Rename old dir to old
-      fs.renameSync(
-        path.resolve(app.getAppPath(), buildName),
-        path.resolve(app.getAppPath(), `${buildName}-old`)
-      )
-      // Rename new dir to current name
-      fs.renameSync(
-        path.resolve(app.getAppPath(), `${buildName}-new`),
-        path.resolve(app.getAppPath(), buildName)
-      )
-      // Remove old dir
-      fs.rmdirSync(path.resolve(app.getAppPath(), `${buildName}-old`), {
+      // Remove the existing build
+      fs.rmdirSync(appDataPath(buildName), {
         recursive: true,
         force: true
       })
 
-      registerBuild(path.resolve(app.getAppPath(), buildName))
+      // Rename web-update dir and move to base folder
+      fs.renameSync(buildPath, appDataPath(buildName))
+
+      // Remove the web-update dir
+      fs.rmdirSync(appDataPath('web-update'), {
+        recursive: true,
+        force: true
+      })
+
+      registerBuild(appDataPath(buildName))
     } catch (error) {
       console.error(error)
     }

--- a/packages/web/src/electron.js
+++ b/packages/web/src/electron.js
@@ -187,8 +187,8 @@ const checkForWebUpdate = () => {
     // Additional check for the version from the build package.json
     // Needed after web updates because the local package.json version is not updated
     if (fs.existsSync(packageJsonPath)) {
-      const buidlPackageJson = JSON.parse(fs.readFileSync(packageJsonPath))
-      currentVersion = buidlPackageJson.version
+      const buildPackageJson = JSON.parse(fs.readFileSync(packageJsonPath))
+      currentVersion = buildPackageJson.version
     }
 
     // If there is a patch version update, download it and notify the user


### PR DESCRIPTION
### Description

* Use `app.getPath('appData')` instead of `app.getAppPath` to store/retrieve the update builds because `app.getAppPath` can't apparently be modified when the app is built using electron-build (it's packaged into a single file)
* On initial build registration, conditionally register the build located in the app data directory (if an update has been previously applied)
* Update logic of replacing builds on update because they are now stored in a different location
> For some reason the `packages/web` path was not being accounted for, did something change the structure of the s3 bucket?
* Add `appDataPath` helper

### Dragons

I would like to test this on windows. Does anyone have a windows machine to test on?

Also need prevent auto updater from downloading full update if only a patch version is required (still think this is happening), will address in separate pr

### How Has This Been Tested?

Tested via `npm run electron:stage` and `npm run dist:stage`

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

