### PR TITLE
[Stems] Don't rewrite to /index.html on stems.audius.co

### DIFF
--- a/packages/stems/scripts/workers-site/index.js
+++ b/packages/stems/scripts/workers-site/index.js
@@ -2,7 +2,7 @@ import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
 
 const DEBUG = false
 
-addEventListener('fetch', event => {
+addEventListener('fetch', (event) => {
   try {
     event.respondWith(handleEvent(event))
   } catch (e) {
@@ -27,13 +27,6 @@ async function handleEvent(event) {
   }
 
   const options = {}
-  // Always map requests to `/`
-  options.mapRequestToAsset = request => {
-    const url = new URL(request.url)
-    url.pathname = `/`
-    return mapRequestToAsset(new Request(url, request))
-  }
-
   try {
     if (DEBUG) {
       // customize caching


### PR DESCRIPTION
### Description

- stems.audius.co was borked because the requests to the bundle/css were being redirected to the root
- Storybook uses query params anyway to route so just turn off the rewrite altogether

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

