### PR TITLE
[C-1090] Improve profile store layout

### DIFF
--- a/packages/common/src/store/challenges/selectors/profile-progress.ts
+++ b/packages/common/src/store/challenges/selectors/profile-progress.ts
@@ -1,4 +1,5 @@
 import { getAccountUser } from 'store/account/selectors'
+import { getProfileUserHandle } from 'store/pages/profile/selectors'
 
 import { Status } from '../../../models/Status'
 import { CommonState } from '../../commonStore'
@@ -118,8 +119,11 @@ export const getOrderedCompletionStages = (state: CommonState) => {
   ]
 }
 
-export const getProfilePageMeterDismissed = (state: CommonState) =>
-  state.pages.profile.profileMeterDismissed
+export const getProfilePageMeterDismissed = (state: CommonState) => {
+  const profileHandle = getProfileUserHandle(state)
+  if (!profileHandle) return false
+  return state.pages.profile.entries[profileHandle]?.profileMeterDismissed
+}
 
 export const getIsAccountLoaded = (state: CommonState) =>
   state.account.status === Status.SUCCESS

--- a/packages/common/src/store/lineup/actions.ts
+++ b/packages/common/src/store/lineup/actions.ts
@@ -83,14 +83,16 @@ export class LineupActions {
     // a boolean indicating whether to overwrite cached entries the fetch may be refetching
     overwrite = false,
     // keyword args payload to send to the "get tracks" query
-    payload?: unknown
+    payload?: unknown,
+    other?: Record<string, unknown>
   ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS),
       offset,
       limit,
       overwrite,
-      payload
+      payload,
+      ...other
     }
   }
 
@@ -98,14 +100,16 @@ export class LineupActions {
     offset = 0,
     limit = 10,
     overwrite = false,
-    payload: unknown
+    payload: unknown,
+    handle?: string
   ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS_REQUESTED),
       offset,
       limit,
       overwrite,
-      payload
+      payload,
+      handle
     }
   }
 
