### PR TITLE
Add Text Button type to Stems

### DIFF
--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -385,17 +385,9 @@
   font-size: var(--font-xs);
 }
 
-.textButton.medium .icon svg {
-  width: var(--font-s);
-  height: var(--font-s);
-}
-.textButton.small .icon svg {
-  width: var(--font-xs);
-  height: var(--font-xs);
-}
-.textButton.tiny .icon svg {
-  width: var(--font-2xs);
-  height: var(--font-2xs);
+.textButton.button .icon svg {
+  width: calc(1em - 2px);
+  height: calc(1em - 2px);
 }
 
 .textButton:hover .textLabel {

--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -375,12 +375,15 @@
   height: unset;
 }
 
+.textButton.medium,
 .textButton.medium .textLabel {
   font-size: var(--font-m);
 }
+.textButton.small,
 .textButton.small .textLabel {
   font-size: var(--font-s);
 }
+.textButton.tiny,
 .textButton.tiny .textLabel {
   font-size: var(--font-xs);
 }

--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -359,3 +359,61 @@
     0 4px 12px -4px rgba(0, 0, 0, 0.3);
   transform: perspective(1px) scale3d(0.99, 0.99, 0.99);
 }
+
+/* Text Button */
+.textButton {
+  background: none;
+  border: none;
+  outline: none;
+  padding: 8px 24px;
+  font-weight: var(--font-bold);
+}
+
+.textButton.button.medium,
+.textButton.button.small,
+.textButton.button.tiny {
+  height: unset;
+}
+
+.textButton.medium .textLabel {
+  font-size: var(--font-m);
+}
+.textButton.small .textLabel {
+  font-size: var(--font-s);
+}
+.textButton.tiny .textLabel {
+  font-size: var(--font-xs);
+}
+
+.textButton.medium .icon svg {
+  width: var(--font-s);
+  height: var(--font-s);
+}
+.textButton.small .icon svg {
+  width: var(--font-xs);
+  height: var(--font-xs);
+}
+.textButton.tiny .icon svg {
+  width: var(--font-2xs);
+  height: var(--font-2xs);
+}
+
+.textButton:hover .textLabel {
+  color: var(--secondary);
+}
+
+.textButton .icon.left {
+  margin-right: var(--unit-1);
+}
+
+.textButton .icon.right {
+  margin-left: var(--unit-1);
+}
+
+.textButton .icon path {
+  transition: all var(--quick);
+}
+
+.textButton:hover .icon path {
+  fill: var(--secondary);
+}

--- a/packages/stems/src/components/Button/Button.tsx
+++ b/packages/stems/src/components/Button/Button.tsx
@@ -21,7 +21,8 @@ const TYPE_STYLE_MAP = {
   [Type.COMMON_ALT]: styles.commonAlt,
   [Type.DISABLED]: styles.disabled,
   [Type.GLASS]: styles.glass,
-  [Type.WHITE]: styles.white
+  [Type.WHITE]: styles.white,
+  [Type.TEXT]: styles.textButton
 }
 
 /**

--- a/packages/stems/src/components/Button/types.ts
+++ b/packages/stems/src/components/Button/types.ts
@@ -8,7 +8,8 @@ export enum Type {
   COMMON_ALT = 'commonAlt',
   DISABLED = 'disabled',
   GLASS = 'glass',
-  WHITE = 'white'
+  WHITE = 'white',
+  TEXT = 'text'
 }
 
 export enum Size {


### PR DESCRIPTION
### Description

Adds a text button type to the `Button` in stems. A simple text button that can have icons and turns `--secondary` color on hover.

Sizes affect the text size and icon size. The icon size is the same as the font size less 2px

https://user-images.githubusercontent.com/3690498/186540418-b982a2f9-ccff-40f1-8ded-d273bcb00cd9.mov


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested against usage in the BuyAudio modal and the $AUDIO rewards page 

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

