### PR TITLE
Fix rewards claiming on mobile C-1043

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -133,6 +133,7 @@ type DiscoveryAPIParams<Endpoint extends DiscoveryEndpoint> = SnakeKeysToCamel<
 let AudiusLibs: any = null
 export let BackendUtils: any = null
 let SanityChecks: any = null
+let RewardsAttester: any = null
 let SolanaUtils: any = null
 
 let audiusLibs: any = null
@@ -636,6 +637,7 @@ export const audiusBackend = ({
     BackendUtils = libsModule.Utils
     SanityChecks = libsModule.SanityChecks
     SolanaUtils = libsModule.SolanaUtils
+    RewardsAttester = libsModule.RewardsAttester
     // initialize libs
     let libsError: Nullable<string> = null
     const { web3Config } = await getWeb3Config(
@@ -3198,8 +3200,7 @@ export const audiusBackend = ({
       })
 
       const encodedUserId = encodeHashId(userId)
-
-      const attester = new AudiusLibs.RewardsAttester({
+      const attester = new RewardsAttester({
         libs: audiusLibs,
         parallelization,
         quorumSize,


### PR DESCRIPTION
### Description
![Screen Shot 2022-09-15 at 2 42 46 PM](https://user-images.githubusercontent.com/36916764/190486665-fabc869f-e133-4165-9e3e-a7e3b0c6e971.png)

The error was that AudiusLibs.RewardsAttester `is not a constructor`. This seems to fix it? Testing on web now, but I'm confused about how this ever worked before.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

