### PR TITLE
[PAY-497] Fix native mobile install challenge

### DIFF
--- a/packages/web/src/common/store/challenges/selectors/optimistic-challenges.ts
+++ b/packages/web/src/common/store/challenges/selectors/optimistic-challenges.ts
@@ -93,7 +93,7 @@ const toOptimisticChallenge = (
   // on DN, so optimistically mark this challenge as complete so the client
   // can start claiming
   if (challenge.challenge_id === 'mobile-install' && NATIVE_MOBILE) {
-    challenge.is_complete = true
+    challengeOverridden.is_complete = true
   }
 
   const state = getUserChallengeState(challengeOverridden)

--- a/packages/web/src/common/store/challenges/selectors/optimistic-challenges.ts
+++ b/packages/web/src/common/store/challenges/selectors/optimistic-challenges.ts
@@ -16,6 +16,7 @@ import { UndisbursedUserChallenge } from 'common/store/pages/audio-rewards/slice
 import { CommonState } from '../..'
 
 import { getCompletionStages } from './profile-progress'
+const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 
 /**
  * Gets the state of a user challenge, with the most progress dominating
@@ -86,6 +87,13 @@ const toOptimisticChallenge = (
     challengeOverridden.current_step_count = currentStepCountOverride
     challengeOverridden.is_complete =
       currentStepCountOverride >= challengeOverridden.max_steps
+  }
+
+  // If we're on native mobile, we might not yet have the is_mobile user_event
+  // on DN, so optimistically mark this challenge as complete so the client
+  // can start claiming
+  if (challenge.challenge_id === 'mobile-install' && NATIVE_MOBILE) {
+    challenge.is_complete = true
   }
 
   const state = getUserChallengeState(challengeOverridden)


### PR DESCRIPTION
### Description
There is a bug where if you sign up on web and then load your account into mobile, we don't mark the mobile install challenge as claimable because your is_mobile user_events haven't propagated to DN yet. So optimistically mark this challenge as claimable if mobile.

I was a bit on the fence about where to put this check - at first I was going to put it in userChallengeOverrides in the slice, which required adding a new action, and then felt that dispatching an action was really indirect compared to just putting this check in the obvious place, even though it makes this code more tightly coupled to a specific challenge now. 

### Dragons

None

### How Has This Been Tested?

I haven't tested this yet :) 

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

