### PR TITLE
Add back modal hook functionality

### DIFF
--- a/packages/web/src/common/hooks/useModalState.ts
+++ b/packages/web/src/common/hooks/useModalState.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { modalsSelectors, modalsActions, Modals } from '@audius/common'
 import { useDispatch } from 'react-redux'
@@ -48,7 +48,13 @@ export const useGetVisibility = (modalName: Modals) => {
  * hooks above.
  */
 export const useModalState = (
-  _modalName: Modals
+  modalName: Modals
 ): [boolean, (isOpen: boolean) => void] => {
-  return [false, () => {}]
+  const isOpen = useGetVisibility(modalName)
+  const setVisibility = useSetVisibility()
+  const setter = useMemo(
+    () => setVisibility(modalName),
+    [modalName, setVisibility]
+  )
+  return [isOpen === true, setter]
 }


### PR DESCRIPTION
### Description

`useModalState` hook implementation was gutted in #1675 , this PR adds back the functionality

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

@nicoback2 does this break anything? Seems like it was intentionally removed...

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

