### PR TITLE
[Reloaded] Keep relevant search results in store c-1117

### DIFF
--- a/packages/common/src/store/pages/search-results/selectors.ts
+++ b/packages/common/src/store/pages/search-results/selectors.ts
@@ -7,6 +7,10 @@ import { createShallowSelector } from 'utils/selectorHelpers'
 
 // Search Results selectors
 export const getBaseState = (state: CommonState) => state.pages.searchResults
+export const getSearchText = (state: CommonState) =>
+  getBaseState(state).searchText
+export const getIsTagSearch = (state: CommonState) =>
+  getBaseState(state).isTagSearch
 export const getSearchTracksLineup = (state: CommonState) =>
   getBaseState(state).tracks
 export const getSearchResults = (state: CommonState) => getBaseState(state)
@@ -19,7 +23,7 @@ const getSearchArtistsIds = (state: CommonState) =>
   getBaseState(state).artistIds || []
 const getUnsortedSearchArtists = createShallowSelector(
   [getSearchArtistsIds, (state) => state],
-  (artistIds, state) => getUsers(state, { ids: artistIds })
+  (artistIds, state) => getUsers(state, { ids: artistIds || [] })
 )
 export const makeGetSearchArtists = () => {
   return createSelector(
@@ -30,7 +34,7 @@ export const makeGetSearchArtists = () => {
 }
 
 const getSearchAlbums = (state: CommonState) =>
-  getCollections(state, { ids: getBaseState(state).albumIds })
+  getCollections(state, { ids: getBaseState(state).albumIds || [] })
 export const makeGetSearchAlbums = () => {
   return createShallowSelector([getSearchAlbums, getUsers], (albums, users) =>
     Object.values(albums)
@@ -45,7 +49,7 @@ export const makeGetSearchAlbums = () => {
 }
 
 const getSearchPlaylists = (state: CommonState) =>
-  getCollections(state, { ids: getBaseState(state).playlistIds })
+  getCollections(state, { ids: getBaseState(state).playlistIds || [] })
 export const makeGetSearchPlaylists = () => {
   return createShallowSelector(
     [getSearchPlaylists, getUsers],

--- a/packages/common/src/store/pages/search-results/types.ts
+++ b/packages/common/src/store/pages/search-results/types.ts
@@ -3,10 +3,11 @@ import { ID, LineupState, Status, Track } from '../../../models'
 export type SearchPageState = {
   status: Status
   searchText: string
-  trackIds: ID[]
-  albumIds: ID[]
-  playlistIds: ID[]
-  artistIds: ID[]
+  trackIds?: ID[]
+  albumIds?: ID[]
+  playlistIds?: ID[]
+  artistIds?: ID[]
+  isTagSearch: boolean
   tracks: LineupState<Track>
 }
 

--- a/packages/mobile/src/screens/search-results-screen/tabs/SearchResultsTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/SearchResultsTab.tsx
@@ -1,13 +1,11 @@
 import type { ReactNode } from 'react'
-import { useContext, useEffect, useState } from 'react'
 
-import { Status, searchResultsPageSelectors } from '@audius/common'
+import { searchResultsPageSelectors, Status } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import { WithLoader } from 'app/components/with-loader/WithLoader'
 
 import { EmptyResults } from '../EmptyResults'
-import { SearchFocusContext } from '../SearchFocusContext'
 const { getSearchStatus } = searchResultsPageSelectors
 
 type SearchResultsTabProps = {
@@ -18,29 +16,12 @@ type SearchResultsTabProps = {
 
 export const SearchResultsTab = (props: SearchResultsTabProps) => {
   const { children, noResults, status } = props
-  const { isFocused } = useContext(SearchFocusContext)
   const searchStatus = useSelector(getSearchStatus)
-  const [isRefreshing, setIsRefreshing] = useState(true)
-
-  useEffect(() => {
-    if (!isFocused) {
-      // Prevents a large rerender in the middle of a stack navigation.
-      // Note: having to manage status with navigation focus may not be needed
-      // when move common store into native.
-      setTimeout(() => {
-        setIsRefreshing(true)
-      }, 1000)
-    }
-    if (searchStatus === Status.LOADING) {
-      setIsRefreshing(false)
-    }
-  }, [isFocused, searchStatus])
 
   return (
     <WithLoader
       loading={Boolean(
-        isRefreshing ||
-          searchStatus === Status.LOADING ||
+        searchStatus === Status.LOADING ||
           (status === Status.LOADING && noResults)
       )}
     >

--- a/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/TracksTab.tsx
@@ -7,7 +7,6 @@ import {
   searchResultsPageTracksLineupActions as tracksActions,
   trimToAlphaNumeric
 } from '@audius/common'
-import { useFocusEffect } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Lineup } from 'app/components/lineup'
@@ -25,13 +24,6 @@ const getSearchTracksLineupMetadatas = makeGetLineupMetadatas(
 export const TracksTab = () => {
   const lineup = useSelector(getSearchTracksLineupMetadatas)
   const dispatch = useDispatch()
-  useFocusEffect(
-    useCallback(() => {
-      return () => {
-        dispatch(tracksActions.reset())
-      }
-    }, [dispatch])
-  )
   const { query, isTagSearch } = useContext(SearchQueryContext)
   const loadMore = useCallback(
     (offset: number, limit: number) => {

--- a/packages/mobile/src/screens/search-results-screen/tabs/useFetchTabResultsEffect.tsx
+++ b/packages/mobile/src/screens/search-results-screen/tabs/useFetchTabResultsEffect.tsx
@@ -1,30 +1,60 @@
 import { useCallback, useContext } from 'react'
 
-import type { SearchKind } from '@audius/common'
-import { searchResultsPageActions } from '@audius/common'
+import {
+  SearchKind,
+  searchResultsPageActions,
+  searchResultsPageSelectors
+} from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
-import { track, make } from 'app/services/analytics'
+import { make, track } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 
 import { SearchQueryContext } from '../SearchQueryContext'
 import { ALL_CATEGORY_RESULTS_LIMIT } from '../constants'
 
+const { getSearchText, getIsTagSearch, getSearchResults } =
+  searchResultsPageSelectors
+
 export const useFetchTabResultsEffect = (searchKind: SearchKind) => {
   const dispatch = useDispatch()
   const { query, isTagSearch } = useContext(SearchQueryContext)
+  const storeSearchText = useSelector(getSearchText)
+  const storeIsTagSearch = useSelector(getIsTagSearch)
+  const searchResults = useSelector(getSearchResults)
+
+  let cachedResult: number[] | undefined | null
+  if (searchKind === SearchKind.ALBUMS) {
+    cachedResult = searchResults.albumIds
+  } else if (searchKind === SearchKind.PLAYLISTS) {
+    cachedResult = searchResults.playlistIds
+  } else if (searchKind === SearchKind.TRACKS) {
+    cachedResult = searchResults.trackIds
+  } else if (searchKind === SearchKind.USERS) {
+    cachedResult = searchResults.artistIds
+  } else {
+    cachedResult = null
+  }
+
+  const shouldFetch =
+    query !== storeSearchText ||
+    storeIsTagSearch !== isTagSearch ||
+    cachedResult === undefined
+
   useFocusEffect(
     useCallback(() => {
       if (isTagSearch) {
-        dispatch(
-          searchResultsPageActions.fetchSearchPageTags(
-            query,
-            searchKind,
-            ALL_CATEGORY_RESULTS_LIMIT,
-            0
+        if (shouldFetch) {
+          dispatch(
+            searchResultsPageActions.fetchSearchPageTags(
+              query,
+              searchKind,
+              ALL_CATEGORY_RESULTS_LIMIT,
+              0
+            )
           )
-        )
+        }
         track(
           make({
             eventName: EventNames.SEARCH_TAG_SEARCH,
@@ -32,14 +62,16 @@ export const useFetchTabResultsEffect = (searchKind: SearchKind) => {
           })
         )
       } else {
-        dispatch(
-          searchResultsPageActions.fetchSearchPageResults(
-            query,
-            searchKind,
-            ALL_CATEGORY_RESULTS_LIMIT,
-            0
+        if (shouldFetch) {
+          dispatch(
+            searchResultsPageActions.fetchSearchPageResults(
+              query,
+              searchKind,
+              ALL_CATEGORY_RESULTS_LIMIT,
+              0
+            )
           )
-        )
+        }
         track(
           make({
             eventName: EventNames.SEARCH_SEARCH,
@@ -47,6 +79,6 @@ export const useFetchTabResultsEffect = (searchKind: SearchKind) => {
           })
         )
       }
-    }, [dispatch, isTagSearch, query, searchKind])
+    }, [dispatch, isTagSearch, query, searchKind, shouldFetch])
   )
 }


### PR DESCRIPTION
### Description
-Improve search results screen performance
Before: When you switched tabs, it would refetch the results even if it was already fetched before
After: We keep and reuse old results for same query

Regular search:
![earchy](https://user-images.githubusercontent.com/36916764/191808670-a93cfa67-4a9c-43b3-b0e6-c12977bb7d96.gif)

Tag search:
![earchy2](https://user-images.githubusercontent.com/36916764/191808679-78a5d313-eeb3-4927-80a2-4f215a27caaf.gif)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested in mobile and tested for regressions on web.

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

