### PR TITLE
Use bulk tracks from API client

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -83,6 +83,7 @@ const FULL_ENDPOINT_MAP = {
   topGenreUsers: '/users/genre/top',
   topArtists: '/users/top',
   getTrack: (trackId: OpaqueID) => `/tracks/${trackId}`,
+  getTracks: () => `/tracks`,
   getTrackByHandleAndSlug: `/tracks`,
   getStems: (trackId: OpaqueID) => `/tracks/${trackId}/stems`,
   getRemixes: (trackId: OpaqueID) => `/tracks/${trackId}/remixes`,
@@ -117,6 +118,11 @@ export type GetTrackArgs = {
     urlTitle: string
     handle: string
   }
+}
+
+type GetTracksArgs = {
+  ids: ID[]
+  currentUserId: Nullable<ID>
 }
 
 type GetTrackByHandleAndSlugArgs = {
@@ -793,6 +799,26 @@ export class AudiusAPIClient {
 
     if (!trackResponse) return null
     const adapted = adapter.makeTrack(trackResponse.data)
+    return adapted
+  }
+
+  async getTracks({ ids, currentUserId }: GetTracksArgs) {
+    this._assertInitialized()
+    const encodedTrackIds = ids.map((id) => this._encodeOrThrow(id))
+    const encodedCurrentUserId = encodeHashId(currentUserId)
+    const params = {
+      id: encodedTrackIds,
+      user_id: encodedCurrentUserId || undefined
+    }
+
+    const trackResponse: Nullable<APIResponse<APITrack[]>> =
+      await this._getResponse(FULL_ENDPOINT_MAP.getTracks(), params, true)
+    if (!trackResponse) {
+      return null
+    }
+    const adapted = trackResponse.data
+      .map((track) => adapter.makeTrack(track))
+      .filter(removeNullable)
     return adapted
   }
 

--- a/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
@@ -218,18 +218,11 @@ export function* retrieveTracks({
     },
     retrieveFromSource: function* (ids: ID[] | UnlistedTrackRequest[]) {
       const apiClient = yield* getContext('apiClient')
-      const audiusBackendInstance = yield* getContext('audiusBackendInstance')
       let fetched: UserTrackMetadata | UserTrackMetadata[] | null | undefined
       if (canBeUnlisted) {
         const ids = trackIds as UnlistedTrackRequest[]
-        // TODO: remove the AudiusBackend
-        // branches here when we support
-        // bulk track fetches in the API.
         if (ids.length > 1) {
-          fetched = yield* call(
-            audiusBackendInstance.getTracksIncludingUnlisted,
-            trackIds as UnlistedTrackRequest[]
-          )
+          throw new Error('Can only query for single unlisted track')
         } else {
           fetched = yield* call([apiClient, 'getTrack'], {
             id: ids[0].id,
@@ -243,10 +236,9 @@ export function* retrieveTracks({
       } else {
         const ids = trackIds as number[]
         if (ids.length > 1) {
-          fetched = yield* call(audiusBackendInstance.getAllTracks, {
-            offset: 0,
-            limit: ids.length,
-            idsArray: ids as ID[]
+          fetched = yield* call([apiClient, 'getTracks'], {
+            ids,
+            currentUserId
           })
         } else {
           fetched = yield* call([apiClient, 'getTrack'], {


### PR DESCRIPTION
### Description

Moves retrieveTracks to the v1 API which is better.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Manually against prod. Went through all usages of retrieveTracks (we never care about bulk hidden ones) because of how the artist dashboard and your own feed work by signing requests.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

