### PR TITLE
[C-962, C-904] Native recovery email

### DIFF
--- a/packages/common/src/store/recovery-email/index.ts
+++ b/packages/common/src/store/recovery-email/index.ts
@@ -1,4 +1,7 @@
 export {
   default as recoveryEmailReducer,
-  actions as recoveryEmailActions
+  actions as recoveryEmailActions,
+  RecoveryEmailState
 } from './slice'
+
+export * as recoveryEmailSelectors from './selectors'

--- a/packages/common/src/store/recovery-email/selectors.ts
+++ b/packages/common/src/store/recovery-email/selectors.ts
@@ -1,0 +1,4 @@
+import { CommonState } from '../commonStore'
+
+export const getRecoveryEmailStatus = (state: CommonState) =>
+  state.ui.recoveryEmail.status

--- a/packages/common/src/store/recovery-email/slice.ts
+++ b/packages/common/src/store/recovery-email/slice.ts
@@ -1,21 +1,30 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
 
-const initialState = {}
+export type RecoveryEmailState = {
+  status: 'idle' | 'pending' | 'resolved' | 'rejected'
+}
 
-type ResendRecoveryEmailPayload = {}
+const initialState: RecoveryEmailState = {
+  status: 'idle'
+}
 
 const slice = createSlice({
   name: 'recovery-email',
   initialState,
   reducers: {
-    resendRecoveryEmail: (
-      _state,
-      _action: PayloadAction<ResendRecoveryEmailPayload>
-    ) => {}
+    resendRecoveryEmail: (state) => {
+      state.status = 'pending'
+    },
+    resendSuccess: (state) => {
+      state.status = 'resolved'
+    },
+    resendError: (state) => {
+      state.status = 'rejected'
+    }
   }
 })
 
-export const { resendRecoveryEmail } = slice.actions
+export const { resendRecoveryEmail, resendSuccess, resendError } = slice.actions
 
 export default slice.reducer
 export const actions = slice.actions

--- a/packages/common/src/store/reducers.ts
+++ b/packages/common/src/store/reducers.ts
@@ -42,6 +42,7 @@ import player, { PlayerState } from './player/slice'
 import queue from './queue/slice'
 import reachability from './reachability/reducer'
 import { ReachabilityState } from './reachability/types'
+import { recoveryEmailReducer, RecoveryEmailState } from './recovery-email'
 import solanaReducer from './solana/slice'
 import stemsUpload from './stems-upload/slice'
 import tippingReducer from './tipping/slice'
@@ -151,7 +152,8 @@ export const reducers = () => ({
       notifications: notificationsUserListReducer
     }),
     theme,
-    vipDiscordModal: vipDiscordModalReducer
+    vipDiscordModal: vipDiscordModalReducer,
+    recoveryEmail: recoveryEmailReducer
   }),
 
   // Pages
@@ -243,6 +245,7 @@ export type CommonState = {
     }
     theme: ThemeState
     vipDiscordModal: VipDiscordModalState
+    recoveryEmail: RecoveryEmailState
   }
 
   pages: {

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import {
   accountSelectors,
   recoveryEmailActions,
+  recoveryEmailSelectors,
   modalsActions
 } from '@audius/common'
 import { Text, View } from 'react-native'
@@ -27,6 +28,7 @@ import type { ProfileTabScreenParamList } from '../app-screen/ProfileTabScreen'
 
 import { AccountSettingsItem } from './AccountSettingsItem'
 const { resendRecoveryEmail } = recoveryEmailActions
+const { getRecoveryEmailStatus } = recoveryEmailSelectors
 const { setVisibility } = modalsActions
 const { getAccountUser } = accountSelectors
 
@@ -37,6 +39,7 @@ const messages = {
     'Store your recovery email safely. This email is the only way to recover your account if you forget your password.',
   recoveryButtonTitle: 'Resend',
   recoveryEmailSent: 'Recovery Email Sent!',
+  recoveryEmailNotSent: 'Unable to send recovery email. Please try again!',
   verifyTitle: 'Get Verified',
   verifyDescription:
     'Get verified by linking a verified social account to Audius',
@@ -76,12 +79,21 @@ export const AccountSettingsScreen = () => {
   const { toast } = useContext(ToastContext)
   const dispatch = useDispatch()
   const accountUser = useSelector(getAccountUser)
+  const recoveryEmailStatus = useSelector(getRecoveryEmailStatus)
   const navigation = useNavigation<ProfileTabScreenParamList>()
 
   const handlePressRecoveryEmail = useCallback(() => {
-    dispatch(resendRecoveryEmail)
-    toast({ content: messages.recoveryEmailSent })
-  }, [dispatch, toast])
+    dispatch(resendRecoveryEmail())
+  }, [dispatch])
+
+  useEffect(() => {
+    if (recoveryEmailStatus === 'resolved') {
+      toast({ content: messages.recoveryEmailSent })
+    }
+    if (recoveryEmailStatus === 'rejected') {
+      toast({ content: messages.recoveryEmailSent })
+    }
+  }, [recoveryEmailStatus, toast])
 
   const handlePressVerification = useCallback(() => {
     navigation.push({

--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -28,6 +28,7 @@ import trendingPageSagas from 'common/store/pages/trending/sagas'
 import playerSagas from 'common/store/player/sagas'
 import profileSagas from 'common/store/profile/sagas'
 import queueSagas from 'common/store/queue/sagas'
+import recoveryEmailSagas from 'common/store/recovery-email/sagas'
 import searchBarSagas from 'common/store/search-bar/sagas'
 import smartCollectionPageSagas from 'common/store/smart-collection/sagas'
 import socialSagas from 'common/store/social/sagas'
@@ -57,6 +58,7 @@ export default function* rootSaga() {
     ...backendSagas(),
     ...analyticsSagas(),
     ...accountSagas(),
+    ...recoveryEmailSagas(),
     ...confirmerSagas(),
     ...searchBarSagas(),
     ...searchResultsSagas(),


### PR DESCRIPTION
### Description

Adds native recovery email
Update recovery sagas to be web/native compatible
Adds status key to ensure success/failure toast is only shown when request finishes
