### PR TITLE
[C-1048] Reset scrubber on song repeat

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -93,7 +93,6 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
 
   const { isOpen, onOpen, onClose } = useDrawer('NowPlaying')
   const playCounter = useSelector(getCounter)
-  console.log({ playCounter })
   const isPlaying = useSelector(getPlaying)
   const [isPlayBarShowing, setIsPlayBarShowing] = useState(false)
 
@@ -165,18 +164,16 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
   const [isGestureEnabled, setIsGestureEnabled] = useState(true)
 
   const track = useSelector(getCurrentTrack)
+  const trackId = track?.track_id
 
   const user = useSelector((state) =>
     getUser(state, track ? { id: track.owner_id } : {})
   )
-  console.log({ track })
-
-  const trackId = track?.track_id
   const [mediaKey, setMediaKey] = useState(0)
 
   useEffect(() => {
     setMediaKey((mediaKey) => mediaKey + 1)
-  }, [trackId, playCounter])
+  }, [playCounter])
 
   const onNext = useCallback(() => {
     if (track?.genre === Genre.PODCASTS) {
@@ -221,14 +218,12 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
   }, [handleDrawerCloseFromSwipe, navigation, user])
 
   const handlePressTitle = useCallback(() => {
-    if (!track) {
+    if (!trackId) {
       return
     }
-    navigation.push('Track', { id: track.track_id })
+    navigation.push('Track', { id: trackId })
     handleDrawerCloseFromSwipe()
-  }, [handleDrawerCloseFromSwipe, navigation, track])
-
-  console.log('media key?', mediaKey)
+  }, [handleDrawerCloseFromSwipe, navigation, trackId])
 
   return (
     <Drawer

--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -37,7 +37,7 @@ import { TrackInfo } from './TrackInfo'
 import { PLAY_BAR_HEIGHT } from './constants'
 const { seek } = playerActions
 
-const { getPlaying, getCurrentTrack } = playerSelectors
+const { getPlaying, getCurrentTrack, getCounter } = playerSelectors
 const { next, previous } = queueActions
 const { getUser } = cacheUsersSelectors
 
@@ -92,6 +92,8 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
   const navigation = useNavigation()
 
   const { isOpen, onOpen, onClose } = useDrawer('NowPlaying')
+  const playCounter = useSelector(getCounter)
+  console.log({ playCounter })
   const isPlaying = useSelector(getPlaying)
   const [isPlayBarShowing, setIsPlayBarShowing] = useState(false)
 
@@ -167,12 +169,14 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
   const user = useSelector((state) =>
     getUser(state, track ? { id: track.owner_id } : {})
   )
+  console.log({ track })
 
   const trackId = track?.track_id
   const [mediaKey, setMediaKey] = useState(0)
+
   useEffect(() => {
     setMediaKey((mediaKey) => mediaKey + 1)
-  }, [trackId])
+  }, [trackId, playCounter])
 
   const onNext = useCallback(() => {
     if (track?.genre === Genre.PODCASTS) {
@@ -223,6 +227,8 @@ const NowPlayingDrawer = ({ translationAnim }: NowPlayingDrawerProps) => {
     navigation.push('Track', { id: track.track_id })
     handleDrawerCloseFromSwipe()
   }, [handleDrawerCloseFromSwipe, navigation, track])
+
+  console.log('media key?', mediaKey)
 
   return (
     <Drawer


### PR DESCRIPTION
### Description

Fixes bug where scrubber doesn't reset when a song is on repeat. This is because the mediaKey was only changing when track_id changed. In reality though, we should actually just look at playCount.

