### PR TITLE
[C-1176] Improve ExploreScreen performance

### DIFF
--- a/packages/common/src/store/pages/explore/selectors.ts
+++ b/packages/common/src/store/pages/explore/selectors.ts
@@ -11,24 +11,16 @@ const getExplore = (state: CommonState) => state.pages.explore
 
 export const getExplorePlaylists = createSelector(
   (state: CommonState) => state.pages.explore.playlists,
-  getCollections,
-  getUsers,
-  (playlists, collections, users) => {
-    const explorePlaylists = playlists
-      .map((id) => collections[id])
-      .filter(Boolean)
-      .map((collection) => ({
-        ...collection,
-        user: users[collection.playlist_owner_id] || {}
-      }))
-    return explorePlaylists
-  }
+  (state: CommonState) => state.collections.entries,
+  (playlists, collections) =>
+    playlists.map((id) => collections[id].metadata).filter(removeNullable)
 )
 
 export const getExploreArtists = createSelector(
   (state: CommonState) => state.pages.explore.profiles,
-  getUsers,
-  (artists, users) => artists.map((id) => users[id]).filter(removeNullable)
+  (state: CommonState) => state.users.entries,
+  (artists, users) =>
+    artists.map((id) => users[id].metadata).filter(removeNullable)
 )
 
 export type GetExplore = {

--- a/packages/mobile/src/screens/explore-screen/tabs/ArtistsTab.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ArtistsTab.tsx
@@ -1,5 +1,4 @@
-import { explorePageSelectors } from '@audius/common'
-import { useSelector } from 'react-redux'
+import { explorePageSelectors, useProxySelector } from '@audius/common'
 
 import { ArtistCard } from 'app/components/artist-card'
 import { CardList } from 'app/components/core'
@@ -12,7 +11,7 @@ const messages = {
 }
 
 export const ArtistsTab = () => {
-  const profiles = useSelector(getExploreArtists)
+  const profiles = useProxySelector(getExploreArtists, [])
 
   return (
     <CardList

--- a/packages/mobile/src/screens/explore-screen/tabs/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/PlaylistsTab.tsx
@@ -1,5 +1,5 @@
-import { explorePageSelectors } from '@audius/common'
-import { useSelector } from 'react-redux'
+import type { UserCollection } from '@audius/common'
+import { explorePageSelectors, useProxySelector } from '@audius/common'
 
 import { CollectionList } from 'app/components/collection-list'
 
@@ -11,12 +11,12 @@ const messages = {
 }
 
 export const PlaylistsTab = () => {
-  const playlists = useSelector(getExplorePlaylists)
+  const playlists = useProxySelector(getExplorePlaylists, [])
 
   return (
     <CollectionList
       ListHeaderComponent={<TabInfo header={messages.infoHeader} />}
-      collection={playlists}
+      collection={playlists as UserCollection[]}
     />
   )
 }

--- a/packages/mobile/src/screens/mood-collection-screen/MoodCollectionScreen.tsx
+++ b/packages/mobile/src/screens/mood-collection-screen/MoodCollectionScreen.tsx
@@ -4,7 +4,8 @@ import {
   Status,
   explorePageCollectionsSelectors,
   ExploreCollectionsVariant,
-  explorePageCollectionsActions
+  explorePageCollectionsActions,
+  useProxySelector
 } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -34,8 +35,10 @@ export const MoodCollectionScreen = ({
     getStatus(state, { variant: ExploreCollectionsVariant.MOOD })
   )
 
-  const exploreData = useSelector((state) =>
-    getCollections(state, { variant: ExploreCollectionsVariant.MOOD })
+  const exploreData = useProxySelector(
+    (state) =>
+      getCollections(state, { variant: ExploreCollectionsVariant.MOOD }),
+    []
   )
 
   return (


### PR DESCRIPTION
### Description

Some QoL updates for explore screen. Reduces re-renders by 5x. There is a lot more work here we can do though, by delaying fetching playlists/artist tab data until you actually go to that tab. Story added for this after reloaded.