### PR TITLE
[C-978] Check for track repeat before advancing shuffle

### DIFF
--- a/packages/common/src/store/queue/slice.ts
+++ b/packages/common/src/store/queue/slice.ts
@@ -125,15 +125,15 @@ const slice = createSlice({
 
       if (state.order.length === 0) return
 
+      if (state.repeat === RepeatMode.SINGLE && !skip) {
+        return
+      }
+
       if (state.shuffle) {
         const newShuffleIndex =
           (state.shuffleIndex + 1) % state.shuffleOrder.length
         state.shuffleIndex = newShuffleIndex
         state.index = state.shuffleOrder[newShuffleIndex]
-        return
-      }
-
-      if (state.repeat === RepeatMode.SINGLE && !skip) {
         return
       }
 

--- a/packages/web/src/common/store/queue/store.test.js
+++ b/packages/web/src/common/store/queue/store.test.js
@@ -325,6 +325,8 @@ describe('watchNext', () => {
     expect(storeState.queue.index).toEqual(0)
   })
 
+  // Note: This test is untested, as the unit testing process was broken when it was written
+  // If it breaks on first run, it may be bugged
   it('repeats the same track when in shuffle mode', async () => {
     const initialQueue = makeInitialQueue({
       index: 0,

--- a/packages/web/src/common/store/queue/store.test.js
+++ b/packages/web/src/common/store/queue/store.test.js
@@ -325,6 +325,28 @@ describe('watchNext', () => {
     expect(storeState.queue.index).toEqual(0)
   })
 
+  it('repeats the same track when in shuffle mode', async () => {
+    const initialQueue = makeInitialQueue({
+      index: 0,
+      repeat: RepeatMode.SINGLE,
+      shuffle: true,
+      shuffleIndex: 0
+    })
+    const playingEntry =
+      initialQueue.order[initialQueue.shuffleOrder[initialQueue.shuffleIndex]]
+    const initialPlayer = makeInitialPlayer({
+      uid: playingEntry.uid,
+      trackId: playingEntry.id,
+      playing: true
+    })
+    const { storeState } = await expectNextSagaAndGetStoreState(
+      initialPlayer,
+      initialQueue,
+      playingEntry
+    )
+    expect(storeState.queue.index).toEqual(0)
+  })
+
   it('does not repeat the same track if skipped', async () => {
     const initialQueue = makeInitialQueue({
       index: 0,


### PR DESCRIPTION
### Description

We were failing to repeat a single track when shuffle was toggled on. This is because the logic to advance the shuffle index was happening before the repeat single track check in the reducer.

### Dragons
N/A

### How Has This Been Tested?
Manually. Unit test added to cover this behavior in the future, but the test itself couldn't be tested due to broken jest setup on main.

### How will this change be monitored?
N/A

### Feature Flags ###
N/A