### PR TITLE
[C-892] Fix multiple menus open at once

### DIFF
--- a/packages/web/src/components/card/desktop/Card.tsx
+++ b/packages/web/src/components/card/desktop/Card.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState, useEffect, useCallback, ReactNode, useRef } from 'react'
+import { useState, useEffect, useCallback, ReactNode, useRef } from 'react'
 
 import {
   ID,
@@ -20,6 +20,7 @@ import RepostFavoritesStats, {
 import UserBadges from 'components/user-badges/UserBadges'
 import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
 import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
+import { isDescendantElementOf } from 'utils/domUtils'
 
 import styles from './Card.module.css'
 
@@ -151,14 +152,10 @@ const Card = ({
   // parent is no longer telling it that it is loading. This allows ordered loading.
   const [artworkLoaded, setArtworkLoaded] = useState(false)
 
-  // Don't call onClick if the click event comes from the menu actions
   const menuActionsRef = useRef<HTMLDivElement>(null)
   const handleClick = useCallback(
     (e) => {
-      if (
-        !menuActionsRef?.current ||
-        !menuActionsRef.current.contains(e.target)
-      ) {
+      if (isDescendantElementOf(e?.target, menuActionsRef.current)) {
         onClick()
       }
     },

--- a/packages/web/src/components/card/desktop/Card.tsx
+++ b/packages/web/src/components/card/desktop/Card.tsx
@@ -155,9 +155,8 @@ const Card = ({
   const menuActionsRef = useRef<HTMLDivElement>(null)
   const handleClick = useCallback(
     (e) => {
-      if (isDescendantElementOf(e?.target, menuActionsRef.current)) {
-        onClick()
-      }
+      if (isDescendantElementOf(e?.target, menuActionsRef.current)) return
+      onClick()
     },
     [menuActionsRef, onClick]
   )

--- a/packages/web/src/components/card/desktop/Card.tsx
+++ b/packages/web/src/components/card/desktop/Card.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useState, useEffect, useCallback, ReactNode } from 'react'
+import { MouseEvent, useState, useEffect, useCallback, ReactNode, useRef } from 'react'
 
 import {
   ID,
@@ -150,6 +150,21 @@ const Card = ({
   // The card is considered `setDidLoad` (and calls it) if the artwork has loaded and its
   // parent is no longer telling it that it is loading. This allows ordered loading.
   const [artworkLoaded, setArtworkLoaded] = useState(false)
+
+  // Don't call onClick if the click event comes from the menu actions
+  const menuActionsRef = useRef<HTMLDivElement>(null)
+  const handleClick = useCallback(
+    (e) => {
+      if (
+        menuActionsRef?.current &&
+        !menuActionsRef.current.contains(e.target)
+      ) {
+        onClick()
+      }
+    },
+    [menuActionsRef, onClick]
+  )
+
   useEffect(() => {
     if (artworkLoaded && setDidLoad) {
       setDidLoad(index!)
@@ -160,18 +175,12 @@ const Card = ({
     setArtworkLoaded(true)
   }, [setArtworkLoaded])
 
-  const onBottomActionsClick = (e: MouseEvent) => {
-    e.stopPropagation()
-  }
   const sizeStyles = cardSizeStyles[size]
 
   let bottomActions = null
   if (menu && (size === 'large' || size === 'medium')) {
     bottomActions = (
-      <div
-        className={sizeStyles.actionsContainer}
-        onClick={onBottomActionsClick}
-      >
+      <div className={sizeStyles.actionsContainer} onClick={handleClick}>
         <ActionsTab
           handle={handle}
           standalone
@@ -189,10 +198,7 @@ const Card = ({
     )
   } else if (menu && size === 'small') {
     bottomActions = (
-      <div
-        className={sizeStyles.actionsContainer}
-        onClick={onBottomActionsClick}
-      >
+      <div className={sizeStyles.actionsContainer} ref={menuActionsRef}>
         <Menu menu={menu}>
           {(ref, triggerPopup) => (
             <div className={styles.iconContainer} onClick={triggerPopup}>
@@ -212,7 +218,7 @@ const Card = ({
   return (
     <div
       className={cn(className, styles.cardContainer, sizeStyles.cardContainer)}
-      onClick={onClick}
+      onClick={handleClick}
     >
       <div
         className={cn(styles.coverArt, sizeStyles.coverArt, {

--- a/packages/web/src/components/card/desktop/Card.tsx
+++ b/packages/web/src/components/card/desktop/Card.tsx
@@ -156,7 +156,7 @@ const Card = ({
   const handleClick = useCallback(
     (e) => {
       if (
-        menuActionsRef?.current &&
+        !menuActionsRef?.current ||
         !menuActionsRef.current.contains(e.target)
       ) {
         onClick()
@@ -180,7 +180,7 @@ const Card = ({
   let bottomActions = null
   if (menu && (size === 'large' || size === 'medium')) {
     bottomActions = (
-      <div className={sizeStyles.actionsContainer} onClick={handleClick}>
+      <div className={sizeStyles.actionsContainer} ref={menuActionsRef}>
         <ActionsTab
           handle={handle}
           standalone

--- a/packages/web/src/components/test-collectibles-playlist-table/TestCollectiblesPlaylistTable.tsx
+++ b/packages/web/src/components/test-collectibles-playlist-table/TestCollectiblesPlaylistTable.tsx
@@ -162,7 +162,7 @@ export const TestCollectiblesPlaylistTable = ({
   )
 
   const handleClickRow = useCallback(
-    (rowInfo, index: number) => {
+    (e, rowInfo, index: number) => {
       const collectible = rowInfo.original
       onClickRow?.(collectible, index)
     },

--- a/packages/web/src/components/test-table/TestTable.tsx
+++ b/packages/web/src/components/test-table/TestTable.tsx
@@ -59,7 +59,7 @@ type TestTableProps = {
   isVirtualized?: boolean
   loading?: boolean
   maxRowNum?: number
-  onClickRow?: (rowInfo: any, index: number) => void
+  onClickRow?: (e: MouseEvent, rowInfo: any, index: number) => void
   onReorder?: (source: number, destination: number) => void
   onSort?: (sortProps: {
     column: { sorter: (a: any, b: any) => number }
@@ -230,7 +230,7 @@ export const TestTable = ({
           )}
           {...props}
           key={key}
-          onClick={() => onClickRow?.(row, row.index)}
+          onClick={(e) => onClickRow?.(e, row, row.index)}
         >
           {row.cells.map(renderCell)}
         </tr>

--- a/packages/web/src/components/test-table/TestTable.tsx
+++ b/packages/web/src/components/test-table/TestTable.tsx
@@ -230,7 +230,7 @@ export const TestTable = ({
           )}
           {...props}
           key={key}
-          onClick={(e) => onClickRow?.(e, row, row.index)}
+          onClick={(e: MouseEvent) => onClickRow?.(e, row, row.index)}
         >
           {row.cells.map(renderCell)}
         </tr>

--- a/packages/web/src/components/test-tracks-table/TestTracksTable.tsx
+++ b/packages/web/src/components/test-tracks-table/TestTracksTable.tsx
@@ -18,6 +18,7 @@ import {
 } from 'components/test-table'
 import Tooltip from 'components/tooltip/Tooltip'
 import UserBadges from 'components/user-badges/UserBadges'
+import { isDescendantElementOf } from 'utils/domUtils'
 
 import styles from './TestTracksTable.module.css'
 
@@ -443,7 +444,7 @@ export const TestTracksTable = ({
         favoriteButtonRef,
         repostButtonRef,
         overflowMenuRef
-      ].some((ref) => ref?.current && !ref.current.contains(e.target))
+      ].some((ref) => isDescendantElementOf(e?.target, ref.current))
 
       if (deleted || clickedActionButton) return
       onClickRow?.(track, index)

--- a/packages/web/src/components/tracks-table/TracksTable.js
+++ b/packages/web/src/components/tracks-table/TracksTable.js
@@ -40,24 +40,28 @@ export const alphaSortFn = function (a, b, aKey, bKey) {
   return a.toLowerCase() > b.toLowerCase() ? 1 : -1
 }
 
-const favoriteButtonRef = createRef()
+const allRowsActionButtonRefs = []
 const favoriteButtonCell = (val, record, props) => {
   const deleted = record.is_delete || !!record.user?.is_deactivated
   const isOwner = record.owner_id === props.userId
   if (deleted || isOwner) return null
+
+  const favoriteButtonRef = createRef()
+  allRowsActionButtonRefs.push(favoriteButtonRef)
   return (
-    <Tooltip text={record.has_current_user_saved ? 'Unfavorite' : 'Favorite'}>
-      <span>
-        <TableFavoriteButton
-          className={cn(styles.favoriteButtonFormatting, {
-            [styles.deleted]: deleted
-          })}
-          onClick={() => props.onClickFavorite(record)}
-          favorited={record.has_current_user_saved}
-          ref={favoriteButtonRef}
-        />
-      </span>
-    </Tooltip>
+    <div ref={favoriteButtonRef}>
+      <Tooltip text={record.has_current_user_saved ? 'Unfavorite' : 'Favorite'}>
+        <span>
+          <TableFavoriteButton
+            className={cn(styles.favoriteButtonFormatting, {
+              [styles.deleted]: deleted
+            })}
+            onClick={() => props.onClickFavorite(record)}
+            favorited={record.has_current_user_saved}
+          />
+        </span>
+      </Tooltip>
+    </div>
   )
 }
 
@@ -103,17 +107,18 @@ const artistNameCell = (val, record, props) => {
   )
 }
 
-const repostButtonRef = createRef()
 const repostButtonCell = (val, record, props) => {
   const deleted = record.is_delete || record.user?.is_deactivated
   if (deleted) return null
-  const isOwner = record.owner_id === props.userId
-  return isOwner ? null : (
+  if (record.owner_id === props.userId) return null
+
+  const repostButtonRef = createRef()
+  allRowsActionButtonRefs.push(repostButtonRef)
+  return (
     <Tooltip text={record.has_current_user_reposted ? 'Unrepost' : 'Repost'}>
-      <div>
+      <div ref={repostButtonRef}>
         <TableRepostButton
           onClick={() => props.onClickRepost(record)}
-          ref={repostButtonRef}
           reposted={record.has_current_user_reposted}
         />
       </div>
@@ -121,30 +126,32 @@ const repostButtonCell = (val, record, props) => {
   )
 }
 
-const optionsButtonRef = createRef()
 const optionsButtonCell = (val, record, index, props) => {
   const deleted = record.is_delete || !!record.user.is_deactivated
+  const optionsButtonRef = createRef()
+  allRowsActionButtonRefs.push(optionsButtonRef)
   return (
-    <TableOptionsButton
-      className={styles.optionsButtonFormatting}
-      isDeleted={deleted}
-      onRemove={props.onClickRemove}
-      removeText={props.removeText}
-      handle={val.handle}
-      trackId={val.track_id}
-      uid={val.uid}
-      date={val.date}
-      isFavorited={val.has_current_user_saved}
-      isOwner={record.owner_id === props.userId}
-      isOwnerDeactivated={!!record.user.is_deactivated}
-      isArtistPick={val.user._artist_pick === val.track_id}
-      index={index}
-      trackTitle={val.name}
-      albumId={null}
-      albumName={null}
-      trackPermalink={val.permalink}
-      ref={optionsButtonRef}
-    />
+    <div ref={optionsButtonRef}>
+      <TableOptionsButton
+        className={styles.optionsButtonFormatting}
+        isDeleted={deleted}
+        onRemove={props.onClickRemove}
+        removeText={props.removeText}
+        handle={val.handle}
+        trackId={val.track_id}
+        uid={val.uid}
+        date={val.date}
+        isFavorited={val.has_current_user_saved}
+        isOwner={record.owner_id === props.userId}
+        isOwnerDeactivated={!!record.user.is_deactivated}
+        isArtistPick={val.user._artist_pick === val.track_id}
+        index={index}
+        trackTitle={val.name}
+        albumId={null}
+        albumName={null}
+        trackPermalink={val.permalink}
+      />
+    </div>
   )
 }
 
@@ -595,11 +602,9 @@ class TracksTable extends Component {
               index: rowIndex,
               onClick: (e) => {
                 const deleted = record.is_delete || record.user?.is_deactivated
-                const clickedActionButton = [
-                  favoriteButtonRef,
-                  repostButtonRef,
-                  optionsButtonRef
-                ].some((ref) => isDescendantElementOf(e?.target, ref.current))
+                const clickedActionButton = allRowsActionButtonRefs.some(
+                  (ref) => isDescendantElementOf(e?.target, ref.current)
+                )
 
                 if (deleted || clickedActionButton) return
                 onClickRow(record, rowIndex)

--- a/packages/web/src/components/tracks-table/TracksTable.js
+++ b/packages/web/src/components/tracks-table/TracksTable.js
@@ -40,14 +40,14 @@ export const alphaSortFn = function (a, b, aKey, bKey) {
   return a.toLowerCase() > b.toLowerCase() ? 1 : -1
 }
 
-const allRowsActionButtonRefs = []
+const allRowsFavoriteButtonRefs = {}
 const favoriteButtonCell = (val, record, props) => {
   const deleted = record.is_delete || !!record.user?.is_deactivated
   const isOwner = record.owner_id === props.userId
   if (deleted || isOwner) return null
 
   const favoriteButtonRef = createRef()
-  allRowsActionButtonRefs.push(favoriteButtonRef)
+  allRowsFavoriteButtonRefs[record.key] = favoriteButtonRef
   return (
     <div ref={favoriteButtonRef}>
       <Tooltip text={record.has_current_user_saved ? 'Unfavorite' : 'Favorite'}>
@@ -107,13 +107,15 @@ const artistNameCell = (val, record, props) => {
   )
 }
 
+const allRowsRepostButtonRefs = {}
 const repostButtonCell = (val, record, props) => {
   const deleted = record.is_delete || record.user?.is_deactivated
   if (deleted) return null
   if (record.owner_id === props.userId) return null
 
   const repostButtonRef = createRef()
-  allRowsActionButtonRefs.push(repostButtonRef)
+  allRowsRepostButtonRefs[record.key] = repostButtonRef
+
   return (
     <Tooltip text={record.has_current_user_reposted ? 'Unrepost' : 'Repost'}>
       <div ref={repostButtonRef}>
@@ -126,10 +128,12 @@ const repostButtonCell = (val, record, props) => {
   )
 }
 
+const allRowsOptionsButtonRefs = {}
 const optionsButtonCell = (val, record, index, props) => {
   const deleted = record.is_delete || !!record.user.is_deactivated
   const optionsButtonRef = createRef()
-  allRowsActionButtonRefs.push(optionsButtonRef)
+  allRowsOptionsButtonRefs[record.key] = optionsButtonRef
+
   return (
     <div ref={optionsButtonRef}>
       <TableOptionsButton
@@ -602,7 +606,13 @@ class TracksTable extends Component {
               index: rowIndex,
               onClick: (e) => {
                 const deleted = record.is_delete || record.user?.is_deactivated
-                const clickedActionButton = allRowsActionButtonRefs.some(
+                const allRowsAllActionButtonRefs = [
+                  ...Object.values(allRowsFavoriteButtonRefs),
+                  ...Object.values(allRowsOptionsButtonRefs),
+                  ...Object.values(allRowsRepostButtonRefs)
+                ]
+
+                const clickedActionButton = allRowsAllActionButtonRefs.some(
                   (ref) => isDescendantElementOf(e?.target, ref.current)
                 )
 

--- a/packages/web/src/components/tracks-table/TracksTable.js
+++ b/packages/web/src/components/tracks-table/TracksTable.js
@@ -51,6 +51,7 @@ const favoriteButtonCell = (val, record, props) => {
             [styles.deleted]: deleted
           })}
           onClick={(e) => {
+            // TODO: remove
             e.stopPropagation()
             props.onClickFavorite(record)
           }}
@@ -67,6 +68,7 @@ const trackNameCell = (val, record, props) => {
     <div
       className={styles.textContainer}
       onClick={(e) => {
+        // This one is ok because it navigates
         e.stopPropagation()
         if (!deleted) props.onClickTrackName(record)
       }}
@@ -88,6 +90,7 @@ const artistNameCell = (val, record, props) => {
       <div
         className={styles.textContainer}
         onClick={(e) => {
+          // This one is ok because it navigates
           e.stopPropagation()
           props.onClickArtistName(record)
         }}
@@ -112,6 +115,8 @@ const repostButtonCell = (val, record, props) => {
       <div>
         <TableRepostButton
           onClick={(e) => {
+            // TODO: Check if this one should stay on the page or not
+            // probably okay?
             e.stopPropagation()
             props.onClickRepost(record)
           }}
@@ -128,6 +133,7 @@ const optionsButtonCell = (val, record, index, props) => {
     <TableOptionsButton
       className={styles.optionsButtonFormatting}
       onClick={(e) => {
+        // TODO: remove
         e.stopPropagation()
       }}
       isDeleted={deleted}
@@ -596,6 +602,7 @@ class TracksTable extends Component {
             onRow={(record, rowIndex) => ({
               index: rowIndex,
               onClick: () => {
+                // TODO: check for ref here
                 const deleted = record.is_delete || record.user?.is_deactivated
                 if (deleted) return
                 onClickRow(record, rowIndex)

--- a/packages/web/src/components/tracks-table/TracksTable.js
+++ b/packages/web/src/components/tracks-table/TracksTable.js
@@ -22,6 +22,7 @@ import TableOptionsButton from 'components/tracks-table/TableOptionsButton'
 import TablePlayButton from 'components/tracks-table/TablePlayButton'
 import TableRepostButton from 'components/tracks-table/TableRepostButton'
 import UserBadges from 'components/user-badges/UserBadges'
+import { isDescendantElementOf } from 'utils/domUtils'
 import { fullTrackPage } from 'utils/route'
 
 import styles from './TracksTable.module.css'
@@ -594,13 +595,11 @@ class TracksTable extends Component {
               index: rowIndex,
               onClick: (e) => {
                 const deleted = record.is_delete || record.user?.is_deactivated
-                const clickedActionButton =
-                  !favoriteButtonRef?.current ||
-                  !favoriteButtonRef.current.contains(e.target) ||
-                  !repostButtonRef?.current ||
-                  !repostButtonRef.current.contains(e.target) ||
-                  !optionsButtonRef?.current ||
-                  !optionsButtonRef.current.contains(e.target)
+                const clickedActionButton = [
+                  favoriteButtonRef,
+                  repostButtonRef,
+                  optionsButtonRef
+                ].some((ref) => isDescendantElementOf(e?.target, ref.current))
 
                 if (deleted || clickedActionButton) return
                 onClickRow(record, rowIndex)

--- a/packages/web/src/components/tracks-table/TracksTable.js
+++ b/packages/web/src/components/tracks-table/TracksTable.js
@@ -1,4 +1,4 @@
-import { Component } from 'react'
+import { createRef, Component } from 'react'
 
 import { formatCount, formatSeconds } from '@audius/common'
 import Table from 'antd/lib/table'
@@ -39,6 +39,7 @@ export const alphaSortFn = function (a, b, aKey, bKey) {
   return a.toLowerCase() > b.toLowerCase() ? 1 : -1
 }
 
+const favoriteButtonRef = createRef()
 const favoriteButtonCell = (val, record, props) => {
   const deleted = record.is_delete || !!record.user?.is_deactivated
   const isOwner = record.owner_id === props.userId
@@ -50,12 +51,9 @@ const favoriteButtonCell = (val, record, props) => {
           className={cn(styles.favoriteButtonFormatting, {
             [styles.deleted]: deleted
           })}
-          onClick={(e) => {
-            // TODO: remove
-            e.stopPropagation()
-            props.onClickFavorite(record)
-          }}
+          onClick={() => props.onClickFavorite(record)}
           favorited={record.has_current_user_saved}
+          ref={favoriteButtonRef}
         />
       </span>
     </Tooltip>
@@ -68,7 +66,6 @@ const trackNameCell = (val, record, props) => {
     <div
       className={styles.textContainer}
       onClick={(e) => {
-        // This one is ok because it navigates
         e.stopPropagation()
         if (!deleted) props.onClickTrackName(record)
       }}
@@ -90,7 +87,6 @@ const artistNameCell = (val, record, props) => {
       <div
         className={styles.textContainer}
         onClick={(e) => {
-          // This one is ok because it navigates
           e.stopPropagation()
           props.onClickArtistName(record)
         }}
@@ -106,6 +102,7 @@ const artistNameCell = (val, record, props) => {
   )
 }
 
+const repostButtonRef = createRef()
 const repostButtonCell = (val, record, props) => {
   const deleted = record.is_delete || record.user?.is_deactivated
   if (deleted) return null
@@ -114,12 +111,8 @@ const repostButtonCell = (val, record, props) => {
     <Tooltip text={record.has_current_user_reposted ? 'Unrepost' : 'Repost'}>
       <div>
         <TableRepostButton
-          onClick={(e) => {
-            // TODO: Check if this one should stay on the page or not
-            // probably okay?
-            e.stopPropagation()
-            props.onClickRepost(record)
-          }}
+          onClick={() => props.onClickRepost(record)}
+          ref={repostButtonRef}
           reposted={record.has_current_user_reposted}
         />
       </div>
@@ -127,15 +120,12 @@ const repostButtonCell = (val, record, props) => {
   )
 }
 
+const optionsButtonRef = createRef()
 const optionsButtonCell = (val, record, index, props) => {
   const deleted = record.is_delete || !!record.user.is_deactivated
   return (
     <TableOptionsButton
       className={styles.optionsButtonFormatting}
-      onClick={(e) => {
-        // TODO: remove
-        e.stopPropagation()
-      }}
       isDeleted={deleted}
       onRemove={props.onClickRemove}
       removeText={props.removeText}
@@ -152,6 +142,7 @@ const optionsButtonCell = (val, record, index, props) => {
       albumId={null}
       albumName={null}
       trackPermalink={val.permalink}
+      ref={optionsButtonRef}
     />
   )
 }
@@ -601,10 +592,17 @@ class TracksTable extends Component {
             fixed
             onRow={(record, rowIndex) => ({
               index: rowIndex,
-              onClick: () => {
-                // TODO: check for ref here
+              onClick: (e) => {
                 const deleted = record.is_delete || record.user?.is_deactivated
-                if (deleted) return
+                const clickedActionButton =
+                  !favoriteButtonRef?.current ||
+                  !favoriteButtonRef.current.contains(e.target) ||
+                  !repostButtonRef?.current ||
+                  !repostButtonRef.current.contains(e.target) ||
+                  !optionsButtonRef?.current ||
+                  !optionsButtonRef.current.contains(e.target)
+
+                if (deleted || clickedActionButton) return
                 onClickRow(record, rowIndex)
               }
             })}

--- a/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
+++ b/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
@@ -138,7 +138,6 @@ const makeColumns = (account: User, isUnlisted: boolean) => {
             isDeleted={record.is_delete}
             includeEdit={false}
             handle={account.handle}
-            onClick={(e: any) => e.stopPropagation()}
             trackId={val.track_id}
             isFavorited={val.has_current_user_saved}
             isOwner


### PR DESCRIPTION
### Description

Extension of https://github.com/AudiusProject/audius-client/pull/1698

Fixes several other occurrences of the same bug. 
Also addresses the same issue in `NEW_TABLES` feature flag's new tables.

From @sddioulde 
> The issue was that there was an event.stopPropagation as the click event from the the kebab menu in the track/playlist was bubbling up. This was there so that the underlying track does not play/pause on kebab menu click. However, because the click event stopped bubbling up, the logic for the click outside of already open menus would not trigger, leaving those menus open.
This PR does not stop the click event from bubbling up to the document, and it prevents the play/pause track if the click target is from the kebab menu.

Note that we should continue to stop propagation for clicks that cause navigation, particularly title and artist page links on a track that would otherwise play/pause onClick for the row/card. This ensures we don't play/pause the track on top of the intended navigation.

### Dragons

No dragons. In the future, we should avoid stopping event propagation except in necessary cases, since it can cause problems outside the component's own scope.

### How Has This Been Tested?

Tested locally on staging data by clicking on menus across the app
https://www.loom.com/share/b961c35db62040108becc73880288454

### How will this change be monitored?

N/A

### Feature Flags ###

We should watch this as `NEW_TABLES` goes out.
