### PR TITLE
c-1127 Fix more search results track lineup

### DIFF
--- a/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import {
   lineupSelectors,
@@ -7,6 +7,7 @@ import {
   searchResultsPageTracksLineupActions as tracksActions,
   trimToAlphaNumeric
 } from '@audius/common'
+import { useFocusEffect } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Lineup } from 'app/components/lineup'
@@ -24,6 +25,13 @@ const getSearchTracksLineupMetadatas = makeGetLineupMetadatas(
 export const TracksTab = () => {
   const lineup = useSelector(getSearchTracksLineupMetadatas)
   const dispatch = useDispatch()
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        dispatch(tracksActions.reset())
+      }
+    }, [dispatch])
+  )
   const { query, isTagSearch } = useContext(SearchQueryContext)
   const loadMore = useCallback(
     (offset: number, limit: number) => {

--- a/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect } from 'react'
+import { useCallback, useContext } from 'react'
 
 import {
   lineupSelectors,

--- a/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
@@ -1,25 +1,50 @@
+import { useCallback, useContext } from 'react'
+
 import {
-  searchResultsPageTracksLineupActions as tracksActions,
+  lineupSelectors,
+  SearchKind,
   searchResultsPageSelectors,
-  SearchKind
+  searchResultsPageTracksLineupActions as tracksActions,
+  trimToAlphaNumeric
 } from '@audius/common'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { Lineup } from 'app/components/lineup'
+
+import { SearchQueryContext } from '../SearchQueryContext'
 
 import { SearchResultsTab } from './SearchResultsTab'
 import { useFetchTabResultsEffect } from './useFetchTabResultsEffect'
 const { getSearchTracksLineup } = searchResultsPageSelectors
+const { makeGetLineupMetadatas } = lineupSelectors
+const getSearchTracksLineupMetadatas = makeGetLineupMetadatas(
+  getSearchTracksLineup
+)
 
 export const TracksTab = () => {
-  const lineup = useSelector(getSearchTracksLineup)
+  const lineup = useSelector(getSearchTracksLineupMetadatas)
+  const dispatch = useDispatch()
+  const { query, isTagSearch } = useContext(SearchQueryContext)
+  const loadMore = useCallback(
+    (offset: number, limit: number) => {
+      dispatch(
+        tracksActions.fetchLineupMetadatas(offset, limit, false, {
+          category: SearchKind.TRACKS,
+          query: trimToAlphaNumeric(query),
+          isTagSearch
+        })
+      )
+    },
+    [dispatch, isTagSearch, query]
+  )
+
   useFetchTabResultsEffect(SearchKind.TRACKS)
   return (
     <SearchResultsTab
       noResults={lineup?.entries.length === 0}
       status={lineup?.status}
     >
-      <Lineup actions={tracksActions} lineup={lineup} />
+      <Lineup actions={tracksActions} lineup={lineup} loadMore={loadMore} />
     </SearchResultsTab>
   )
 }


### PR DESCRIPTION
### Description
![searchlineup](https://user-images.githubusercontent.com/36916764/191408464-4859eab4-90e1-463d-8861-cbdbc72efe10.gif)

Ignore the known console errors in the gif lol. 
Before:
-Search something, go to more results then tracks tab
-Scroll to bottom -> crash

After:
-Loads more tracks matching query

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

