### PR TITLE
[C-988] Fix social actions by fixing metro imports

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,6 +20,7 @@
     "build": "rollup -c",
     "lint": "eslint --cache src",
     "lint:fix": "npm run lint -- --fix",
+    "postinstall": "rm -rf node_modules/react",
     "start": "rollup -c -w",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -50,11 +50,18 @@ module.exports = (async () => {
     resolver: {
       assetExts: assetExts.filter((ext) => ext !== 'svg'),
       sourceExts: [...sourceExts, 'svg', 'cjs'],
-      nodeModulesPaths: [path.resolve(__dirname, 'node_modules')],
       extraNodeModules: {
         ...require('node-libs-react-native'),
         // Alias for 'src' to allow for absolute paths
         app: path.resolve(__dirname, 'src'),
+
+        // The following imports are needed for @audius/common
+        // and audius-client to compile correctly
+        'react-redux': resolveModule('react-redux'),
+        'react-native-svg': resolveModule('react-native-svg'),
+        'react-native': resolveModule('react-native'),
+        react: resolveModule('react'),
+
         // Aliases for 'audius-client' to allow for absolute paths
         ...getClientAliases(),
 


### PR DESCRIPTION
### Description

Fixes issue where metro-config's `nodeModulesPaths` broke expected node_module resolution, resulting `eth-sig-util` resolving to v7 unconditionally, even though some libraries needed v5.

Removing `nodeModulesPaths` fixes this issue, but introduces others. The following "extraNodeModules" resolves those issues. (each case is fairly complex, but can explain further if needed, but suffice to say these complained until added.)
