### PR TITLE
[C-1041] Fix infinite 404

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -426,7 +426,7 @@ type GetUserSupporterArgs = {
 
 type AudiusAPIClientConfig = {
   audiusBackendInstance: AudiusBackend
-  audiusLibs?: AudiusLibs
+  getAudiusLibs: () => AudiusLibs
   overrideEndpoint?: string
   remoteConfigInstance: RemoteConfigInstance
   localStorage: LocalStorage
@@ -439,7 +439,7 @@ export class AudiusAPIClient {
   }
 
   audiusBackendInstance: AudiusBackend
-  audiusLibs?: AudiusLibs
+  getAudiusLibs: () => AudiusLibs
   overrideEndpoint?: string
   remoteConfigInstance: RemoteConfigInstance
   localStorage: LocalStorage
@@ -447,14 +447,14 @@ export class AudiusAPIClient {
 
   constructor({
     audiusBackendInstance,
-    audiusLibs,
+    getAudiusLibs,
     overrideEndpoint,
     remoteConfigInstance,
     localStorage,
     env
   }: AudiusAPIClientConfig) {
     this.audiusBackendInstance = audiusBackendInstance
-    this.audiusLibs = audiusLibs
+    this.getAudiusLibs = getAudiusLibs
     this.overrideEndpoint = overrideEndpoint
     this.remoteConfigInstance = remoteConfigInstance
     this.localStorage = localStorage
@@ -1513,11 +1513,10 @@ export class AudiusAPIClient {
     }, {})
 
     const formattedPath = this._formatPath(pathType, path)
-    const audiusLibs =
-      this.audiusLibs ??
-      (this.initializationState.type === 'libs' && window.audiusLibs)
-    if (audiusLibs) {
-      const data = await audiusLibs.discoveryProvider._makeRequest(
+    const audiusLibs = this.getAudiusLibs()
+
+    if (audiusLibs && this.initializationState.type === 'libs') {
+      const data = await audiusLibs.discoveryProvider?._makeRequest(
         {
           endpoint: formattedPath,
           queryParams: sanitizedParams,

--- a/packages/mobile/src/services/audius-api-client/apiClient.ts
+++ b/packages/mobile/src/services/audius-api-client/apiClient.ts
@@ -8,8 +8,7 @@ import { remoteConfigInstance } from '../remote-config'
 export const apiClient = new AudiusAPIClient({
   audiusBackendInstance,
   remoteConfigInstance,
-  // @ts-ignore
-  audiusLibs,
+  getAudiusLibs: () => audiusLibs,
   localStorage,
   env
 })

--- a/packages/web/src/services/audius-api-client/apiClient.ts
+++ b/packages/web/src/services/audius-api-client/apiClient.ts
@@ -8,7 +8,7 @@ import { remoteConfigInstance } from 'services/remote-config/remote-config-insta
 export const apiClient = new AudiusAPIClient({
   audiusBackendInstance,
   remoteConfigInstance,
-  audiusLibs: window.audiusLibs,
+  getAudiusLibs: () => window.audiusLibs,
   localStorage,
   env
 })


### PR DESCRIPTION
### Description

* AudiusAPIClient was referencing `window.audiusLibs`, so when a 404 happened the recursion never ended because`audiusLibs` was always undefined

I was able to repro this by going to `hotelgaruda`'s profile on mobile

### Dragons

This does not enable eager load inside of AudiusBackend, but we are already doing eager load when AudiusAPIClient is used. Might be valuable to rethink this logic in general because if a request 404s, we keep retrying until AudiusLibs is initialized

Can enable eager load in AudiusBackend in the future

Can also dig into why we are requesting a deleted track in the first place

### How Has This Been Tested?

Tested both mobile and web, confirmed that 404 requests only fail until libs is initialized

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

