### PR TITLE
Remove duplicate create user bank on sign up

### DIFF
--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -93,7 +93,7 @@ function* recordIPIfNotRecent(handle) {
 
 // Tasks to be run on account successfully fetched, e.g.
 // recording metrics, setting user data
-function* onFetchAccount(account) {
+function* onFetchAccount(account, isSignUp = false) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const isNativeMobile = yield getContext('isNativeMobile')
   if (account && account.handle) {
@@ -128,7 +128,9 @@ function* onFetchAccount(account) {
   yield fork(addPlaylistsNotInLibrary)
 
   const feePayerOverride = yield select(getFeePayer)
-  yield call(createUserBankIfNeeded, feePayerOverride)
+  if (!isSignUp) {
+    yield call(createUserBankIfNeeded, feePayerOverride)
+  }
 
   // Repair users from flare-101 that were impacted and lost connected wallets
   // TODO: this should be removed after sufficient time has passed or users have gotten
@@ -173,16 +175,12 @@ function* onFetchAccount(account) {
   }
 }
 
-export function* fetchAccountAsync(action) {
+export function* fetchAccountAsync({ fromSource = false, isSignUp = false }) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const remoteConfigInstance = yield getContext('remoteConfigInstance')
   const localStorage = yield getContext('localStorage')
   const isNativeMobile = yield getContext('isNativeMobile')
 
-  let fromSource = false
-  if (action) {
-    fromSource = action.fromSource
-  }
   yield put(accountActions.fetchAccountRequested())
 
   if (!fromSource) {
@@ -262,7 +260,7 @@ export function* fetchAccountAsync(action) {
 
   // Cache the account and fire the onFetch callback. We're done.
   yield call(cacheAccount, account)
-  yield call(onFetchAccount, account)
+  yield call(onFetchAccount, account, isSignUp)
 }
 
 function* cacheAccount(account) {

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -427,7 +427,7 @@ function* signUp() {
       },
       function* () {
         yield put(signOnActions.signUpSucceeded())
-        yield call(fetchAccountAsync)
+        yield call(fetchAccountAsync, { isSignUp: true })
       },
       function* ({ timeout }) {
         if (timeout) {


### PR DESCRIPTION
### Description

Currently we create user banks twice on sign up most of the time because
1. createUserBank is performed async and might take some time
2. we call the onFetchAccount hook after sign up succeeds before the solana RPC would say that the user bank exists
3. we check if we need a user bank and try to create one. The relay then fails of course.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally vs. staging & dev

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

