### PR TITLE
[C-887] Host sourcemaps on s3, fixes cloudflare deploy

### DIFF
--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -116,6 +116,7 @@ web-deploy-cloudflare:
     - checkout
     - attach_workspace:
         at: ./
+    - web-install-wrangler
     - run:
         name: Move sourcemaps
         command: |

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -134,20 +134,16 @@ web-deploy-cloudflare:
         command: |
           cd packages/web
           echo ${GA_ACCESS_TOKEN} | npx wrangler secret put GA_ACCESS_TOKEN --env << parameters.environment >>
-          npx wrangler publish --env << parameters.environment >> --site-exclude *.map
+          npx wrangler publish --env << parameters.environment >>
 
 web-deploy-sourcemaps-s3:
-  parameters:
-    build-type:
-      default: 'production'
-      type: string
   steps:
     - web-install-awscli
     - attach_workspace:
         at: ./
     - run:
         name: Deploy to S3
-        command: aws s3 sync --exclude "*" --include "*.map" packages/web/build-<< parameters.build-type >>/static/js s3://sourcemaps.audius.co --delete --cache-control max-age=604800
+        command: aws s3 sync packages/web/sourcemaps s3://sourcemaps.audius.co --delete --cache-control max-age=604800
 
 web-deploy-ipfs:
   parameters:

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -121,7 +121,7 @@ web-deploy-cloudflare:
         name: Move sourcemaps
         command: |
           cd packages/web
