### PR TITLE
[C-536] Cache makeStyles StyleSheets

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -18046,6 +18046,11 @@
         }
       }
     },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+    },
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -72,6 +72,7 @@
     "moment": "2.24.0",
     "node-libs-react-native": "1.2.1",
     "numeral": "2.0.6",
+    "object-hash": "^3.0.0",
     "path-dirname": "1.0.2",
     "proxy-memoize": "1.2.0",
     "query-string": "7.0.1",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -72,7 +72,7 @@
     "moment": "2.24.0",
     "node-libs-react-native": "1.2.1",
     "numeral": "2.0.6",
-    "object-hash": "^3.0.0",
+    "object-hash": "3.0.0",
     "path-dirname": "1.0.2",
     "proxy-memoize": "1.2.0",
     "query-string": "7.0.1",

--- a/packages/mobile/src/styles/makeStyles.ts
+++ b/packages/mobile/src/styles/makeStyles.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react'
 
 import { isEqual } from 'lodash'
+import hash from 'object-hash'
 import type { TextStyle, ViewStyle, ImageStyle } from 'react-native'
 import { StyleSheet } from 'react-native'
 
@@ -49,6 +50,8 @@ type Styles<T extends NamedStyles<T>, PropsT> = (
   props?: PropsT
 ) => T | NamedStyles<T>
 
+const styleCache = {}
+
 export const makeStyles = <PropsT, T extends NamedStyles<T> = NamedStyles<any>>(
   styles: Styles<T, PropsT>
 ) => {
@@ -61,7 +64,14 @@ export const makeStyles = <PropsT, T extends NamedStyles<T> = NamedStyles<any>>(
     const stylesheet = useMemo(() => {
       const theme = { palette, typography, spacing, type: themeVariant }
       const namedStyles = styles(theme, memoizedProps)
-      return StyleSheet.create(namedStyles)
+      const namedStylesHash = hash(namedStyles)
+      const cachedStyle = styleCache[namedStylesHash]
+      if (cachedStyle) {
+        return cachedStyle
+      }
+      const stylesheet = StyleSheet.create(namedStyles)
+      styleCache[namedStylesHash] = stylesheet
+      return stylesheet
     }, [palette, themeVariant, memoizedProps])
 
     return stylesheet


### PR DESCRIPTION
### Description

Drastically reduces calls (up to 10x less) to `Stylesheet.create` by using style cache. This majorly improves renders for small items, like track-tiles that would otherwise each create their own stylesheet.
