### PR TITLE
C-822 Fix dark mode "Follows you" chip

### DIFF
--- a/packages/web/src/components/artist/ArtistChip.module.css
+++ b/packages/web/src/components/artist/ArtistChip.module.css
@@ -109,6 +109,13 @@
   color: var(--neutral-light-4);
 }
 
+.followersContainer .followsYou.darkMode {
+  box-shadow: none;
+  border: 1px solid var(--neutral-light-4);
+  color: var(--neutral-light-4);
+  background: none;
+}
+
 .tipContainer .rank {
   margin-right: 24px;
 }

--- a/packages/web/src/components/artist/ArtistChipFollowers.tsx
+++ b/packages/web/src/components/artist/ArtistChipFollowers.tsx
@@ -3,6 +3,7 @@ import cn from 'classnames'
 
 import { ReactComponent as IconUser } from 'assets/img/iconUser.svg'
 import FollowsYouBadge from 'components/user-badges/FollowsYouBadge'
+import { isDarkMode } from 'utils/theme/theme'
 
 import styles from './ArtistChip.module.css'
 
@@ -19,6 +20,7 @@ export const ArtistChipFollowers = ({
   followerCount,
   doesFollowCurrentUser
 }: ArtistChipFollowersProps) => {
+  const darkMode = isDarkMode()
   return (
     <div className={styles.followersContainer}>
       <div className={cn(styles.followers, 'followers')}>
@@ -31,7 +33,9 @@ export const ArtistChipFollowers = ({
         </span>
       </div>
       {doesFollowCurrentUser ? (
-        <FollowsYouBadge className={styles.followsYou} />
+        <FollowsYouBadge
+          className={cn(styles.followsYou, { [styles.darkMode]: darkMode })}
+        />
       ) : null}
     </div>
   )


### PR DESCRIPTION
Fix: https://linear.app/audius/issue/C-822/[qa]-dark-mode-desktop-follows-you-tag-is-not-displayed-properly-in

<img width="665" alt="Screen Shot 2022-09-06 at 1 39 55 PM" src="https://user-images.githubusercontent.com/36916764/188703782-5ce43861-ebb8-4379-b24b-b6bf90011340.png">

This is only a problem in the "Followers/Following" modal which is why I made the change in ArtistChip instead of the Follows You badge component itself

### Description

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

