### PR TITLE
Disable account-sync to test app failure

### DIFF
--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -1,13 +1,9 @@
-import { useState } from 'react'
-
 import { PortalProvider } from '@gorhom/portal'
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import * as Sentry from '@sentry/react-native'
 import { Platform, UIManager } from 'react-native'
 import Config from 'react-native-config'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { Provider } from 'react-redux'
-import { useAsync } from 'react-use'
 
 import Audio from 'app/components/audio/Audio'
 import HCaptcha from 'app/components/hcaptcha'
@@ -18,12 +14,10 @@ import { ToastContextProvider } from 'app/components/toast/ToastContext'
 import { incrementSessionCount } from 'app/hooks/useSessionCount'
 import { RootScreen } from 'app/screens/root-screen'
 import { store } from 'app/store'
-import { ENTROPY_KEY } from 'app/store/account/sagas'
 
 import { Drawers } from './Drawers'
 import ErrorBoundary from './ErrorBoundary'
 import { NotificationReminder } from './components/notification-reminder/NotificationReminder'
-import { WebAppAccountSync } from './components/web-app-account-sync/WebAppAccountSync'
 
 Sentry.init({
   dsn: Config.SENTRY_DSN
@@ -49,14 +43,6 @@ const Modals = () => {
 }
 
 const App = () => {
-  const [isReadyToSetupBackend, setIsReadyToSetupBackend] = useState(false)
-
-  useAsync(async () => {
-    // Require entropy to exist before setting up backend
-    const entropy = await AsyncStorage.getItem(ENTROPY_KEY)
-    setIsReadyToSetupBackend(!!entropy)
-  }, [])
-
   return (
     <SafeAreaProvider>
       <Provider store={store}>
@@ -64,13 +50,8 @@ const App = () => {
           <ToastContextProvider>
             <ErrorBoundary>
               <NavigationContainer>
-                {!isReadyToSetupBackend ? (
-                  <WebAppAccountSync
-                    setIsReadyToSetupBackend={setIsReadyToSetupBackend}
-                  />
-                ) : null}
                 <Airplay />
-                <RootScreen isReadyToSetupBackend={isReadyToSetupBackend} />
+                <RootScreen isReadyToSetupBackend />
                 <Drawers />
                 <Modals />
                 <Audio />


### PR DESCRIPTION
### Description

Disabling account sync to check if bounce app breaks on load. This will help us debug whether the issue is ios16 related, or static-server related
