### PR TITLE
Fix account profile screen loading

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -63,7 +63,10 @@ export const ProfileScreen = () => {
     'handle',
     'does_current_user_follow'
   ])
-  const handle = params.handle ?? profile?.handle
+  const handle =
+    params.handle && params.handle !== 'accountUser'
+      ? params.handle
+      : profile?.handle
   const accountId = useSelector(getUserId)
   const dispatch = useDispatch()
   const status = useSelector(getProfileStatus)


### PR DESCRIPTION
### Description

#1916 made  it so the handle coming from params is used to fetch the profile, but on the user's own account the param value is `accountUser`. Need to check for this to allow the screen to load

### Dragons

We don't have anyone who actually has the handle `accountUser`, but I wonder if it would break?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

