### PR TITLE
[PAY-531] Fix become first supporter bug

### DIFF
--- a/packages/mobile/src/screens/tip-artist-screen/SendTipScreen.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/SendTipScreen.tsx
@@ -10,7 +10,8 @@ import {
 } from 'audius-client/src/common/store/tipping/selectors'
 import {
   sendTip,
-  fetchUserSupporter
+  fetchUserSupporter,
+  refreshSupport
 } from 'audius-client/src/common/store/tipping/slice'
 import { getAccountBalance } from 'audius-client/src/common/store/wallet/selectors'
 import { getBalance } from 'audius-client/src/common/store/wallet/slice'
@@ -66,6 +67,7 @@ export const SendTipScreen = () => {
   const {
     amountToTipToBecomeTopSupporter,
     shouldFetchUserSupporter,
+    shouldFetchSupportersForReceiver,
     isFirstSupporter,
     tipAmountWei,
     hasInsufficientBalance
@@ -89,6 +91,17 @@ export const SendTipScreen = () => {
       )
     }
   }, [shouldFetchUserSupporter, account, receiver, dispatchWeb])
+
+  useEffect(() => {
+    if (shouldFetchSupportersForReceiver && account && receiver) {
+      dispatchWeb(
+        refreshSupport({
+          senderUserId: account.user_id,
+          receiverUserId: receiver.user_id
+        })
+      )
+    }
+  }, [shouldFetchSupportersForReceiver, account, receiver, dispatchWeb])
 
   const handleBack = useCallback(() => {
     navigation.goBack()

--- a/packages/web/src/common/store/tipping/selectors.ts
+++ b/packages/web/src/common/store/tipping/selectors.ts
@@ -53,7 +53,7 @@ const mergeMaps = <
       // in the overrides but not in the default,
       // OR
       // if the existing value in the default map has a smaller amount
-      // than that in the override, the update default value with the
+      // than that in the override, then update default value with the
       // override value
       const supportIds = Object.keys(mapOverrides[userId]) as unknown as ID[]
       for (const supportId of supportIds) {

--- a/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
+++ b/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
@@ -12,10 +12,7 @@ import {
 
 import { SupportersMap, SupportingMap } from 'common/store/tipping/types'
 import { parseWeiNumber } from 'common/utils/formatUtil'
-import {
-  parseAudioInputToWei,
-  stringWeiToBN
-} from 'common/utils/wallet'
+import { parseAudioInputToWei, stringWeiToBN } from 'common/utils/wallet'
 
 const zeroWei = stringWeiToBN('0' as StringWei)
 

--- a/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
+++ b/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
@@ -77,7 +77,7 @@ export const useGetFirstOrTopSupporter = ({
    * not the same as the current user
    */
   useEffect(() => {
-    if (!account || !receiver) return
+    if (!receiver) return
 
     const supportersForReceiver = supportersMap[receiver.user_id]
 
@@ -108,7 +108,7 @@ export const useGetFirstOrTopSupporter = ({
     } else {
       setIsFirstSupporter(true)
     }
-  }, [account, receiver, supportersMap])
+  }, [receiver, supportersMap])
 
   /**
    * Check whether or not to display prompt to become top or first supporter

--- a/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
+++ b/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
@@ -16,8 +16,6 @@ import {
   parseAudioInputToWei,
   stringWeiToBN
 } from 'common/utils/wallet'
-// import { useDispatch } from 'react-redux'
-// import { refreshSupport } from 'common/store/tipping/slice'
 
 const zeroWei = stringWeiToBN('0' as StringWei)
 
@@ -43,7 +41,6 @@ export const useGetFirstOrTopSupporter = ({
   supportingMap,
   supportersMap
 }: UseGetSupportProps) => {
-  // const dispatch = useDispatch()
   const [amountToTipToBecomeTopSupporter, setAmountToTipToBecomeTopSupporter] =
     useState<Nullable<BNWei>>(null)
   const [supportingAmount, setSupportingAmount] =
@@ -94,13 +91,6 @@ export const useGetFirstOrTopSupporter = ({
     // but that user's supporters may not have been fetched yet.
     if (!supportersForReceiver) {
       setShouldFetchSupportersForReceiver(true)
-      // dispatch(fetchSupportingForUser({ userId: account.user_id }))
-      // dispatch(
-      //   refreshSupport({
-      //     senderUserId: account.user_id,
-      //     receiverUserId: receiver.user_id
-      //   })
-      // )
       return
     }
 
@@ -122,7 +112,6 @@ export const useGetFirstOrTopSupporter = ({
       setIsFirstSupporter(true)
     }
   }, [account, receiver, supportersMap])
-  // }, [dispatch, account, receiver, supportersMap])
 
   /**
    * Check whether or not to display prompt to become top or first supporter

--- a/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
+++ b/packages/web/src/hooks/useGetFirstOrTopSupporter.ts
@@ -82,7 +82,7 @@ export const useGetFirstOrTopSupporter = ({
     const supportersForReceiver = supportersMap[receiver.user_id]
 
     // It's possible that the receiver's supporters have not yet
-    // been fetched, in this case we fetch that data.
+    // been fetched, in this case we prompt to fetch that data.
     // E.g. for a user whose top supporter changed, clicking on
     // the dethroned notification will go to the send tip modal/drawer
     // but that user's supporters may not have been fetched yet.


### PR DESCRIPTION
### Description

This bug is new because it's now possible to tip a user without going to their profile and without clicking from the feed tip tile. The bug is because the receiver's supporters weren't fetched and so the UI thinks there is no supporter for the user.
So the fix is to fetch that user i.e. the receiver's supporters.

=====

I think this change will make sure that the account and receiver's necessary supporting / supporters exist, so if there is another UI flow that goes into tipping in the future, we'd still be okay.

https://user-images.githubusercontent.com/9600175/185279845-c84e3b50-af10-4df7-9660-8913f2be4ce0.mov

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

mobile against local dapp pointing to prod

### How will this change be monitored?

n/a

### Feature Flags ###

none

