### PR TITLE
[PAY-605][PAY-601][PAY-548] Buy Audio modal design changes

### DIFF
--- a/packages/common/src/store/ui/buy-audio/slice.ts
+++ b/packages/common/src/store/ui/buy-audio/slice.ts
@@ -110,7 +110,9 @@ const slice = createSlice({
       state.stage = BuyAudioStage.PURCHASING
     },
     onRampCanceled: (state) => {
-      state.error = true
+      if (state.stage === BuyAudioStage.PURCHASING) {
+        state.error = true
+      }
     },
     onRampSucceeded: (state) => {
       state.stage = BuyAudioStage.CONFIRMING_PURCHASE

--- a/packages/common/src/store/ui/buy-audio/slice.ts
+++ b/packages/common/src/store/ui/buy-audio/slice.ts
@@ -83,6 +83,9 @@ const slice = createSlice({
       }
       state.purchaseInfoStatus = Status.ERROR
     },
+    precalculateSwapFees: () => {
+      // Triggers a saga to calculate and cache swap fees
+    },
     cacheAssociatedTokenAccount: (
       state,
       {
@@ -149,7 +152,8 @@ export const {
   swapStarted,
   swapCompleted,
   transferStarted,
-  transferCompleted
+  transferCompleted,
+  precalculateSwapFees
 } = slice.actions
 
 export default slice.reducer

--- a/packages/web/src/components/buy-audio-modal/components/AmountInputPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/AmountInputPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 
 import { buyAudioActions, buyAudioSelectors } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
@@ -8,7 +8,7 @@ import { AudioAmountPicker } from './AudioAmountPicker'
 import { CoinbaseBuyAudioButton } from './CoinbaseBuyAudioButton'
 import { PurchaseQuote } from './PurchaseQuote'
 
-const { calculateAudioPurchaseInfo, precalculateSwapFees } = buyAudioActions
+const { calculateAudioPurchaseInfo } = buyAudioActions
 const { getAudioPurchaseInfo } = buyAudioSelectors
 
 const messages = {

--- a/packages/web/src/components/buy-audio-modal/components/AmountInputPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/AmountInputPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { buyAudioActions, buyAudioSelectors } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
@@ -8,7 +8,7 @@ import { AudioAmountPicker } from './AudioAmountPicker'
 import { CoinbaseBuyAudioButton } from './CoinbaseBuyAudioButton'
 import { PurchaseQuote } from './PurchaseQuote'
 
-const { calculateAudioPurchaseInfo } = buyAudioActions
+const { calculateAudioPurchaseInfo, precalculateSwapFees } = buyAudioActions
 const { getAudioPurchaseInfo } = buyAudioSelectors
 
 const messages = {

--- a/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.module.css
+++ b/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.module.css
@@ -1,0 +1,10 @@
+.coinbasePayButton {
+  width: 100%;
+}
+
+.tooltip :global(.ant-tooltip-inner) {
+  border-radius: 8px;
+  padding: 12px 24px;
+  font-size: var(--font-m);
+  font-weight: var(--font-demi-bold);
+}

--- a/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
@@ -8,10 +8,20 @@ import {
   CoinbasePayContext,
   CoinbasePayButtonCustom
 } from 'components/coinbase-pay-button'
+import Tooltip from 'components/tooltip/Tooltip'
 import { getRootSolanaAccount } from 'services/audius-backend/BuyAudio'
+import { getCurrentThemeColors } from 'utils/theme/theme'
+
+import styles from './CoinbaseBuyAudioButton.module.css'
 
 const { onRampOpened, onRampCanceled, onRampSucceeded } = buyAudioActions
 const { getAudioPurchaseInfo, getAudioPurchaseInfoStatus } = buyAudioSelectors
+
+const messages = {
+  belowSolThreshold: 'Coinbase requires a purchase minimum of 0.05 SOL'
+}
+
+const themeColors = getCurrentThemeColors()
 
 export const CoinbaseBuyAudioButton = ({
   amount
@@ -23,7 +33,11 @@ export const CoinbaseBuyAudioButton = ({
   const rootAccount = useAsync(getRootSolanaAccount)
   const purchaseInfoStatus = useSelector(getAudioPurchaseInfoStatus)
   const purchaseInfo = useSelector(getAudioPurchaseInfo)
-  const isDisabled = purchaseInfoStatus !== Status.SUCCESS
+  const belowSolThreshold =
+    !purchaseInfo?.isError && purchaseInfo?.estimatedSOL?.uiAmount
+      ? purchaseInfo.estimatedSOL.uiAmount < 0.05
+      : false
+  const isDisabled = purchaseInfoStatus !== Status.SUCCESS || belowSolThreshold
 
   const handleExit = useCallback(() => {
     dispatch(onRampCanceled())
@@ -58,10 +72,21 @@ export const CoinbaseBuyAudioButton = ({
   ])
 
   return (
-    <CoinbasePayButtonCustom
-      disabled={isDisabled}
-      isDisabled={isDisabled}
-      onClick={handleClick}
-    />
+    <Tooltip
+      className={styles.tooltip}
+      text={messages.belowSolThreshold}
+      disabled={!belowSolThreshold}
+      color={themeColors['--secondary']}
+      shouldWrapContent={false}
+    >
+      <div>
+        <CoinbasePayButtonCustom
+          className={styles.coinbasePayButton}
+          disabled={isDisabled}
+          isDisabled={isDisabled}
+          onClick={handleClick}
+        />
+      </div>
+    </Tooltip>
   )
 }

--- a/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
@@ -34,7 +34,7 @@ export const CoinbaseBuyAudioButton = ({
   const purchaseInfoStatus = useSelector(getAudioPurchaseInfoStatus)
   const purchaseInfo = useSelector(getAudioPurchaseInfo)
   const belowSolThreshold =
-    !purchaseInfo?.isError && purchaseInfo?.estimatedSOL?.uiAmount
+    !purchaseInfo?.isError && purchaseInfo?.estimatedSOL
       ? purchaseInfo.estimatedSOL.uiAmount < 0.05
       : false
   const isDisabled = purchaseInfoStatus !== Status.SUCCESS || belowSolThreshold

--- a/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/CoinbaseBuyAudioButton.tsx
@@ -10,7 +10,6 @@ import {
 } from 'components/coinbase-pay-button'
 import Tooltip from 'components/tooltip/Tooltip'
 import { getRootSolanaAccount } from 'services/audius-backend/BuyAudio'
-import { getCurrentThemeColors } from 'utils/theme/theme'
 
 import styles from './CoinbaseBuyAudioButton.module.css'
 
@@ -20,8 +19,6 @@ const { getAudioPurchaseInfo, getAudioPurchaseInfoStatus } = buyAudioSelectors
 const messages = {
   belowSolThreshold: 'Coinbase requires a purchase minimum of 0.05 SOL'
 }
-
-const themeColors = getCurrentThemeColors()
 
 export const CoinbaseBuyAudioButton = ({
   amount
@@ -76,7 +73,7 @@ export const CoinbaseBuyAudioButton = ({
       className={styles.tooltip}
       text={messages.belowSolThreshold}
       disabled={!belowSolThreshold}
-      color={themeColors['--secondary']}
+      color={'--secondary'}
       shouldWrapContent={false}
     >
       <div>

--- a/packages/web/src/components/buy-audio-modal/components/InProgressPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/InProgressPage.tsx
@@ -20,9 +20,9 @@ const { getAudioPurchaseInfo, getBuyAudioFlowStage, getBuyAudioFlowError } =
 const messages = {
   pleaseHold: 'Please hold on. This may take a few moments.',
   completeWithCoinbase: 'Complete this step with Coinbase',
-  step1: 'Step 1',
-  step2: 'Step 2',
-  step3: 'Step 3',
+  step1: 'Step 1/3',
+  step2: 'Step 2/3',
+  step3: 'Step 3/3',
   purchasingSol: 'Purchasing SOL',
   convertingSol: 'Converting SOL to $AUDIO',
   finishingUp: 'Finalizing Transaction',
@@ -55,6 +55,7 @@ const stageToStep = (stage: BuyAudioStage) => {
     case BuyAudioStage.TRANSFERRING:
       return 3
   }
+  console.error('Reached unexpected stage in InProgressPage.tsx:', stage)
   return 1
 }
 

--- a/packages/web/src/components/buy-audio-modal/components/InProgressPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/InProgressPage.tsx
@@ -22,8 +22,10 @@ const messages = {
   completeWithCoinbase: 'Complete this step with Coinbase',
   step1: 'Step 1',
   step2: 'Step 2',
+  step3: 'Step 3',
   purchasingSol: 'Purchasing SOL',
   convertingSol: 'Converting SOL to $AUDIO',
+  finishingUp: 'Finalizing Transaction',
   moreInfo: 'More Info',
   lessInfo: 'Less Info',
   usd: 'USD',
@@ -42,11 +44,40 @@ type Token = {
   icon: ReactNode
 }
 
+const stageToStep = (stage: BuyAudioStage) => {
+  switch (stage) {
+    case BuyAudioStage.PURCHASING:
+      return 1
+    case BuyAudioStage.CONFIRMING_PURCHASE:
+    case BuyAudioStage.SWAPPING:
+      return 2
+    case BuyAudioStage.CONFIRMING_SWAP:
+    case BuyAudioStage.TRANSFERRING:
+      return 3
+  }
+  return 1
+}
+
+const stepMessages = {
+  1: {
+    stepName: messages.step1,
+    moreInfo: messages.purchasingSol
+  },
+  2: {
+    stepName: messages.step2,
+    moreInfo: messages.convertingSol
+  },
+  3: {
+    stepName: messages.step3,
+    moreInfo: messages.finishingUp
+  }
+}
+
 export const InProgressPage = () => {
   const purchaseInfo = useSelector(getAudioPurchaseInfo)
   const buyAudioFlowStage = useSelector(getBuyAudioFlowStage)
   const isError = useSelector(getBuyAudioFlowError)
-  const isStepOne = buyAudioFlowStage === BuyAudioStage.PURCHASING
+  const step = stageToStep(buyAudioFlowStage)
   let firstToken: Token | undefined
   let secondToken: Token | undefined
   if (purchaseInfo?.isError === false) {
@@ -57,7 +88,17 @@ export const InProgressPage = () => {
         maxDecimals: 2
       })
     }
-    if (isStepOne) {
+    const audioToken = {
+      label: messages.audio,
+      icon: <IconAUDIO />,
+      amount: formatNumberString(
+        purchaseInfo.desiredAudioAmount.uiAmountString,
+        {
+          maxDecimals: 2
+        }
+      )
+    }
+    if (step === 1) {
       firstToken = {
         label: messages.usd,
         icon: <IconUSD />,
@@ -67,18 +108,11 @@ export const InProgressPage = () => {
         })
       }
       secondToken = solToken
-    } else {
+    } else if (step === 2) {
       firstToken = solToken
-      secondToken = {
-        label: messages.audio,
-        icon: <IconAUDIO />,
-        amount: formatNumberString(
-          purchaseInfo.desiredAudioAmount.uiAmountString,
-          {
-            maxDecimals: 2
-          }
-        )
-      }
+      secondToken = audioToken
+    } else {
+      firstToken = audioToken
     }
   }
   return (
@@ -90,9 +124,7 @@ export const InProgressPage = () => {
         ) : (
           <LoadingSpinner className={styles.spinner} />
         )}
-        <span className={styles.headerCaps}>
-          {isStepOne ? messages.step1 : messages.step2}
-        </span>
+        <span className={styles.headerCaps}>{stepMessages[step].stepName}</span>
       </div>
       {isError ? (
         <div className={styles.error}>
@@ -102,7 +134,7 @@ export const InProgressPage = () => {
             ? messages.coinbaseErrorMessage
             : messages.swapErrorMessage}
         </div>
-      ) : isStepOne ? (
+      ) : step === 1 ? (
         <div className={styles.callToAction}>
           {messages.completeWithCoinbase}
         </div>
@@ -115,17 +147,19 @@ export const InProgressPage = () => {
         hideText={messages.lessInfo}
       >
         <div className={styles.moreInfo}>
-          <div className={styles.headerCaps}>
-            {isStepOne ? messages.purchasingSol : messages.convertingSol}
-          </div>
+          <div className={styles.headerCaps}>{stepMessages[step].moreInfo}</div>
           <div className={styles.quote}>
             {firstToken?.icon}
             <span className={styles.amount}>{firstToken?.amount}</span>
             <span className={styles.headerCaps}>{firstToken?.label}</span>
-            <IconCaretDown className={styles.caret} />
-            {secondToken?.icon}
-            <span className={styles.amount}>{secondToken?.amount}</span>
-            <span className={styles.headerCaps}>{secondToken?.label}</span>
+            {secondToken ? (
+              <>
+                <IconCaretDown className={styles.caret} />
+                {secondToken.icon}
+                <span className={styles.amount}>{secondToken.amount}</span>
+                <span className={styles.headerCaps}>{secondToken.label}</span>
+              </>
+            ) : null}
           </div>
         </div>
       </CollapsibleContent>

--- a/packages/web/src/components/buy-audio-modal/components/PurchaseQuote.module.css
+++ b/packages/web/src/components/buy-audio-modal/components/PurchaseQuote.module.css
@@ -42,8 +42,8 @@
 }
 
 .spinner {
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
 }
 
 .error {

--- a/packages/web/src/components/buy-audio-modal/components/PurchaseQuote.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/PurchaseQuote.tsx
@@ -47,9 +47,6 @@ export const PurchaseQuote = () => {
         {purchaseInfo?.isError ? (
           <div className={styles.error}>
             <span>{errorMessage}</span>
-            {purchaseInfoStatus === Status.LOADING ? (
-              <LoadingSpinner className={styles.spinner} />
-            ) : null}
           </div>
         ) : (
           <>
@@ -67,9 +64,6 @@ export const PurchaseQuote = () => {
               }
             )}
             <span className={styles.tokenLabel}>{messages.audio}</span>
-            {purchaseInfoStatus === Status.LOADING ? (
-              <LoadingSpinner className={styles.spinner} />
-            ) : null}
           </>
         )}
       </div>
@@ -77,20 +71,23 @@ export const PurchaseQuote = () => {
         <div className={styles.row}>
           <IconUSD />
           <span className={styles.tokenLabel}>{messages.usd}</span>
-          {purchaseInfoStatus === Status.LOADING ? (
-            <LoadingSpinner className={styles.spinner} />
-          ) : null}
         </div>
         <div className={styles.dollarEstimate}>
-          <span className={styles.tokenLabel}>$</span>
-          {formatNumberString(
-            !purchaseInfo?.isError
-              ? purchaseInfo?.estimatedUSD.uiAmountString ?? '0'
-              : '0',
-            {
-              minDecimals: 2,
-              maxDecimals: 2
-            }
+          {purchaseInfoStatus === Status.LOADING ? (
+            <LoadingSpinner className={styles.spinner} />
+          ) : (
+            <>
+              <span className={styles.tokenLabel}>$</span>
+              {formatNumberString(
+                !purchaseInfo?.isError
+                  ? purchaseInfo?.estimatedUSD.uiAmountString ?? '0'
+                  : '0',
+                {
+                  minDecimals: 2,
+                  maxDecimals: 2
+                }
+              )}
+            </>
           )}
         </div>
       </div>

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import {
   Nullable,
@@ -6,7 +6,8 @@ import {
   tokenDashboardPageActions,
   walletSelectors,
   tokenDashboardPageSelectors,
-  formatWei
+  formatWei,
+  buyAudioActions
 } from '@audius/common'
 import { Button, ButtonType, IconInfo } from '@audius/stems'
 import BN from 'bn.js'
@@ -44,6 +45,8 @@ const messages = {
   advancedOptions: 'Advanced Options'
 }
 const IS_NATIVE_MOBILE = process.env.REACT_APP_NATIVE_MOBILE
+
+const { precalculateSwapFees } = buyAudioActions
 
 const AdvancedWalletActions = () => {
   const balance = useSelector(getAccountBalance) ?? (new BN(0) as BNWei)
@@ -131,17 +134,24 @@ const AdvancedWalletActions = () => {
 }
 
 export const WalletManagementTile = () => {
+  const dispatch = useDispatch()
   const totalBalance: Nullable<BNWei> =
     useSelector(getAccountTotalBalance) ?? null
   const hasMultipleWallets = useSelector(getHasAssociatedWallets)
   const [, setOpen] = useModalState('AudioBreakdown')
   const [, setBuyAudioModalOpen] = useModalState('BuyAudio')
+
   const onClickOpen = useCallback(() => {
     setOpen(true)
   }, [setOpen])
+
   const onBuyAudioClicked = useCallback(() => {
     setBuyAudioModalOpen(true)
   }, [setBuyAudioModalOpen])
+
+  useEffect(() => {
+    dispatch(precalculateSwapFees())
+  }, [dispatch])
 
   return (
     <div className={styles.walletManagementTile}>

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -399,11 +399,14 @@ function* getAudioPurchaseInfo({
       'finalized'
     )
 
-    const estimatedLamports = new BN(inSol)
-      .add(new BN(associatedAccountCreationFees))
-      .add(new BN(transactionFees))
-      .add(new BN(rootAccountMinBalance))
-      .sub(new BN(existingBalance))
+    const estimatedLamports = BN.max(
+      new BN(inSol)
+        .add(new BN(associatedAccountCreationFees))
+        .add(new BN(transactionFees))
+        .add(new BN(rootAccountMinBalance))
+        .sub(new BN(existingBalance)),
+      new BN(0)
+    )
 
     // Get SOL => USDC quote to estimate $USD cost
     const quoteUSD = yield* call(JupiterSingleton.getQuote, {

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -65,7 +65,8 @@ const {
   transferCompleted,
   clearFeesCache,
   calculateAudioPurchaseInfoFailed,
-  buyAudioFlowFailed
+  buyAudioFlowFailed,
+  precalculateSwapFees
 } = buyAudioActions
 
 const { getBuyAudioFlowStage, getFeesCache } = buyAudioSelectors
@@ -669,6 +670,23 @@ function* watchOnRampStarted() {
   yield takeLatest(onRampOpened, startBuyAudioFlow)
 }
 
+function* watchPrecalculateSwapFees() {
+  yield takeLatest(precalculateSwapFees, function* () {
+    // Get SOL => AUDIO quote to calculate fees
+    const quote = yield* call(JupiterSingleton.getQuote, {
+      inputTokenSymbol: 'SOL',
+      outputTokenSymbol: 'AUDIO',
+      inputAmount: 0,
+      slippage: 0
+    })
+    yield* call(getSwapFees, { route: quote.route })
+  })
+}
+
 export default function sagas() {
-  return [watchOnRampStarted, watchCalculateAudioPurchaseInfo]
+  return [
+    watchOnRampStarted,
+    watchCalculateAudioPurchaseInfo,
+    watchPrecalculateSwapFees
+  ]
 }


### PR DESCRIPTION
### Description

- Consolidate the two spinners into one on the input page, replace the USD estimate
- Disable the buy button if the estimated SOL < 0.05 for coinbase
- Add a step 3 and add the total number of steps "Step 3/3"
- Fix bug where a stray coinbase close event can make the system think it errored when it didn't
- Preload the transaction fees/account creation rent on wallet management tile load to speed up estimates
- Fix the quote being negative causing weird estimates


https://user-images.githubusercontent.com/3690498/188028960-4e07fed7-7540-40e6-9360-9cbfa664509a.mov

![image](https://user-images.githubusercontent.com/3690498/188028988-0d32ac6b-99d8-436f-9496-0ea330192d90.png)

![image](https://user-images.githubusercontent.com/3690498/188029025-8cd0b03b-d78c-48c2-8d5f-6f439ad64327.png)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

