### PR TITLE
Cleans up code for Challenge Twitter icon fill color

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/modals/ChallengeRewards.module.css
@@ -379,15 +379,14 @@
 }
 .twitterButton .twitterIcon {
   margin-right: 8px !important;
-  fill: var(--static-white) !important;
 }
 .twitterButton .twitterIcon path {
-  fill: var(--static-white) !important;
+  fill: var(--static-white);
 }
 .twitterButton .twitterIcon svg {
   width: 24px;
   height: 18px;
-  fill: var(--static-white) !important;
+  fill: var(--static-white);
 }
 .buttonSpacer {
   width: 10px;


### PR DESCRIPTION
### Description

Removes unnecessary !important and fill property from fix for PAY-438 (#1760).
<img width="346" alt="Screen Shot 2022-08-24 at 11 40 08 AM" src="https://user-images.githubusercontent.com/3893871/186461874-fa650b9b-f4fe-4add-895f-caf020cedf59.png">

