### PR TITLE
[C-877] Make tooltips use updated colors when theme is applied

### DIFF
--- a/packages/web/src/components/co-sign/CoSign.tsx
+++ b/packages/web/src/components/co-sign/CoSign.tsx
@@ -5,14 +5,11 @@ import cn from 'classnames'
 
 import Tooltip from 'components/tooltip/Tooltip'
 import { useIsMobile } from 'utils/clientUtil'
-import { getCurrentThemeColors } from 'utils/theme/theme'
 
 import Check from './Check'
 import styles from './CoSign.module.css'
 import HoverInfo from './HoverInfo'
 import { Size } from './types'
-
-const themeColors = getCurrentThemeColors()
 
 const CoSignCheck = ({
   coSignName,
@@ -46,7 +43,7 @@ const CoSignCheck = ({
       text={tooltipText}
       mount='page'
       className={styles.tooltip}
-      color={themeColors['--white']}
+      color={'--white'}
     >
       <div>
         <Check size={size} />

--- a/packages/web/src/components/profile-progress/components/ProfileCompletionTooltip.js
+++ b/packages/web/src/components/profile-progress/components/ProfileCompletionTooltip.js
@@ -1,12 +1,9 @@
 import Tooltip from 'components/tooltip/Tooltip'
-import { getCurrentThemeColors } from 'utils/theme/theme'
 
 import { getPercentageComplete } from './ProfileCompletionHeroCard'
 import styles from './ProfileCompletionTooltip.module.css'
 import { CompletionStageArray } from './PropTypes'
 import TaskCompletionList from './TaskCompletionList'
-
-const themeColors = getCurrentThemeColors()
 
 const makeStrings = ({ completionPercentage }) => ({
   completionPercentage: `Profile ${completionPercentage}% Complete`
@@ -40,7 +37,7 @@ const ProfileCompletionTooltip = ({
 }) => {
   return (
     <Tooltip
-      color={themeColors['--secondary']}
+      color={'--secondary'}
       shouldWrapContent={false}
       className={styles.tooltip}
       disabled={isDisabled}

--- a/packages/web/src/components/tooltip/Tooltip.module.css
+++ b/packages/web/src/components/tooltip/Tooltip.module.css
@@ -18,38 +18,5 @@
 
 .tooltip :global(.ant-tooltip-inner) {
   border-radius: 4px;
-  background-color: var(--tooltip-background-color);
   box-shadow: none;
-}
-
-/* The little tooltip arrow is a square rotated 45 deg
- * clockwise, so take that + the modal position into account
- * to figure out which two border segments to color.
- */
-.tooltip:global(.ant-tooltip-placement-right .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-rightTop .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-rightBottom .ant-tooltip-arrow) {
-  border-left-color: var(--tooltip-background-color);
-  border-bottom-color: var(--tooltip-background-color);
-}
-
-.tooltip:global(.ant-tooltip-placement-bottom .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-bottomLeft .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-bottomRight .ant-tooltip-arrow) {
-  border-top-color: var(--tooltip-background-color);
-  border-left-color: var(--tooltip-background-color);
-}
-
-.tooltip:global(.ant-tooltip-placement-left .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-leftTop .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-leftBottom .ant-tooltip-arrow) {
-  border-right-color: var(--tooltip-background-color);
-  border-top-color: var(--tooltip-background-color);
-}
-
-.tooltip:global(.ant-tooltip-placement-top .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-topLeft .ant-tooltip-arrow),
-.tooltip:global(.ant-tooltip-placement-topRight .ant-tooltip-arrow) {
-  border-right-color: var(--tooltip-background-color);
-  border-bottom-color: var(--tooltip-background-color);
 }

--- a/packages/web/src/components/tooltip/Tooltip.tsx
+++ b/packages/web/src/components/tooltip/Tooltip.tsx
@@ -8,12 +8,10 @@ import { getCurrentThemeColors } from 'utils/theme/theme'
 import styles from './Tooltip.module.css'
 import { TooltipProps } from './types'
 
-const themeColors = getCurrentThemeColors()
-
 export const Tooltip = ({
   children,
   className = '',
-  color = themeColors['--secondary-transparent'],
+  color = '--secondary-transparent',
   disabled = false,
   mount = 'parent',
   getPopupContainer,
@@ -24,6 +22,10 @@ export const Tooltip = ({
   shouldWrapContent = true,
   text = ''
 }: TooltipProps) => {
+  // This is part of the render cycle so that when the theme changes the new
+  // color is applied
+  const themedColor = getCurrentThemeColors()[color]
+
   // Keep track of a hidden state ourselves so we can dismiss the tooltip on click
   const [isHiddenOverride, setIsHiddenOverride] = useState(false)
 
@@ -88,7 +90,7 @@ export const Tooltip = ({
       overlayStyle={overlayStyle}
       placement={placement}
       title={text}
-      color={color}
+      color={themedColor}
       // @ts-ignore
       getPopupContainer={getPopupContainer || popupContainer}
       overlayClassName={cn(styles.tooltip, className, {

--- a/packages/web/src/components/tooltip/types.ts
+++ b/packages/web/src/components/tooltip/types.ts
@@ -2,14 +2,13 @@ import React from 'react'
 
 import { TooltipPlacement } from 'antd/lib/tooltip'
 
+import { ThemeColor } from 'utils/theme/theme'
+
 export type TooltipProps = {
   children: React.ReactNode
-  // Background color can be changed by overriding
-  // `--tooltip-background-color` CSS variable
   className?: string
   // Color from theme
-  // Use getThemeColors to pass in a theme color
-  color?: string
+  color?: ThemeColor
   // determines if it should display.
   disabled?: boolean
   // Where the tooltip gets mounted.

--- a/packages/web/src/utils/theme/theme.ts
+++ b/packages/web/src/utils/theme/theme.ts
@@ -11,6 +11,10 @@ const NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
 const THEME_KEY = 'theme'
 export const PREFERS_DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)'
 
+export type ThemeColor = keyof typeof DefaultTheme &
+  keyof typeof DarkTheme &
+  keyof typeof MatrixTheme
+
 const applyTheme = (themeObject: { [key: string]: string }) => {
   Object.keys(themeObject).forEach((key) => {
     document.documentElement.style.setProperty(key, themeObject[key])


### PR DESCRIPTION
### Description

* Fix issue where tooltips would have initial theme's colors after a new theme was applied
* Remove styles referencing `--tooltip-background-color` - this css variable didn't exist

### Dragons

`Tooltip` now does a `localstorage.getItem` on every render. I considered using `useLocalStorage` but that effectively does the same thing

### How Has This Been Tested?

Tested locally and compared tooltip colors & behavior against prod

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

