### PR TITLE
[PAY-580] Add Success Page to BuyAudio Modal

### DIFF
--- a/packages/web/src/components/buy-audio-modal/components/SuccessPage.module.css
+++ b/packages/web/src/components/buy-audio-modal/components/SuccessPage.module.css
@@ -1,0 +1,52 @@
+.successPage {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: stretch;
+  gap: 24px;
+  padding-bottom: 24px;
+
+  font-weight: var(--font-bold);
+}
+
+.message {
+  text-align: center;
+  font-size: var(--font-l);
+}
+
+.label,
+.message,
+.review {
+  color: var(--neutral-light-4);
+}
+.review .reviewButtonIcon svg path {
+  fill: var(--neutral-light-4);
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.purchasedAmount {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--static-accent-green);
+  font-size: var(--font-l);
+}
+
+.newBalance {
+  display: flex;
+  gap: 4px;
+  font-size: var(--font-3xl);
+}
+
+.review {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  font-size: var(--font-s);
+}

--- a/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import {
   BNAudio,
   BNWei,
@@ -8,6 +10,7 @@ import {
 import { Button, ButtonSize, ButtonType, IconInfo } from '@audius/stems'
 import BN from 'bn.js'
 
+import { useModalState } from 'common/hooks/useModalState'
 import { useSelector } from 'common/hooks/useSelector'
 
 import { IconAUDIO } from './Icons'
@@ -16,7 +19,8 @@ import styles from './SuccessPage.module.css'
 const messages = {
   successMessage: 'Transaction Was Successful!',
   audio: '$AUDIO',
-  review: 'Review Transaction'
+  review: 'Review Transaction',
+  done: 'Done'
 }
 
 const { getAccountTotalBalance } = walletSelectors
@@ -26,6 +30,11 @@ export const SuccessPage = () => {
   const totalBalance = useSelector<BNAudio>(getAccountTotalBalance)
   const uiBalance = formatWei(totalBalance || (new BN(0) as BNWei), true, 0)
   const purchaseInfo = useSelector(getAudioPurchaseInfo)
+  const [, setModalVisibility] = useModalState('BuyAudio')
+
+  const handleDoneClicked = useCallback(() => {
+    setModalVisibility(false)
+  }, [setModalVisibility])
 
   return (
     <div className={styles.successPage}>
@@ -46,7 +55,11 @@ export const SuccessPage = () => {
           <span className={styles.label}>{messages.audio}</span>
         </div>
       </div>
-      <Button text='Done' type={ButtonType.PRIMARY_ALT} />
+      <Button
+        text={messages.done}
+        type={ButtonType.PRIMARY_ALT}
+        onClick={handleDoneClicked}
+      />
       <div className={styles.review}>
         <Button
           iconClassName={styles.reviewButtonIcon}

--- a/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
@@ -1,0 +1,61 @@
+import {
+  BNAudio,
+  BNWei,
+  buyAudioSelectors,
+  formatWei,
+  walletSelectors
+} from '@audius/common'
+import { Button, ButtonSize, ButtonType, IconInfo } from '@audius/stems'
+import BN from 'bn.js'
+
+import { useSelector } from 'common/hooks/useSelector'
+
+import { IconAUDIO } from './Icons'
+import styles from './SuccessPage.module.css'
+
+const messages = {
+  successMessage: 'Transaction Was Successful!',
+  audio: '$AUDIO',
+  review: 'Review Transaction'
+}
+
+const { getAccountTotalBalance } = walletSelectors
+const { getAudioPurchaseInfo } = buyAudioSelectors
+
+export const SuccessPage = () => {
+  const totalBalance = useSelector<BNAudio>(getAccountTotalBalance)
+  const uiBalance = formatWei(totalBalance || (new BN(0) as BNWei), true, 0)
+  const purchaseInfo = useSelector(getAudioPurchaseInfo)
+
+  return (
+    <div className={styles.successPage}>
+      <div className={styles.message}>{messages.successMessage}</div>
+      <div className={styles.results}>
+        <div className={styles.purchasedAmount}>
+          <IconAUDIO />
+          <span className={styles.label}>{messages.audio}</span>
+          <span>
+            +
+            {purchaseInfo?.isError === false
+              ? purchaseInfo.desiredAudioAmount.uiAmountString
+              : '0'}
+          </span>
+        </div>
+        <div className={styles.newBalance}>
+          {uiBalance}
+          <span className={styles.label}>{messages.audio}</span>
+        </div>
+      </div>
+      <Button text='Done' type={ButtonType.PRIMARY_ALT} />
+      <div className={styles.review}>
+        <Button
+          iconClassName={styles.reviewButtonIcon}
+          type={ButtonType.TEXT}
+          size={ButtonSize.SMALL}
+          text={messages.review}
+          leftIcon={<IconInfo />}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### Description

- Adds the success page of the buy $AUDIO modal

![image](https://user-images.githubusercontent.com/3690498/186718991-6b76408f-f7d6-4661-9436-dcff21768dc3.png)


Note:
- Does not have TransactionDetails wired up
- Not wired up to Modal (yet)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested by manually swapping the page for the BuyAudioModal to the SuccessPage and triggering the saga manually

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

Already behind BUY_AUDIO_ENABLED feature flag
