### PR TITLE
Get sign in/out working end to end

### DIFF
--- a/packages/mobile/src/components/sign-out-confirmation-drawer/SignOutConfirmationDrawer.tsx
+++ b/packages/mobile/src/components/sign-out-confirmation-drawer/SignOutConfirmationDrawer.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from 'react'
 
-import { signOut } from 'audius-client/src/common/store/sign-out/slice'
+import { signOut } from 'common/store/sign-out/slice'
 import { View } from 'react-native'
+import { useDispatch } from 'react-redux'
 
 import { Button, Text } from 'app/components/core'
 import { AppDrawer, useDrawerState } from 'app/components/drawer/AppDrawer'
@@ -37,16 +38,18 @@ const useStyles = makeStyles(({ spacing }) => ({
 export const SignOutConfirmationDrawer = () => {
   const styles = useStyles()
   const dispatchWeb = useDispatchWeb()
+  const dispatch = useDispatch()
   const { clearHistory } = useSearchHistory()
 
   const { onClose } = useDrawerState(MODAL_NAME)
 
   const handleSignOut = useCallback(() => {
-    dispatchWeb(signOut)
+    dispatch(signOut({}))
     // TODO: move to the sign-out saga when store migrated to react-native
+    dispatchWeb(signOut)
     clearHistory()
     onClose()
-  }, [dispatchWeb, clearHistory, onClose])
+  }, [dispatchWeb, dispatch, clearHistory, onClose])
 
   return (
     <AppDrawer modalName={MODAL_NAME} title={messages.drawerTitle}>

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -649,7 +649,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
                   // in case email is what was wrong with the credentials
                   setShowDefaultError(true)
                 }
-              } else if (emailIsAvailable && emailStatus === 'done') {
+              } else if (emailIsAvailable && emailStatus === 'success') {
                 dispatch(signOnActionsLegacy.signinFailedReset())
                 setIsWorking(false)
                 navigation.replace('CreatePassword', { email })

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -2,7 +2,13 @@ import { useState, useRef, useEffect, useCallback } from 'react'
 
 import Clipboard from '@react-native-clipboard/clipboard'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
-import * as signOnActions from 'audius-client/src/common/store/pages/signon/actions'
+import { getAccountUser } from 'audius-client/src/common/store/account/selectors'
+import * as signOnActions from 'common/store/pages/signon/actions'
+import {
+  getPasswordField,
+  getEmailField,
+  getStatus
+} from 'common/store/pages/signon/selectors'
 import querystring from 'query-string'
 import {
   Animated,
@@ -36,14 +42,8 @@ import { MessageType } from 'app/message/types'
 import { track, make } from 'app/services/analytics'
 import { setVisibility } from 'app/store/drawers/slice'
 import { getIsKeyboardOpen } from 'app/store/keyboard/selectors'
-import { getIsSignedIn, getDappLoaded } from 'app/store/lifecycle/selectors'
+import { getDappLoaded, getIsSignedIn } from 'app/store/lifecycle/selectors'
 import * as signOnActionsLegacy from 'app/store/signon/actions'
-import {
-  getEmailIsAvailable,
-  getEmailIsValid,
-  getEmailStatus,
-  getIsSigninError
-} from 'app/store/signon/selectors'
 import { EventNames } from 'app/types/analytics'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -336,13 +336,25 @@ const SignOn = ({ navigation }: SignOnProps) => {
   const [showEmptyPasswordError, setShowEmptyPasswordError] = useState(false)
   const [showDefaultError, setShowDefaultError] = useState(false)
 
-  const isSigninError = useSelector(getIsSigninError)
-  const dappLoaded = useSelector(getDappLoaded)
-  const signedIn = useSelector(getIsSignedIn)
-  const emailIsAvailable = useSelector(getEmailIsAvailable)
-  const emailIsValid = useSelector(getEmailIsValid)
-  const emailStatus = useSelector(getEmailStatus)
   const isKeyboardOpen = useSelector(getIsKeyboardOpen)
+
+  // TODO: Remove when fully on react native store
+  const dappLoaded = useSelector(getDappLoaded)
+  const lifecycleSignIn = useSelector(getIsSignedIn)
+
+  const signOnStatus = useSelector(getStatus)
+  const passwordFieldValue: { error: string } = useSelector(getPasswordField)
+  const emailFieldValue: {
+    error: '' | 'inUse' | 'characters'
+    status: 'success' | 'failure'
+  } = useSelector(getEmailField)
+  const accountUser = useSelector(getAccountUser)
+
+  const signedIn = signOnStatus === 'success'
+  const isSigninError = passwordFieldValue.error
+  const emailIsAvailable = emailFieldValue.error !== 'inUse'
+  const emailIsValid = emailFieldValue.error !== 'characters'
+  const emailStatus = emailFieldValue.status
 
   const topDrawer = useRef(new Animated.Value(-800)).current
   const animateDrawer = useCallback(() => {
@@ -380,14 +392,14 @@ const SignOn = ({ navigation }: SignOnProps) => {
   }, [isSigninError, isWorking])
 
   useEffect(() => {
-    if (signedIn) {
+    if (signedIn && accountUser && lifecycleSignIn) {
       setIsWorking(false)
       setEmail('')
       setPassword('')
 
       remindUserToTurnOnNotifications(dispatch)
     }
-  }, [signedIn, dispatch])
+  }, [signedIn, accountUser, lifecycleSignIn, dispatch])
 
   useEffect(() => {
     if (dappLoaded) {

--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -1,13 +1,14 @@
 import analyticsSagas from 'audius-client/src/common/store/analytics/sagas'
-// import signOnSagas from 'audius-client/src/common/store/pages/signon/sagas'
-// import accountSagas from 'common/store/account/sagas'
+import accountSagas from 'common/store/account/sagas'
 import backendSagas, { setupBackend } from 'common/store/backend/sagas'
-// import collectionsSagas from 'common/store/cache/collections/sagas'
-// import coreCacheSagas from 'common/store/cache/sagas'
-// import tracksSagas from 'common/store/cache/tracks/sagas'
-// import usersSagas from 'common/store/cache/users/sagas'
+import collectionsSagas from 'common/store/cache/collections/sagas'
+import coreCacheSagas from 'common/store/cache/sagas'
+import tracksSagas from 'common/store/cache/tracks/sagas'
+import usersSagas from 'common/store/cache/users/sagas'
 import confirmerSagas from 'common/store/confirmer/sagas'
+import signOnSagas from 'common/store/pages/signon/sagas'
 import remoteConfig from 'common/store/remote-config/sagas'
+import signOutSagas from 'common/store/sign-out/sagas'
 import { all, fork } from 'typed-redux-saga'
 
 import initKeyboardEvents from './keyboard/sagas'
@@ -19,16 +20,19 @@ export default function* rootSaga() {
     // config
     ...backendSagas(),
     ...analyticsSagas(),
-    // ...accountSagas(),
+    ...accountSagas(),
     ...confirmerSagas(),
 
     // Cache
-    // ...coreCacheSagas(),
-    // ...collectionsSagas(),
-    // ...tracksSagas(),
-    // ...usersSagas(),
+    ...coreCacheSagas(),
+    ...collectionsSagas(),
+    ...tracksSagas(),
+    ...usersSagas(),
 
-    // ...signOnSagas(),
+    // Sign in / Sign out
+    ...signOnSagas(),
+    ...signOutSagas(),
+
     initKeyboardEvents,
     ...remoteConfig(),
     ...oauthSagas()

--- a/packages/mobile/src/store/store.ts
+++ b/packages/mobile/src/store/store.ts
@@ -67,7 +67,7 @@ const createRootReducer = () =>
 
 const sagaMiddleware = createSagaMiddleware({ context: storeContext })
 const middlewares = applyMiddleware(sagaMiddleware)
-const composeEnhancers = composeWithDevTools({ trace: true, traceLimit: 25 })
+const composeEnhancers = composeWithDevTools({ trace: true, traceLimit: 250 })
 export const store = createStore(
   createRootReducer(),
   composeEnhancers(middlewares)

--- a/packages/web/src/common/store/account/reducer.ts
+++ b/packages/web/src/common/store/account/reducer.ts
@@ -169,7 +169,10 @@ const slice = createSlice({
       state,
       action: PayloadAction<InstagramAccountPayload>
     ) => {},
-    showPushNotificationConfirmation: () => {}
+    showPushNotificationConfirmation: () => {},
+    resetAccount: () => {
+      return initialState
+    }
   }
 })
 
@@ -195,7 +198,8 @@ export const {
   unsubscribeBrowserPushNotifications,
   instagramLogin,
   twitterLogin,
-  showPushNotificationConfirmation
+  showPushNotificationConfirmation,
+  resetAccount
 } = slice.actions
 
 export default slice

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -395,8 +395,11 @@ function* signUp() {
 
         yield put(signOnActions.signUpSucceededWithId(userId))
 
-        // Set the has request browser permission to true as the signon provider will open it
-        setHasRequestedBrowserPermission()
+        const isNativeMobile = yield getContext('isNativeMobile')
+        if (!isNativeMobile) {
+          // Set the has request browser permission to true as the signon provider will open it
+          setHasRequestedBrowserPermission()
+        }
 
         yield call(waitForRemoteConfig)
 
@@ -489,8 +492,11 @@ function* signIn(action) {
       // Reset the sign on in the background after page load as to relieve the UI loading
       yield delay(1000)
       yield put(signOnActions.resetSignOn())
-      setHasRequestedBrowserPermission()
-      yield put(accountActions.showPushNotificationConfirmation())
+      const isNativeMobile = yield getContext('isNativeMobile')
+      if (!isNativeMobile) {
+        setHasRequestedBrowserPermission()
+        yield put(accountActions.showPushNotificationConfirmation())
+      }
     } else if (
       !signInResponse.error &&
       signInResponse.user &&

--- a/packages/web/src/common/store/sign-out/sagas.ts
+++ b/packages/web/src/common/store/sign-out/sagas.ts
@@ -1,6 +1,7 @@
 import { Name } from '@audius/common'
 import { takeLatest, put, call } from 'redux-saga/effects'
 
+import { resetAccount } from 'common/store/account/reducer'
 import { make } from 'common/store/analytics/actions'
 import { disablePushNotifications } from 'pages/settings-page/store/mobileSagas'
 import { signOut } from 'utils/signOut'
@@ -15,6 +16,7 @@ function* watchSignOut() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const localStorage = yield* getContext('localStorage')
   yield takeLatest(signOutAction.type, function* () {
+    yield put(resetAccount())
     if (NATIVE_MOBILE) {
       disablePushNotifications(audiusBackendInstance)
       yield put(make(Name.SETTINGS_LOG_OUT, {}))


### PR DESCRIPTION
### Description

Ended up struggling to test sign up stuff without sign out, so I went ahead in that direction. Hopefully didn't steal too much.

Curious for thoughts here. I believe this is "shippable" with the sagas on mobile enabled at this point. That might save us some pain of having everything be off & then on while we're working.

This is all a good learning exercise for me. I'm starting to get the feeling that we're doing an "in then back out" approach to things.
1. Mirror dispatch & fetch logic in core stuff like account/sign in (double dispatch/select)
2. Move all the "inner pages" onto the local redux store instead of common
3. Go back to the core stuff and remove the web dispatch/select stuff
Maybe this was already obvious to folks...

https://user-images.githubusercontent.com/2731362/185336740-0e9de7ab-45b7-446a-80d5-3b27745bad68.mp4



### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Local simulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

