### PR TITLE
Use .env.dev instead of .env.dev.local

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -127,7 +127,7 @@
   "scripts": {
     "publish-scripts": "./scripts/publishScripts.sh",
     "start": "craco --max-old-space-size=8076 start",
-    "start:dev": "npm run write-sha && npm run publish-scripts && env-cmd --no-override ./.env/.env.dev.local npm start",
+    "start:dev": "npm run write-sha && npm run publish-scripts && env-cmd --no-override ./.env/.env.dev npm start",
     "start:stage": "npm run write-sha && npm run publish-scripts && env-cmd --no-override ./.env/.env.stage npm start",
     "start:prod": "npm run write-sha && npm run publish-scripts && env-cmd --no-override ./.env/.env.prod npm start",
     "start:ipfs-prod": "env-cmd ./.env/.env.ipfs.prod npm run start:prod",


### PR DESCRIPTION
### Description

Bad rebase 2 from https://github.com/AudiusProject/audius-client/pull/1577
Env should use .env.dev now instead of the generated .dev.local

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

npm run start:dev

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

