### PR TITLE
Wire up initial BuyAudioModal

### DIFF
--- a/packages/common/src/store/ui/buy-audio/selectors.ts
+++ b/packages/common/src/store/ui/buy-audio/selectors.ts
@@ -6,7 +6,7 @@ export const getBuyAudioFlowStage = (state: CommonState) =>
 export const getAudioPurchaseInfo = (state: CommonState) =>
   state.ui.buyAudio.purchaseInfo
 
-export const getAudioPurchaseInfoStatus = (state: AppState) =>
+export const getAudioPurchaseInfoStatus = (state: CommonState) =>
   state.ui.buyAudio.purchaseInfoStatus
 
 export const getFeesCache = (state: CommonState) => state.ui.buyAudio.feesCache

--- a/packages/common/src/store/ui/buy-audio/selectors.ts
+++ b/packages/common/src/store/ui/buy-audio/selectors.ts
@@ -6,4 +6,7 @@ export const getBuyAudioFlowStage = (state: CommonState) =>
 export const getAudioPurchaseInfo = (state: CommonState) =>
   state.ui.buyAudio.purchaseInfo
 
+export const getAudioPurchaseInfoStatus = (state: AppState) =>
+  state.ui.buyAudio.purchaseInfoStatus
+
 export const getFeesCache = (state: CommonState) => state.ui.buyAudio.feesCache

--- a/packages/web/src/components/buy-audio-modal/BuyAudioModal.module.css
+++ b/packages/web/src/components/buy-audio-modal/BuyAudioModal.module.css
@@ -1,0 +1,8 @@
+.modal {
+  width: 520px;
+}
+
+/** Allow conversion notice to be flush with the bottom of the modal **/
+.modalContent {
+  padding-bottom: 0;
+}

--- a/packages/web/src/components/buy-audio-modal/BuyAudioModal.tsx
+++ b/packages/web/src/components/buy-audio-modal/BuyAudioModal.tsx
@@ -1,0 +1,36 @@
+import React, { useCallback } from 'react'
+
+import { Modal, ModalContent, ModalHeader, ModalTitle } from '@audius/stems'
+
+import IconGoldBadgeSrc from 'assets/img/tokenBadgeGold40@2x.png'
+import { useModalState } from 'common/hooks/useModalState'
+
+import styles from './BuyAudioModal.module.css'
+
+const messages = {
+  buyAudio: 'Buy Audio'
+}
+
+const IconGoldBadge = () => (
+  <img
+    draggable={false}
+    src={IconGoldBadgeSrc}
+    alt='Gold Badge Icon'
+    width={24}
+    height={24}
+  />
+)
+
+export const BuyAudioModal = () => {
+  const [isOpen, setIsOpen] = useModalState('BuyAudio')
+  const onClose = useCallback(() => setIsOpen(false), [setIsOpen])
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} bodyClassName={styles.modal}>
+      <ModalHeader onClose={onClose}>
+        <ModalTitle title={messages.buyAudio} icon={<IconGoldBadge />} />
+      </ModalHeader>
+      <ModalContent className={styles.modalContent}></ModalContent>
+    </Modal>
+  )
+}

--- a/packages/web/src/components/coinbase-pay-button/index.ts
+++ b/packages/web/src/components/coinbase-pay-button/index.ts
@@ -1,3 +1,6 @@
 export { CoinbasePayButtonCustom } from './CoinbasePayButtonCustom'
 export { CoinbasePayButton } from './CoinbasePayButton'
-export { CoinbasePayButtonProvider } from './CoinbasePayButtonProvider'
+export {
+  CoinbasePayButtonProvider,
+  CoinbasePayContext
+} from './CoinbasePayButtonProvider'

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -165,9 +165,13 @@ export const WalletManagementTile = () => {
     useSelector(getAccountTotalBalance) ?? null
   const hasMultipleWallets = useSelector(getHasAssociatedWallets)
   const [, setOpen] = useModalState('AudioBreakdown')
+  const [, setBuyAudioModalOpen] = useModalState('BuyAudio')
   const onClickOpen = useCallback(() => {
     setOpen(true)
   }, [setOpen])
+  const onBuyAudioClicked = useCallback(() => {
+    setBuyAudioModalOpen(true)
+  }, [setBuyAudioModalOpen])
 
   return (
     <div className={styles.walletManagementTile}>
@@ -210,7 +214,7 @@ export const WalletManagementTile = () => {
             </div>
           </div>
         </div>
-        <CoinbasePayButtonCustom />
+        <CoinbasePayButtonCustom onClick={onBuyAudioClicked} />
         <ToggleCollapseButton
           className={styles.advancedToggle}
           showText={messages.showAdvanced}

--- a/packages/web/src/pages/modals/Modals.tsx
+++ b/packages/web/src/pages/modals/Modals.tsx
@@ -6,6 +6,7 @@ import type { Modals as ModalTypes } from '@audius/common'
 import AddToPlaylistModal from 'components/add-to-playlist/desktop/AddToPlaylistModal'
 import AppCTAModal from 'components/app-cta-modal/AppCTAModal'
 import BrowserPushConfirmationModal from 'components/browser-push-confirmation-modal/BrowserPushConfirmationModal'
+import { BuyAudioModal } from 'components/buy-audio-modal/BuyAudioModal'
 import CollectibleDetailsModal from 'components/collectibles/components/CollectibleDetailsModal'
 import DeletePlaylistConfirmationModal from 'components/delete-playlist-confirmation-modal/DeletePlaylistConfirmationModal'
 import EditFolderModal from 'components/edit-folder-modal/EditFolderModal'
@@ -89,6 +90,7 @@ const Modals = () => {
       )}
 
       {!NATIVE_MOBILE && <TipAudioModal />}
+      {!NATIVE_MOBILE ? <BuyAudioModal /> : null}
     </>
   )
 }


### PR DESCRIPTION
### Description

Creates a new (currently empty) modal for buying $AUDIO and wires it up to the new $AUDIO & Rewards page.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested against stage with the BUY_AUDIO_ENABLED feature flag turned on.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

Behind BUY_AUDIO_ENABLED feature flag

