### PR TITLE
Fixes profile pictures in top supporters tile

### DIFF
--- a/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
+++ b/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
@@ -23,14 +23,21 @@ const imageLoadDelay = 250
 type ProfilePictureProps = {
   user: User
   className?: string
+  innerClassName?: string
   disablePopover?: boolean
   disableClick?: boolean
   stopPropagation?: boolean
 }
 
 export const ProfilePicture = (props: ProfilePictureProps) => {
-  const { user, className, disablePopover, disableClick, stopPropagation } =
-    props
+  const {
+    user,
+    className,
+    innerClassName,
+    disablePopover,
+    disableClick,
+    stopPropagation
+  } = props
   const { user_id, _profile_picture_sizes, handle } = user
   const [loadImage, setLoadImage] = useState(false)
   const dispatch = useDispatch()
@@ -75,9 +82,9 @@ export const ProfilePicture = (props: ProfilePictureProps) => {
   const profilePictureElement = (
     <DynamicImage
       onClick={handleClick}
-      wrapperClassName={styles.profilePictureWrapper}
+      wrapperClassName={cn(styles.profilePictureWrapper, className)}
       skeletonClassName={styles.profilePictureSkeleton}
-      className={cn(styles.profilePicture, className)}
+      className={cn(styles.profilePicture, innerClassName)}
       image={profilePicture}
     />
   )

--- a/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.module.css
+++ b/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.module.css
@@ -44,8 +44,10 @@
   align-items: center;
   margin: 10px 0;
 }
-.profilePicture {
+.profilePictureWrapper {
   cursor: pointer;
+}
+.profilePicture {
   border: 1px solid var(--neutral-light-8);
 }
 .name {

--- a/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.tsx
+++ b/packages/web/src/components/tipping/feed-tip-tile/FeedTipTile.tsx
@@ -242,7 +242,8 @@ export const FeedTipTile = () => {
         <div className={styles.recipientContainer}>
           <ProfilePicture
             key={tipToDisplay.receiver_id}
-            className={styles.profilePicture}
+            className={styles.profilePictureWrapper}
+            innerClassName={styles.profilePicture}
             user={usersMap[tipToDisplay.receiver_id]}
           />
           <ArtistPopover


### PR DESCRIPTION
### Description
Last hotfix for feed tip tile had broken profile pictures in top supporters list. This commit fixes that while also keeping the border in the feed tip tile.

### Dragons
Would have preferred to name things differently - `wrapperClassName` for the wrapper and just `classname` for the profile picture class but that would mean I'd have to change the names everywhere else that this is referenced.

### How Has This Been Tested?

Tested on local web.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

