### PR TITLE
Fix pull to refresh

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -156,14 +156,21 @@ export const Lineup = ({
   const dispatch = useDispatch()
   const ref = useRef<RNSectionList>(null)
   const [isPastLoadThreshold, setIsPastLoadThreshold] = useState(false)
+  const [refreshing, setRefreshing] = useState(refreshingProp)
   const selectedLineup = useSelector(lineupSelector)
   const lineup = selectedLineup ?? lineupProp
   const { status } = lineup
-  const refreshing = refreshingProp ?? status === Status.LOADING
 
   const handleRefresh = useCallback(() => {
+    setRefreshing(true)
     dispatch(actions.refreshInView(true))
   }, [dispatch, actions])
+
+  useEffect(() => {
+    if (status !== Status.LOADING) {
+      setRefreshing(false)
+    }
+  }, [status])
 
   const refresh = refreshProp ?? handleRefresh
 


### PR DESCRIPTION
### Description

* Because we were using the lineup status to set `refreshing`, scrolling to the bottom and loading more lineup items would scroll to the top and show the refresh indicator

https://user-images.githubusercontent.com/19916043/190211757-a04d3ef0-269d-4a3a-99be-33d81f62fc91.mov

Fixed by setting a local refreshing state that gets cleared when the lineup status is not loading


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

