### PR TITLE
[PAY-479] Check recipient wallet SOL before send

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2867,6 +2867,17 @@ export const audiusBackend = ({
   }
 
   /**
+   * Fetches the Sol balance for the given wallet address
+   * @param {string} The solana wallet address
+   * @returns {Promise<BNWei>}
+   */
+  async function getAddressSolBalance(address: string): Promise<BNWei> {
+    await waitForLibsInit()
+    const solBalance = await audiusLibs.solanaWeb3Manager.getSolBalance(address)
+    return solBalance
+  }
+
+  /**
    * Make a request to fetch the balance, staked and delegated total of the wallet address
    * @params {string} address The wallet address to fetch the balance for
    * @params {bool} bustCache
@@ -3153,6 +3164,7 @@ export const audiusBackend = ({
     getAccount,
     getAddressTotalStakedBalance,
     getAddressWAudioBalance,
+    getAddressSolBalance,
     getAssociatedTokenAccountInfo,
     getAllTracks,
     getArtistTracks,

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -3027,17 +3027,6 @@ export const audiusBackend = ({
   }
 
   /**
-   * Fetches the Sol balance for the given wallet address
-   * @param {string} The solana wallet address
-   * @returns {Promise<BNWei>}
-   */
-  async function getAddressSolBalance(address: string): Promise<BNWei> {
-    await waitForLibsInit()
-    const solBalance = await audiusLibs.solanaWeb3Manager.getSolBalance(address)
-    return solBalance
-  }
-
-  /**
    * Aggregate, submit, and evaluate attestations for a given challenge for a user
    */
   async function submitAndEvaluateAttestations({
@@ -3164,7 +3153,6 @@ export const audiusBackend = ({
     getAccount,
     getAddressTotalStakedBalance,
     getAddressWAudioBalance,
-    getAddressSolBalance,
     getAssociatedTokenAccountInfo,
     getAllTracks,
     getArtistTracks,

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2941,7 +2941,7 @@ export const audiusBackend = ({
       tokenAccountInfo = await audiusLibs.solanaWeb3Manager.getTokenAccountInfo(
         associatedTokenAccount.toString()
       )
-
+    }
     return tokenAccountInfo
   }
 

--- a/packages/common/src/services/audius-backend/eagerLoadUtils.ts
+++ b/packages/common/src/services/audius-backend/eagerLoadUtils.ts
@@ -3,6 +3,25 @@ import { LocalStorage } from '../local-storage'
 
 const DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-node-timestamp'
 
+export const LIBS_INITTED_EVENT = 'LIBS_INITTED_EVENT'
+
+/**
+ * Wait for the `LIBS_INITTED_EVENT` or pass through if there
+ * already exists a mounted `window.audiusLibs` object.
+ */
+export const waitForLibsInit = async () => {
+  // If libs is already defined, it has already loaded & initted
+  // so do nothing
+  // @ts-ignore
+  if (window.audiusLibs) return
+  // Add an event listener and resolve when that returns
+  return new Promise((resolve) => {
+    // @ts-ignore
+    if (window.audiusLibs) resolve()
+    window.addEventListener(LIBS_INITTED_EVENT, resolve)
+  })
+}
+
 export const getEagerDiscprov = async (
   localStorage: LocalStorage,
   env: Env

--- a/packages/common/src/services/audius-backend/eagerLoadUtils.ts
+++ b/packages/common/src/services/audius-backend/eagerLoadUtils.ts
@@ -3,25 +3,6 @@ import { LocalStorage } from '../local-storage'
 
 const DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-node-timestamp'
 
-export const LIBS_INITTED_EVENT = 'LIBS_INITTED_EVENT'
-
-/**
- * Wait for the `LIBS_INITTED_EVENT` or pass through if there
- * already exists a mounted `window.audiusLibs` object.
- */
-export const waitForLibsInit = async () => {
-  // If libs is already defined, it has already loaded & initted
-  // so do nothing
-  // @ts-ignore
-  if (window.audiusLibs) return
-  // Add an event listener and resolve when that returns
-  return new Promise((resolve) => {
-    // @ts-ignore
-    if (window.audiusLibs) resolve()
-    window.addEventListener(LIBS_INITTED_EVENT, resolve)
-  })
-}
-
 export const getEagerDiscprov = async (
   localStorage: LocalStorage,
   env: Env

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -48,6 +48,16 @@ export class WalletClient {
     }
   }
 
+  async getAssociatedTokenAccountInfo(address: string) {
+    try {
+      const tokenAccountInfo =
+        await this.audiusBackendInstance.getAssociatedTokenAccountInfo(address)
+      return tokenAccountInfo
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   async transferTokensFromEthToSol(): Promise<void> {
     const balance = await this.audiusBackendInstance.getBalance(true)
     if (balance.gt(new BN('0'))) {
@@ -125,6 +135,18 @@ export class WalletClient {
     } catch (err) {
       console.error(err)
       return []
+    }
+  }
+
+  async getWalletSolBalance(wallet: string): Promise<BNWei> {
+    try {
+      const balance = await this.audiusBackendInstance.getAddressSolBalance(
+        wallet
+      )
+      return balance as BNWei
+    } catch (err) {
+      console.error(err)
+      throw err
     }
   }
 

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -2,6 +2,7 @@ import BN from 'bn.js'
 
 import { ID } from 'models/Identifiers'
 import { BNWei, StringWei, WalletAddress } from 'models/Wallet'
+import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 import { stringWeiToBN } from 'utils/wallet'
 
 import { AudiusAPIClient } from '../audius-api-client'
@@ -12,6 +13,7 @@ export const MIN_TRANSFERRABLE_WEI = stringWeiToBN(
   '1000000000000000' as StringWei
 )
 
+const libs = () => window.audiusLibs
 const BN_ZERO = new BN('0') as BNWei
 
 type WalletClientConfig = {
@@ -139,10 +141,9 @@ export class WalletClient {
   }
 
   async getWalletSolBalance(wallet: string): Promise<BNWei> {
+    await waitForLibsInit()
     try {
-      const balance = await this.audiusBackendInstance.getAddressSolBalance(
-        wallet
-      )
+      const balance = await libs().solanaWeb3Manager.getSolBalance(wallet)
       return balance as BNWei
     } catch (err) {
       console.error(err)

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -2,7 +2,6 @@ import BN from 'bn.js'
 
 import { ID } from 'models/Identifiers'
 import { BNWei, StringWei, WalletAddress } from 'models/Wallet'
-import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 import { stringWeiToBN } from 'utils/wallet'
 
 import { AudiusAPIClient } from '../audius-api-client'
@@ -13,7 +12,6 @@ export const MIN_TRANSFERRABLE_WEI = stringWeiToBN(
   '1000000000000000' as StringWei
 )
 
-const libs = () => window.audiusLibs
 const BN_ZERO = new BN('0') as BNWei
 
 type WalletClientConfig = {
@@ -141,9 +139,10 @@ export class WalletClient {
   }
 
   async getWalletSolBalance(wallet: string): Promise<BNWei> {
-    await waitForLibsInit()
     try {
-      const balance = await libs().solanaWeb3Manager.getSolBalance(wallet)
+      const balance = await this.audiusBackendInstance.getAddressSolBalance(
+        wallet
+      )
       return balance as BNWei
     } catch (err) {
       console.error(err)

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -140,6 +140,7 @@ export class WalletClient {
 
   async getWalletSolBalance(wallet: string): Promise<BNWei> {
     try {
+      await new Promise((resolve) => setTimeout(resolve, 10000))
       const balance = await this.audiusBackendInstance.getAddressSolBalance(
         wallet
       )

--- a/packages/common/src/services/wallet-client/WalletClient.ts
+++ b/packages/common/src/services/wallet-client/WalletClient.ts
@@ -140,7 +140,6 @@ export class WalletClient {
 
   async getWalletSolBalance(wallet: string): Promise<BNWei> {
     try {
-      await new Promise((resolve) => setTimeout(resolve, 10000))
       const balance = await this.audiusBackendInstance.getAddressSolBalance(
         wallet
       )

--- a/packages/common/src/store/pages/token-dashboard/selectors.ts
+++ b/packages/common/src/store/pages/token-dashboard/selectors.ts
@@ -36,16 +36,6 @@ export const getHasAssociatedWallets = (state: CommonState) => {
 }
 export const getRemoveWallet = (state: CommonState) =>
   state.pages.tokenDashboard.associatedWallets.removeWallet
-export const getAwaitingConfirmationIsLoading = (state: CommonState) => {
-  if (
-    state.pages.tokenDashboard.modalState?.stage === 'SEND' &&
-    state.pages.tokenDashboard.modalState.flowState.stage ===
-      'AWAITING_CONFIRMATION'
-  ) {
-    return state.pages.tokenDashboard.modalState?.flowState.loading
-  }
-  return false
-}
 export const getCanRecipientReceiveWAudio = (state: CommonState) => {
   if (
     state.pages.tokenDashboard.modalState?.stage === 'SEND' &&
@@ -53,7 +43,7 @@ export const getCanRecipientReceiveWAudio = (state: CommonState) => {
       'AWAITING_CONFIRMATION'
   ) {
     return state.pages.tokenDashboard.modalState.flowState
-      .canRecipientReceiveWAudio
+      .canRecipientReceiveWAudio.state
   }
   return false
 }

--- a/packages/common/src/store/pages/token-dashboard/selectors.ts
+++ b/packages/common/src/store/pages/token-dashboard/selectors.ts
@@ -45,7 +45,5 @@ export const getCanRecipientReceiveWAudio = (state: CommonState) => {
     return state.pages.tokenDashboard.modalState.flowState
       .canRecipientReceiveWAudio
   }
-  throw new Error(
-    'Tried to access canRecipientReceiveWAudio outside of correct flow state.'
-  )
+  return false
 }

--- a/packages/common/src/store/pages/token-dashboard/selectors.ts
+++ b/packages/common/src/store/pages/token-dashboard/selectors.ts
@@ -36,3 +36,16 @@ export const getHasAssociatedWallets = (state: CommonState) => {
 }
 export const getRemoveWallet = (state: CommonState) =>
   state.pages.tokenDashboard.associatedWallets.removeWallet
+export const getCanRecipientReceiveWAudio = (state: CommonState) => {
+  if (
+    state.pages.tokenDashboard.modalState?.stage === 'SEND' &&
+    state.pages.tokenDashboard.modalState.flowState.stage ===
+      'AWAITING_CONFIRMATION'
+  ) {
+    return state.pages.tokenDashboard.modalState.flowState
+      .canRecipientReceiveWAudio
+  }
+  throw new Error(
+    'Tried to access canRecipientReceiveWAudio outside of correct flow state.'
+  )
+}

--- a/packages/common/src/store/pages/token-dashboard/selectors.ts
+++ b/packages/common/src/store/pages/token-dashboard/selectors.ts
@@ -43,7 +43,7 @@ export const getCanRecipientReceiveWAudio = (state: CommonState) => {
       'AWAITING_CONFIRMATION'
   ) {
     return state.pages.tokenDashboard.modalState.flowState
-      .canRecipientReceiveWAudio.state
+      .canRecipientReceiveWAudio
   }
-  return false
+  return 'false'
 }

--- a/packages/common/src/store/pages/token-dashboard/selectors.ts
+++ b/packages/common/src/store/pages/token-dashboard/selectors.ts
@@ -36,6 +36,16 @@ export const getHasAssociatedWallets = (state: CommonState) => {
 }
 export const getRemoveWallet = (state: CommonState) =>
   state.pages.tokenDashboard.associatedWallets.removeWallet
+export const getAwaitingConfirmationIsLoading = (state: CommonState) => {
+  if (
+    state.pages.tokenDashboard.modalState?.stage === 'SEND' &&
+    state.pages.tokenDashboard.modalState.flowState.stage ===
+      'AWAITING_CONFIRMATION'
+  ) {
+    return state.pages.tokenDashboard.modalState?.flowState.loading
+  }
+  return false
+}
 export const getCanRecipientReceiveWAudio = (state: CommonState) => {
   if (
     state.pages.tokenDashboard.modalState?.stage === 'SEND' &&

--- a/packages/common/src/store/pages/token-dashboard/slice.ts
+++ b/packages/common/src/store/pages/token-dashboard/slice.ts
@@ -70,10 +70,29 @@ const slice = createSlice({
           stage: 'AWAITING_CONFIRMATION',
           amount,
           recipientWallet: wallet,
-          chain
+          chain,
+          canRecipientReceiveWAudio: true
         }
       }
       state.modalState = newState
+    },
+    setCanRecipientReceiveWAudio: (
+      state,
+      {
+        payload: { canRecipientReceiveWAudio }
+      }: PayloadAction<{ canRecipientReceiveWAudio: boolean }>
+    ) => {
+      if (
+        state.modalState?.stage === 'SEND' &&
+        state.modalState.flowState.stage === 'AWAITING_CONFIRMATION'
+      ) {
+        state.modalState.flowState.canRecipientReceiveWAudio =
+          canRecipientReceiveWAudio
+      } else {
+        console.error(
+          'Tried to set canRecipientReceiveWAudio outside of correct flow state.'
+        )
+      }
     },
     transferEthAudioToSolWAudio: (state) => {
       if (
@@ -293,7 +312,8 @@ export const {
   updateWalletError,
   preloadWalletProviders,
   resetStatus,
-  transferEthAudioToSolWAudio
+  transferEthAudioToSolWAudio,
+  setCanRecipientReceiveWAudio
 } = slice.actions
 export const actions = slice.actions
 export default slice

--- a/packages/common/src/store/pages/token-dashboard/slice.ts
+++ b/packages/common/src/store/pages/token-dashboard/slice.ts
@@ -65,7 +65,8 @@ const slice = createSlice({
           amount,
           recipientWallet: wallet,
           chain,
-          canRecipientReceiveWAudio: false
+          canRecipientReceiveWAudio: false,
+          loading: true
         }
       }
       state.modalState = newState
@@ -82,6 +83,7 @@ const slice = createSlice({
       ) {
         state.modalState.flowState.canRecipientReceiveWAudio =
           canRecipientReceiveWAudio
+        state.modalState.flowState.loading = false
       } else {
         console.error(
           'Tried to set canRecipientReceiveWAudio outside of correct flow state.'

--- a/packages/common/src/store/pages/token-dashboard/slice.ts
+++ b/packages/common/src/store/pages/token-dashboard/slice.ts
@@ -8,6 +8,7 @@ import { BNWei, StringWei, WalletAddress } from '../../../models/Wallet'
 
 import {
   AssociatedWallets,
+  canReceiveWAudio,
   ConfirmRemoveWalletAction,
   TokenDashboardPageModalState,
   TokenDashboardState
@@ -65,8 +66,7 @@ const slice = createSlice({
           amount,
           recipientWallet: wallet,
           chain,
-          canRecipientReceiveWAudio: false,
-          loading: true
+          canRecipientReceiveWAudio: { state: 'false' }
         }
       }
       state.modalState = newState
@@ -75,7 +75,7 @@ const slice = createSlice({
       state,
       {
         payload: { canRecipientReceiveWAudio }
-      }: PayloadAction<{ canRecipientReceiveWAudio: boolean }>
+      }: PayloadAction<{ canRecipientReceiveWAudio: CanReceiveWAudio }>
     ) => {
       if (
         state.modalState?.stage === 'SEND' &&
@@ -83,7 +83,6 @@ const slice = createSlice({
       ) {
         state.modalState.flowState.canRecipientReceiveWAudio =
           canRecipientReceiveWAudio
-        state.modalState.flowState.loading = false
       } else {
         console.error(
           'Tried to set canRecipientReceiveWAudio outside of correct flow state.'

--- a/packages/common/src/store/pages/token-dashboard/slice.ts
+++ b/packages/common/src/store/pages/token-dashboard/slice.ts
@@ -8,7 +8,7 @@ import { BNWei, StringWei, WalletAddress } from '../../../models/Wallet'
 
 import {
   AssociatedWallets,
-  canReceiveWAudio,
+  CanReceiveWAudio,
   ConfirmRemoveWalletAction,
   TokenDashboardPageModalState,
   TokenDashboardState
@@ -66,7 +66,7 @@ const slice = createSlice({
           amount,
           recipientWallet: wallet,
           chain,
-          canRecipientReceiveWAudio: { state: 'false' }
+          canRecipientReceiveWAudio: 'loading'
         }
       }
       state.modalState = newState

--- a/packages/common/src/store/pages/token-dashboard/slice.ts
+++ b/packages/common/src/store/pages/token-dashboard/slice.ts
@@ -56,13 +56,7 @@ const slice = createSlice({
     },
     inputSendData: (
       state,
-      {
-        payload: { amount, wallet, chain }
-      }: PayloadAction<{
-        amount: StringWei
-        wallet: WalletAddress
-        chain: Chain
-      }>
+      { payload: { amount, wallet, chain } }: InputSendDataAction
     ) => {
       const newState: TokenDashboardPageModalState = {
         stage: 'SEND' as const,
@@ -71,7 +65,7 @@ const slice = createSlice({
           amount,
           recipientWallet: wallet,
           chain,
-          canRecipientReceiveWAudio: true
+          canRecipientReceiveWAudio: false
         }
       }
       state.modalState = newState

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -60,6 +60,13 @@ export type ConfirmRemoveWalletAction = PayloadAction<{
   chain: Chain
 }>
 
+export type InputSendDataAction = PayloadAction<{
+    amount: StringWei
+    wallet: WalletAddress
+    chain: Chain
+  }>
+}
+
 export type AssociatedWalletsState = {
   status: Nullable<'Connecting' | 'Confirming' | 'Confirmed'>
   connectedEthWallets: Nullable<AssociatedWallets>

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -47,10 +47,11 @@ export type TokenDashboardPageModalState = Nullable<
   | { stage: 'DISCORD_CODE' }
 >
 
-export type CanReceiveWAudio =
-  | { state: 'false' }
-  | { state: 'loading' }
-  | { state: 'true' }
+export enum CanReceiveWAudio {
+  'false',
+  'loading',
+  'true'
+}
 
 export type AssociatedWallet = {
   address: string

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -15,6 +15,7 @@ type SendingState =
       recipientWallet: string
       chain: Chain
       canRecipientReceiveWAudio: boolean
+      loading: false
     }
   | {
       stage: 'AWAITING_CONVERTING_ETH_AUDIO_TO_SOL'

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -14,8 +14,7 @@ type SendingState =
       amount: StringWei
       recipientWallet: string
       chain: Chain
-      canRecipientReceiveWAudio: boolean
-      loading: false
+      canRecipientReceiveWAudio: CanReceiveWAudio
     }
   | {
       stage: 'AWAITING_CONVERTING_ETH_AUDIO_TO_SOL'
@@ -47,6 +46,11 @@ export type TokenDashboardPageModalState = Nullable<
   | { stage: 'SEND'; flowState: SendingState }
   | { stage: 'DISCORD_CODE' }
 >
+
+export type CanReceiveWAudio =
+  | { state: 'false' }
+  | { state: 'loading' }
+  | { state: 'true' }
 
 export type AssociatedWallet = {
   address: string

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -61,11 +61,10 @@ export type ConfirmRemoveWalletAction = PayloadAction<{
 }>
 
 export type InputSendDataAction = PayloadAction<{
-    amount: StringWei
-    wallet: WalletAddress
-    chain: Chain
-  }>
-}
+  amount: StringWei
+  wallet: WalletAddress
+  chain: Chain
+}>
 
 export type AssociatedWalletsState = {
   status: Nullable<'Connecting' | 'Confirming' | 'Confirmed'>

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -47,11 +47,7 @@ export type TokenDashboardPageModalState = Nullable<
   | { stage: 'DISCORD_CODE' }
 >
 
-export enum CanReceiveWAudio {
-  'false',
-  'loading',
-  'true'
-}
+export type CanReceiveWAudio = 'false' | 'loading' | 'true'
 
 export type AssociatedWallet = {
   address: string

--- a/packages/common/src/store/pages/token-dashboard/types.ts
+++ b/packages/common/src/store/pages/token-dashboard/types.ts
@@ -14,6 +14,7 @@ type SendingState =
       amount: StringWei
       recipientWallet: string
       chain: Chain
+      canRecipientReceiveWAudio: boolean
     }
   | {
       stage: 'AWAITING_CONVERTING_ETH_AUDIO_TO_SOL'

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.module.css
@@ -33,3 +33,12 @@
   line-height: 1.2;
   text-align: center;
 }
+
+.loadingSpinner {
+  height: 24px;
+  width: 24px;
+}
+
+.loadingSpinner g path {
+  stroke: var(--static-white) !important;
+}

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.module.css
@@ -25,3 +25,11 @@
 .buttonWrapper {
   margin: 24px 0px;
 }
+
+.errorMessage {
+  margin: 8px 32px 32px 32px;
+  color: var(--accent-red);
+  font-weight: var(--font-demi-bold);
+  line-height: 1.2;
+  text-align: center;
+}

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
@@ -8,6 +8,7 @@ import {
 } from '@audius/common'
 import { Button, ButtonType, IconArrow } from '@audius/stems'
 
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useSelector } from 'utils/reducer'
 
 import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
@@ -15,7 +16,8 @@ import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
 import DashboardTokenValueSlider from './DashboardTokenValueSlider'
 import DisplayAudio from './DisplayAudio'
 import styles from './SendInputConfirmation.module.css'
-const { getCanRecipientReceiveWAudio } = tokenDashboardPageSelectors
+const { getCanRecipientReceiveWAudio, getAwaitingConfirmationIsLoading } =
+  tokenDashboardPageSelectors
 
 const messages = {
   title: "YOU'RE ABOUT TO SEND",
@@ -47,6 +49,7 @@ const SendInputConfirmation = ({
   onSend
 }: SendInputConfirmationProps) => {
   const canRecipientReceiveWAudio = useSelector(getCanRecipientReceiveWAudio)
+  const isLoading = useSelector(getAwaitingConfirmationIsLoading)
   return (
     <ModalBodyWrapper>
       <div className={styles.titleWrapper}>
@@ -64,10 +67,15 @@ const SendInputConfirmation = ({
           text={messages.sendButton}
           onClick={onSend}
           type={ButtonType.PRIMARY_ALT}
-          disabled={!canRecipientReceiveWAudio}
+          disabled={!canRecipientReceiveWAudio || isLoading}
+          rightIcon={
+            isLoading ? (
+              <LoadingSpinner className={styles.loadingSpinner} />
+            ) : null
+          }
         />
       </div>
-      {canRecipientReceiveWAudio ? null : (
+      {canRecipientReceiveWAudio || isLoading ? null : (
         <div className={styles.errorMessage}>{messages.errorMessage}</div>
       )}
     </ModalBodyWrapper>

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+
 import {
   BNWei,
   StringAudio,
@@ -8,7 +10,6 @@ import {
 } from '@audius/common'
 import { Button, ButtonType, IconArrow } from '@audius/stems'
 
-import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useSelector } from 'utils/reducer'
 
 import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
@@ -16,8 +17,7 @@ import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
 import DashboardTokenValueSlider from './DashboardTokenValueSlider'
 import DisplayAudio from './DisplayAudio'
 import styles from './SendInputConfirmation.module.css'
-const { getCanRecipientReceiveWAudio, getAwaitingConfirmationIsLoading } =
-  tokenDashboardPageSelectors
+const { getCanRecipientReceiveWAudio } = tokenDashboardPageSelectors
 
 const messages = {
   title: "YOU'RE ABOUT TO SEND",
@@ -48,8 +48,13 @@ const SendInputConfirmation = ({
   recipientAddress,
   onSend
 }: SendInputConfirmationProps) => {
+  const [isLongLoading, setIsLongLoading] = useState(false)
+
+  useEffect(() => {
+    setTimeout(() => setIsLongLoading(true), 1000)
+  }, [])
+
   const canRecipientReceiveWAudio = useSelector(getCanRecipientReceiveWAudio)
-  const isLoading = useSelector(getAwaitingConfirmationIsLoading)
   return (
     <ModalBodyWrapper>
       <div className={styles.titleWrapper}>
@@ -67,17 +72,12 @@ const SendInputConfirmation = ({
           text={messages.sendButton}
           onClick={onSend}
           type={ButtonType.PRIMARY_ALT}
-          disabled={!canRecipientReceiveWAudio || isLoading}
-          rightIcon={
-            isLoading ? (
-              <LoadingSpinner className={styles.loadingSpinner} />
-            ) : null
-          }
+          disabled={canRecipientReceiveWAudio !== 'true'}
         />
       </div>
-      {canRecipientReceiveWAudio || isLoading ? null : (
+      {canRecipientReceiveWAudio !== 'true' ? (
         <div className={styles.errorMessage}>{messages.errorMessage}</div>
-      )}
+      ) : null}
     </ModalBodyWrapper>
   )
 }

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
@@ -27,6 +27,8 @@ const messages = {
     'This account does not contain enough SOL to create an $AUDIO wallet.'
 }
 
+const LOADING_DURATION = 1000
+
 type SendInputConfirmationProps = {
   balance: BNWei
   amountToTransfer: BNWei
@@ -49,17 +51,18 @@ const SendInputConfirmation = ({
   recipientAddress,
   onSend
 }: SendInputConfirmationProps) => {
-  const [hasOneSecondElapsed, setHasOneSecondElapsed] = useState(false)
+  const [hasLoadingDurationElapsed, setHasLoadingDurationElapsed] =
+    useState(false)
   const canRecipientReceiveWAudio = useSelector(getCanRecipientReceiveWAudio)
   const isLongLoading =
-    hasOneSecondElapsed && canRecipientReceiveWAudio === 'loading'
+    hasLoadingDurationElapsed && canRecipientReceiveWAudio === 'loading'
 
   // State to help determine whether to show a loading spinner,
   // for example if Solana is being slow
   useEffect(() => {
     const timer = setTimeout(() => {
-      setHasOneSecondElapsed(true)
-    }, 1000)
+      setHasLoadingDurationElapsed(true)
+    }, LOADING_DURATION)
     return () => clearTimeout(timer)
   })
 

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
@@ -78,7 +78,7 @@ const SendInputConfirmation = ({
       <div className={styles.buttonWrapper}>
         <Button
           text={messages.sendButton}
-          onClick={canRecipientReceiveWAudio === 'true' ? onSend : null}
+          onClick={canRecipientReceiveWAudio === 'true' ? onSend : undefined}
           type={ButtonType.PRIMARY_ALT}
           disabled={canRecipientReceiveWAudio === 'false' || isLongLoading}
           rightIcon={

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
@@ -10,6 +10,7 @@ import {
 } from '@audius/common'
 import { Button, ButtonType, IconArrow } from '@audius/stems'
 
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { useSelector } from 'utils/reducer'
 
 import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
@@ -48,13 +49,20 @@ const SendInputConfirmation = ({
   recipientAddress,
   onSend
 }: SendInputConfirmationProps) => {
-  const [isLongLoading, setIsLongLoading] = useState(false)
-
-  useEffect(() => {
-    setTimeout(() => setIsLongLoading(true), 1000)
-  }, [])
-
+  const [hasOneSecondElapsed, setHasOneSecondElapsed] = useState(false)
   const canRecipientReceiveWAudio = useSelector(getCanRecipientReceiveWAudio)
+  const isLongLoading =
+    hasOneSecondElapsed && canRecipientReceiveWAudio === 'loading'
+
+  // State to help determine whether to show a loading spinner,
+  // for example if Solana is being slow
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setHasOneSecondElapsed(true)
+    }, 1000)
+    return () => clearTimeout(timer)
+  })
+
   return (
     <ModalBodyWrapper>
       <div className={styles.titleWrapper}>
@@ -70,12 +78,17 @@ const SendInputConfirmation = ({
       <div className={styles.buttonWrapper}>
         <Button
           text={messages.sendButton}
-          onClick={onSend}
+          onClick={canRecipientReceiveWAudio === 'true' ? onSend : null}
           type={ButtonType.PRIMARY_ALT}
-          disabled={canRecipientReceiveWAudio !== 'true'}
+          disabled={canRecipientReceiveWAudio === 'false' || isLongLoading}
+          rightIcon={
+            isLongLoading ? (
+              <LoadingSpinner className={styles.loadingSpinner} />
+            ) : null
+          }
         />
       </div>
-      {canRecipientReceiveWAudio !== 'true' ? (
+      {canRecipientReceiveWAudio === 'false' ? (
         <div className={styles.errorMessage}>{messages.errorMessage}</div>
       ) : null}
     </ModalBodyWrapper>

--- a/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/SendInputConfirmation.tsx
@@ -3,19 +3,25 @@ import {
   StringAudio,
   WalletAddress,
   stringAudioToBN,
-  weiToAudio
+  weiToAudio,
+  tokenDashboardPageSelectors
 } from '@audius/common'
 import { Button, ButtonType, IconArrow } from '@audius/stems'
+
+import { useSelector } from 'utils/reducer'
 
 import { ModalBodyTitle, ModalBodyWrapper } from '../WalletModal'
 
 import DashboardTokenValueSlider from './DashboardTokenValueSlider'
 import DisplayAudio from './DisplayAudio'
 import styles from './SendInputConfirmation.module.css'
+const { getCanRecipientReceiveWAudio } = tokenDashboardPageSelectors
 
 const messages = {
   title: "YOU'RE ABOUT TO SEND",
-  sendButton: 'SEND $AUDIO'
+  sendButton: 'SEND $AUDIO',
+  errorMessage:
+    'This account does not contain enough SOL to create an $AUDIO wallet.'
 }
 
 type SendInputConfirmationProps = {
@@ -40,6 +46,7 @@ const SendInputConfirmation = ({
   recipientAddress,
   onSend
 }: SendInputConfirmationProps) => {
+  const canRecipientReceiveWAudio = useSelector(getCanRecipientReceiveWAudio)
   return (
     <ModalBodyWrapper>
       <div className={styles.titleWrapper}>
@@ -57,8 +64,12 @@ const SendInputConfirmation = ({
           text={messages.sendButton}
           onClick={onSend}
           type={ButtonType.PRIMARY_ALT}
+          disabled={!canRecipientReceiveWAudio}
         />
       </div>
+      {canRecipientReceiveWAudio ? null : (
+        <div className={styles.errorMessage}>{messages.errorMessage}</div>
+      )}
     </ModalBodyWrapper>
   )
 }

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -9,8 +9,8 @@ import {
   accountSelectors,
   accountActions,
   tokenDashboardPageActions,
-  tokenDashboardPageSelectors,
   walletSelectors,
+  InputSendDataAction,
   walletActions,
   getContext,
   waitForAccount
@@ -38,7 +38,6 @@ const {
   setCanRecipientReceiveWAudio,
   inputSendData
 } = tokenDashboardPageActions
-const { getSendData } = tokenDashboardPageSelectors
 const fetchAccountSucceeded = accountActions.fetchAccountSucceeded
 const getAccountUser = accountSelectors.getAccountUser
 
@@ -236,11 +235,9 @@ function* fetchBalanceAsync() {
  * Check if we can send WAudio to a recipient by checking if they already have
  * an associated WAudio token account, or if they have enough SOL to create one.
  */
-function* checkAssociatedTokenAccountOrSol() {
+function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
   const walletClient = yield* getContext('walletClient')
-  const ret = yield* select(getSendData)
-  const { recipientWallet: address } = ret as { recipientWallet: string }
-
+  const address = action.payload.wallet
   const associatedTokenAccount = yield* call(() =>
     walletClient.getAssociatedTokenAccountInfo(address)
   )

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -231,7 +231,7 @@ function* fetchBalanceAsync() {
  * Check if we can send WAudio to a recipient by checking if they already have
  * an associated WAudio token account, or if they have enough SOL to create one.
  */
-function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
+async function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
   const walletClient = yield* getContext('walletClient')
   const address = action.payload.wallet
   const associatedTokenAccount = yield* call(() =>

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -231,7 +231,7 @@ function* fetchBalanceAsync() {
  * Check if we can send WAudio to a recipient by checking if they already have
  * an associated WAudio token account, or if they have enough SOL to create one.
  */
-async function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
+function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
   const walletClient = yield* getContext('walletClient')
   const address = action.payload.wallet
   const associatedTokenAccount = yield* call(() =>
@@ -245,12 +245,14 @@ async function* checkAssociatedTokenAccountOrSol(action: InputSendDataAction) {
     const minRentBN = new BN(minRentForATA)
     if (balance.lt(minRentBN)) {
       yield* put(
-        setCanRecipientReceiveWAudio({ canRecipientReceiveWAudio: false })
+        setCanRecipientReceiveWAudio({ canRecipientReceiveWAudio: 'false' })
       )
       return
     }
   }
-  yield* put(setCanRecipientReceiveWAudio({ canRecipientReceiveWAudio: true }))
+  yield* put(
+    setCanRecipientReceiveWAudio({ canRecipientReceiveWAudio: 'true' })
+  )
 }
 
 function* watchSend() {

--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -15,6 +15,7 @@ import {
   getContext,
   waitForAccount
 } from '@audius/common'
+import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import BN from 'bn.js'
 import { all, call, put, take, takeEvery, select } from 'typed-redux-saga'
 
@@ -45,6 +46,10 @@ const getAccountUser = accountSelectors.getAccountUser
 const errors = {
   rateLimitError: 'Please wait before trying again'
 }
+
+const ASSOCIATED_TOKEN_ACCOUNT_CREATION_FEE = new BN(
+  0.02 * LAMPORTS_PER_SOL
+) as BNWei
 
 function* getIsBalanceFrozen() {
   const freezeUntil = yield* select(getFreezeUntilTime)
@@ -241,7 +246,7 @@ function* checkAssociatedTokenAccountOrSol() {
   )
   if (!associatedTokenAccount) {
     const balance = yield* call(() => walletClient.getWalletSolBalance(address))
-    if (balance.isZero()) {
+    if (balance.lt(ASSOCIATED_TOKEN_ACCOUNT_CREATION_FEE)) {
       yield* put(
         setCanRecipientReceiveWAudio({ canRecipientReceiveWAudio: false })
       )


### PR DESCRIPTION
### Description
When transferring WAudio to an external wallet, throw an error if the recipient wouldn't be able to receive it, ie. if the recipient doesn't have an associated WAudio token account AND doesn't have a SOL balance to fund the creation of one.


### Dragons

I'm throwing an error in the selector for canRecipientReceiveWAudio on the assumption that if something is trying to access it from the incorrect state, then the caller probably depends on it in some incorrect way and so things should break. But open to suggestions!

Also in the selector and action, I am nesting the happy path but I think this is a case where it's necessary.

### How Has This Been Tested?

Tested on local browser.


https://user-images.githubusercontent.com/3893871/186984425-43bd5c4e-5d5f-4bac-ac90-d6788e4f5703.mov


https://user-images.githubusercontent.com/3893871/186984432-710f99b7-fd15-4e5e-a9f0-1979a9b96635.mov




