### PR TITLE
[C-1137] Add debounce to change in NetworkInfo status

### DIFF
--- a/packages/mobile/src/utils/connectivity.ts
+++ b/packages/mobile/src/utils/connectivity.ts
@@ -29,6 +29,4 @@ const updateConnectivity = (state: NetInfoState) => {
   }
 }
 
-NetInfo.addEventListener(
-  debounce(updateConnectivity, 2000, { maxWait: 5000 })
-)
+NetInfo.addEventListener(debounce(updateConnectivity, 2000, { maxWait: 5000 }))

--- a/packages/mobile/src/utils/connectivity.ts
+++ b/packages/mobile/src/utils/connectivity.ts
@@ -1,6 +1,7 @@
 import { reachabilityActions } from '@audius/common'
 import type { NetInfoState } from '@react-native-community/netinfo'
 import NetInfo from '@react-native-community/netinfo'
+import { debounce } from 'lodash'
 
 import { dispatch } from './../store/store'
 
@@ -17,7 +18,8 @@ export const checkConnectivity = (netInfo: NetInfoState | null) => {
 
 // Latest connectivity value
 export const Connectivity: { netInfo: NetInfoState | null } = { netInfo: null }
-NetInfo.addEventListener((state: NetInfoState) => {
+
+const updateConnectivity = (state: NetInfoState) => {
   Connectivity.netInfo = state
   const newValue = checkConnectivity(state)
   if (!newValue) {
@@ -25,4 +27,8 @@ NetInfo.addEventListener((state: NetInfoState) => {
   } else {
     dispatch(reachabilityActions.setReachable())
   }
-})
+}
+
+NetInfo.addEventListener(
+  debounce((state) => updateConnectivity(state), 2000, { maxWait: 5000 })
+)

--- a/packages/mobile/src/utils/connectivity.ts
+++ b/packages/mobile/src/utils/connectivity.ts
@@ -30,5 +30,5 @@ const updateConnectivity = (state: NetInfoState) => {
 }
 
 NetInfo.addEventListener(
-  debounce((state) => updateConnectivity(state), 2000, { maxWait: 5000 })
+  debounce(updateConnectivity, 2000, { maxWait: 5000 })
 )


### PR DESCRIPTION
### Description

Prevent offline placeholder from flashing on and off when network status is changing rapidly.

We will wait 2 sec before making a call to `updateConnectivity` and only process the last call within the 5 second window.

### How Has This Been Tested?

iOS simulator