### PR TITLE
Follow up fix track removal from playlist with entity manager

### DIFF
--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -597,11 +597,26 @@ function* removeTrackFromPlaylistAsync(action) {
   const playlist = yield select(getCollection, { id: action.playlistId })
 
   // Find the index of the track based on the track's id and timestamp
-  const index = playlist.playlist_contents.track_ids.findIndex(
-    (t) =>
-      t.time === (action.metadata_timestamp ?? action.timestamp) &&
-      t.track === action.trackId
-  )
+  const index = playlist.playlist_contents.track_ids.findIndex((t) => {
+    if (t.track !== action.trackId) {
+      return false
+    }
+
+    if (t.metadata_time) {
+      if (t.metadata_time === action.timestamp) {
+        // entity manager is enabled
+        return true
+      } else {
+        return false
+      }
+    }
+
+    if (t.time !== action.timestamp) {
+      return false
+    }
+
+    return true
+  })
   if (index === -1) {
     console.error('Could not find the index of to-be-deleted track')
     return


### PR DESCRIPTION
### Description

If entity manager is enabled, we can return false early if they do not match. Don't check for index time `t.time`.

Follow up https://github.com/AudiusProject/audius-client/pull/1815.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

- [X] normal remove track - legacy playlist
- [X] normal remove track - entity manager playlist
- [X] cached remove track (quick add/remove) - entity manager playlist

cached remove track on legacy is broken on prod. entity manager will fix this.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

