### PR TITLE
Fix static server error

### DIFF
--- a/packages/mobile/src/components/web-app-account-sync/WebAppAccountSync.tsx
+++ b/packages/mobile/src/components/web-app-account-sync/WebAppAccountSync.tsx
@@ -2,6 +2,8 @@ import { getErrorMessage } from '@audius/common'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { NativeSyntheticEvent } from 'react-native'
 import { View } from 'react-native'
+import Config from 'react-native-config'
+import RNFS from 'react-native-fs'
 import StaticServer from 'react-native-static-server'
 import { WebView } from 'react-native-webview'
 import type { WebViewMessage } from 'react-native-webview/lib/WebViewTypes'
@@ -17,6 +19,7 @@ const injected = `
   )
 })();
 `
+const OLD_WEB_APP_STATIC_SERVER_PORT = Config.OLD_WEB_APP_STATIC_SERVER_PORT
 
 type WebAppAccountSyncProps = {
   setIsReadyToSetupBackend: (isReadyToSetupBackend: boolean) => void
@@ -32,11 +35,14 @@ export const WebAppAccountSync = (props: WebAppAccountSyncProps) => {
   const { setIsReadyToSetupBackend } = props
 
   const { value: uri, error } = useAsync(async () => {
-    // Hardcoding port here to test bonce app loading issue
-    const server = new StaticServer(3101, {
-      localOnly: true,
-      keepAlive: true
-    })
+    const server = new StaticServer(
+      OLD_WEB_APP_STATIC_SERVER_PORT,
+      RNFS.DocumentDirectoryPath,
+      {
+        localOnly: true,
+        keepAlive: true
+      }
+    )
 
     return await server.start()
   }, [])


### PR DESCRIPTION
### Description

* On android was getting this error: https://github.com/futurepress/react-native-static-server/issues/110
* Adding the default path fixed the error

### Dragons

Still need to check that the entropy sync still works with this, because potentially the contents of the webview changed?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

