### PR TITLE
[C-1004] Fix sign-up -> sign-in email bug

### DIFF
--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -552,7 +552,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
       }
 
       if (!keepEmail) {
-        console.log('guessing we arent keeping email?')
         setEmail('')
       }
 
@@ -564,8 +563,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
       Keyboard.dismiss()
     }
   }
-
-  console.log('email?', email)
 
   const passwordInputField = () => {
     if (isSignin) {

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -552,6 +552,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
       }
 
       if (!keepEmail) {
+        console.log('guessing we arent keeping email?')
         setEmail('')
       }
 
@@ -563,6 +564,8 @@ const SignOn = ({ navigation }: SignOnProps) => {
       Keyboard.dismiss()
     }
   }
+
+  console.log('email?', email)
 
   const passwordInputField = () => {
     if (isSignin) {
@@ -648,7 +651,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
                     () => {
                       // On unavailable email (e.g. user exists with that email),
                       // Switch to the sign in form
-                      switchForm()
+                      switchForm(true)
                       setIsWorking(false)
                     },
                     () => {


### PR DESCRIPTION
### Description

Fixes bug where typing in email in sign-up, and redirecting to sign-in and inputting password results in "invalid email" which is very confusing. It can be resolved if you click email, delete a value and add it, which resets the email state.

This fix ensures that email doesn't get flushed when moving over
