### PR TITLE
Consume new Text button in CollapsibleContent

### DIFF
--- a/packages/web/src/components/buy-audio-modal/components/InProgressPage.module.css
+++ b/packages/web/src/components/buy-audio-modal/components/InProgressPage.module.css
@@ -37,14 +37,16 @@
 .showMoreToggle {
   width: 100%;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 .showMoreToggle:global(.collapsed) {
   border-top: 1px solid var(--neutral-light-8);
 }
 .showMoreToggle .showMoreToggleButton {
-  margin: 0 auto;
-  padding: 24px 0;
-  font-size: var(--large);
+  padding-top: 24px;
+  padding-bottom: 24px;
 }
 
 .moreInfo {

--- a/packages/web/src/components/collapsible-content/CollapsibleContent.module.css
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.module.css
@@ -1,33 +1,17 @@
-.toggleCollapsedButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: var(--font-bold);
-  font-size: var(--font-s);
-  color: var(--neutral-light-4);
-  padding: 8px 24px;
-  gap: 5px;
-
-  background: transparent;
-  outline: 0;
-  border: 0;
-}
-.toggleCollapsedButton:hover {
-  cursor: pointer;
-}
-.toggleCollapsedButton:hover span {
-  color: var(--secondary);
-  transition: color 0.07s ease-out;
-}
-.toggleCollapsedButton:hover svg path {
-  fill: var(--secondary);
-  transition: fill 0.07s ease-out;
-}
-.toggleCollapsedContentsContainer {
+.collapsibleContainer {
   /** Unfortunately, this calcluates to overflow: auto hidden; */
   overflow: visible hidden;
   /** Hack to hide horizontal scrollbars **/
   padding: 0 150px;
   margin: 0 -150px;
   transition: height var(--quick);
+}
+
+.toggleCollapsedButton {
+  color: var(--neutral-light-4);
+  margin: 0 auto;
+}
+
+.toggleCollapsedButton .toggleCollapsedButtonIcon path {
+  fill: var(--neutral-light-4);
 }

--- a/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
+++ b/packages/web/src/components/collapsible-content/CollapsibleContent.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 
+import { Button, ButtonSize, ButtonType } from '@audius/stems'
 import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
 import useMeasure from 'react-use-measure'
@@ -45,22 +46,22 @@ export const CollapsibleContent = ({
     <div className={cn(className, { collapsed: isCollapsed })}>
       <div
         id={id}
-        className={styles.toggleCollapsedContentsContainer}
+        className={styles.collapsibleContainer}
         style={{ height: isCollapsed ? collapsedHeight : bounds.height }}
       >
-        <div ref={ref} className={styles.toggleCollapsedContents}>
-          {children}
-        </div>
+        <div ref={ref}>{children}</div>
       </div>
-      <button
+      <Button
         className={cn(styles.toggleCollapsedButton, toggleButtonClassName)}
+        iconClassName={styles.toggleCollapsedButtonIcon}
         aria-controls={id}
         aria-expanded={!isCollapsed}
+        type={ButtonType.TEXT}
+        size={ButtonSize.SMALL}
+        text={isCollapsed ? showText : hideText}
+        rightIcon={isCollapsed ? <IconCaretDownLine /> : <IconCaretUpLine />}
         onClick={handleToggle}
-      >
-        <span>{isCollapsed ? showText : hideText}</span>
-        {isCollapsed ? <IconCaretDownLine /> : <IconCaretUpLine />}
-      </button>
+      />
     </div>
   )
 }

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.module.css
@@ -99,9 +99,10 @@
   align-self: flex-start;
 }
 
-.toggle .advancedToggle {
-  width: 100%;
+.toggle {
   border-top: 1px solid var(--neutral-light-8);
+}
+.toggle .advancedToggle {
   padding-top: 20px;
 }
 
@@ -111,9 +112,9 @@
   align-items: center;
   width: 100%;
   padding-top: 16px;
-  padding-bottom: 24px;
+  padding-bottom: 16px;
   gap: 16px;
-  border-top: 1px solid var(--neutral-light-8);
+  border-bottom: 1px solid var(--neutral-light-8);
 }
 .advancedOptions {
   display: flex;

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -31,8 +31,8 @@ const { pressReceive, pressSend, pressConnectWallets } =
 const { getAccountBalance, getAccountTotalBalance } = walletSelectors
 
 const messages = {
-  receiveLabel: 'Receive $AUDIO',
-  sendLabel: 'Send $AUDIO',
+  receiveLabel: 'Receive',
+  sendLabel: 'Send',
   audio: '$AUDIO',
   manageWallets: 'Manage Wallets',
   connectWallets: 'Connect Other Wallets',


### PR DESCRIPTION
### Description

Depends on #1789 

- Consumes Text button in collapsible content
- Adjusts button on $AUDIO rewards page to not be full width
- Changes text of send/receive buttons in advanced section to match Figma

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested locally against stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

