### PR TITLE
[C-940] Fix infinite lineup fetch

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -255,6 +255,7 @@ export const Lineup = ({
   // trigger another load
   useEffect(() => {
     if (isPastLoadThreshold && lineup.status !== Status.LOADING) {
+      setIsPastLoadThreshold(false)
       handleLoadMore()
     }
   }, [isPastLoadThreshold, lineup.status, handleLoadMore])


### PR DESCRIPTION
### Description

![image](https://user-images.githubusercontent.com/19916043/190745981-b2a62486-a63f-4291-82c1-e5992c8e3708.png)

* Sets `isPastLoadThreshold` to false when loading in more items so another scroll has to happen before loading in more items

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

