### PR TITLE
[C-1181] skip connection check if not in foreground

### DIFF
--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -24,7 +24,7 @@ import { refreshConnectivity } from 'app/utils/connectivity'
 import { Drawers } from './Drawers'
 import ErrorBoundary from './ErrorBoundary'
 import { NotificationReminder } from './components/notification-reminder/NotificationReminder'
-import useAppState from './hooks/useAppState'
+import { useEnterForeground } from './hooks/useAppState'
 
 Sentry.init({
   dsn: Config.SENTRY_DSN
@@ -62,14 +62,9 @@ const App = () => {
     refreshConnectivity()
   })
 
-  useAppState(
-    // onEnterForeground
-    () => {
-      refreshConnectivity()
-    },
-    // onEnterBackground
-    () => {}
-  )
+  useEnterForeground(() => {
+    refreshConnectivity()
+  })
 
   return (
     <SafeAreaProvider>

--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -19,12 +19,12 @@ import { incrementSessionCount } from 'app/hooks/useSessionCount'
 import { RootScreen } from 'app/screens/root-screen'
 import { store } from 'app/store'
 import { ENTROPY_KEY } from 'app/store/account/sagas'
-
-import 'app/utils/connectivity'
+import { refreshConnectivity } from 'app/utils/connectivity'
 
 import { Drawers } from './Drawers'
 import ErrorBoundary from './ErrorBoundary'
 import { NotificationReminder } from './components/notification-reminder/NotificationReminder'
+import useAppState from './hooks/useAppState'
 
 Sentry.init({
   dsn: Config.SENTRY_DSN
@@ -57,6 +57,15 @@ const App = () => {
     const entropy = await AsyncStorage.getItem(ENTROPY_KEY)
     setIsReadyToSetupBackend(!entropy)
   }, [])
+
+  useAppState(
+    // onEnterForeground
+    () => {
+      refreshConnectivity()
+    },
+    // onEnterBackground
+    () => {}
+  )
 
   return (
     <SafeAreaProvider>

--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -19,7 +19,10 @@ import { incrementSessionCount } from 'app/hooks/useSessionCount'
 import { RootScreen } from 'app/screens/root-screen'
 import { store } from 'app/store'
 import { ENTROPY_KEY } from 'app/store/account/sagas'
-import { refreshConnectivity } from 'app/utils/connectivity'
+import {
+  refreshConnectivity,
+  subscribeToNetworkStatusUpdates
+} from 'app/utils/connectivity'
 
 import { Drawers } from './Drawers'
 import ErrorBoundary from './ErrorBoundary'
@@ -59,7 +62,7 @@ const App = () => {
   }, [])
 
   useEffectOnce(() => {
-    refreshConnectivity()
+    subscribeToNetworkStatusUpdates()
   })
 
   useEnterForeground(() => {

--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -7,7 +7,7 @@ import { Platform, UIManager } from 'react-native'
 import Config from 'react-native-config'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { Provider } from 'react-redux'
-import { useAsync } from 'react-use'
+import { useAsync, useEffectOnce } from 'react-use'
 
 import { Audio } from 'app/components/audio/Audio'
 import HCaptcha from 'app/components/hcaptcha'
@@ -57,6 +57,10 @@ const App = () => {
     const entropy = await AsyncStorage.getItem(ENTROPY_KEY)
     setIsReadyToSetupBackend(!entropy)
   }, [])
+
+  useEffectOnce(() => {
+    refreshConnectivity()
+  })
 
   useAppState(
     // onEnterForeground

--- a/packages/mobile/src/hooks/useAppState.ts
+++ b/packages/mobile/src/hooks/useAppState.ts
@@ -19,8 +19,8 @@ type OnEnterBackground = () => any
 const NotActive = /inactive|background/g
 
 export const useAppState = (
-  onEnterForeground: OnEnterForeground,
-  onEnterBackground: OnEnterBackground
+  onEnterForeground: OnEnterForeground | null,
+  onEnterBackground: OnEnterBackground | null
 ) => {
   const [appState, setAppState] = useState<AppStateStatus>(
     AppState.currentState
@@ -57,6 +57,14 @@ export const useAppState = (
   }, [handleAppStateChange])
 
   return appState
+}
+
+export const useEnterForeground = (onEnterForeground: OnEnterForeground) => {
+  return useAppState(onEnterForeground, null)
+}
+
+export const useEnterBackground = (onEnterBackground: OnEnterBackground) => {
+  return useAppState(null, onEnterBackground)
 }
 
 export default useAppState

--- a/packages/mobile/src/utils/connectivity.ts
+++ b/packages/mobile/src/utils/connectivity.ts
@@ -38,7 +38,7 @@ export const refreshConnectivity = async () => {
 }
 
 NetInfo.addEventListener(
-  debounce(updateConnectivity, 2000, {
+  debounce(updateConnectivity, 2500, {
     maxWait: 5000
   })
 )

--- a/packages/mobile/src/utils/connectivity.ts
+++ b/packages/mobile/src/utils/connectivity.ts
@@ -37,8 +37,10 @@ export const refreshConnectivity = async () => {
   updateConnectivity(currentState)
 }
 
-NetInfo.addEventListener(
-  debounce(updateConnectivity, 2500, {
-    maxWait: 5000
-  })
-)
+export const subscribeToNetworkStatusUpdates = () => {
+  NetInfo.addEventListener(
+    debounce(updateConnectivity, 2500, {
+      maxWait: 5000
+    })
+  )
+}

--- a/packages/mobile/src/utils/connectivity.ts
+++ b/packages/mobile/src/utils/connectivity.ts
@@ -22,7 +22,7 @@ export const Connectivity: { netInfo: NetInfoState | null } = { netInfo: null }
 
 const updateConnectivity = (state: NetInfoState) => {
   Connectivity.netInfo = state
-  if (!(AppState.currentState === 'active')) return
+  if (AppState.currentState !== 'active') return
   const newValue = checkConnectivity(state)
   if (!newValue) {
     dispatch(reachabilityActions.setUnreachable())

--- a/packages/mobile/src/utils/connectivity.ts
+++ b/packages/mobile/src/utils/connectivity.ts
@@ -2,6 +2,7 @@ import { reachabilityActions } from '@audius/common'
 import type { NetInfoState } from '@react-native-community/netinfo'
 import NetInfo from '@react-native-community/netinfo'
 import { debounce } from 'lodash'
+import { AppState } from 'react-native'
 
 import { dispatch } from './../store/store'
 
@@ -21,6 +22,7 @@ export const Connectivity: { netInfo: NetInfoState | null } = { netInfo: null }
 
 const updateConnectivity = (state: NetInfoState) => {
   Connectivity.netInfo = state
+  if (!(AppState.currentState === 'active')) return
   const newValue = checkConnectivity(state)
   if (!newValue) {
     dispatch(reachabilityActions.setUnreachable())
@@ -29,4 +31,14 @@ const updateConnectivity = (state: NetInfoState) => {
   }
 }
 
-NetInfo.addEventListener(debounce(updateConnectivity, 2000, { maxWait: 5000 }))
+export const refreshConnectivity = async () => {
+  NetInfo.refresh()
+  const currentState = await NetInfo.fetch()
+  updateConnectivity(currentState)
+}
+
+NetInfo.addEventListener(
+  debounce(updateConnectivity, 2000, {
+    maxWait: 5000
+  })
+)


### PR DESCRIPTION
### Description

Skip updates to connectivity state when in background.
Manually trigger connectivity state update when app returns to foreground.

### Dragons

If we have background processes that rely on the connectivity state, we may need to rethink this. Offline mode comes to mind.

### How Has This Been Tested?

Tested on iPhone 11

