### PR TITLE
[C-879] Fix rewards page navigation

### DIFF
--- a/packages/web/src/hooks/useRequiresAccount.ts
+++ b/packages/web/src/hooks/useRequiresAccount.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-import { accountSelectors } from '@audius/common'
+import { accountSelectors, Status } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
 
@@ -10,7 +10,7 @@ import {
 } from 'common/store/pages/signon/actions'
 import { useSelector } from 'utils/reducer'
 import { SIGN_UP_PAGE } from 'utils/route'
-const getAccountUser = accountSelectors.getAccountUser
+const { getAccountUser, getAccountStatus } = accountSelectors
 
 /**
  * Checks that a user is signed in, else redirects to the sign in
@@ -18,12 +18,14 @@ const getAccountUser = accountSelectors.getAccountUser
  */
 export const useRequiresAccount = (route?: string) => {
   const account = useSelector(getAccountUser)
+  const accountStatus = useSelector(getAccountStatus)
   const dispatch = useDispatch()
+
   useEffect(() => {
-    if (!account) {
+    if (accountStatus !== Status.LOADING && !account) {
       if (route) dispatch(updateRouteOnExit(route))
       dispatch(pushRoute(SIGN_UP_PAGE))
       dispatch(showRequiresAccountModal())
     }
-  }, [dispatch, account, route])
+  }, [dispatch, accountStatus, account, route])
 }


### PR DESCRIPTION
### Description

Fixes issue where signed in users navigating to /audio page are redirected to /trending page

Essentially our `useRequiresAccount` is not waiting for user object before redirecting.
