### PR TITLE
[C-1118] Send tip -> send audio

### DIFF
--- a/packages/mobile/src/components/feed-tip-tile/SendTipButton.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/SendTipButton.tsx
@@ -2,17 +2,19 @@ import { useCallback, useState } from 'react'
 
 import type { User } from '@audius/common'
 import { tippingActions } from '@audius/common'
-import { View } from 'react-native'
+import { View, Platform } from 'react-native'
 import { useDispatch } from 'react-redux'
 
 import { Text, Button } from 'app/components/core'
 import UserBadges from 'app/components/user-badges'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
+
 const { beginTip } = tippingActions
 
 const messages = {
-  sendTipToPrefix: 'SEND TIP TO '
+  sendTipToPrefix: 'SEND TIP TO ',
+  sendAudioToPrefix: 'SEND $AUDIO TO ' // iOS only
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
@@ -72,7 +74,10 @@ export const SendTipButton = ({ receiver }: SendTipButtonProps) => {
             <Text
               style={[styles.sendTipButtonTitle, isActive && styles.textWhite]}
             >
-              {messages.sendTipToPrefix}
+              {/* NOTE: Send tip -> Send $AUDIO change */}
+              {Platform.OS === 'ios'
+                ? messages.sendAudioToPrefix
+                : messages.sendTipToPrefix}
             </Text>
             <Text
               style={[styles.buttonReceiverName, isActive && styles.textWhite]}

--- a/packages/mobile/src/components/feed-tip-tile/SenderDetails.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/SenderDetails.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 
 import type { User } from '@audius/common'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 
 import IconTip from 'app/assets/images/iconTip.svg'
 import { Text } from 'app/components/core'
@@ -15,6 +15,8 @@ import { NUM_FEED_TIPPERS_DISPLAYED } from './constants'
 
 const messages = {
   wasTippedBy: 'Was Tipped By',
+  // NOTE: Send tip -> Send $AUDIO change
+  receivedAudioFrom: 'Received $AUDIO From', // iOS only
   andOthers: (num: number) => `& ${num} ${num > 1 ? 'others' : 'other'}`
 }
 
@@ -80,7 +82,11 @@ export const SenderDetails = ({ senders, receiver }: SenderDetailsProps) => {
   return (
     <View style={styles.wasTippedByContainer}>
       <IconTip fill={neutralLight4} height={16} width={16} />
-      <Text style={styles.wasTippedBy}>{messages.wasTippedBy}</Text>
+      <Text style={styles.wasTippedBy}>
+        {Platform.OS === 'ios'
+          ? messages.receivedAudioFrom
+          : messages.wasTippedBy}
+      </Text>
       <PressableText style={styles.tippers} onPress={handlePressTippers}>
         {({ pressed }) => {
           const textStyle = [styles.tipperText, pressed && styles.pressedText]

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
@@ -62,7 +62,7 @@ const challengeInfoMap: Record<
   'send-first-tip': {
     title: '🤑 Send Your First Tip',
     // NOTE: Send tip -> Send $AUDIO change
-    iosTitle: '🤑 Send $AUDIO',
+    iosTitle: '🤑 Send Your First $AUDIO',
     amount: 2
   },
   'first-playlist': {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
@@ -2,6 +2,7 @@ import type {
   ChallengeRewardID,
   ChallengeRewardNotification as ChallengeRewardNotificationType
 } from '@audius/common'
+import { Platform } from 'react-native'
 
 import IconAudius from 'app/assets/images/iconAudius.svg'
 
@@ -24,7 +25,7 @@ const messages = {
 
 const challengeInfoMap: Record<
   ChallengeRewardID,
-  { title: string; amount: number }
+  { title: string; amount: number; iosTitle?: string }
 > = {
   'profile-completion': {
     title: '✅️ Complete your Profile',
@@ -60,6 +61,8 @@ const challengeInfoMap: Record<
   },
   'send-first-tip': {
     title: '🤑 Send Your First Tip',
+    // NOTE: Send tip -> Send $AUDIO change
+    iosTitle: '🤑 Send $AUDIO',
     amount: 2
   },
   'first-playlist': {
@@ -77,11 +80,13 @@ export const ChallengeRewardNotification = (
 ) => {
   const { notification } = props
   const { challengeId } = notification
-  const { title, amount } = challengeInfoMap[challengeId]
+  const { title, amount, iosTitle } = challengeInfoMap[challengeId]
   return (
     <NotificationTile notification={notification}>
       <NotificationHeader icon={IconAudius}>
-        <NotificationTitle>{title}</NotificationTitle>
+        <NotificationTitle>
+          {Platform.OS === 'ios' && iosTitle != null ? iosTitle : title}
+        </NotificationTitle>
       </NotificationHeader>
       <NotificationText>
         {messages.amountEarned(amount)}{' '}

--- a/packages/mobile/src/screens/notifications-screen/Notifications/SupporterDethronedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/SupporterDethronedNotification.tsx
@@ -9,6 +9,7 @@ import type {
   Nullable,
   SupporterDethronedNotification as SupporterDethroned
 } from '@audius/common'
+import { Platform } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconCrownSource from 'app/assets/images/crown2x.png'
@@ -39,6 +40,8 @@ const messages = {
   title: "You've Been Dethroned!",
   body1: ' Dethroned You as ',
   body2: "'s #1 Top Supporter! Tip to Reclaim Your Spot?",
+  // NOTE: Send tip -> Send $AUDIO change
+  body2Alt: "'s #1 Top Supporter! Send $AUDIO to Reclaim Your Spot?", // iOS only
   twitterShare: (usurperHandle: string, supportingHandle: string) =>
     `I've been dethroned! ${usurperHandle} dethroned me as ${supportingHandle}'s #1 Top Supporter! #Audius $AUDIO #AUDIOTip`
 }
@@ -94,7 +97,7 @@ export const SupporterDethronedNotification = (
           <UserNameLink user={usurpingUser} />
           {messages.body1}
           <UserNameLink user={supportedUser} />
-          {messages.body2}
+          {Platform.OS === 'ios' ? messages.body2Alt : messages.body2}
         </NotificationText>
       </NotificationBody>
       <NotificationTwitterButton

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
@@ -6,7 +6,7 @@ import {
   notificationsSelectors,
   getReactionFromRawValue
 } from '@audius/common'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import IconTip from 'app/assets/images/iconTip.svg'
@@ -32,9 +32,14 @@ const { getNotificationUser } = notificationsSelectors
 
 const messages = {
   reacted: 'reacted',
+  // NOTE: Send tip -> Send $AUDIO change
   react: 'reacted to your tip of ',
-  twitterShare: (handle: string) =>
-    `I got a thanks from ${handle} for tipping them $AUDIO on @audiusproject! #Audius #AUDIOTip`
+  reactAlt: 'reacted to your sending of ', // iOS only
+  // NOTE: Send tip -> Send $AUDIO change
+  twitterShare: (handle: string, ios: boolean) =>
+    `I got a thanks from ${handle} for ${
+      ios ? 'sending' : 'tipping'
+    } them $AUDIO on @audiusproject! #Audius ${ios ? '#AUDIO' : '#AUDIOTip'}`
 }
 
 const useStyles = makeStyles(() => ({
@@ -81,7 +86,7 @@ export const TipReactionNotification = (
   const handlePress = useGoToProfile(user)
 
   const handleTwitterShare = useCallback((handle: string) => {
-    const shareText = messages.twitterShare(handle)
+    const shareText = messages.twitterShare(handle, Platform.OS === 'ios')
     return {
       shareText,
       analytics: make({
@@ -115,7 +120,7 @@ export const TipReactionNotification = (
             <UserBadges user={user} hideName />
           </View>
           <NotificationText>
-            {messages.react}
+            {Platform.OS === 'ios' ? messages.reactAlt : messages.react}
             <TipText value={uiAmount} />
           </NotificationText>
         </View>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
@@ -34,7 +34,8 @@ const messages = {
   reacted: 'reacted',
   // NOTE: Send tip -> Send $AUDIO change
   react: 'reacted to your tip of ',
-  reactAlt: 'reacted to you sending them ', // iOS only
+  reactAltPrefix: 'reacted to the ', // iOS only
+  reactAltSuffix: ' you sent them', // iOS only
   // NOTE: Send tip -> Send $AUDIO change
   twitterShare: (handle: string, ios: boolean) =>
     `I got a thanks from ${handle} for ${
@@ -120,8 +121,9 @@ export const TipReactionNotification = (
             <UserBadges user={user} hideName />
           </View>
           <NotificationText>
-            {Platform.OS === 'ios' ? messages.reactAlt : messages.react}
+            {Platform.OS === 'ios' ? messages.reactAltPrefix : messages.react}
             <TipText value={uiAmount} />
+            {Platform.OS === 'ios' ? messages.reactAltSuffix : ''}
           </NotificationText>
         </View>
       </View>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
@@ -34,7 +34,7 @@ const messages = {
   reacted: 'reacted',
   // NOTE: Send tip -> Send $AUDIO change
   react: 'reacted to your tip of ',
-  reactAlt: 'reacted to your sending of ', // iOS only
+  reactAlt: 'reacted to you sending them ', // iOS only
   // NOTE: Send tip -> Send $AUDIO change
   twitterShare: (handle: string, ios: boolean) =>
     `I got a thanks from ${handle} for ${

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipReceivedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipReceivedNotification.tsx
@@ -12,7 +12,7 @@ import type {
   TipReceiveNotification,
   ReactionTypes
 } from '@audius/common'
-import { Image, View } from 'react-native'
+import { Image, Platform, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Checkmark from 'app/assets/images/emojis/white-heavy-check-mark.png'
@@ -41,14 +41,18 @@ const { getNotificationUser } = notificationsSelectors
 
 const messages = {
   title: 'You Received a Tip!',
+  // NOTE: Send tip -> Send $AUDIO change
+  titleAlt: 'You Received $AUDIO!', // iOS only
   sent: 'sent you a tip of',
+  sentAlt: 'sent you', // iOS only
   audio: '$AUDIO',
   sayThanks: 'Say Thanks With a Reaction',
   reactionSent: 'Reaction Sent!',
-  twitterShare: (senderHandle: string, amount: number) =>
-    `Thanks ${senderHandle} for the ${formatNumberCommas(
-      amount
-    )} $AUDIO tip on @AudiusProject! #Audius #AUDIOTip`
+  // NOTE: Send tip -> Send $AUDIO change
+  twitterShare: (senderHandle: string, amount: number, ios: boolean) =>
+    `Thanks ${senderHandle} for the ${formatNumberCommas(amount)} ${
+      ios ? '$AUDIO' : '$AUDIO tip'
+    } on @AudiusProject! #Audius ${ios ? '#AUDIO' : '#AUDIOTip'}`
 }
 
 const useSetReaction = (tipTxSignature: string) => {
@@ -85,7 +89,11 @@ export const TipReceivedNotification = (
 
   const handleTwitterShare = useCallback(
     (senderHandle: string) => {
-      const shareText = messages.twitterShare(senderHandle, uiAmount)
+      const shareText = messages.twitterShare(
+        senderHandle,
+        uiAmount,
+        Platform.OS === 'ios'
+      )
       return {
         shareText,
         analytics: make({
@@ -102,12 +110,15 @@ export const TipReceivedNotification = (
   return (
     <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={IconTip}>
-        <NotificationTitle>{messages.title}</NotificationTitle>
+        <NotificationTitle>
+          {Platform.OS === 'ios' ? messages.titleAlt : messages.title}
+        </NotificationTitle>
       </NotificationHeader>
       <NotificationBody>
         <ProfilePicture profile={user} />
         <NotificationText>
-          <UserNameLink user={user} /> {messages.sent}{' '}
+          <UserNameLink user={user} />{' '}
+          {Platform.OS === 'ios' ? messages.sentAlt : messages.sent}{' '}
           <TipText value={uiAmount} />
         </NotificationText>
       </NotificationBody>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipSentNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipSentNotification.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import type { TipSendNotification } from '@audius/common'
 import { useUIAudio, notificationsSelectors } from '@audius/common'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import IconTip from 'app/assets/images/iconTip.svg'
@@ -25,10 +25,18 @@ const { getNotificationUser } = notificationsSelectors
 
 const messages = {
   title: 'Your Tip Was Sent!',
+  // NOTE: Send tip -> Send $AUDIO change
+  titleAlt: 'Your $AUDIO Was Sent!', // iOS only
   sent: 'You successfully sent a tip of',
+  sentAlt: 'You successfully sent', // iOS only
   to: 'to',
-  twitterShare: (senderHandle: string, uiAmount: number) =>
-    `I just tipped ${senderHandle} ${uiAmount} $AUDIO on @AudiusProject #Audius #AUDIOTip`
+  // NOTE: Send tip -> Send $AUDIO changes
+  twitterShare: (senderHandle: string, uiAmount: number, ios: boolean) =>
+    `I just ${
+      ios ? 'tipped' : 'sent'
+    } ${senderHandle} ${uiAmount} $AUDIO on @AudiusProject #Audius ${
+      ios ? '$#AUDIO' : '#AUDIOTip'
+    }`
 }
 
 type TipSentNotificationProps = {
@@ -47,7 +55,11 @@ export const TipSentNotification = (props: TipSentNotificationProps) => {
 
   const handleTwitterShare = useCallback(
     (senderHandle: string) => {
-      const shareText = messages.twitterShare(senderHandle, uiAmount)
+      const shareText = messages.twitterShare(
+        senderHandle,
+        uiAmount,
+        Platform.OS === 'ios'
+      )
       return {
         shareText,
         analytics: make({
@@ -64,7 +76,9 @@ export const TipSentNotification = (props: TipSentNotificationProps) => {
   return (
     <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={IconTip}>
-        <NotificationTitle>{messages.title}</NotificationTitle>
+        <NotificationTitle>
+          {Platform.OS === 'ios' ? messages.titleAlt : messages.title}
+        </NotificationTitle>
       </NotificationHeader>
       <View
         style={{
@@ -74,7 +88,8 @@ export const TipSentNotification = (props: TipSentNotificationProps) => {
       >
         <ProfilePicture profile={user} />
         <NotificationText style={{ flexShrink: 1 }}>
-          {messages.sent} <TipText value={uiAmount} /> {messages.to}{' '}
+          {Platform.OS === 'ios' ? messages.sentAlt : messages.sent}{' '}
+          <TipText value={uiAmount} /> {messages.to}{' '}
           <UserNameLink user={user} />
         </NotificationText>
       </View>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TopSupporterNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TopSupporterNotification.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import type { SupporterRankUpNotification } from '@audius/common'
 import { notificationsSelectors } from '@audius/common'
+import { Platform } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import { make } from 'app/services/analytics'
@@ -17,8 +18,11 @@ const messages = {
   title: 'Top Supporter',
   supporterChange: 'Became your',
   supporter: 'Top Supporter',
-  twitterShare: (handle: string, rank: number) =>
-    `${handle} just became my #${rank} Top Supporter on @AudiusProject #Audius $AUDIO #AUDIOTip`
+  // NOTE: Send tip -> Send $AUDIO change
+  twitterShare: (handle: string, rank: number, ios: boolean) =>
+    `${handle} just became my #${rank} Top Supporter on @AudiusProject #Audius $AUDIO${
+      ios ? '' : ' #AUDIOTip'
+    }`
 }
 
 type TopSupporterNotificationProps = {
@@ -37,7 +41,11 @@ export const TopSupporterNotification = (
 
   const handleTwitterShare = useCallback(
     (handle: string) => {
-      const shareText = messages.twitterShare(handle, rank)
+      const shareText = messages.twitterShare(
+        handle,
+        rank,
+        Platform.OS === 'ios'
+      )
       return {
         shareText,
         analytics: make({

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TopSupportingNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TopSupportingNotification.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import type { SupportingRankUpNotification } from '@audius/common'
 import { notificationsSelectors } from '@audius/common'
+import { Platform } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import { make } from 'app/services/analytics'
@@ -17,8 +18,11 @@ const messages = {
   title: 'Top Supporter',
   supporterChange: "You're now their",
   supporter: 'Top Supporter',
-  twitterShare: (handle: string, rank: number) =>
-    `I'm now ${handle}'s #${rank} Top Supporter on @AudiusProject #Audius $AUDIO #AUDIOTip`
+  // NOTE: Send tip -> Send $AUDIO change
+  twitterShare: (handle: string, rank: number, ios: boolean) =>
+    `I'm now ${handle}'s #${rank} Top Supporter on @AudiusProject #Audius $AUDIO${
+      ios ? '' : ' #AUDIOTip'
+    }`
 }
 
 type TopSupportingNotificationProps = {
@@ -37,7 +41,11 @@ export const TopSupportingNotification = (
 
   const handleTwitterShare = useCallback(
     (handle: string) => {
-      const shareText = messages.twitterShare(handle, rank)
+      const shareText = messages.twitterShare(
+        handle,
+        rank,
+        Platform.OS === 'ios'
+      )
       return {
         shareText,
         analytics: make({

--- a/packages/mobile/src/screens/profile-screen/TipAudioButton.tsx
+++ b/packages/mobile/src/screens/profile-screen/TipAudioButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 
 import { tippingActions } from '@audius/common'
+import { Platform } from 'react-native'
 import { useDispatch } from 'react-redux'
 
 import IconGoldBadge from 'app/assets/images/IconGoldBadge.svg'
@@ -13,7 +14,10 @@ const { beginTip } = tippingActions
 
 const messages = {
   title: 'Tip $AUDIO',
-  label: 'Tip Audio tokens'
+  // NOTE: Send tip -> Send $AUDIO change
+  titleAlt: 'Send $AUDIO', // iOS only
+  label: 'Tip Audio tokens',
+  labelAlt: 'Send Audio tokens' // iOS only
 }
 
 const useStyles = makeStyles(() => ({
@@ -37,8 +41,10 @@ export const TipAudioButton = () => {
   return (
     <Button
       variant='primary'
-      accessibilityLabel={messages.label}
-      title={messages.title}
+      accessibilityLabel={
+        Platform.OS === 'ios' ? messages.labelAlt : messages.label
+      }
+      title={Platform.OS === 'ios' ? messages.titleAlt : messages.title}
       icon={IconGoldBadge}
       iconPosition='left'
       fullWidth

--- a/packages/mobile/src/screens/tip-artist-screen/AvailableAudio.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/AvailableAudio.tsx
@@ -1,7 +1,7 @@
 import type { BNWei } from '@audius/common'
 import { formatWei, walletSelectors } from '@audius/common'
 import BN from 'bn.js'
-import { Image, View } from 'react-native'
+import { Image, Platform, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import TokenBadgeNoTier from 'app/assets/images/tokenBadgeNoTier.png'
@@ -34,7 +34,9 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
 
 const messages = {
   available: 'Available to send',
-  disclaimer: '$AUDIO held in linked wallets cannot be used to tip'
+  disclaimer: '$AUDIO held in linked wallets cannot be used to tip',
+  // NOTE: Send tip -> Send $AUDIO change
+  disclaimerAlt: 'Cannot use $AUDIO held in linked wallets' // iOS only
 }
 
 export const AvailableAudio = () => {
@@ -53,7 +55,7 @@ export const AvailableAudio = () => {
         </Text>
       </View>
       <Text variant='body2' color='neutralLight4'>
-        {messages.disclaimer}
+        {Platform.OS === 'ios' ? messages.disclaimerAlt : messages.disclaimer}
       </Text>
     </View>
   )

--- a/packages/mobile/src/screens/tip-artist-screen/BecomeFirstSupporter.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/BecomeFirstSupporter.tsx
@@ -1,4 +1,4 @@
-import { Text } from 'react-native'
+import { Platform, Text } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
@@ -6,7 +6,9 @@ import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
 const messages = {
-  becomeFirstSupporter: 'Tip to become their first supporter'
+  becomeFirstSupporter: 'Tip to become their first supporter',
+  // NOTE: Send tip -> Send $AUDIO change
+  becomeFirstSupporterAlt: 'Send $AUDIO to become their first supporter' // iOS only
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
@@ -39,7 +41,11 @@ export const BecomeFirstSupporter = () => {
       colors={[pageHeaderGradientColor2, pageHeaderGradientColor1]}
     >
       <IconTrophy fill={white} width={16} height={16} />
-      <Text style={styles.text}>{messages.becomeFirstSupporter}</Text>
+      <Text style={styles.text}>
+        {Platform.OS === 'ios'
+          ? messages.becomeFirstSupporterAlt
+          : messages.becomeFirstSupporter}
+      </Text>
     </LinearGradient>
   )
 }

--- a/packages/mobile/src/screens/tip-artist-screen/BecomeTopSupporter.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/BecomeTopSupporter.tsx
@@ -1,6 +1,6 @@
 import type { BNWei } from '@audius/common'
 import { formatWei } from '@audius/common'
-import { Text } from 'react-native'
+import { Platform, Text } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
@@ -9,6 +9,8 @@ import { useThemeColors } from 'app/utils/theme'
 
 const messages = {
   becomeTopSupporterPrefix: 'Tip ',
+  // NOTE: Send tip -> Send $AUDIO change
+  becomeTopSupporterPrefixAlt: 'Send ', // iOS only
   becomeTopSupporterSuffix: ' $AUDIO to become their top supporter'
 }
 
@@ -51,7 +53,9 @@ export const BecomeTopSupporter = ({
     >
       <IconTrophy fill={white} width={16} height={16} />
       <Text style={styles.text}>
-        {messages.becomeTopSupporterPrefix}
+        {Platform.OS === 'ios'
+          ? messages.becomeTopSupporterPrefixAlt
+          : messages.becomeTopSupporterPrefix}
         {formatWei(amountToTipToBecomeTopSupporter, true, 0)}
         {messages.becomeTopSupporterSuffix}
       </Text>

--- a/packages/mobile/src/screens/tip-artist-screen/ConfirmSendTipScreen.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/ConfirmSendTipScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react'
 
 import { tippingSelectors, tippingActions } from '@audius/common'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Platform } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconCaretLeft from 'app/assets/images/iconCaretLeft.svg'
@@ -21,7 +22,10 @@ const { getSendTipData } = tippingSelectors
 
 const messages = {
   title: 'Confirm Tip',
+  // NOTE: Send tip -> Send $AUDIO change
+  titleAlt: 'Confirm', // iOS only
   confirm: 'Confirm Tip',
+  confirmAlt: 'Confirm', // iOS only
   goBack: 'Go Back'
 }
 
@@ -82,7 +86,7 @@ export const ConfirmSendTipScreen = ({
 
   return (
     <TipScreen
-      title={messages.title}
+      title={Platform.OS === 'ios' ? messages.titleAlt : messages.title}
       topbarLeft={inProgress ? null : undefined}
     >
       <TipHeader status='confirm' />
@@ -91,7 +95,7 @@ export const ConfirmSendTipScreen = ({
       <Button
         variant='primary'
         size='large'
-        title={messages.confirm}
+        title={Platform.OS === 'ios' ? messages.confirmAlt : messages.confirm}
         onPress={handleConfirm}
         icon={inProgress ? LoadingSpinner : IconCheck}
         disabled={inProgress}

--- a/packages/mobile/src/screens/tip-artist-screen/SendTipScreen.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/SendTipScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import BN from 'bn.js'
+import { Platform } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconArrow from 'app/assets/images/iconArrow.svg'
@@ -39,6 +40,8 @@ const getAccountUser = accountSelectors.getAccountUser
 
 const messages = {
   sendTip: 'Send Tip',
+  // NOTE: Send tip -> Send $AUDIO change
+  sendAudio: 'Send $AUDIO', // iOS only
   insufficientBalance: 'Insufficient Balance'
 }
 
@@ -119,7 +122,7 @@ export const SendTipScreen = () => {
 
   return (
     <TipScreen
-      title={messages.sendTip}
+      title={Platform.OS === 'ios' ? messages.sendAudio : messages.sendTip}
       topbarLeft={<TopBarIconButton icon={IconRemove} onPress={handleBack} />}
     >
       <ReceiverDetails />
@@ -136,7 +139,7 @@ export const SendTipScreen = () => {
       <Button
         variant='primary'
         size='large'
-        title={messages.sendTip}
+        title={Platform.OS === 'ios' ? messages.sendAudio : messages.sendTip}
         onPress={handleSendTip}
         icon={IconArrow}
         iconPosition='right'

--- a/packages/mobile/src/screens/tip-artist-screen/SendTipStatusText.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/SendTipStatusText.tsx
@@ -1,5 +1,5 @@
 import { tippingSelectors } from '@audius/common'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import { DescriptionText } from './DescriptionText'
@@ -7,6 +7,8 @@ const { getSendStatus } = tippingSelectors
 
 const messages = {
   disclaimer: 'Are you sure? This tip cannot be reversed.',
+  // NOTE: Send tip -> Send $AUDIO change
+  disclaimerAlt: 'Are you sure? This action cannot be reversed.', // iOS only
   maintenance: 'We’re performing some necessary one-time maintenance.',
   fewMinutes: 'This may take a few minutes.',
   holdOn: 'Don’t close this screen or restart the app.',
@@ -17,7 +19,11 @@ export const SendTipStatusText = () => {
   const sendStatus = useSelector(getSendStatus)
 
   if (sendStatus === 'CONFIRM')
-    return <DescriptionText>{messages.disclaimer}</DescriptionText>
+    return (
+      <DescriptionText>
+        {Platform.OS === 'ios' ? messages.disclaimerAlt : messages.disclaimer}
+      </DescriptionText>
+    )
   if (sendStatus === 'SENDING') return null
   if (sendStatus === 'CONVERTING')
     return (

--- a/packages/mobile/src/screens/tip-artist-screen/TipSentScreen.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/TipSentScreen.tsx
@@ -6,6 +6,7 @@ import {
   tippingSelectors
 } from '@audius/common'
 import { useNavigation } from '@react-navigation/native'
+import { Platform } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import IconCheck from 'app/assets/images/iconCheck.svg'
@@ -27,9 +28,12 @@ const getAccountUser = accountSelectors.getAccountUser
 
 const messages = {
   title: 'Tip Sent',
+  // NOTE: Send tip -> Send $AUDIO change
+  titleAlt: '$AUDIO Sent', // iOS only
   description: 'Share your support on Twitter!',
   done: 'Done',
   twitterCopyPrefix: 'I just tipped ',
+  twitterCopyPrefixAlt: 'I just sent ', // iOS only
   twitterCopySuffix: ' $AUDIO on @AudiusProject #Audius #AUDIOTip'
 }
 
@@ -59,7 +63,11 @@ export const TipSentScreen = () => {
       if (recipient.twitter_handle) {
         recipientAndAmount = `@${recipient.twitter_handle} ${formattedSendAmount}`
       }
-      return `${messages.twitterCopyPrefix}${recipientAndAmount}${messages.twitterCopySuffix}`
+      return `${
+        Platform.OS === 'ios'
+          ? messages.twitterCopyPrefixAlt
+          : messages.twitterCopyPrefix
+      }${recipientAndAmount}${messages.twitterCopySuffix}`
     }
     return ''
   }
@@ -70,7 +78,7 @@ export const TipSentScreen = () => {
 
   return (
     <TipScreen
-      title={messages.title}
+      title={Platform.OS === 'ios' ? messages.titleAlt : messages.title}
       topbarLeft={<TopBarIconButton icon={IconRemove} onPress={handleClose} />}
     >
       <TipHeader status='sent' />

--- a/packages/mobile/src/screens/tip-artist-screen/TipSentScreen.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/TipSentScreen.tsx
@@ -34,7 +34,8 @@ const messages = {
   done: 'Done',
   twitterCopyPrefix: 'I just tipped ',
   twitterCopyPrefixAlt: 'I just sent ', // iOS only
-  twitterCopySuffix: ' $AUDIO on @AudiusProject #Audius #AUDIOTip'
+  twitterCopySuffix: ' $AUDIO on @AudiusProject #Audius #AUDIOTip',
+  twitterCopySuffixAlt: ' $AUDIO on @AudiusProject #Audius #AUDIO' // iOS only
 }
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -67,7 +68,11 @@ export const TipSentScreen = () => {
         Platform.OS === 'ios'
           ? messages.twitterCopyPrefixAlt
           : messages.twitterCopyPrefix
-      }${recipientAndAmount}${messages.twitterCopySuffix}`
+      }${recipientAndAmount}${
+        Platform.OS === 'ios'
+          ? messages.twitterCopySuffixAlt
+          : messages.twitterCopySuffix
+      }`
     }
     return ''
   }

--- a/packages/mobile/src/utils/challenges.tsx
+++ b/packages/mobile/src/utils/challenges.tsx
@@ -86,7 +86,7 @@ export const challenges = {
   // Send First Tip
   sendFirstTipTitle: 'Send Your First Tip',
   // NOTE: Send tip -> Send $AUDIO change
-  sendFirstTipTitleAlt: 'Send $AUDIO', // iOS only
+  sendFirstTipTitleAlt: 'Send Your First $AUDIO', // iOS only
   sendFirstTipDescription:
     'Show some love to your favorite artist and send them a tip',
   sendFirstTipShortDescription:

--- a/packages/mobile/src/utils/challenges.tsx
+++ b/packages/mobile/src/utils/challenges.tsx
@@ -1,5 +1,6 @@
 import type { ChallengeRewardID, TrendingRewardID } from '@audius/common'
 import type { ImageSourcePropType } from 'react-native'
+import { Platform } from 'react-native'
 
 import ChartIncreasing from 'app/assets/images/emojis/chart-increasing.png'
 import Headphone from 'app/assets/images/emojis/headphone.png'
@@ -84,12 +85,19 @@ export const challenges = {
 
   // Send First Tip
   sendFirstTipTitle: 'Send Your First Tip',
+  // NOTE: Send tip -> Send $AUDIO change
+  sendFirstTipTitleAlt: 'Send $AUDIO', // iOS only
   sendFirstTipDescription:
     'Show some love to your favorite artist and send them a tip',
   sendFirstTipShortDescription:
     'Show some love to your favorite artist and send them a tip',
+  sendFirstTipDescriptionAlt:
+    'Show some love to your favorite artist and send them $AUDIO', // iOS only
+  sendFirstTipShortDescriptionAlt:
+    'Show some love to your favorite artist and send them $AUDIO', // iOS only
   sendFirstTipProgressLabel: 'Not Earned',
   sendFirstTipButton: 'Find Someone To Tip',
+  sendFirstTipButtonAlt: 'Find Someone To Send To', // iOS only
 
   // First Playlist
   firstPlaylistTitle: 'Create Your First Playlist',
@@ -218,12 +226,24 @@ export const challengesConfig: Record<ChallengeRewardID, ChallengeConfig> = {
   },
   'send-first-tip': {
     icon: MoneyMouthFace,
-    title: challenges.sendFirstTipTitle,
-    description: challenges.sendFirstTipDescription,
-    shortDescription: challenges.sendFirstTipShortDescription,
+    title:
+      Platform.OS === 'ios'
+        ? challenges.sendFirstTipTitleAlt
+        : challenges.sendFirstTipTitle,
+    description:
+      Platform.OS === 'ios'
+        ? challenges.sendFirstTipDescriptionAlt
+        : challenges.sendFirstTipDescription,
+    shortDescription:
+      Platform.OS === 'ios'
+        ? challenges.sendFirstTipShortDescriptionAlt
+        : challenges.sendFirstTipShortDescription,
     progressLabel: challenges.sendFirstTipProgressLabel,
     buttonInfo: {
-      label: challenges.sendFirstTipButton,
+      label:
+        Platform.OS === 'ios'
+          ? challenges.sendFirstTipButtonAlt
+          : challenges.sendFirstTipButton,
       navigation: {
         screen: 'explore',
         params: { screen: 'HeavyRotation' }


### PR DESCRIPTION
### Description
Context: https://audius-internal.slack.com/archives/C03C2V84A1L/p1663274118032509

Rename tipping feature to "Send $AUDIO" on iOS only.

Some copy I wasn't sure whether we needed to change or not - left comments in code to highlight in PR review but will delete before merging.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Testing now on release branch v1.3.3 ran locally

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

