### PR TITLE
[PAY-476] Display error when send to wallet fails

### DIFF
--- a/packages/web/src/store/wallet/sagas.ts
+++ b/packages/web/src/store/wallet/sagas.ts
@@ -117,6 +117,10 @@ function* sendAsync({
           yield* put(sendFailed({ error: errorMessage }))
           return
         }
+        yield* put(
+          sendFailed({ error: 'Something has gone wrong, please try again.' })
+        )
+        return
       }
     }
 


### PR DESCRIPTION
### Description
Adds a generic error message when sending to an external wallet fails.

### Dragons


### How Has This Been Tested?


### How will this change be monitored?


### Feature Flags ###