-          mkdir sourcemaps/static/js
+          mkdir -p sourcemaps/static/js
           mv build-<< parameters.build-type >>/static/js/*.map sourcemaps/static/js
     - run:
         name: Set up workers site

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -116,7 +116,6 @@ web-deploy-cloudflare:
     - checkout
     - attach_workspace:
         at: ./
-    - web-install-wrangler
     - run:
         name: Move sourcemaps
         command: |

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -144,7 +144,9 @@ web-deploy-cloudflare:
 
 web-deploy-sourcemaps-s3:
   steps:
-    - web-install-awscli
+    - run:
+        name: install-awscli
+        command: pip install awscli
     - attach_workspace:
         at: ./
     - run:

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -107,6 +107,7 @@ web-move-sourcemaps:
       default: 'production'
       type: string
   steps:
+    - checkout
     - attach_workspace:
         at: ./
     - run:

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -101,22 +101,6 @@ web-install-wrangler:
         name: install wrangler
         command: 'cd packages/web && npm install @cloudflare/wrangler'
 
-web-move-sourcemaps:
-  parameters:
-    build-type:
-      default: 'production'
-      type: string
-  steps:
-    - checkout
-    - attach_workspace:
-        at: ./
-    - run:
-        name: Move sourcemaps
-        command: |
-          cd packages/web
-          mkdir sourcemaps
-          mv build-<< parameters.build-type >>/static/js/*.map sourcemaps
-
 web-deploy-cloudflare:
   parameters:
     build-type:
@@ -133,6 +117,12 @@ web-deploy-cloudflare:
     - attach_workspace:
         at: ./
     - web-install-wrangler
+    - run:
+        name: Move sourcemaps
+        command: |
+          cd packages/web
+          mkdir sourcemaps
+          mv build-<< parameters.build-type >>/static/js/*.map sourcemaps
     - run:
         name: Set up workers site
         command: |

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -101,6 +101,20 @@ web-install-wrangler:
         name: install wrangler
         command: 'cd packages/web && npm install @cloudflare/wrangler'
 
+web-move-sourcemaps:
+  parameters:
+    build-type:
+      default: 'production'
+      type: string
+  steps:
+    - checkout
+    - run:
+        name: Move sourcemaps
+        command: |
+          cd packages/web
+          mkdir sourcemaps
+          mv build-<< parameters.build-type >>/static/js/*.map sourcemaps
+
 web-deploy-cloudflare:
   parameters:
     build-type:

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -121,8 +121,8 @@ web-deploy-cloudflare:
         name: Move sourcemaps
         command: |
           cd packages/web
-          mkdir sourcemaps
-          mv build-<< parameters.build-type >>/static/js/*.map sourcemaps
+          mkdir sourcemaps/static/js
+          mv build-<< parameters.build-type >>/static/js/*.map sourcemaps/static/js
     - run:
         name: Set up workers site
         command: |

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -107,7 +107,8 @@ web-move-sourcemaps:
       default: 'production'
       type: string
   steps:
-    - checkout
+    - attach_workspace:
+        at: ./
     - run:
         name: Move sourcemaps
         command: |

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -147,7 +147,7 @@ web-deploy-sourcemaps-s3:
         at: ./
     - run:
         name: Deploy to S3
-        command: aws s3 sync packages/web/build-<< parameters.build-type >>/static/js/*.map s3://sourcemaps.audius.co --delete --cache-control max-age=604800
+        command: aws s3 sync --exclude "*" --include "*.map" packages/web/build-<< parameters.build-type >>/static/js s3://sourcemaps.audius.co --delete --cache-control max-age=604800
 
 web-deploy-ipfs:
   parameters:

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -51,13 +51,13 @@ web-pr-comment:
 web-build:
   parameters:
     build-type:
-      default: "prod-source-maps"
+      default: 'prod-source-maps'
       type: string
     build-directory:
-      default: "packages/web/build-production"
+      default: 'packages/web/build-production'
       type: string
     build-name:
-      default: "build-production"
+      default: 'build-production'
       type: string
   steps:
     - checkout
@@ -77,7 +77,7 @@ web-build:
 web-distribute:
   parameters:
     build-type:
-      default: "mac-publish-production"
+      default: 'mac-publish-production'
       type: string
   steps:
     - checkout
@@ -99,15 +99,15 @@ web-install-wrangler:
   steps:
     - run:
         name: install wrangler
-        command: "cd packages/web && npm install @cloudflare/wrangler"
+        command: 'cd packages/web && npm install @cloudflare/wrangler'
 
 web-deploy-cloudflare:
   parameters:
     build-type:
-      default: "production"
+      default: 'production'
       type: string
     environment:
-      default: "production"
+      default: 'production'
       type: string
     copy-robots:
       default: false
@@ -134,12 +134,25 @@ web-deploy-cloudflare:
         command: |
           cd packages/web
           echo ${GA_ACCESS_TOKEN} | npx wrangler secret put GA_ACCESS_TOKEN --env << parameters.environment >>
-          npx wrangler publish --env << parameters.environment >>
+          npx wrangler publish --env << parameters.environment >> --site-exclude *.map
+
+web-deploy-sourcemaps-s3:
+  parameters:
+    build-type:
+      default: 'production'
+      type: string
+  steps:
+    - web-install-awscli
+    - attach_workspace:
+        at: ./
+    - run:
+        name: Deploy to S3
+        command: aws s3 sync packages/web/build-<< parameters.build-type >>/static/js/*.map s3://sourcemaps.audius.co --delete --cache-control max-age=604800
 
 web-deploy-ipfs:
   parameters:
     build-type:
-      default: "production"
+      default: 'production'
       type: string
   steps:
     - web-install-awscli
@@ -152,7 +165,7 @@ web-deploy-ipfs:
 web-update-ga-ipfs-build:
   parameters:
     build-type:
-      default: "prod"
+      default: 'prod'
       type: string
   steps:
     - checkout
@@ -171,7 +184,7 @@ web-update-ga-ipfs-build:
 web-publish-build-cids:
   parameters:
     build-type:
-      default: "production"
+      default: 'production'
       type: string
   steps:
     - web-install-awscli
@@ -184,10 +197,10 @@ web-publish-build-cids:
 web-update-ipfs-records:
   parameters:
     dns-name:
-      default: "_dnslink.ipfs.audius.co"
+      default: '_dnslink.ipfs.audius.co'
       type: string
     dns-id:
-      default: "${CLOUDFLARE_PROD_SITE_IPFS_DNS_ID}"
+      default: '${CLOUDFLARE_PROD_SITE_IPFS_DNS_ID}'
       type: string
   steps:
     - attach_workspace:

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -204,7 +204,7 @@ web-deploy-staging-s3:
 web-deploy-staging-cloudflare:
   working_directory: ~/audius-client
   docker:
-    - image: circleci/node:14.18
+    - image: cimg/python:3.10.6-node
   steps:
     - web-deploy-cloudflare:
         build-type: staging

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -284,7 +284,7 @@ web-deploy-production-s3:
 web-deploy-production-cloudflare:
   working_directory: ~/audius-client
   docker:
-    - image: circleci/node:14.18
+    - image: cimg/python:3.10.6-node
   steps:
     - web-deploy-cloudflare:
         build-type: production

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -210,6 +210,8 @@ web-deploy-staging-cloudflare:
         build-type: staging
         environment: staging
         copy-robots: false
+    - web-deploy-sourcemaps-s3:
+        build-type: staging
 
 web-deploy-ipfs-staging:
   working_directory: ~/audius-client

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -206,12 +206,16 @@ web-deploy-staging-cloudflare:
   docker:
     - image: circleci/node:14.18
   steps:
+    - run:
+        name: Move sourcemaps
+        command: |
+          mkdir sourcemaps
+          mv build-staging/static/js/*.map sourcemaps
     - web-deploy-cloudflare:
         build-type: staging
         environment: staging
         copy-robots: false
-    - web-deploy-sourcemaps-s3:
-        build-type: staging
+    - web-deploy-sourcemaps-s3
 
 web-deploy-ipfs-staging:
   working_directory: ~/audius-client
@@ -347,7 +351,7 @@ web-deploy-sentry-sourcemaps:
         name: upload-sourcemaps
         command: |
           cd packages/web
-          node_modules/.bin/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client files ${CIRCLE_SHA1} upload-sourcemaps --no-rewrite build-production
+          node_modules/.bin/sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} releases --org audius --project audius-client files ${CIRCLE_SHA1} upload-sourcemaps --no-rewrite sourcemaps
     - run:
         name: finalize-release
         command: |

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -206,8 +206,6 @@ web-deploy-staging-cloudflare:
   docker:
     - image: circleci/node:14.18
   steps:
-    - web-move-sourcemaps:
-        build-type: staging
     - web-deploy-cloudflare:
         build-type: staging
         environment: staging

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -204,7 +204,7 @@ web-deploy-staging-s3:
 web-deploy-staging-cloudflare:
   working_directory: ~/audius-client
   docker:
-    - image: cimg/python:3.10.6-node
+    - image: cimg/python:3.7.12-node
   steps:
     - web-deploy-cloudflare:
         build-type: staging
@@ -284,7 +284,7 @@ web-deploy-production-s3:
 web-deploy-production-cloudflare:
   working_directory: ~/audius-client
   docker:
-    - image: cimg/python:3.10.6-node
+    - image: cimg/python:3.7.12-node
   steps:
     - web-deploy-cloudflare:
         build-type: production

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -206,11 +206,8 @@ web-deploy-staging-cloudflare:
   docker:
     - image: circleci/node:14.18
   steps:
-    - run:
-        name: Move sourcemaps
-        command: |
-          mkdir sourcemaps
-          mv build-staging/static/js/*.map sourcemaps
+    - web-move-sourcemaps:
+        build-type: staging
     - web-deploy-cloudflare:
         build-type: staging
         environment: staging

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -248,7 +248,7 @@ web-update-ipfs-staging-records:
 web-deploy-release-candidate:
   working_directory: ~/audius-client
   docker:
-    - image: circleci/node:14.18
+    - image: cimg/python:3.7.12-node
   steps:
     - web-deploy-cloudflare:
         build-type: production

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -45,9 +45,9 @@ jobs:
       context: Audius Client
       requires:
         - web-build-staging
-      filters:
-        branches:
-          only: /^main$/
+      # filters:
+      #   branches:
+      #     only: /^main$/
 
   - web-deploy-release-candidate:
       context: Audius Client

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -45,9 +45,9 @@ jobs:
       context: Audius Client
       requires:
         - web-build-staging
-      # filters:
-      #   branches:
-      #     only: /^main$/
+      filters:
+        branches:
+          only: /^main$/
 
   - web-deploy-release-candidate:
       context: Audius Client

--- a/package-lock.json
+++ b/package-lock.json
@@ -2147,7 +2147,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "astral-regex": {
@@ -2701,13 +2701,13 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -2725,7 +2725,7 @@
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
     "deep-is": {
@@ -2761,7 +2761,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "dev": true
     },
     "deprecation": {
@@ -2930,7 +2930,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint": {
       "version": "8.19.0",
@@ -4292,7 +4292,7 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true
     },
     "is-plain-object": {
@@ -4368,7 +4368,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-unicode-supported": {
@@ -4400,7 +4400,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
     "js-tokens": {
@@ -4451,7 +4451,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "json5": {
@@ -4476,7 +4476,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
     },
     "jsx-ast-utils": {
@@ -4662,7 +4662,7 @@
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
     "lodash.merge": {
@@ -4959,7 +4959,7 @@
         "arrify": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
           "dev": true
         }
       }
@@ -5677,12 +5677,12 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "dev": true
     },
     "p-limit": {
@@ -6313,7 +6313,7 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true
     },
     "promise-retry": {
@@ -6349,7 +6349,7 @@
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
     },
     "protocols": {
@@ -6367,7 +6367,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "dev": true
     },
     "queue-microtask": {
@@ -6594,7 +6594,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "resolve": {
@@ -6643,7 +6643,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true
     },
     "reusify": {
@@ -6706,7 +6706,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "shallow-clone": {
@@ -7479,7 +7479,7 @@
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
       "dev": true
     },
     "text-extensions": {
@@ -7497,7 +7497,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "through2": {
       "version": "4.0.2",
@@ -7591,7 +7591,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "typedarray-to-buffer": {
@@ -7676,7 +7676,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "8.3.2",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1092,6 +1092,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
       "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.3",
         "@redux-saga/deferred": "^1.1.2",
@@ -1106,12 +1107,14 @@
     "@redux-saga/deferred": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
-      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ==",
+      "dev": true
     },
     "@redux-saga/delay-p": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
       "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "dev": true,
       "requires": {
         "@redux-saga/symbols": "^1.1.2"
       }
@@ -1120,6 +1123,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
       "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "dev": true,
       "requires": {
         "@redux-saga/symbols": "^1.1.2",
         "@redux-saga/types": "^1.1.0"
@@ -1128,12 +1132,14 @@
     "@redux-saga/symbols": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
-      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ==",
+      "dev": true
     },
     "@redux-saga/types": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg==",
+      "dev": true
     },
     "@reduxjs/toolkit": {
       "version": "1.3.4",
@@ -5420,18 +5426,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "react-redux": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
-      "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "hoist-non-react-statics": "^3.3.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.9.0"
-      }
-    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -5455,6 +5449,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
       "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "dev": true,
       "requires": {
         "@redux-saga/core": "^1.1.3"
       }
@@ -6326,6 +6321,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
       "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "dev": true,
       "requires": {
         "typescript-logic": "^0.0.0"
       }
@@ -6333,12 +6329,14 @@
     "typescript-logic": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
-      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q==",
+      "dev": true
     },
     "typescript-tuple": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
       "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "dev": true,
       "requires": {
         "typescript-compare": "^0.0.2"
       }

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -7081,7 +7081,7 @@
     "absolute-path": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/absolute-path/-/absolute-path-0.0.0.tgz",
-      "integrity": "sha1-p4di+9rftSl76ZsV01p4Wy8JW/c="
+      "integrity": "sha512-HQiug4c+/s3WOvEnDRxXVmNtSG5s2gJM9r19BTcqjp7BWcE48PB+Y2G6jE65kqI0LpsQeMZygt/b60Gi4KxGyA=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -9088,7 +9088,7 @@
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -9249,7 +9249,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "compare-versions": {
       "version": "3.6.0",
@@ -9286,7 +9286,7 @@
         "bytes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+          "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
         },
         "debug": {
           "version": "2.6.9",
@@ -9299,7 +9299,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
     },
@@ -9365,7 +9365,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
     },
@@ -9889,7 +9889,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "requires": {
         "clone": "^1.0.2"
       }
@@ -9962,7 +9962,7 @@
     "denodeify": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-      "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
+      "integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg=="
     },
     "depd": {
       "version": "2.0.0",
@@ -12291,7 +12291,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "on-finished": {
           "version": "2.3.0",
@@ -15298,7 +15298,7 @@
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
       "requires": {
         "graceful-fs": "^4.1.9"
       }
@@ -15517,7 +15517,7 @@
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="
     },
     "lodash.tostring": {
       "version": "4.1.4",
@@ -16080,7 +16080,7 @@
         "fs-extra": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+          "integrity": "sha512-VerQV6vEKuhDWD2HGOybV6v5I73syoc/cXAbKlgTC7M/oFVEtklWlp9QH2Ijw3IaWDOQcMkldSPa7zXy79Z/UQ==",
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0",
@@ -16169,7 +16169,7 @@
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -16240,7 +16240,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "normalize-path": {
           "version": "3.0.0",
@@ -16289,7 +16289,7 @@
         "ultron": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+          "integrity": "sha512-QMpnpVtYaWEeY+MwKDN/UdKlE/LsFZXM5lO1u7GaZzNgmIbGixHEmVMIKT+vqYOALu3m5GYQy9kz4Xu4IVn7Ow=="
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -16480,7 +16480,7 @@
         "import-fresh": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
@@ -16507,7 +16507,7 @@
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -16532,7 +16532,7 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+          "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -16823,7 +16823,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
         "string-width": {
           "version": "4.2.3",
@@ -16846,7 +16846,7 @@
         "ultron": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+          "integrity": "sha512-QMpnpVtYaWEeY+MwKDN/UdKlE/LsFZXM5lO1u7GaZzNgmIbGixHEmVMIKT+vqYOALu3m5GYQy9kz4Xu4IVn7Ow=="
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -17531,7 +17531,7 @@
     "murmurhash": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-0.0.2.tgz",
-      "integrity": "sha1-bwe9ihEF5wnCb8iUIMtZMMJFhf4="
+      "integrity": "sha512-LKlwdZKWzvCQpMszb2HO5leJ7P9T4m5XuDKku8bM0uElrzqK9cn0+iozwQS8jO4SNjrp4w7olalgd8WgsIjhWA=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -17667,7 +17667,7 @@
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
       "requires": {
         "minimatch": "^3.0.2"
       }
@@ -18158,7 +18158,7 @@
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg=="
     },
     "ora": {
       "version": "3.4.0",
@@ -19155,7 +19155,7 @@
         "import-fresh": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
@@ -19164,7 +19164,7 @@
         "parse-json": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -19197,7 +19197,7 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+          "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw=="
         },
         "semver": {
           "version": "6.3.0",
@@ -19983,7 +19983,7 @@
     "readline": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw="
+      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "realpath-native": {
       "version": "1.1.0",
@@ -20297,7 +20297,7 @@
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -20311,7 +20311,7 @@
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
           "requires": {
             "mimic-fn": "^1.0.0"
           }
@@ -20577,7 +20577,7 @@
     "serialize-error": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw=="
     },
     "serve-static": {
       "version": "1.15.0",
@@ -21538,7 +21538,7 @@
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-      "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
+      "integrity": "sha512-jtnWJs6B1cZlHs9wPG7BrowKxZw/rf6+UpGAkr8AaYmiTyTO7zQlLoST8zx/8TcUPnZmeBoB+H8ARuHZaSijVw==",
       "requires": {
         "os-tmpdir": "^1.0.0",
         "rimraf": "~2.2.6"
@@ -21547,7 +21547,7 @@
         "rimraf": {
           "version": "2.2.8",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+          "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg=="
         }
       }
     },
@@ -22361,7 +22361,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "requires": {
         "defaults": "^1.0.3"
       }

--- a/packages/web/craco.config.ts
+++ b/packages/web/craco.config.ts
@@ -61,7 +61,7 @@ export default {
           }),
           new SourceMapDevToolPlugin({
             publicPath:
-              'https://s3.us-west-1.amazonaws.com/sourcemaps.audius.co',
+              'https://s3.us-west-1.amazonaws.com/sourcemaps.audius.co/',
             filename: '[file].map'
           })
         ],

--- a/packages/web/craco.config.ts
+++ b/packages/web/craco.config.ts
@@ -9,6 +9,8 @@ import {
 
 const isNative = process.env.REACT_APP_NATIVE_NAVIGATION_ENABLED === 'true'
 
+const SOURCEMAP_URL = 'https://s3.us-west-1.amazonaws.com/sourcemaps.audius.co/'
+
 type ModuleScopePlugin = ResolvePluginInstance & {
   allowedPaths: string[]
 }
@@ -60,8 +62,7 @@ export default {
             Buffer: ['buffer', 'Buffer']
           }),
           new SourceMapDevToolPlugin({
-            publicPath:
-              'https://s3.us-west-1.amazonaws.com/sourcemaps.audius.co/',
+            publicPath: SOURCEMAP_URL,
             filename: '[file].map'
           })
         ],

--- a/packages/web/craco.config.ts
+++ b/packages/web/craco.config.ts
@@ -1,5 +1,11 @@
 import path from 'path'
-import { Configuration, ProvidePlugin, ResolvePluginInstance } from 'webpack'
+
+import {
+  Configuration,
+  ProvidePlugin,
+  ResolvePluginInstance,
+  SourceMapDevToolPlugin
+} from 'webpack'
 
 const isNative = process.env.REACT_APP_NATIVE_NAVIGATION_ENABLED === 'true'
 
@@ -10,7 +16,7 @@ type ModuleScopePlugin = ResolvePluginInstance & {
 // This ensures we can use the resolve.alias for react/react-dom
 function addReactToModuleScopePlugin(plugin: ModuleScopePlugin) {
   const reactLibs = ['react', 'react-dom']
-  const reactPaths = reactLibs.map(reactLib =>
+  const reactPaths = reactLibs.map((reactLib) =>
     path.resolve(__dirname, 'node_modules', reactLib)
   )
   plugin.allowedPaths = [...plugin.allowedPaths, ...reactPaths]
@@ -52,6 +58,11 @@ export default {
           new ProvidePlugin({
             process: 'process/browser',
             Buffer: ['buffer', 'Buffer']
+          }),
+          new SourceMapDevToolPlugin({
+            publicPath:
+              'https://s3.us-west-1.amazonaws.com/sourcemaps.audius.co',
+            filename: '[file].map'
           })
         ],
         experiments: {

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -7582,17 +7582,6 @@
       "dev": true,
       "optional": true
     },
-    "@types/webpack": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-5.28.0.tgz",
-      "integrity": "sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "tapable": "^2.2.0",
-        "webpack": "^5"
-      }
-    },
     "@types/webpack-bundle-analyzer": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.1.tgz",
@@ -12098,7 +12087,7 @@
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -13140,7 +13129,7 @@
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -13692,7 +13681,7 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA=="
     },
     "earcut": {
       "version": "2.2.3",
@@ -16674,12 +16663,12 @@
         "Base64": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-          "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw=="
+          "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
         },
         "JSONStream": {
           "version": "0.8.4",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-          "integrity": "sha512-l0NN3IcqrZfZBJp7JWDJIHsnPV7yzJWqsYxQzL8Fwdx1BmEMjLuvtYkv+P9pbvpyfP75/f4MeDZhWNU4is32uA==",
+          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
           "requires": {
             "jsonparse": "0.0.5",
             "through": ">=2.2.7 <3"
@@ -16688,7 +16677,7 @@
         "acorn": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug=="
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         },
         "acorn-node": {
           "version": "1.8.2",
@@ -16720,7 +16709,7 @@
         "align-text": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -16730,7 +16719,7 @@
         "amdefine": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "asn1.js": {
           "version": "5.4.1",
@@ -16753,7 +16742,7 @@
         "assert": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
-          "integrity": "sha512-pSLN/C6u6JFR8L+0TzQ0Elc+VboxUXFtNw11RI1UcTcHEktQqIKIKK5S4nAZX4j8mpTpnCtmqpR+thPfqT11Kg==",
+          "integrity": "sha1-raoExGu1jG3R8pTaPrJuYijrbkQ=",
           "requires": {
             "util": "0.10.3"
           },
@@ -16761,12 +16750,12 @@
             "inherits": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
             },
             "util": {
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
+              "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
               "requires": {
                 "inherits": "2.0.1"
               }
@@ -16776,7 +16765,7 @@
         "astw": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-          "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
+          "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
           "requires": {
             "acorn": "^4.0.3"
           }
@@ -16784,7 +16773,7 @@
         "async": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "balanced-match": {
           "version": "1.0.2",
@@ -16794,7 +16783,7 @@
         "base64-js": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
         },
         "bn.js": {
           "version": "5.2.1",
@@ -16813,12 +16802,12 @@
         "brorand": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browser-pack": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
-          "integrity": "sha512-BHla5EbbxjNyLMFUMamVjeTY+q1QwHbrYNXlWOkw71QcBqAQF7maJyNh3OI/V0d5YyNdMYD6tiPhJB9ukBo99Q==",
+          "integrity": "sha1-+qHLxBSHsazEdH43PhFIrf/Q4tk=",
           "requires": {
             "JSONStream": "~0.8.4",
             "combine-source-map": "~0.3.0",
@@ -16831,7 +16820,7 @@
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -16842,7 +16831,7 @@
             "through2": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "requires": {
                 "readable-stream": "~1.0.17",
                 "xtend": "~3.0.0"
@@ -16861,14 +16850,14 @@
             "resolve": {
               "version": "1.1.7",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
             }
           }
         },
         "browserify": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-7.1.0.tgz",
-          "integrity": "sha512-BHHshSNeACBbVMAo/QCeJ4chEVOfrF1S4/8YTdNPnmP4GmuyS+RmZKHcKD0SmjJjvjBiHsT4eYuv/VUA0/9XnA==",
+          "integrity": "sha1-FmB3XJPD7+rrQvPGY4psTCtBTxQ=",
           "requires": {
             "JSONStream": "~0.8.3",
             "assert": "~1.1.0",
@@ -17003,7 +16992,7 @@
         "browserify-zlib": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
             "pako": "~0.2.0"
           }
@@ -17021,34 +17010,34 @@
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             }
           }
         },
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "builtins": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-          "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw=="
+          "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo="
         },
         "callsite": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-          "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ=="
+          "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
         },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g=="
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
         },
         "center-align": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "requires": {
             "align-text": "^0.1.3",
             "lazy-cache": "^1.0.3"
@@ -17066,7 +17055,7 @@
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
             "center-align": "^0.1.1",
             "right-align": "^0.1.1",
@@ -17076,14 +17065,14 @@
             "wordwrap": {
               "version": "0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
             }
           }
         },
         "combine-source-map": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
-          "integrity": "sha512-HRKa6g9SC1xd6ifto8ay6SxvyHaaQ50/8NO1ZONXx2hsIF9t/52qXa7Eeivaf5KFOSowK7Nm8TkIL/VC4khdBA==",
+          "integrity": "sha1-2edPWT2c1DgHMSy12EbUUe+qnrc=",
           "requires": {
             "convert-source-map": "~0.3.0",
             "inline-source-map": "~0.3.0",
@@ -17093,12 +17082,12 @@
         "commondir": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-          "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg=="
+          "integrity": "sha1-ifAP3NUbUZxXhzP+xWPmptp/W+I="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
           "version": "1.4.11",
@@ -17118,12 +17107,12 @@
         "constants-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-          "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA=="
+          "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI="
         },
         "convert-source-map": {
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-          "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg=="
+          "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
         },
         "core-util-is": {
           "version": "1.0.3",
@@ -17192,22 +17181,22 @@
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "deep-equal": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-          "integrity": "sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ=="
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
         },
         "defined": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-          "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg=="
+          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
         },
         "deps-sort": {
           "version": "1.3.9",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
-          "integrity": "sha512-aEnmQuu/Hf5h8akL8QshYWzk9MVBg/JYMyNq/Lz68i69nR17tunjP6o/AC6Tn48c8ayzG6aeKs6OoFOtVCtvrQ==",
+          "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
           "requires": {
             "JSONStream": "^1.0.3",
             "shasum": "^1.0.0",
@@ -17227,7 +17216,7 @@
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             }
           }
         },
@@ -17257,7 +17246,7 @@
             "defined": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             }
           }
         },
@@ -17281,12 +17270,12 @@
         "domain-browser": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-          "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q=="
+          "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
         },
         "duplexer2": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
           "requires": {
             "readable-stream": "~1.1.9"
           }
@@ -17315,7 +17304,7 @@
         "events": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
-          "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ=="
+          "integrity": "sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ="
         },
         "evp_bytestokey": {
           "version": "1.0.3",
@@ -17334,7 +17323,7 @@
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -17392,7 +17381,7 @@
         "hmac-drbg": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-          "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -17402,7 +17391,7 @@
         "http-browserify": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
+          "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
           "requires": {
             "Base64": "~0.2.0",
             "inherits": "~2.0.1"
@@ -17411,7 +17400,7 @@
         "https-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-          "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ=="
+          "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
         },
         "ieee754": {
           "version": "1.2.1",
@@ -17421,12 +17410,12 @@
         "indexof": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-          "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
+          "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -17440,7 +17429,7 @@
         "inline-source-map": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-          "integrity": "sha512-RNlldBXZ7BBcVm3HjXIXiwKxih1lnuKbzeLBRDSB/qaqk8/g4JEZBjxpBQMhqEthQyGv7ycu8r/8PKGgBdIqrA==",
+          "integrity": "sha1-pSi1FOaJ/OkNswiehw2S9Sestes=",
           "requires": {
             "source-map": "~0.3.0"
           },
@@ -17448,7 +17437,7 @@
             "source-map": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-              "integrity": "sha512-jz8leTIGS8+qJywWiO9mKza0hJxexdeIYXhDHw9avTQcXSNAGk3hiiRMpmI2Qf9dOrZDrDpgH9VNefzuacWC9A==",
+              "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -17458,7 +17447,7 @@
         "insert-module-globals": {
           "version": "6.6.3",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
-          "integrity": "sha512-ryk8hTKUZCc300SPOOwx30WhE5oRUssPDVlIoO8vtoMNBy5HGeesVRl3HF7ra4ll42T0IdnwD9XR9svh6+RRhg==",
+          "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
           "requires": {
             "JSONStream": "^1.0.3",
             "combine-source-map": "~0.6.1",
@@ -17482,7 +17471,7 @@
             "combine-source-map": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
-              "integrity": "sha512-XKRNtuZRlVDTuSGKsfZpXYz80y0XDbYS4a+FzafTgmYHy/ckruFBx7Nd6WaQnFHVI3O6IseWVdXUvZutMpjSkQ==",
+              "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
               "requires": {
                 "convert-source-map": "~1.1.0",
                 "inline-source-map": "~0.5.0",
@@ -17493,12 +17482,12 @@
             "convert-source-map": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-              "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg=="
+              "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
             },
             "inline-source-map": {
               "version": "0.5.0",
               "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
-              "integrity": "sha512-2WtHG0qX9OH9TVcxsLVfq3Tzr+qtL6PtWgoh0XAAKe4KkdA/57Q+OGJuRJHA4mZ2OZnkJ/ZAaXf9krLB12/nIg==",
+              "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
               "requires": {
                 "source-map": "~0.4.0"
               }
@@ -17506,17 +17495,17 @@
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             },
             "process": {
               "version": "0.11.10",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
             },
             "source-map": {
               "version": "0.4.4",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -17544,12 +17533,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "json-stable-stringify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-          "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
+          "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
           "requires": {
             "jsonify": "~0.0.0"
           }
@@ -17557,17 +17546,17 @@
         "jsonify": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA=="
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsonparse": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
-          "integrity": "sha512-fw7Q/8gFR8iSekUi9I+HqWIap6mywuoe7hQIg3buTVjuZgALKj4HAmm0X6f+TaL4c9NJbvyFQdaI2ppr5p6dnQ=="
+          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
         },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -17575,7 +17564,7 @@
         "labeled-stream-splicer": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
-          "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
+          "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
           "requires": {
             "inherits": "^2.0.1",
             "isarray": "~0.0.1",
@@ -17585,12 +17574,12 @@
         "lazy-cache": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
         },
         "lexical-scope": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-          "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
+          "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
           "requires": {
             "astw": "^2.0.0"
           }
@@ -17598,12 +17587,12 @@
         "lodash.memoize": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-          "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A=="
+          "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
         },
         "longest": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg=="
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "md5.js": {
           "version": "1.3.5",
@@ -17639,12 +17628,12 @@
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
             "brace-expansion": "^1.0.0"
           }
@@ -17657,7 +17646,7 @@
         "module-deps": {
           "version": "3.9.1",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
-          "integrity": "sha512-EbWWlSGaCVidEsLsSzkY6l/jm0IcGDSQ8tGwtjM8joTrxqxP0om02Px9Np8D7FMZ/vZFdsOGbio+WqkKQxYuTA==",
+          "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
           "requires": {
             "JSONStream": "^1.0.3",
             "browser-resolve": "^1.7.0",
@@ -17687,17 +17676,17 @@
             "defined": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
             },
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
             },
             "parents": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-              "integrity": "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==",
+              "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
               "requires": {
                 "path-platform": "~0.11.15"
               }
@@ -17722,7 +17711,7 @@
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
@@ -17730,7 +17719,7 @@
         "optimist": {
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "requires": {
             "wordwrap": "~0.0.2"
           }
@@ -17738,17 +17727,17 @@
         "os-browserify": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-          "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA=="
+          "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
         },
         "pako": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
         },
         "parents": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
-          "integrity": "sha512-ASkdjFPS2nrxujzSBZGt8ZCKeG0/K2ZZVKveqXt7XGtXfu+ssnk4DQhnK91KRvt83f36LjfxOfwi0cv1+Re0eA==",
+          "integrity": "sha1-+iEvAk2fpjGNu2tM5nbIvkk7nEM=",
           "requires": {
             "path-platform": "^0.0.1"
           },
@@ -17756,7 +17745,7 @@
             "path-platform": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
-              "integrity": "sha512-ydK1VKZFYwy0mT2JvimJfxt5z6Z6sjBbLfsFMoJczbwZ/ul0AjgpXLHinUzclf4/XYC8mtsWGuFERZ95Rnm8wA=="
+              "integrity": "sha1-tVhdfDxGPYmqAGDYZhHPGv1hfio="
             }
           }
         },
@@ -17785,7 +17774,7 @@
         "path-platform": {
           "version": "0.11.15",
           "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-          "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg=="
+          "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
         },
         "pbkdf2": {
           "version": "3.1.2",
@@ -17802,7 +17791,7 @@
         "process": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz",
-          "integrity": "sha512-g7Lv2/7sZaS5oNElebRqsd40W/k0QCTmq8WeNZ/w3PVTqRsz0giER3sMsFQXobi+/Gmuy/qbnksrh76o21DEDA=="
+          "integrity": "sha1-e7r3GH/m3tP9W+DLYQP7qcrLl5g="
         },
         "public-encrypt": {
           "version": "4.0.3",
@@ -17827,17 +17816,17 @@
         "punycode": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
-          "integrity": "sha512-h/vscxLPvI2l7k/0dFUKZ5I5TgMCJ/Pl+J6rw77PDuQM6UApf/GaRVkjv/YSm2k+fbp7Yw8dxsoe29DolT7h7w=="
+          "integrity": "sha1-VACKyXKux0F13vnLpt9/qdORh0A="
         },
         "querystring": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "querystring-es3": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-          "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="
+          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
         },
         "randombytes": {
           "version": "2.1.0",
@@ -17859,7 +17848,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -17870,7 +17859,7 @@
         "readable-wrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-          "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
+          "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
           "requires": {
             "readable-stream": "^1.1.13-1"
           }
@@ -17878,17 +17867,17 @@
         "repeat-string": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "resolve": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-          "integrity": "sha512-zxmAcifDjKxmUbk7chQdKhDSn8ml08g+MYyU37xhEXBp+N81cfbYsm4e0Gn9jtLbAvbR8w8Ox09xqUZtPuCoeA=="
+          "integrity": "sha1-OVqe+ehz+/4SvRRAi9kbuTYAPWk="
         },
         "rfile": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-          "integrity": "sha512-aNeTpY8g6DYmqPvakau22B0SipQTskO8FtYXzn8qg4X4bN9ExIH8VAhq/L9w7N8HvESYeSSwk3e4GmW+rLLAxQ==",
+          "integrity": "sha1-WXCM+Qyh50xUw8/Fw2/bmBBDUmE=",
           "requires": {
             "callsite": "~1.0.0",
             "resolve": "~0.3.0"
@@ -17897,14 +17886,14 @@
             "resolve": {
               "version": "0.3.1",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-              "integrity": "sha512-mxx/I/wLjxtryDBtrrb0ZNzaYERVWaHpJ0W0Arm8N4l8b+jiX/U5yKcsj0zQpF9UuKN1uz80EUTOudON6OPuaQ=="
+              "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ="
             }
           }
         },
         "right-align": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "requires": {
             "align-text": "^0.1.1"
           }
@@ -17921,7 +17910,7 @@
         "ruglify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-          "integrity": "sha512-XfRj1YJdm/gnZNvmpQ5L+2YGRHglDGMPgJRbitgCxC3GzKVQF/t+ij1aNcNg2AnEXGtLHJDwoSWrAq3TUm0EVg==",
+          "integrity": "sha1-3Ikw4qlUSidDAcyZcldMDQmGtnU=",
           "requires": {
             "rfile": "~1.0",
             "uglify-js": "~2.2"
@@ -17930,7 +17919,7 @@
             "uglify-js": {
               "version": "2.2.5",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-              "integrity": "sha512-viLk+/8G0zm2aKt1JJAVcz5J/5ytdiNaIsKgrre3yvSUjwVG6ZUujGH7E2TiPigZUwLYCe7eaIUEP2Zka2VJPA==",
+              "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
               "requires": {
                 "optimist": "~0.3.5",
                 "source-map": "~0.1.7"
@@ -17960,12 +17949,12 @@
         "shallow-copy": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-          "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
+          "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
         },
         "shasum": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-          "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
+          "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
           "requires": {
             "json-stable-stringify": "~0.0.0",
             "sha.js": "~2.4.4"
@@ -17974,12 +17963,12 @@
         "shell-quote": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
-          "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ=="
+          "integrity": "sha1-GkEZbzwDM8SCMjWT1ohuzxU92YY="
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -17987,7 +17976,7 @@
         "stream-browserify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
+          "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
           "requires": {
             "inherits": "~2.0.1",
             "readable-stream": "^1.0.27-1"
@@ -17996,7 +17985,7 @@
         "stream-combiner2": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
-          "integrity": "sha512-7DO1SfBVnyIyo9ytUjSyVojT5bp1ZY6h3pj7HUs6PwcRSd/r8mBOHbRwYC7nbHRakKzMKyNp5HWJRv4GgVherA==",
+          "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
           "requires": {
             "duplexer2": "~0.0.2",
             "through2": "~0.5.1"
@@ -18005,7 +17994,7 @@
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -18016,7 +18005,7 @@
             "through2": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "requires": {
                 "readable-stream": "~1.0.17",
                 "xtend": "~3.0.0"
@@ -18027,7 +18016,7 @@
         "stream-splicer": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-          "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
+          "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
           "requires": {
             "indexof": "0.0.1",
             "inherits": "^2.0.1",
@@ -18040,12 +18029,12 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "subarg": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-          "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+          "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
           "requires": {
             "minimist": "^1.1.0"
           }
@@ -18066,12 +18055,12 @@
         "through": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
+          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
           "requires": {
             "readable-stream": ">=1.1.13-1 <1.2.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -18087,7 +18076,7 @@
         "timers-browserify": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-          "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+          "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
           "requires": {
             "process": "~0.11.0"
           },
@@ -18095,7 +18084,7 @@
             "process": {
               "version": "0.11.10",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
             }
           }
         },
@@ -18107,12 +18096,12 @@
         "typedarray": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
             "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
@@ -18122,12 +18111,12 @@
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
             },
             "yargs": {
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "requires": {
                 "camelcase": "^1.0.2",
                 "cliui": "^2.1.0",
@@ -18140,12 +18129,12 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q=="
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
         },
         "umd": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-          "integrity": "sha512-mEAJeceExHnblcAwN3BQtDPYOrTy4ALeBh6nQ9KW0cUCd0UU714jAfil2jvq09b67IizwJIiTVFOjE+/52Dyvw==",
+          "integrity": "sha1-SmMHt2LxfwLSAbX6FU5nM5bCY88=",
           "requires": {
             "rfile": "~1.0.0",
             "ruglify": "~1.0.0",
@@ -18156,7 +18145,7 @@
             "source-map": {
               "version": "0.1.34",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-              "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+              "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -18164,7 +18153,7 @@
             "uglify-js": {
               "version": "2.4.24",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-              "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
+              "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
               "requires": {
                 "async": "~0.2.6",
                 "source-map": "0.1.34",
@@ -18177,7 +18166,7 @@
         "url": {
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
           "requires": {
             "punycode": "1.3.2",
             "querystring": "0.2.0"
@@ -18186,7 +18175,7 @@
             "punycode": {
               "version": "1.3.2",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-              "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
             }
           }
         },
@@ -18201,19 +18190,19 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vm-browserify": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
+          "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
           "requires": {
             "indexof": "0.0.1"
           }
@@ -18221,27 +18210,27 @@
         "window-size": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg=="
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
         },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xtend": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg=="
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
         },
         "yargs": {
           "version": "3.5.4",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
+          "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
           "requires": {
             "camelcase": "^1.0.2",
             "decamelize": "^1.0.0",
@@ -18252,7 +18241,7 @@
             "wordwrap": {
               "version": "0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
             }
           }
         }
@@ -22549,7 +22538,7 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ=="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -22625,7 +22614,7 @@
     "json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
       "requires": {
         "string-convert": "^0.2.0"
       }
@@ -26101,7 +26090,7 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -28993,7 +28982,7 @@
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -30327,7 +30316,7 @@
     "string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "string-length": {
       "version": "4.0.2",
@@ -32510,7 +32499,7 @@
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
       "requires": {
         "prepend-http": "^2.0.0"
       }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -223,7 +223,6 @@
     "@types/redux-saga": "0.10.5",
     "@types/redux-sentry-middleware": "0.2.1",
     "@types/resize-observer-browser": "0.1.7",
-    "@types/webpack": "5.28.0",
     "@types/webpack-bundle-analyzer": "4.4.1",
     "@types/webpack-env": "1.17.0",
     "abort-controller": "3.0.0",


### PR DESCRIPTION
### Description

* Add ci to upload sourcemaps to `sourcemaps.audius.co` s3 bucket
* Remove sourcemaps from build deployed to cloudflare
* Update craco config to point at s3 bucket for sourcemaps
* Remove `@types/webpack` (included with webpack v5)
* Uses `cimg/python:3.7.12-node` image for cloudflare deploy steps because it has both node 14 and python

Was initially going to do the sourcemap move as a separate job but that required attaching and persisting the workspace which added unnecessary run time.

### Dragons

Right now all source maps are `sync`ed into the same directory in the bucket, this is never getting pruned so could get big/expensive. Can do another pass to create separate directories for the different builds, and overwrite existing files. But wanna merge this to unblock builds for now

### How Has This Been Tested?

Tested by deploying to staging and checking new sourcemaps work

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

