### PR TITLE
Fix profile clearing

### DIFF
--- a/packages/common/src/store/pages/profile/lineups/tracks/actions.ts
+++ b/packages/common/src/store/pages/profile/lineups/tracks/actions.ts
@@ -1,6 +1,4 @@
-// @ts-nocheck
-// TODO(nkang) - convert to TS
-import { LineupActions } from '../../../../../store/lineup/actions'
+import { LineupActions } from '../../../../lineup/actions'
 
 export const PREFIX = 'PROFILE_TRACKS'
 

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -11,6 +11,7 @@ import {
   profilePageFeedLineupActions as feedActions
 } from '@audius/common'
 import { PortalHost } from '@gorhom/portal'
+import { useFocusEffect } from '@react-navigation/native'
 import { Animated, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -31,8 +32,6 @@ import { ProfileTabNavigator } from './ProfileTabNavigator'
 import { useSelectProfile } from './selectors'
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { fetchProfile: fetchProfileAction, resetProfile } = profilePageActions
-const { reset: resetTracks } = tracksActions
-const { reset: resetFeed } = feedActions
 const { getProfileStatus } = profilePageSelectors
 const getUserId = accountSelectors.getUserId
 
@@ -71,15 +70,18 @@ export const ProfileScreen = () => {
     [dispatch, handle, user_id]
   )
 
-  useEffect(() => {
-    fetchProfile()
+  const clearProfile = useCallback(() => {
+    dispatch(resetProfile())
+    dispatch(tracksActions.reset())
+    dispatch(feedActions.reset())
+  }, [dispatch])
 
-    return () => {
-      dispatch(resetProfile())
-      dispatch(resetTracks())
-      dispatch(resetFeed())
-    }
-  }, [dispatch, fetchProfile])
+  const handleLoadProfile = useCallback(() => {
+    fetchProfile()
+    return clearProfile
+  }, [fetchProfile, clearProfile])
+
+  useFocusEffect(handleLoadProfile)
 
   const handleRefresh = useCallback(() => {
     if (profile) {


### PR DESCRIPTION
### Description

- Interesting case where the lineup actions are classes, so individual methods cannot be destructured without loosing `this`context
- I did a quick search across rest of mobile app and didn't see other cases where we are destructuring lineup actions

