### PR TITLE
[PAY-600][PAY-599][PAY-607][PAY-617] RemoteConfig for Buy Audio and better transactiondetails link

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -26,7 +26,9 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.CHALLENGE_CLAIM_COMPLETION_POLL_FREQUENCY_MS]: 1000,
   [IntKeys.CHALLENGE_CLAIM_COMPLETION_POLL_TIMEOUT_MS]: 10000,
   [IntKeys.MIN_AUDIO_PURCHASE_AMOUNT]: 5,
-  [IntKeys.MAX_AUDIO_PURCHASE_AMOUNT]: 999
+  [IntKeys.MAX_AUDIO_PURCHASE_AMOUNT]: 999,
+  [IntKeys.BUY_AUDIO_WALLET_POLL_DELAY_MS]: 1000,
+  [IntKeys.BUY_AUDIO_WALLET_POLL_MAX_RETRIES]: 120
 }
 
 export const remoteConfigStringDefaults: {

--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -60,7 +60,8 @@ export const remoteConfigStringDefaults: {
   [StringKeys.ORACLE_ETH_ADDRESS]: null,
   [StringKeys.ORACLE_ENDPOINT]: null,
   [StringKeys.REWARDS_ATTESTATION_ENDPOINTS]: null,
-  [StringKeys.MIN_APP_VERSION]: '1.0.0'
+  [StringKeys.MIN_APP_VERSION]: '1.0.0',
+  [StringKeys.BUY_AUDIO_PRESET_AMOUNTS]: '5,10,25,50,100'
 }
 export const remoteConfigDoubleDefaults: {
   [key in DoubleKeys]: number | null

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -127,7 +127,17 @@ export enum IntKeys {
   /**
    * Maximum AUDIO required to purchase in the BuyAudio modal
    */
-  MAX_AUDIO_PURCHASE_AMOUNT = 'MAX_AUDIO_PURCHASE_AMOUNT'
+  MAX_AUDIO_PURCHASE_AMOUNT = 'MAX_AUDIO_PURCHASE_AMOUNT',
+
+  /**
+   * The time to delay between polls of the user wallet when performing a purchase of $AUDIO
+   */
+  BUY_AUDIO_WALLET_POLL_DELAY_MS = 'BUY_AUDIO_WALLET_POLL_DELAY_MS',
+
+  /**
+   * The maximum amount of times to poll the user wallet before giving up on an $AUDIO purchase
+   */
+  BUY_AUDIO_WALLET_POLL_MAX_RETRIES = 'BUY_AUDIO_WALLET_POLL_MAX_RETRIES'
 }
 
 export enum BooleanKeys {

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -268,7 +268,10 @@ export enum StringKeys {
   REWARDS_ATTESTATION_ENDPOINTS = 'REWARDS_ATTESTATION_ENDPOINTS',
 
   /** Minimum required version for the app */
-  MIN_APP_VERSION = 'MIN_APP_VERSION'
+  MIN_APP_VERSION = 'MIN_APP_VERSION',
+
+  /** Preset amounts for the Buy Audio modal */
+  BUY_AUDIO_PRESET_AMOUNTS = 'BUY_AUDIO_PRESET_AMOUNTS'
 }
 
 export type AllRemoteConfigKeys =

--- a/packages/web/src/components/buy-audio-modal/BuyAudioModal.tsx
+++ b/packages/web/src/components/buy-audio-modal/BuyAudioModal.tsx
@@ -57,6 +57,7 @@ export const BuyAudioModal = () => {
   const [isOpen, setIsOpen] = useModalState('BuyAudio')
   const stage = useSelector(getBuyAudioFlowStage)
   const currentPage = stageToPage(stage)
+  const inProgress = currentPage === 1
 
   const handleClose = useCallback(() => {
     setIsOpen(false)
@@ -73,8 +74,9 @@ export const BuyAudioModal = () => {
       onClose={handleClose}
       onClosed={handleClosed}
       bodyClassName={styles.modal}
+      dismissOnClickOutside={!inProgress}
     >
-      <ModalHeader onClose={handleClose}>
+      <ModalHeader onClose={handleClose} showDismissButton={!inProgress}>
         <ModalTitle title={messages.buyAudio} icon={<IconGoldBadge />} />
       </ModalHeader>
       <ModalContentPages

--- a/packages/web/src/components/buy-audio-modal/components/AmountInputPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/AmountInputPage.tsx
@@ -1,7 +1,9 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import { buyAudioActions, buyAudioSelectors } from '@audius/common'
+import { buyAudioActions, buyAudioSelectors, StringKeys } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
+
+import { useRemoteVar } from 'hooks/useRemoteConfig'
 
 import styles from './AmountInputPage.module.css'
 import { AudioAmountPicker } from './AudioAmountPicker'
@@ -18,6 +20,7 @@ const messages = {
 export const AmountInputPage = () => {
   const dispatch = useDispatch()
   const purchaseInfo = useSelector(getAudioPurchaseInfo)
+  const presetAmountsConfig = useRemoteVar(StringKeys.BUY_AUDIO_PRESET_AMOUNTS)
 
   const handleAmountChange = useCallback(
     (amount) => {
@@ -33,10 +36,14 @@ export const AmountInputPage = () => {
     [dispatch]
   )
 
+  const presetAmounts = useMemo(() => {
+    return presetAmountsConfig.split(',').map((amount) => amount.trim())
+  }, [presetAmountsConfig])
+
   return (
     <div className={styles.inputPage}>
       <AudioAmountPicker
-        presetAmounts={['5', '10', '25', '50', '100']}
+        presetAmounts={presetAmounts}
         onAmountChanged={handleAmountChange}
       />
       <PurchaseQuote />

--- a/packages/web/src/components/transaction-details-modal/components/Block.module.css
+++ b/packages/web/src/components/transaction-details-modal/components/Block.module.css
@@ -29,6 +29,10 @@
   color: var(--neutral-light-4);
 }
 
+.blockHeader svg path {
+  fill: var(--neutral-light-4);
+}
+
 .blockContent {
   display: flex;
   align-items: center;

--- a/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.module.css
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.module.css
@@ -1,10 +1,21 @@
-.iconButton {
-  display: flex;
+.link {
+  transition: color var(--quick);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
 }
-.iconButton svg {
-  width: 16px;
-  height: 16px;
+.link svg {
+  width: 1em;
+  height: 1em;
 }
-.iconButton path {
+.link svg path {
+  transition: fill var(--quick);
   fill: var(--neutral-light-4);
+}
+.link:hover {
+  color: var(--secondary);
+}
+.link:hover svg path {
+  fill: var(--secondary);
 }

--- a/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
@@ -1,5 +1,5 @@
 import { InAppAudioPurchaseMetadata, formatNumberString } from '@audius/common'
-import { IconButton } from '@audius/stems'
+import { Button, ButtonType, IconButton } from '@audius/stems'
 
 import { ReactComponent as IconExternalLink } from 'assets/img/iconExternalLink.svg'
 import {
@@ -31,17 +31,15 @@ export const TransactionPurchaseMetadata = ({
       </Block>
       <Block
         header={
-          <>
-            {messages.purchased}
-            <IconButton
-              className={styles.iconButton}
-              icon={<IconExternalLink />}
-              title={messages.viewOnExplorer}
-              aria-label={messages.viewOnExplorer}
-              href={`https://explorer.solana.com/tx/${metadata.purchaseTransactionId}`}
-              target='_blank'
-            />
-          </>
+          <a
+            className={styles.link}
+            href={`https://explorer.solana.com/tx/${metadata.purchaseTransactionId}`}
+            target='_blank'
+            title={messages.viewOnExplorer}
+            rel='noreferrer'
+          >
+            {messages.purchased} <IconExternalLink />
+          </a>
         }
       >
         <IconSOL />
@@ -49,17 +47,15 @@ export const TransactionPurchaseMetadata = ({
       </Block>
       <Block
         header={
-          <>
-            {messages.convertedTo}
-            <IconButton
-              className={styles.iconButton}
-              icon={<IconExternalLink />}
-              title={messages.viewOnExplorer}
-              aria-label={messages.viewOnExplorer}
-              href={`https://explorer.solana.com/tx/${metadata.swapTransactionId}`}
-              target='_blank'
-            />
-          </>
+          <a
+            className={styles.link}
+            href={`https://explorer.solana.com/tx/${metadata.swapTransactionId}`}
+            target='_blank'
+            title={messages.viewOnExplorer}
+            rel='noreferrer'
+          >
+            {messages.convertedTo} <IconExternalLink />
+          </a>
         }
       >
         <IconAUDIO />

--- a/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
@@ -1,5 +1,4 @@
 import { InAppAudioPurchaseMetadata, formatNumberString } from '@audius/common'
-import { Button, ButtonType, IconButton } from '@audius/stems'
 
 import { ReactComponent as IconExternalLink } from 'assets/img/iconExternalLink.svg'
 import {


### PR DESCRIPTION
### Description

See commit messages:
- [PAY-600 Add optimizely config for button presets](https://linear.app/audius/issue/PAY-600/add-optimizely-config-for-button-presets)
- [PAY-599 Make balance polling timeout configurable](https://linear.app/audius/issue/PAY-599/make-balance-polling-timeout-configurable)
- [PAY-607 Fix icon buttons ("View on Solana Explorer") in Transaction Details](https://linear.app/audius/issue/PAY-607/fix-icon-buttons-view-on-solana-explorer-in-transaction-details)
- [PAY-617 Buy Audio Modal should not be dismissable when in progress](https://linear.app/audius/issue/PAY-617/buy-audio-modal-should-not-be-dismissable-when-in-progress)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally against stage. All vars are now in optimizely

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

All still behind BUY_AUDIO_ENABLED