### PR TITLE
Fix track removal from playlist with entity manager

### DIFF
--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -597,11 +597,22 @@ function* removeTrackFromPlaylistAsync(action) {
   const playlist = yield select(getCollection, { id: action.playlistId })
 
   // Find the index of the track based on the track's id and timestamp
-  const index = playlist.playlist_contents.track_ids.findIndex(
-    (t) =>
-      t.time === (action.metadata_timestamp ?? action.timestamp) &&
-      t.track === action.trackId
-  )
+  const index = playlist.playlist_contents.track_ids.findIndex((t) => {
+    if (t.track !== action.trackId) {
+      return false
+    }
+
+    if (t.metadata_time && t.metadata_time !== action.timestamp) {
+      // entity manager is enabled
+      return false
+    }
+
+    if (t.time !== action.timestamp) {
+      return false
+    }
+
+    return true
+  })
   if (index === -1) {
     console.error('Could not find the index of to-be-deleted track')
     return


### PR DESCRIPTION
### Description

Entity manager enabled track removals were broken. The metadata_timestamp would not match the playlist indexing timestamp so no track would be removed. This logic will check if the playlist is enabled / has a metadata_timestamp then match based on that. If entity manager is disabled, it will use indexing timestamp instead.


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested against staging.
Test track addition/removal with without cached state.
Tested legacy flow as well.

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###
This change is behind the playlist_entity_manager_enabled flag.
*Are all new features properly feature flagged? Describe added feature flags.*

