### PR TITLE
Clean up remote-config init handlers

### DIFF
--- a/packages/common/src/services/remote-config/index.ts
+++ b/packages/common/src/services/remote-config/index.ts
@@ -1,7 +1,7 @@
 export { IntKeys, StringKeys, DoubleKeys, BooleanKeys } from './types'
 export { AllRemoteConfigKeys } from './types'
 export { FeatureFlags } from './feature-flags'
-export { remoteConfig, USER_ID_AVAILABLE_EVENT } from './remote-config'
+export { remoteConfig } from './remote-config'
 export { RemoteConfigInstance } from './remote-config'
 export {
   remoteConfigIntDefaults,

--- a/packages/common/src/services/remote-config/remote-config.ts
+++ b/packages/common/src/services/remote-config/remote-config.ts
@@ -86,8 +86,6 @@ export const remoteConfig = <
     })
   }
 
-  // API
-
   /**
    * Register a callback for client ready.
    */
@@ -119,9 +117,11 @@ export const remoteConfig = <
     }
   }
 
+  // API
+
   /**
    * Set the userId for calls to Optimizely.
-   * Prior to calling, uses the ANONYMOUS_USER_ID constant.
+   * Prior to calling, uses session ID
    */
   function setUserId(userId: ID) {
     state.id = userId
@@ -226,7 +226,7 @@ export const remoteConfig = <
    * Need this function for feature flags that depend on user id.
    * This is because the waitForRemoteConfig does not ensure that
    * user id is available before its promise resolution, meaning
-   * that it will sometimes fallback to the anonymous id
+   * that it will sometimes fallback to the session id
    * that is set during initialization
    */
   const waitForUserRemoteConfig = async () => {
@@ -270,8 +270,6 @@ export const remoteConfig = <
     getFeatureEnabled,
     getRemoteVar,
     init,
-    onClientReady,
-    onUserReady,
     setUserId,
     waitForRemoteConfig,
     waitForUserRemoteConfig,

--- a/packages/common/src/store/remote-config/sagas.ts
+++ b/packages/common/src/store/remote-config/sagas.ts
@@ -1,25 +1,13 @@
-import { eventChannel, END } from 'redux-saga'
-import { put, take } from 'typed-redux-saga'
+import { call, put } from 'typed-redux-saga'
 
 import { getContext } from '../effects'
 
 import { setDidLoad } from './slice'
 
-const CLIENT_READY_EVENT = 'CLIENT_READY'
-
 function* watchRemoteConfigLoad() {
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
-  // Emit event when provider is ready
-  const chan = eventChannel((emitter) => {
-    remoteConfigInstance.onClientReady(() => {
-      emitter(CLIENT_READY_EVENT)
-      emitter(END)
-    })
-    return () => {}
-  })
 
-  // await event before setting didLoad
-  yield* take(chan)
+  yield* call(remoteConfigInstance.waitForRemoteConfig)
   yield* put(setDidLoad())
 }
 

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -1,6 +1,5 @@
 import {
   Kind,
-  USER_ID_AVAILABLE_EVENT,
   accountSelectors,
   accountActions,
   cacheActions,
@@ -248,11 +247,8 @@ export function* fetchAccountAsync(action) {
     return
   }
 
-  // Set account ID and let remote-config provider
-  // know that the user id is available
+  // Set the userId in the remoteConfigInstance
   remoteConfigInstance.setUserId(account.user_id)
-  const event = new CustomEvent(USER_ID_AVAILABLE_EVENT)
-  window.dispatchEvent(event)
 
   // Fire-and-forget fp identify
   const clientOrigin = isMobile() ? 'mobile' : isElectron() ? 'desktop' : 'web'


### PR DESCRIPTION
### Description

* Makes `waitForUserRemoteConfig` platform agnostic by using EventEmitter instead of window events
* Updates `init` to be consistent with `setUserId` in using the EventEmitter

### Dragons

Removes the `USER_ID_AVAILABLE_EVENT` event, removed all references in the codebase though

### How Has This Been Tested?

Tested on web, ensured that both callbacks were being hit at the correct time and the Feature Flag override modal still works properly

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

