### PR TITLE
Fix eager discovery loader

### DIFF
--- a/packages/web/src/services/audius-backend/eagerLoadUtils.ts
+++ b/packages/web/src/services/audius-backend/eagerLoadUtils.ts
@@ -13,24 +13,19 @@ export const getEagerDiscprov = () => {
   const cachedDiscProvData = window.localStorage.getItem(
     DISCOVERY_PROVIDER_TIMESTAMP
   )
-  if (!cachedDiscProvData) {
-    return null
-  }
-
-  const cachedDiscprov = JSON.parse(cachedDiscProvData)
-
-  const EAGER_DISCOVERY_NODES = process.env.REACT_APP_EAGER_DISCOVERY_NODES
-    ? process.env.REACT_APP_EAGER_DISCOVERY_NODES.split(',')
-    : []
 
   // Set the eager discprov to use to either
   // 1. local storage discprov if available
   // 2. dapp whitelist
   // Note: This discovery provider is only used on intial paint
   let eagerDiscprov: string
-  if (cachedDiscprov) {
+  if (cachedDiscProvData) {
+    const cachedDiscprov = JSON.parse(cachedDiscProvData)
     eagerDiscprov = cachedDiscprov.endpoint
   } else {
+    const EAGER_DISCOVERY_NODES = process.env.REACT_APP_EAGER_DISCOVERY_NODES
+      ? process.env.REACT_APP_EAGER_DISCOVERY_NODES.split(',')
+      : []
     eagerDiscprov =
       EAGER_DISCOVERY_NODES[
         Math.floor(Math.random() * EAGER_DISCOVERY_NODES.length)


### PR DESCRIPTION
### Description

Eager loader is returning early if no cached value. Instead we should pull from the env vars set in the .env file.

Observed behavior is when you load localhost:3001/df/playlist/probers_playlist_do_not_delete-511 in incognito for the first time, it would crash b/c we can't initialize API client w/o some discovery node.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally w/ probers

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

