### PR TITLE
Fix profile left nav tile spacing and order

### DIFF
--- a/packages/web/src/components/upload/UploadChip.module.css
+++ b/packages/web/src/components/upload/UploadChip.module.css
@@ -19,6 +19,7 @@
   color: var(--neutral-light-2);
 
   padding: 32px;
+  margin-top: 32px;
 }
 
 .uploadChip:hover {

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -204,8 +204,8 @@ export const ProfileLeftNav = (props: ProfileLeftNavProps) => {
         ) : null}
         <SupportingList />
         <TopSupporters />
-        {isArtist ? <ProfileTags goToRoute={goToRoute} tags={tags} /> : null}
         <ProfileMutuals />
+        {isArtist ? <ProfileTags goToRoute={goToRoute} tags={tags} /> : null}
         {isOwner && !isArtist && (
           <UploadChip type='track' variant='nav' onClick={onClickUploadChip} />
         )}

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileTags.module.css
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileTags.module.css
@@ -27,7 +27,7 @@
 }
 
 .tags {
-  padding-bottom: 24px;
+  margin-top: 32px;
 }
 
 .tags > .tagsContent {


### PR DESCRIPTION
### Description

Fixed lack of spacing below:
<img width="371" alt="Screen Shot 2022-09-07 at 1 07 41 PM" src="https://user-images.githubusercontent.com/9600175/188942057-484403de-0113-483a-9a6b-a23cbd6bdf81.png">

to:
<img width="225" alt="Screen Shot 2022-09-07 at 1 30 33 PM" src="https://user-images.githubusercontent.com/9600175/188942154-f8c697a3-4da7-4906-92dc-18f1b3206572.png">

Also fixed order of profile mutuals and profile tags based on this design:
<img width="233" alt="Screen Shot 2022-09-07 at 1 31 27 PM" src="https://user-images.githubusercontent.com/9600175/188942311-f6bbe5bf-0c10-46d2-8523-1fb7c55b1326.png">

Fixed the profile tags spacing too.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

locally v stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

