### PR TITLE
Wait for libs before signing data

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2475,6 +2475,7 @@ export const audiusBackend = ({
   }
 
   async function signData() {
+    await waitForLibsInit()
     const unixTs = Math.round(new Date().getTime() / 1000) // current unix timestamp (sec)
     const data = `Click sign to authenticate with identity service: ${unixTs}`
     const signature = await audiusLibs.Account.web3Manager.sign(


### PR DESCRIPTION
### Description

Artist pages are broken on release candidate: https://release-candidate.audius.co/rac

Only happens when directly visiting the page (not via navigating in the app). Fix is to wait for libs before using it to sign data

### Dragons

This needs to be cherry picked onto release

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

