### PR TITLE
[C-1151] Fix empty profile tab

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -425,12 +425,9 @@ export const Lineup = ({
     const data = [...items, ...skeletonItems]
 
     if (data.length === 0) {
-      return [
-        {
-          delineate: false,
-          data: prependFeedTipTileIfNeeded([])
-        }
-      ]
+      const data = prependFeedTipTileIfNeeded([])
+      if (data.length === 0) return []
+      return [{ delineate: false, data }]
     }
 
     return [

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -118,7 +118,7 @@ function* fetchLineupMetadatasAsync(
 ) {
   const initLineup = yield select(lineupSelector)
   const initSource = sourceSelector
-    ? yield select(sourceSelector)
+    ? yield select((state) => sourceSelector(state, action.handle))
     : initLineup.prefix
 
   const task = yield fork(function* () {

--- a/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
@@ -106,7 +106,8 @@ function* getTracks({ offset, limit, payload, handle }) {
   }
 }
 
-const sourceSelector = (state) => `${PREFIX}:${getProfileUserId(state)}`
+const sourceSelector = (state, handle) =>
+  `${PREFIX}:${getProfileUserId(state, handle)}`
 
 class TracksSagas extends LineupSagas {
   constructor() {


### PR DESCRIPTION
### Description

Fixes case where empty lineups don't show the `ListEmptyComponent`
Also fixes minor bug related to sourceSelector