### PR TITLE
[PAY-507] Fix feed tip tile tip button resizing

### DIFF
--- a/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.module.css
+++ b/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.module.css
@@ -31,8 +31,19 @@
 
 .usersContainer {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   font-size: var(--font-s);
+  column-gap: 10px;
+}
+.recipientContainer {
+  display: flex;
+  align-items: center;
+}
+.senderContainer {
+  display: flex;
+  align-items: center;
+  margin: 10px 0;
 }
 .profilePicture {
   cursor: pointer;
@@ -60,7 +71,6 @@
 .wasTippedByContainer {
   display: flex;
   align-items: center;
-  margin-left: 10px;
 }
 .wasTippedByIcon {
   width: 14px;

--- a/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.tsx
+++ b/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.tsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  useCallback,
-  useEffect,
-  useRef,
-  MutableRefObject
-} from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import {
   Name,


### PR DESCRIPTION
### Description
Fixes feed tip tile "send tip" button resizing issue. Now also wraps the recipient info and "was tipped by" section.

### Dragons

Some jumpiness if the user resizes the window quickly, see the end of the video.

Now 
### How Has This Been Tested?

Tested on local web

https://user-images.githubusercontent.com/3893871/187829466-d366ffe3-5a9c-46c7-899f-3e8325e55848.mov


### How will this change be monitored?


### Feature Flags ###


