### PR TITLE
[PAY-591] Improve supporter count visibility

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureList.tsx
@@ -34,13 +34,23 @@ const useStyles = makeStyles(
       justifyContent: 'center',
       alignItems: 'center'
     },
+    imageExtraDim: {
+      marginLeft: spacing(2.5) - imageDimensions.width,
+      backgroundColor: 'rgba(0,0,0,0.1)',
+      borderRadius: 15,
+      width: 24,
+      height: 24
+    },
     imageCount: {
       width: imageDimensions.width,
-      marginLeft: spacing(2) - imageDimensions.width,
+      marginLeft: spacing(0.5) - imageDimensions.width,
       textAlign: 'center',
       color: palette.staticWhite,
       fontSize: typography.fontSize.small,
-      fontFamily: typography.fontByWeight.bold
+      fontFamily: typography.fontByWeight.bold,
+      textShadowColor: 'rgba(0,0,0,0.25)',
+      textShadowOffset: { width: 0, height: 2 },
+      textShadowRadius: 1
     }
   })
 )
@@ -112,6 +122,7 @@ export const ProfilePictureList = (props: ProfilePictureListProps) => {
             navigationType={navigationType}
             interactive={interactive}
           />
+          <View style={styles.imageExtraDim} />
           <Text style={styles.imageCount}>
             {`+${formatCount(remainingUsersCount)}`}
           </Text>


### PR DESCRIPTION
### Description
Adds text shadow to follower count, and adds a black view with 10% opacity on top of the last profile picture in supporters.
Before:
<img width="143" alt="Screen Shot 2022-09-01 at 2 13 45 PM" src="https://user-images.githubusercontent.com/3893871/187985238-93c3d2ac-4ea2-430a-b2bc-ef032726b979.png">

After:
<img width="141" alt="Screen Shot 2022-09-01 at 2 13 51 PM" src="https://user-images.githubusercontent.com/3893871/187985247-2623c97d-9e01-4419-8740-0b0a9aea00aa.png">

### Dragons


### How Has This Been Tested?

Tested on ios simulator

### How will this change be monitored?


### Feature Flags ###


