### PR TITLE
[PAY-552] Change playllenge challenge button text

### DIFF
--- a/packages/mobile/src/utils/challenges.tsx
+++ b/packages/mobile/src/utils/challenges.tsx
@@ -102,7 +102,7 @@ export const challenges = {
   firstPlaylistShortDescription:
     'Create your first playlist & add a track to it',
   firstPlaylistProgressLabel: 'Not Earned',
-  firstPlaylistButton: 'Create Your First Playlist'
+  firstPlaylistButton: 'Create a Playlist'
 }
 
 export type ChallengesParamList = {

--- a/packages/web/src/pages/audio-rewards-page/config.tsx
+++ b/packages/web/src/pages/audio-rewards-page/config.tsx
@@ -76,7 +76,7 @@ const linkButtonMap: Record<LinkButtonType, LinkButtonInfo> = {
     link: () => EXPLORE_HEAVY_ROTATION_PAGE
   },
   firstPlaylist: {
-    label: 'Create Your First Playlist',
+    label: 'Create a Playlist',
     leftIcon: null,
     rightIcon: <IconArrow />,
     link: () => FAVORITES_PAGE
@@ -263,7 +263,7 @@ export const challengeRewardsConfig: Record<
     fullDescription: () => 'Create your first playlist & add a track to it',
     progressLabel: 'Not Earned',
     amount: amounts['first-playlist'],
-    panelButtonText: 'Create Your First Playlist',
+    panelButtonText: 'Create a Playlist',
     modalButtonInfo: {
       incomplete: linkButtonMap.firstPlaylist,
       inProgress: linkButtonMap.firstPlaylist,


### PR DESCRIPTION
### Description
Change text of first playlist challenge button to "Create a Playlist" so it doesn't read "Create Your First Playlist" even after the user has completed the challenge.

### Dragons

### How Has This Been Tested?

Ran on local browser + ios simulator

### How will this change be monitored?


### Feature Flags ###


