### PR TITLE
[C-858] Add track page sagas to native, Refactor TrackScreen

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,9 +17,10 @@
     "url": "git+https://github.com/AudiusProject/audius-client.git"
   },
   "scripts": {
+    "build": "rollup -c",
     "lint": "eslint --cache src",
     "lint:fix": "npm run lint -- --fix",
-    "build": "rollup -c"
+    "typecheck": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/AudiusProject/audius-client/issues"

--- a/packages/common/src/store/pages/track/actions.ts
+++ b/packages/common/src/store/pages/track/actions.ts
@@ -35,7 +35,7 @@ export const makeTrackPublic = (trackId) => ({
 })
 
 export const fetchTrack = (
-  trackId: number,
+  trackId: Nullable<number>,
   slug?: string,
   handle?: string,
   canBeUnlisted?: boolean

--- a/packages/common/src/store/pages/track/actions.ts
+++ b/packages/common/src/store/pages/track/actions.ts
@@ -34,7 +34,12 @@ export const makeTrackPublic = (trackId) => ({
   trackId
 })
 
-export const fetchTrack = (trackId, slug, handle, canBeUnlisted) => ({
+export const fetchTrack = (
+  trackId: number,
+  slug?: string,
+  handle?: string,
+  canBeUnlisted?: boolean
+) => ({
   type: FETCH_TRACK,
   trackId,
   slug,

--- a/packages/mobile/src/hooks/useImageSize.ts
+++ b/packages/mobile/src/hooks/useImageSize.ts
@@ -8,9 +8,7 @@ import type {
 } from '@audius/common'
 import type { ImageSourcePropType } from 'react-native'
 import { Image } from 'react-native'
-import type { useDispatch } from 'react-redux'
-
-import { useDispatchWeb } from 'app/hooks/useDispatchWeb'
+import { useDispatch } from 'react-redux'
 
 type UseImageSizeOptions = Parameters<typeof useImageSizeCommon>[0]
 
@@ -33,7 +31,7 @@ export const getUseImageSizeHook = <Sizes extends SquareSizes | WidthSizes>({
       size: Sizes
     }
   ) => {
-    const dispatch = useDispatchWeb() as typeof useDispatch
+    const dispatch = useDispatch()
 
     // This resolves a statically imported image into a uri
     const defaultImage = Image.resolveAssetSource(defaultImageSource).uri

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -1,11 +1,15 @@
+import { useEffect } from 'react'
+
 import {
   lineupSelectors,
   trackPageLineupActions,
+  trackPageActions,
   trackPageSelectors
 } from '@audius/common'
 import { trackRemixesPage } from 'audius-client/src/utils/route'
-import { omit } from 'lodash'
+import { useSelector } from 'common/hooks/useSelector'
 import { Text, View } from 'react-native'
+import { useDispatch } from 'react-redux'
 
 import IconArrow from 'app/assets/images/iconArrow.svg'
 import { Button, Screen } from 'app/components/core'
@@ -16,6 +20,7 @@ import { isEqual, useSelectorWeb } from 'app/hooks/useSelectorWeb'
 import { makeStyles } from 'app/styles'
 
 import { TrackScreenMainContent } from './TrackScreenMainContent'
+const { fetchTrack } = trackPageActions
 const { tracksActions } = trackPageLineupActions
 const { getLineup, getRemixParentTrack, getTrack, getUser } = trackPageSelectors
 const { makeGetLineupMetadatas } = lineupSelectors
@@ -51,20 +56,16 @@ export const TrackScreen = () => {
   const styles = useStyles()
   const navigation = useNavigation()
   const { params } = useRoute<'Track'>()
+  const dispatch = useDispatch()
 
   // params is incorrectly typed and can sometimes be undefined
-  const { searchTrack } = params ?? {}
+  const { searchTrack, id } = params ?? {}
 
-  const cachedTrack = useSelectorWeb(
-    (state) => getTrack(state, params),
-    // Omitting uneeded fields from the equality check because they are
-    // causing extra renders when added to the `track` object
-    (a, b) => {
-      const omitUneeded = <T extends object | null>(o: T) =>
-        omit(o, ['_stems', '_remix_parents'])
-      return isEqual(omitUneeded(a), omitUneeded(b))
-    }
-  )
+  useEffect(() => {
+    dispatch(fetchTrack(id))
+  }, [dispatch, id])
+
+  const cachedTrack = useSelector((state) => getTrack(state, params))
 
   const track = cachedTrack ?? searchTrack
 

--- a/packages/mobile/src/services/audius-backend-instance.ts
+++ b/packages/mobile/src/services/audius-backend-instance.ts
@@ -100,14 +100,15 @@ export const audiusBackendInstance = audiusBackend({
     registryAddress,
     entityManagerAddress,
     web3ProviderUrls
-  ) => {
-    const config = {
-      error: false,
-      web3Config: libs.configInternalWeb3(registryAddress, web3ProviderUrls)
-    }
-    console.log(config, 'HI')
-    return config
-  },
+  ) => ({
+    error: false,
+    web3Config: libs.configInternalWeb3(
+      registryAddress,
+      web3ProviderUrls,
+      null,
+      entityManagerAddress
+    )
+  }),
   hedgehogConfig: {
     createKey
   },
@@ -160,5 +161,6 @@ export const audiusBackendInstance = audiusBackend({
     if (audiusLibs) {
       return normal(audiusLibs)(...args)
     }
-  }
+  },
+  disableImagePreload: true
 })

--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -8,6 +8,7 @@ import tracksSagas from 'common/store/cache/tracks/sagas'
 import usersSagas from 'common/store/cache/users/sagas'
 import confirmerSagas from 'common/store/confirmer/sagas'
 import signOnSagas from 'common/store/pages/signon/sagas'
+import trackPageSagas from 'common/store/pages/track/sagas'
 import signOutSagas from 'common/store/sign-out/sagas'
 import { all, fork } from 'typed-redux-saga'
 
@@ -32,6 +33,9 @@ export default function* rootSaga() {
     // Sign in / Sign out
     ...signOnSagas(),
     ...signOutSagas(),
+
+    // Pages
+    ...trackPageSagas(),
 
     initKeyboardEvents,
     ...remoteConfig(),

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -24,8 +24,8 @@ import {
 import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { retrieveTracks } from 'common/store/cache/tracks/utils'
 import { retrieveTrackByHandleAndSlug } from 'common/store/cache/tracks/utils/retrieveTracks'
-import tracksSagas from 'pages/track-page/store/lineups/tracks/sagas'
 import { NOT_FOUND_PAGE, trackRemixesPage } from 'utils/route'
+
 const { getIsReachable } = reachabilitySelectors
 const { tracksActions } = trackPageLineupActions
 const { getSourceSelector, getTrack, getTrendingTrackRanks, getUser } =
@@ -38,6 +38,10 @@ export const TRENDING_BADGE_LIMIT = 10
 function* watchTrackBadge() {
   const apiClient = yield getContext('apiClient')
   const remoteConfigInstance = yield getContext('remoteConfigInstance')
+  const audiusBackendInstance = yield getContext('audiusBackendInstance')
+  const audiusLibs = yield call([audiusBackendInstance, 'getAudiusLibs'])
+  const web3 = audiusLibs.web3Manager.web3
+
   yield takeEvery(trackPageActions.GET_TRACK_RANKS, function* (action) {
     try {
       yield call(waitForBackendSetup)
@@ -52,15 +56,15 @@ function* watchTrackBadge() {
         })
         if (TF.size > 0) {
           trendingRanks.week = trendingRanks.week.filter((i) => {
-            const shaId = window.Web3.utils.sha3(i.toString())
+            const shaId = web3.utils.sha3(i.toString())
             return !TF.has(shaId)
           })
           trendingRanks.month = trendingRanks.month.filter((i) => {
-            const shaId = window.Web3.utils.sha3(i.toString())
+            const shaId = web3.utils.sha3(i.toString())
             return !TF.has(shaId)
           })
           trendingRanks.year = trendingRanks.year.filter((i) => {
-            const shaId = window.Web3.utils.sha3(i.toString())
+            const shaId = web3.utils.sha3(i.toString())
             return !TF.has(shaId)
           })
         }
@@ -255,7 +259,6 @@ function* watchGoToRemixesOfParentPage() {
 
 export default function sagas() {
   return [
-    ...tracksSagas(),
     watchFetchTrack,
     watchFetchTrackSucceeded,
     watchRefetchLineup,

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -38,6 +38,7 @@ import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 
 import { TrackEvent, make } from 'common/store/analytics/actions'
+import { TRENDING_BADGE_LIMIT } from 'common/store/pages/track/sagas'
 import { makeGetCurrent } from 'common/store/queue/selectors'
 import * as unfollowConfirmationActions from 'components/unfollow-confirmation-modal/store/actions'
 import DeletedPage from 'pages/deleted-page/DeletedPage'
@@ -69,7 +70,6 @@ import { getTrackPageTitle, getTrackPageDescription } from 'utils/seo'
 import StemsSEOHint from './components/StemsSEOHint'
 import { OwnProps as DesktopTrackPageProps } from './components/desktop/TrackPage'
 import { OwnProps as MobileTrackPageProps } from './components/mobile/TrackPage'
-import { TRENDING_BADGE_LIMIT } from './store/sagas'
 const { setFavorite } = favoritesUserListActions
 const { setRepost } = repostsUserListActions
 const { requestOpen: requestOpenShareModal } = shareModalUIActions

--- a/packages/web/src/store/sagas.ts
+++ b/packages/web/src/store/sagas.ts
@@ -19,6 +19,7 @@ import confirmerSagas from 'common/store/confirmer/sagas'
 import exploreCollectionsPageSagas from 'common/store/pages/explore/exploreCollections/sagas'
 import explorePageSagas from 'common/store/pages/explore/sagas'
 import signOnSaga from 'common/store/pages/signon/sagas'
+import trackSagas from 'common/store/pages/track/sagas'
 import reachabilitySagas from 'common/store/reachability/sagas'
 import recoveryEmailSagas from 'common/store/recovery-email/sagas'
 import serviceSelectionSagas from 'common/store/service-selection/sagas'
@@ -54,7 +55,7 @@ import settingsSagas from 'pages/settings-page/store/sagas'
 import smartCollectionPageSagas from 'pages/smart-collection/store/sagas'
 import supportingPageSagas from 'pages/supporting-page/sagas'
 import topSupportersPageSagas from 'pages/top-supporters-page/sagas'
-import trackSagas from 'pages/track-page/store/sagas'
+import trackLineupSagas from 'pages/track-page/store/lineups/tracks/sagas'
 import trendingPageSagas from 'pages/trending-page/store/sagas'
 import trendingPlaylistSagas from 'pages/trending-playlists/store/sagas'
 import trendingUndergroundSagas from 'pages/trending-underground/store/sagas'
@@ -118,6 +119,7 @@ export default function* rootSaga() {
     signOnSaga(),
     socialSagas(),
     trackSagas(),
+    trackLineupSagas(),
     trendingPageSagas(),
     trendingPlaylistSagas(),
     trendingUndergroundSagas(),


### PR DESCRIPTION
### Description

- Adds track-page sagas to native
- Refactors TrackScreen to fetch tracks within native


### Dragons

- For now, useImageSize is not only using `useDispatch` breaking other places it's used, like profile. Thinking this is okay in the interim.
- Added `disableImagePreload` to mobile audius-backend, which simplifies fetching the track image. This seems like a decent approach, until we maybe want to add a native version of preload?
- Loading track page is slower perf right now since we can't rely on a cached version from the lineup screen. should be fixed as we continue to migrate, but just an fyi
- Separated trackPageLineupSagas from trackPageSagas since lineup requires work with player first