### PR TITLE
[C-838] Fix desktop update banner flow

### DIFF
--- a/packages/web/src/electron.js
+++ b/packages/web/src/electron.js
@@ -468,6 +468,7 @@ ipcMain.on('quit', (event, arg) => {
   app.exit(0)
 })
 
+// We have finished downloading the electron update
 autoUpdater.on('update-downloaded', (info) => {
   console.log('update-downloaded', info)
   canUpdate = true
@@ -475,18 +476,11 @@ autoUpdater.on('update-downloaded', (info) => {
   if (mainWindow) mainWindow.webContents.send('updateDownloaded', info)
 })
 
+// We have discovered that there is an available electron update
 autoUpdater.on('update-available', (info) => {
   console.log('update-available', info)
   info.currentVersion = autoUpdater.currentVersion.version
-  const sameMajorAndMinor =
-    semver.major(info.currentVersion) === semver.major(info.version) &&
-    semver.minor(info.currentVersion) === semver.minor(info.version)
-
-  if (!sameMajorAndMinor && mainWindow) {
-    // Display an update available UI in the case that a non-patch version is
-    // available. Otherwise, result to install on quit.
-    mainWindow.webContents.send('updateAvailable', info)
-  }
+  if (mainWindow) mainWindow.webContents.send('updateAvailable', info)
 })
 
 autoUpdater.on('download-progress', (info) => {

--- a/packages/web/src/electron.js
+++ b/packages/web/src/electron.js
@@ -478,7 +478,15 @@ autoUpdater.on('update-downloaded', (info) => {
 autoUpdater.on('update-available', (info) => {
   console.log('update-available', info)
   info.currentVersion = autoUpdater.currentVersion.version
-  if (mainWindow) mainWindow.webContents.send('updateAvailable', info)
+  const sameMajorAndMinor =
+    semver.major(info.currentVersion) === semver.major(info.version) &&
+    semver.minor(info.currentVersion) === semver.minor(info.version)
+
+  if (!sameMajorAndMinor && mainWindow) {
+    // Display an update available UI in the case that a non-patch version is
+    // available. Otherwise, result to install on quit.
+    mainWindow.webContents.send('updateAvailable', info)
+  }
 })
 
 autoUpdater.on('download-progress', (info) => {

--- a/packages/web/src/pages/App.js
+++ b/packages/web/src/pages/App.js
@@ -209,10 +209,13 @@ class App extends Component {
     showCTABanner: false,
     showWeb3ErrorBanner: null,
 
-    showUpdateAppBanner: false,
+    // A patch version update of the web app is available
     showWebUpdateBanner: false,
-    showRequiresUpdate: false,
+    // A version update of the web app is required
     showRequiresWebUpdate: false,
+    // A minor version update of the entire electron app is required
+    showRequiresUpdate: false,
+
     isUpdating: false,
 
     initialPage: true,
@@ -255,7 +258,6 @@ class App extends Component {
       // We downloaded an update, the user can safely restart
       this.ipc.on('updateDownloaded', (event, arg) => {
         console.info('updateDownload', event, arg)
-        this.setState({ showUpdateAppBanner: true })
       })
 
       this.ipc.on('updateDownloadProgress', (event, arg) => {
@@ -437,9 +439,6 @@ class App extends Component {
   }
 
   acceptUpdateApp = () => {
-    if (this.state.showUpdateAppBanner) {
-      this.dismissUpdateAppBanner()
-    }
     this.setState({ isUpdating: true })
     this.ipc.send('update')
   }
@@ -452,10 +451,6 @@ class App extends Component {
     }
     this.setState({ isUpdating: true })
     this.ipc.send('web-update')
-  }
-
-  dismissUpdateAppBanner = () => {
-    this.setState({ showUpdateAppBanner: false })
   }
 
   dismissUpdateWebAppBanner = () => {
@@ -487,8 +482,7 @@ class App extends Component {
 
     const {
       showCTABanner,
-      showUpdateAppBanner,
-      showWebUpdate,
+      showWebUpdateBanner,
       showWeb3ErrorBanner,
       isUpdating,
       showRequiresUpdate,
@@ -517,7 +511,7 @@ class App extends Component {
       )
 
     const showBanner =
-      showCTABanner || showUpdateAppBanner || showWeb3ErrorBanner
+      showCTABanner || showWeb3ErrorBanner || showWebUpdateBanner
     if (this.headerGutterRef.current) {
       if (showBanner) {
         this.headerGutterRef.current.classList.add(styles.bannerMargin)
@@ -540,12 +534,6 @@ class App extends Component {
             onAccept={this.showDownloadAppModal}
           />
         ) : null}
-        {showUpdateAppBanner ? (
-          <UpdateAppBanner
-            onClose={this.dismissUpdateAppBanner}
-            onAccept={this.acceptUpdateApp}
-          />
-        ) : null}
         {showWeb3ErrorBanner ? (
           <Web3ErrorBanner
             alert
@@ -553,7 +541,7 @@ class App extends Component {
             onClose={this.dismissWeb3ErrorBanner}
           />
         ) : null}
-        {showWebUpdate ? (
+        {showWebUpdateBanner ? (
           <UpdateAppBanner
             onAccept={this.acceptWebUpdate}
             onClose={this.dismissUpdateWebAppBanner}

--- a/packages/web/src/pages/App.js
+++ b/packages/web/src/pages/App.js
@@ -280,7 +280,7 @@ class App extends Component {
         if (semver.lt(currentVersion, minAppVersion)) {
           this.setState({ showRequiresWebUpdate: true })
         } else {
-          this.setState({ showWebUpdate: true })
+          this.setState({ showWebUpdateBanner: true })
         }
       })
 


### PR DESCRIPTION
### Description

Redid this PR from scratch. @sliptype / @Kyle-Shanks could use extra scrutiny here.

I think there are still two issues with the desktop update flow that prevent "web app" updates from working:

1. we trigger an electron banner update and a web banner update at the same time
2. we are using some state variable `showWebUpdate` to determine whether to show the web update banner, and i'm pretty sure that never gets set to true (it's `showWebUpdateBanner`), so `#1` isn't actually an issue we observe

These changes are set up in a way such though that when we download the electron changes in the background, on restarting, the user will still get the full electron update.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Will test after merge to main via the staging desktop app

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