@@ -114,7 +118,8 @@ export class LineupActions {
     offset: number,
     limit: number,
     deleted: boolean,
-    nullCount: boolean
+    nullCount: boolean,
+    handle?: string
   ) {
     return {
       type: addPrefix(this.prefix, FETCH_LINEUP_METADATAS_SUCCEEDED),
@@ -122,7 +127,8 @@ export class LineupActions {
       offset,
       limit,
       deleted,
-      nullCount
+      nullCount,
+      handle
     }
   }
 

--- a/packages/common/src/store/lineup/reducer.ts
+++ b/packages/common/src/store/lineup/reducer.ts
@@ -31,7 +31,7 @@ export const initialLineupState = {
   total: 0,
   deleted: 0,
   nullCount: 0,
-  status: Status.LOADING,
+  status: Status.IDLE,
   hasMore: true,
   inView: false,
   // Boolean if the lineup should remove duplicate content in entries
@@ -54,6 +54,7 @@ type FetchLineupMetadatasRequestedAction = {
   type: typeof FETCH_LINEUP_METADATAS_REQUESTED
   limit: number
   offset: number
+  handle: string
 }
 
 type FetchLineupMetadatasSucceededAction<T> = {
@@ -258,6 +259,9 @@ export const asLineup =
     state: LineupStateType | undefined,
     action: LineupActionType | LineupActions<EntryT>
   ): LineupStateType => {
+    if (!action.type.startsWith(prefix)) {
+      return reducer(state, action as LineupActionType)
+    }
     const baseActionType = stripPrefix(
       prefix,
       action.type

--- a/packages/common/src/store/pages/profile/actions.ts
+++ b/packages/common/src/store/pages/profile/actions.ts
@@ -58,8 +58,8 @@ export function fetchProfileSucceeded(
   return { type: FETCH_PROFILE_SUCCEEDED, handle, userId, fetchOnly }
 }
 
-export function fetchProfileFailed() {
-  return { type: FETCH_PROFILE_FAILED }
+export function fetchProfileFailed(handle: string) {
+  return { type: FETCH_PROFILE_FAILED, handle }
 }
 
 export function updateProfile(metadata: UserMetadata) {
@@ -82,8 +82,8 @@ export function updateCollectionSortMode(mode: CollectionSortMode) {
   return { type: UPDATE_COLLECTION_SORT_MODE, mode }
 }
 
-export function setProfileField(field: string, value: string) {
-  return { type: SET_PROFILE_FIELD, field, value }
+export function setProfileField(field: string, value: string, handle: string) {
+  return { type: SET_PROFILE_FIELD, field, value, handle }
 }
 
 export function updateCurrentUserFollows(follow = false) {
@@ -93,32 +93,42 @@ export function updateCurrentUserFollows(follow = false) {
 export function fetchFollowUsers(
   followerGroup: User[],
   limit = 15,
-  offset = 0
+  offset = 0,
+  handle?: string
 ) {
-  return { type: FETCH_FOLLOW_USERS, followerGroup, offset, limit }
+  return { type: FETCH_FOLLOW_USERS, followerGroup, offset, limit, handle }
 }
 
 export function fetchFollowUsersSucceeded(
   followerGroup: User[],
   userIds: ID[],
   limit: number,
-  offset: number
+  offset: number,
+  handle: string
 ) {
   return {
     type: FETCH_FOLLOW_USERS_SUCCEEDED,
     followerGroup,
     userIds,
     limit,
-    offset
+    offset,
+    handle
   }
 }
 
 export function fetchFollowUsersFailed(
   followerGroup: User[],
   limit: number,
-  offset: number
+  offset: number,
+  handle: string
 ) {
-  return { type: FETCH_FOLLOW_USERS_FAILED, followerGroup, limit, offset }
+  return {
+    type: FETCH_FOLLOW_USERS_FAILED,
+    followerGroup,
+    limit,
+    offset,
+    handle
+  }
 }
 
 export function profileMeterDismissed() {

--- a/packages/common/src/store/pages/profile/actions.ts
+++ b/packages/common/src/store/pages/profile/actions.ts
@@ -12,8 +12,6 @@ export const UPDATE_PROFILE = 'PROFILE/UPDATE_PROFILE'
 export const UPDATE_PROFILE_SUCCEEDED = 'PROFILE/UPDATE_PROFILE_SUCCEEDED'
 export const UPDATE_PROFILE_FAILED = 'PROFILE/UPDATE_PROFILE_FAILED'
 
-export const RESET_PROFILE = 'PROFILE/RESET_PROFILE'
-
 export const UPDATE_COLLECTION_SORT_MODE = 'PROFILE/UPDATE_COLLECTION_SORT_MODE'
 export const SET_PROFILE_FIELD = 'PROFILE/SET_PROFILE_FIELD'
 export const UPDATE_CURRENT_USER_FOLLOWS = 'PROFILE/UPDATE_CURRENT_USER_FOLLOWS'
@@ -72,10 +70,6 @@ export function updateProfileSucceeded(userId: ID) {
 
 export function updateProfileFailed() {
   return { type: UPDATE_PROFILE_FAILED }
-}
-
-export function resetProfile() {
-  return { type: RESET_PROFILE }
 }
 
 export function updateCollectionSortMode(mode: CollectionSortMode) {

--- a/packages/common/src/store/pages/profile/lineups/feed/reducer.ts
+++ b/packages/common/src/store/pages/profile/lineups/feed/reducer.ts
@@ -2,9 +2,9 @@ import { RESET_SUCCEEDED, stripPrefix } from 'store/lineup/actions'
 import { initialLineupState } from 'store/lineup/reducer'
 import { PREFIX } from 'store/pages/profile/lineups/feed/actions'
 
-import { LineupState, Track } from '../../../../../models'
+import { LineupState } from '../../../../../models'
 
-const initialState: LineupState<Track> = {
+export const initialState: LineupState<{ id: number }> = {
   ...initialLineupState,
   prefix: PREFIX,
   containsDeleted: false
@@ -15,7 +15,10 @@ type ResetSucceededAction = {
 }
 
 const actionsMap = {
-  [RESET_SUCCEEDED](_state: LineupState<Track>, _action: ResetSucceededAction) {
+  [RESET_SUCCEEDED](
+    _state: LineupState<{ id: number }>,
+    _action: ResetSucceededAction
+  ) {
     const newState = initialState
     return newState
   }

--- a/packages/common/src/store/pages/profile/lineups/tracks/reducer.ts
+++ b/packages/common/src/store/pages/profile/lineups/tracks/reducer.ts
@@ -4,7 +4,7 @@ import { RESET_SUCCEEDED, stripPrefix } from 'store/lineup/actions'
 import { initialLineupState } from 'store/lineup/reducer'
 import { PREFIX } from 'store/pages/profile/lineups/tracks/actions'
 
-const initialState = {
+export const initialState = {
   ...initialLineupState,
   prefix: PREFIX,
   containsDeleted: false

--- a/packages/common/src/store/pages/profile/selectors.ts
+++ b/packages/common/src/store/pages/profile/selectors.ts
@@ -60,7 +60,11 @@ export const getProfileTracksLineup = (state: CommonState, handle?: string) =>
   getProfile(state, handle)?.tracks ?? initialTracksState
 
 export const getProfileCollections = createDeepEqualSelector(
-  [getProfileUserId, getUsers, getCollections],
+  [
+    (state: CommonState, handle: string) => getProfileUserId(state, handle),
+    getUsers,
+    getCollections
+  ],
   (userId, users, collections) => {
     if (!userId) return []
     const user: User = users[userId]

--- a/packages/common/src/store/pages/profile/selectors.ts
+++ b/packages/common/src/store/pages/profile/selectors.ts
@@ -5,44 +5,65 @@ import { getUser, getUsers } from 'store/cache/users/selectors'
 import { CommonState } from 'store/commonStore'
 import { removeNullable, createDeepEqualSelector } from 'utils'
 
-import { ID, UserCollection } from '../../../models'
+import { ID, Status, User, UserCollection } from '../../../models'
 
+import { initialState as initialFeedState } from './lineups/feed/reducer'
+import { initialState as initialTracksState } from './lineups/tracks/reducer'
 import { CollectionSortMode } from './types'
 
+const getProfile = (state: CommonState, handle?: string) => {
+  const profileHandle = handle ?? state.pages.profile.currentUser
+  if (!profileHandle) return null
+  return state.pages.profile.entries[profileHandle]
+}
+
+const emptyList: any[] = []
+
 // Profile selectors
-export const getProfileStatus = (state: CommonState) =>
-  state.pages.profile.status
-export const getProfileError = (state: CommonState) => state.pages.profile.error
-export const getProfileUserId = (state: CommonState) =>
-  state.pages.profile.userId
+export const getProfileStatus = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.status ?? Status.IDLE
+export const getProfileError = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.error
+export const getProfileUserId = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.userId
 export const getProfileUserHandle = (state: CommonState) =>
-  state.pages.profile.handle
-export const getProfileMostUsedTags = (state: CommonState) =>
-  state.pages.profile.mostUsedTags
-export const getProfileCollectionSortMode = (state: CommonState) =>
-  state.pages.profile.collectionSortMode
-export const getProfileFollowers = (state: CommonState) =>
-  state.pages.profile.followers
-export const getProfileFollowees = (state: CommonState) =>
-  state.pages.profile.followees
-export const getFolloweeFollows = (state: CommonState) =>
-  state.pages.profile.followeeFollows
-export const getIsSubscribed = (state: CommonState) =>
-  state.pages.profile.isNotificationSubscribed
+  state.pages.profile.currentUser
+export const getProfileMostUsedTags = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.mostUsedTags ?? ([] as string[])
+export const getProfileCollectionSortMode = (
+  state: CommonState,
+  handle: string
+) => getProfile(state, handle)?.collectionSortMode
+export const getProfileFollowers = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.followers
+export const getProfileFollowees = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.followees
+export const getFolloweeFollows = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.followeeFollows
+export const getIsSubscribed = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.isNotificationSubscribed
 export const getProfileUser = (
   state: CommonState,
-  params: { handle?: string | null; id?: ID } = { id: getProfileUserId(state) }
-) => getUser(state, params)
+  params?: { handle?: string | null; id?: ID }
+) => {
+  const profileHandle = getProfileUserHandle(state)
+  if (!params) return getUser(state, { handle: profileHandle })
 
-export const getProfileFeedLineup = (state: CommonState) =>
-  state.pages.profile.feed
-export const getProfileTracksLineup = (state: CommonState) =>
-  state.pages.profile.tracks
+  const { id, handle } = params
+  if (id) return getUser(state, params)
+  return getUser(state, { handle: handle ?? profileHandle })
+}
+
+export const getProfileFeedLineup = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.feed ?? initialFeedState
+export const getProfileTracksLineup = (state: CommonState, handle?: string) =>
+  getProfile(state, handle)?.tracks ?? initialTracksState
 
 export const getProfileCollections = createDeepEqualSelector(
   [getProfileUserId, getUsers, getCollections],
   (userId, users, collections) => {
-    const user = users[userId]
+    if (!userId) return []
+    const user: User = users[userId]
     if (!user) return []
     const { handle, _collectionIds } = user
     const userCollections = _collectionIds
@@ -107,6 +128,7 @@ export const makeGetProfile = () => {
         status
       }
       if (error) return { ...emptyState, error: true }
+      if (!userId) return emptyState
       if (!(userId in users)) return emptyState
 
       // Get playlists & albums.
@@ -140,24 +162,33 @@ export const makeGetProfile = () => {
           (a, b) => moment(b.created_at) - moment(a.created_at)
         )
       }
-      const followersPopulated = followers.userIds
-        .map(({ id }) => {
-          if (id in users) return users[id]
-          return null
-        })
-        .filter(removeNullable)
-      const followeesPopulated = followees.userIds
-        .map(({ id }) => {
-          if (id in users) return users[id]
-          return null
-        })
-        .filter(removeNullable)
+      const followersPopulated =
+        followers?.userIds
+          .map(({ id }) => {
+            if (id in users) return users[id]
+            return null
+          })
+          .filter(removeNullable) ?? (emptyList as User[])
+
+      const followeesPopulated =
+        followees?.userIds
+          .map(({ id }) => {
+            if (id in users) return users[id]
+            return null
+          })
+          .filter(removeNullable) ?? (emptyList as User[])
 
       return {
         profile: {
           ...users[userId],
-          followers: { status: followers.status, users: followersPopulated },
-          followees: { status: followees.status, users: followeesPopulated }
+          followers: {
+            status: followers?.status ?? Status.IDLE,
+            users: followersPopulated
+          },
+          followees: {
+            status: followees?.status ?? Status.IDLE,
+            users: followeesPopulated
+          }
         },
         mostUsedTags,
         playlists,

--- a/packages/common/src/store/pages/profile/types.ts
+++ b/packages/common/src/store/pages/profile/types.ts
@@ -1,4 +1,5 @@
 import { ID, UID, LineupState, Status, User } from '../../../models'
+import { Nullable } from '../../../utils/typeUtils'
 
 export enum FollowType {
   FOLLOWERS = 'followers',
@@ -21,7 +22,7 @@ export type ProfilePageFollow = {
   status: Status
 }
 
-export type ProfilePageState = {
+export type ProfileState = {
   handle: string
   userId: number
   status: Status
@@ -40,6 +41,11 @@ export type ProfilePageState = {
   isNotificationSubscribed: boolean
   error?: string
   mostUsedTags: string[]
+}
+
+export type ProfilePageState = {
+  currentUser: Nullable<string>
+  entries: Record<string, ProfileState>
 }
 
 export enum ProfilePageTabs {

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -16307,7 +16307,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "normalize-path": {
           "version": "3.0.0",
@@ -20393,7 +20393,7 @@
         "onetime": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "requires": {
             "mimic-fn": "^1.0.0"
           }

--- a/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
+++ b/packages/mobile/src/components/audio-rewards/TiersExplainerDrawer.tsx
@@ -68,7 +68,7 @@ export const TiersExplainerDrawer = () => {
   const styles = useStyles()
 
   const profileId = useSelector(getProfileUserId)
-  const { tier, tierNumber } = useSelectTierInfo(profileId)
+  const { tier, tierNumber } = useSelectTierInfo(profileId!)
 
   const { minAudio } = badgeTiers.find(
     (tierReq) => tierReq.tier === tier

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -150,6 +150,7 @@ export const Lineup = ({
   selfLoad,
   includeLineupStatus,
   limit = Infinity,
+  extraFetchOptions,
   ...listProps
 }: LineupProps) => {
   const showTip = useSelector(getShowTip)
@@ -159,7 +160,8 @@ export const Lineup = ({
   const [refreshing, setRefreshing] = useState(refreshingProp)
   const selectedLineup = useSelector(lineupSelector)
   const lineup = selectedLineup ?? lineupProp
-  const { status } = lineup
+  const { status, entries } = lineup
+  const lineupLength = entries.length
 
   const handleRefresh = useCallback(() => {
     setRefreshing(true)
@@ -208,7 +210,6 @@ export const Lineup = ({
       status
     } = lineup
 
-    const lineupLength = entries.length
     const offset = lineupLength + deleted + nullCount
 
     const shouldLoadMore =
@@ -234,7 +235,13 @@ export const Lineup = ({
         loadMore(offset, limit, page === 0)
       } else {
         dispatch(
-          actions.fetchLineupMetadatas(offset, limit, page === 0, fetchPayload)
+          actions.fetchLineupMetadatas(
+            offset,
+            limit,
+            page === 0,
+            fetchPayload,
+            extraFetchOptions
+          )
         )
       }
     }
@@ -247,24 +254,26 @@ export const Lineup = ({
     itemCounts,
     limit,
     lineup,
+    lineupLength,
     loadMore,
-    pageItemCount
+    pageItemCount,
+    extraFetchOptions
   ])
 
   // When scrolled past the end threshold of the lineup and the lineup is not loading,
   // trigger another load
   useEffect(() => {
-    if (isPastLoadThreshold && lineup.status !== Status.LOADING) {
+    if (isPastLoadThreshold && status !== Status.LOADING) {
       setIsPastLoadThreshold(false)
       handleLoadMore()
     }
-  }, [isPastLoadThreshold, lineup.status, handleLoadMore])
+  }, [isPastLoadThreshold, status, handleLoadMore])
 
   useEffect(() => {
-    if (selfLoad && lineup.entries.length === 0) {
+    if (selfLoad && lineupLength === 0 && status !== Status.LOADING) {
       handleLoadMore()
     }
-  }, [handleLoadMore, selfLoad, lineup])
+  }, [handleLoadMore, selfLoad, lineupLength, status])
 
   const togglePlay = useCallback(
     ({ uid, id, source, isPlayingUid, isPlaying }: TogglePlayConfig) => {

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -57,6 +57,11 @@ export type LineupProps = {
   fetchPayload?: any
 
   /**
+   * Extra fetch payload (merged in with fetch action) used to pass extra information to lineup actions/reducers/sagas
+   */
+  extraFetchOptions?: Record<string, unknown>
+
+  /**
    * A header to display at the top of the lineup,
    * will scroll with the rest of the content
    */

--- a/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
@@ -4,10 +4,12 @@ import { useSelector } from 'react-redux'
 import { CollectionList } from 'app/components/collection-list/CollectionList'
 
 import { useEmptyProfileText } from './EmptyProfileTile'
+import { useSelectProfile } from './selectors'
 const { getProfileAlbums } = profilePageSelectors
 
 export const AlbumsTab = () => {
-  const albums = useSelector(getProfileAlbums)
+  const { handle } = useSelectProfile(['handle'])
+  const albums = useSelector((state) => getProfileAlbums(state, handle))
 
   const emptyListText = useEmptyProfileText('albums')
 

--- a/packages/mobile/src/screens/profile-screen/CollectiblesTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/CollectiblesTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useRef } from 'react'
 
-import { accountSelectors } from '@audius/common'
+import { accountSelectors, useProxySelector } from '@audius/common'
 import Clipboard from '@react-native-clipboard/clipboard'
 import type { FlatList as RNFlatList } from 'react-native'
 import { View, Text } from 'react-native'
@@ -15,7 +15,7 @@ import { makeStyles } from 'app/styles'
 import { getCollectiblesRoute } from 'app/utils/routes'
 
 import { CollectiblesCard } from './CollectiblesCard'
-import { getProfile } from './selectors'
+import { getProfile, useSelectProfile } from './selectors'
 const getUserId = accountSelectors.getUserId
 
 const messages = {
@@ -69,7 +69,11 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
 
 export const CollectiblesTab = () => {
   const styles = useStyles()
-  const { profile } = useSelector(getProfile)
+  const { handle } = useSelectProfile(['handle'])
+  const { profile } = useProxySelector(
+    (state) => getProfile(state, handle),
+    [handle]
+  )
   const accountId = useSelector(getUserId)
   const isOwner = profile?.user_id === accountId
   const { toast } = useContext(ToastContext)

--- a/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
@@ -4,10 +4,12 @@ import { useSelector } from 'react-redux'
 import { CollectionList } from 'app/components/collection-list'
 
 import { useEmptyProfileText } from './EmptyProfileTile'
+import { useSelectProfile } from './selectors'
 const { getProfilePlaylists } = profilePageSelectors
 
 export const PlaylistsTab = () => {
-  const playlists = useSelector(getProfilePlaylists)
+  const { handle } = useSelectProfile(['handle'])
+  const playlists = useSelector((state) => getProfilePlaylists(state, handle))
 
   const emptyListText = useEmptyProfileText('playlists')
 

--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -1,3 +1,4 @@
+import type { CommonState } from '@audius/common'
 import { FollowSource, reachabilitySelectors } from '@audius/common'
 import { View, Text } from 'react-native'
 import { useSelector } from 'react-redux'
@@ -93,7 +94,7 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
   const { name, handle, does_current_user_follow, does_follow_current_user } =
     profile
 
-  const isOwner = useSelector(getIsOwner)
+  const isOwner = useSelector((state: CommonState) => getIsOwner(state, handle))
   const profileButton = isOwner ? (
     <EditProfileButton style={styles.followButton} />
   ) : (

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -7,9 +7,7 @@ import {
   profilePageSelectors,
   profilePageActions,
   reachabilitySelectors,
-  shareModalUIActions,
-  profilePageTracksLineupActions as tracksActions,
-  profilePageFeedLineupActions as feedActions
+  shareModalUIActions
 } from '@audius/common'
 import { PortalHost } from '@gorhom/portal'
 import { useFocusEffect } from '@react-navigation/native'
@@ -34,7 +32,7 @@ import { ProfileHeader } from './ProfileHeader'
 import { ProfileTabNavigator } from './ProfileTabNavigator'
 import { useSelectProfileRoot } from './selectors'
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
-const { fetchProfile: fetchProfileAction, resetProfile } = profilePageActions
+const { fetchProfile: fetchProfileAction } = profilePageActions
 const { getProfileStatus } = profilePageSelectors
 const { getIsReachable } = reachabilitySelectors
 const getUserId = accountSelectors.getUserId
@@ -72,7 +70,7 @@ export const ProfileScreen = () => {
       : profile?.handle
   const accountId = useSelector(getUserId)
   const dispatch = useDispatch()
-  const status = useSelector(getProfileStatus)
+  const status = useSelector((state) => getProfileStatus(state, handle))
   const [isRefreshing, setIsRefreshing] = useState(false)
   const { neutralLight4, accentOrange } = useThemeColors()
   const navigation = useNavigation<ProfileTabScreenParamList>()
@@ -82,16 +80,9 @@ export const ProfileScreen = () => {
     dispatch(fetchProfileAction(handle, null, true, true, false))
   }, [dispatch, handle])
 
-  const clearProfile = useCallback(() => {
-    dispatch(resetProfile())
-    dispatch(tracksActions.reset())
-    dispatch(feedActions.reset())
-  }, [dispatch])
-
   const handleLoadProfile = useCallback(() => {
     fetchProfile()
-    return clearProfile
-  }, [fetchProfile, clearProfile])
+  }, [fetchProfile])
 
   useFocusEffect(handleLoadProfile)
 

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -1,9 +1,10 @@
+import { useMemo } from 'react'
+
 import {
-  lineupSelectors,
   profilePageSelectors,
-  profilePageFeedLineupActions as feedActions
+  profilePageFeedLineupActions as feedActions,
+  useProxySelector
 } from '@audius/common'
-import { useSelector } from 'react-redux'
 
 import { Lineup } from 'app/components/lineup'
 
@@ -11,24 +12,31 @@ import { EmptyProfileTile } from './EmptyProfileTile'
 import { useSelectProfile } from './selectors'
 
 const { getProfileFeedLineup } = profilePageSelectors
-const { makeGetLineupMetadatas } = lineupSelectors
-
-const getUserFeedMetadatas = makeGetLineupMetadatas(getProfileFeedLineup)
 
 export const RepostsTab = () => {
-  const lineup = useSelector(getUserFeedMetadatas)
+  const { handle } = useSelectProfile(['handle'])
+  // const lineup = useSelector((state) => getProfileFeedLineup(state, handle))
+  const lineup = useProxySelector(
+    (state) => getProfileFeedLineup(state, handle),
+    [handle]
+  )
   const { repost_count } = useSelectProfile(['repost_count'])
+
+  const extraFetchOptions = useMemo(() => ({ handle }), [handle])
+
+  if (!lineup) return null
 
   return (
     <Lineup
       listKey='profile-reposts'
+      selfLoad
       actions={feedActions}
       lineup={lineup}
-      selfLoad
       limit={repost_count}
       disableTopTabScroll
       ListEmptyComponent={<EmptyProfileTile tab='reposts' />}
       showsVerticalScrollIndicator={false}
+      extraFetchOptions={extraFetchOptions}
     />
   )
 }

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -15,7 +15,6 @@ const { getProfileFeedLineup } = profilePageSelectors
 
 export const RepostsTab = () => {
   const { handle } = useSelectProfile(['handle'])
-  // const lineup = useSelector((state) => getProfileFeedLineup(state, handle))
   const lineup = useProxySelector(
     (state) => getProfileFeedLineup(state, handle),
     [handle]

--- a/packages/mobile/src/screens/profile-screen/SubscribeButton.tsx
+++ b/packages/mobile/src/screens/profile-screen/SubscribeButton.tsx
@@ -1,15 +1,15 @@
 import { useCallback } from 'react'
 
 import type { User } from '@audius/common'
-import { profilePageActions } from '@audius/common'
+import { profilePageSelectors, profilePageActions } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconNotification from 'app/assets/images/iconNotification.svg'
 import { Button } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 
-import { getIsSubscribed } from './selectors'
 const { setNotificationSubscription } = profilePageActions
+const { getIsSubscribed } = profilePageSelectors
 
 const messages = {
   subscribe: 'subscribe',
@@ -32,8 +32,10 @@ type SubscribeButtonProps = {
 export const SubscribeButton = (props: SubscribeButtonProps) => {
   const styles = useStyles()
   const { profile } = props
+  const isSubscribed = useSelector((state) =>
+    getIsSubscribed(state, profile.handle)
+  )
   const { user_id } = profile
-  const isSubscribed = useSelector(getIsSubscribed)
   const dispatch = useDispatch()
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -2,54 +2,65 @@ import { useCallback, useEffect } from 'react'
 
 import {
   profilePageSelectors,
-  profilePageTracksLineupActions as tracksActions
+  profilePageTracksLineupActions as tracksActions,
+  useProxySelector
 } from '@audius/common'
-import type { RouteProp } from '@react-navigation/core'
-import { useRoute } from '@react-navigation/core'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 
 import { Lineup } from 'app/components/lineup'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
-import { getIsOwner, useSelectProfile } from './selectors'
-const { getProfileTracksLineup, getProfileUserHandle } = profilePageSelectors
+import { useIsProfileLoaded, useSelectProfile } from './selectors'
+const { getProfileTracksLineup } = profilePageSelectors
 
 export const TracksTab = () => {
-  const { params } =
-    useRoute<RouteProp<{ Tracks: { handle: string } }, 'Tracks'>>()
-  const lineup = useSelector(getProfileTracksLineup)
+  const isProfileLoaded = useIsProfileLoaded()
   const dispatch = useDispatch()
 
-  const profileHandle = useSelector(getProfileUserHandle)
-  const isOwner = useSelector(getIsOwner)
-
-  const isProfileLoaded =
-    profileHandle === params?.handle ||
-    (params?.handle === 'accountUser' && isOwner)
-
-  const { user_id, track_count, _artist_pick } = useSelectProfile([
+  const { handle, user_id, track_count, _artist_pick } = useSelectProfile([
+    'handle',
     'user_id',
     'track_count',
     '_artist_pick'
   ])
 
+  const lineup = useProxySelector(
+    (state) => getProfileTracksLineup(state, handle),
+    [handle]
+  )
+
   useEffect(() => {
     if (isProfileLoaded) {
-      dispatch(tracksActions.fetchLineupMetadatas())
+      dispatch(
+        tracksActions.fetchLineupMetadatas(
+          undefined,
+          undefined,
+          undefined,
+          { userId: user_id },
+          { handle }
+        )
+      )
     }
-  }, [dispatch, isProfileLoaded])
+  }, [dispatch, isProfileLoaded, user_id, handle])
 
-  // TODO: use fetchPayload (or change Remixes page)
   const loadMore = useCallback(
     (offset: number, limit: number) => {
       dispatch(
-        tracksActions.fetchLineupMetadatas(offset, limit, false, {
-          userId: user_id
-        })
+        tracksActions.fetchLineupMetadatas(
+          offset,
+          limit,
+          false,
+          {
+            userId: user_id
+          },
+          { handle }
+        )
       )
     },
-    [dispatch, user_id]
+    [dispatch, user_id, handle]
   )
+
+  if (!lineup) return null
 
   /**
    * If the profile isn't loaded yet, pass the lineup an empty entries
@@ -60,7 +71,7 @@ export const TracksTab = () => {
       leadingElementId={_artist_pick}
       listKey='profile-tracks'
       actions={tracksActions}
-      lineup={isProfileLoaded ? lineup : { ...lineup, entries: [] }}
+      lineup={lineup}
       limit={track_count}
       loadMore={loadMore}
       disableTopTabScroll

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -1,5 +1,6 @@
-import type { Nullable, User } from '@audius/common'
+import type { Nullable, User, CommonState } from '@audius/common'
 import {
+  Status,
   useProxySelector,
   accountSelectors,
   profilePageSelectors
@@ -8,12 +9,8 @@ import { useSelector } from 'react-redux'
 import { createSelector } from 'reselect'
 
 import { useRoute } from 'app/hooks/useRoute'
-const {
-  getProfileUser,
-  getProfileUserHandle,
-  getProfileUserId,
-  makeGetProfile
-} = profilePageSelectors
+const { getProfileUser, getProfileStatus, makeGetProfile, getProfileUserId } =
+  profilePageSelectors
 const { getAccountUser, getUserId } = accountSelectors
 
 /*
@@ -53,23 +50,21 @@ export const useSelectProfile = (deps: Array<keyof User>) => {
 
 export const getProfile = makeGetProfile()
 
-export const getIsSubscribed = createSelector(
-  [getProfile],
-  (profile) => profile.isSubscribed
-)
-
 export const getIsOwner = createSelector(
-  [getProfileUserId, getUserId],
-  (profileUserId, accountUserId) => profileUserId === accountUserId
+  (state: CommonState, handle: string) => getProfileUserId(state, handle),
+  getUserId,
+  (profileUserId, accountUserId) => accountUserId === profileUserId
 )
 
 export const useIsProfileLoaded = () => {
   const { params } = useRoute<'Profile'>()
+  const { handle } = params
+  const profileStatus = useSelector((state) => getProfileStatus(state, handle))
+  const account = useSelector(getAccountUser)
+  const isOwner = handle === account?.handle
 
-  const profileHandle = useSelector(getProfileUserHandle)
-  const isOwner = useSelector(getIsOwner)
   return (
-    profileHandle === params.handle ||
-    (params.handle === 'accountUser' && isOwner)
+    (params.handle === 'accountUser' && isOwner) ||
+    profileStatus === Status.SUCCESS
   )
 }

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -60,11 +60,6 @@ export const useIsProfileLoaded = () => {
   const { params } = useRoute<'Profile'>()
   const { handle } = params
   const profileStatus = useSelector((state) => getProfileStatus(state, handle))
-  const account = useSelector(getAccountUser)
-  const isOwner = handle === account?.handle
 
-  return (
-    (params.handle === 'accountUser' && isOwner) ||
-    profileStatus === Status.SUCCESS
-  )
+  return handle === 'accountUser' || profileStatus === Status.SUCCESS
 }

--- a/packages/mobile/src/screens/profile-screen/utils.ts
+++ b/packages/mobile/src/screens/profile-screen/utils.ts
@@ -1,3 +1,4 @@
+import type { CommonState } from '@audius/common'
 import { badgeTiers, useSelectTierInfo } from '@audius/common'
 import { useSelector } from 'react-redux'
 
@@ -17,19 +18,21 @@ import { getIsOwner, useSelectProfile } from './selectors'
  */
 export const useShouldShowCollectiblesTab = () => {
   const {
+    handle,
     user_id,
     has_collectibles,
     collectibleList,
     solanaCollectibleList,
     collectibles
   } = useSelectProfile([
+    'handle',
     'user_id',
     'has_collectibles',
     'collectibleList',
     'solanaCollectibleList',
     'collectibles'
   ])
-  const isOwner = useSelector(getIsOwner)
+  const isOwner = useSelector((state: CommonState) => getIsOwner(state, handle))
   const { tierNumber } = useSelectTierInfo(user_id)
 
   const hasCollectiblesTierRequirement =

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -128,7 +128,8 @@ function* fetchLineupMetadatasAsync(
           action.offset,
           action.limit,
           action.overwrite,
-          action.payload
+          action.payload,
+          action.handle
         )
       )
 
@@ -139,14 +140,12 @@ function* fetchLineupMetadatasAsync(
         yield delay(100)
       }
 
-      const lineupMetadatasResponse = yield call(lineupMetadatasCall, {
-        offset: action.offset,
-        limit: action.limit,
-        payload: action.payload
-      })
+      const lineupMetadatasResponse = yield call(lineupMetadatasCall, action)
 
       if (lineupMetadatasResponse === null) return
-      const lineup = yield select(lineupSelector)
+      const lineup = yield select((state) =>
+        lineupSelector(state, action.handle)
+      )
       const source = sourceSelector
         ? yield select(sourceSelector)
         : lineup.prefix
@@ -271,7 +270,8 @@ function* fetchLineupMetadatasAsync(
           action.offset,
           action.limit,
           deletedCount,
-          nullCount
+          nullCount,
+          action.handle
         )
       )
 

--- a/packages/web/src/common/store/pages/profile/lineups/feed/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/feed/sagas.js
@@ -21,14 +21,15 @@ const { getTracks } = cacheTracksSelectors
 const { getCollections } = cacheCollectionsSelectors
 const getUserId = accountSelectors.getUserId
 
-function* getReposts({ offset, limit }) {
-  const handle = yield select(getProfileUserHandle)
+function* getReposts({ offset, limit, handle }) {
   const profileId = yield select(getProfileUserId)
+  const currentProfileHandle = yield select(getProfileUserHandle)
+  const profileHandle = handle ?? currentProfileHandle
 
   yield waitForAccount()
   const currentUserId = yield select(getUserId)
   let reposts = yield call(retrieveUserReposts, {
-    handle,
+    handle: profileHandle,
     currentUserId,
     offset,
     limit

--- a/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
@@ -27,10 +27,11 @@ const { DELETE_TRACK } = cacheTracksActions
 const getUserId = accountSelectors.getUserId
 const PREFIX = tracksActions.prefix
 
-function* getTracks({ offset, limit, payload }) {
-  const handle = yield select(getProfileUserHandle)
+function* getTracks({ offset, limit, payload, handle }) {
   yield waitForAccount()
   const currentUserId = yield select(getUserId)
+  const currentProfileHandle = yield select(getProfileUserHandle)
+  const profileHandle = handle ?? currentProfileHandle
 
   // Wait for user to receive social handles
   // We need to know ahead of time whether we want to request
@@ -40,7 +41,7 @@ function* getTracks({ offset, limit, payload }) {
     waitForValue,
     getUser,
     {
-      handle: handle.toLowerCase()
+      handle: profileHandle.toLowerCase()
     },
     (user) => 'twitter_handle' in user
   )
@@ -51,7 +52,7 @@ function* getTracks({ offset, limit, payload }) {
     let [pinnedTrack, processed] = yield all([
       call(retrieveTracks, { trackIds: [user._artist_pick] }),
       call(retrieveUserTracks, {
-        handle,
+        handle: profileHandle,
         currentUserId,
         sort,
         limit,
@@ -94,7 +95,7 @@ function* getTracks({ offset, limit, payload }) {
     }
   } else {
     const processed = yield call(retrieveUserTracks, {
-      handle,
+      handle: profileHandle,
       currentUserId,
       sort,
       limit,

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -318,8 +318,10 @@ function* fetchMostUsedTags(userId, trackCount) {
 }
 
 function* fetchFolloweeFollows(action) {
+  const { handle } = action
+  if (!handle) return
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  const profileUserId = yield select(getProfileUserId)
+  const profileUserId = yield select((state) => getProfileUserId(state, handle))
   if (!profileUserId) return
   const followeeFollows = yield call(
     audiusBackendInstance.getFolloweeFollows,

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileMutuals.tsx
@@ -36,9 +36,11 @@ const MAX_MUTUALS = 5
 const selectMutuals = createSelector(
   [getFolloweeFollows, getUsers],
   (followeeFollows, users) => {
-    return followeeFollows.userIds
-      .map(({ id }) => users[id])
-      .filter(removeNullable)
+    return (
+      followeeFollows?.userIds
+        .map(({ id }) => users[id])
+        .filter(removeNullable) ?? []
+    )
   }
 )
 
@@ -47,11 +49,11 @@ export const ProfileMutuals = () => {
   const accountId = useSelector(getUserId)
   const profile = useSelector(getProfileUser)
 
-  // @ts-ignore -- fixed in typescript v4
   const mutuals = useSelector(selectMutuals)
   const dispatch = useDispatch()
 
   const handleClick = useCallback(() => {
+    if (!userId) return
     dispatch(
       setUsers({
         userListType: UserListType.MUTUAL_FOLLOWER,

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -382,8 +382,8 @@ const ProfilePage = ({
     const elements = [
       <div key={ProfilePageTabs.TRACKS} className={styles.tiles}>
         {renderProfileCompletionCard()}
-        {status !== Status.LOADING ? (
-          artistTracks.status !== Status.LOADING &&
+        {status === Status.SUCCESS ? (
+          artistTracks.status === Status.SUCCESS &&
           artistTracks.entries.length === 0 ? (
             <EmptyTab
               isOwner={isOwner}
@@ -430,8 +430,8 @@ const ProfilePage = ({
         )}
       </div>,
       <div key={ProfilePageTabs.REPOSTS} className={styles.tiles}>
-        {status !== Status.LOADING ? (
-          (userFeed.status !== Status.LOADING &&
+        {status === Status.SUCCESS ? (
+          (userFeed.status === Status.SUCCESS &&
             userFeed.entries.length === 0) ||
           profile.repost_count === 0 ? (
             <EmptyTab

--- a/packages/web/src/store/configureStore.ts
+++ b/packages/web/src/store/configureStore.ts
@@ -47,6 +47,9 @@ const onSagaError = (
 // Can't send up the entire Redux state b/c it's too fat
 // for Sentry to handle, and there is sensitive data
 const statePruner = (state: AppState) => {
+  const currentProfileHandle = state.pages.profile.currentUser ?? ''
+  const currentProfile = state.pages.profile.entries[currentProfileHandle] ?? {}
+
   return {
     account: {
       status: state.account.status,
@@ -54,12 +57,12 @@ const statePruner = (state: AppState) => {
     },
     pages: {
       profile: {
-        handle: state.pages.profile.handle,
-        status: state.pages.profile.status,
-        updateError: state.pages.profile.updateError,
-        updateSuccess: state.pages.profile.updateSuccess,
-        updating: state.pages.profile.updating,
-        userId: state.pages.profile.userId
+        handle: currentProfile.handle,
+        status: currentProfile.status,
+        updateError: currentProfile.updateError,
+        updateSuccess: currentProfile.updateSuccess,
+        updating: currentProfile.updating,
+        userId: currentProfile.userId
       }
     },
     router: {

--- a/packages/web/src/store/reducers.ts
+++ b/packages/web/src/store/reducers.ts
@@ -1,5 +1,4 @@
 import {
-  profilePageReducer as profile,
   queueReducer as queue,
   remoteConfigReducer as remoteConfig,
   reducers as clientStoreReducers
@@ -57,7 +56,6 @@ const createRootReducer = (routeHistory: History) =>
 
     // Pages
     upload,
-    profile,
     dashboard,
     serviceSelection,
 

--- a/packages/web/src/store/storeContext.ts
+++ b/packages/web/src/store/storeContext.ts
@@ -35,6 +35,7 @@ export const storeContext: CommonStoreContext = {
   isElectron: isElectron(),
   env,
   explore,
+  // @ts-ignore js file
   getLineupSelectorForRoute,
   audioPlayer,
   solanaClient: new SolanaClient({


### PR DESCRIPTION
### Description

- Improves profile store layout, by allowing multiple profile page states to be saved at once.
- This improves mobile profile navigation, since we don't have to reset profile state, which causes poor navigation performance and ui.
- Written in a backwards-compatible way, so web doesn't need to do anything different. Eventually we may want to apply this new system to web though.
- Updates lineup default state from .LOADING to .IDLE

