### PR TITLE
Omit creator_node_endpoint when updating metadata via collectible fetch

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -66,10 +66,8 @@ export const Audio = () => {
   const repeatMode = useSelector(getRepeat)
   const isShuffleOn = useSelector(getShuffle)
   const shuffleIndex = useSelector(getShuffleIndex)
-  const trackOwner = useSelector(
-    (state) => getUser(state, { id: track?.owner_id }),
-    // Equality function to prevent audio restart when visiting profile screen
-    (left, right) => left?.user_id === right?.user_id
+  const trackOwner = useSelector((state) =>
+    getUser(state, { id: track?.owner_id })
   )
   const currentUserId = useSelector(getUserId)
 

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -61,7 +61,11 @@ function* fetchProfileCustomizedCollectibles(user) {
   )
   const cid = user?.metadata_multihash ?? null
   if (cid) {
-    const { is_verified: ignored_is_verified, ...metadata } = yield call(
+    const {
+      is_verified: ignored_is_verified,
+      creator_node_endpoint: ignored_creator_node_endpoint,
+      ...metadata
+    } = yield call(
       audiusBackendInstance.fetchCID,
       cid,
       gateways,


### PR DESCRIPTION
### Description

* This fixes the track restart bug when going to the artists profile on mobile
* `creator_node_endpoint` from content node should not be used anyway so we can safely omit it when updating metadata

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

