### PR TITLE
[C-1195] Fix image loading in image hooks

### DIFF
--- a/packages/common/src/hooks/useImageSize.ts
+++ b/packages/common/src/hooks/useImageSize.ts
@@ -183,7 +183,7 @@ export function useImageSize<
   ])
 
   let imageUrl: Maybe<URL>
-  let imageType: Maybe<string>
+  let imageType: Maybe<ImageType>
 
   if (!onDemand) {
     const { url, type } = getImageSize()

--- a/packages/common/src/hooks/useImageSize.ts
+++ b/packages/common/src/hooks/useImageSize.ts
@@ -1,16 +1,17 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { Dispatch } from 'redux'
 
-import { useInstanceVar } from 'hooks/useInstanceVar'
 import {
   DefaultSizes,
   ImageSizesObject,
   SquareSizes,
   URL,
   WidthSizes
-} from 'models/ImageSizes'
-import { Maybe } from 'utils/typeUtils'
+} from '../models/ImageSizes'
+import { Maybe } from '../utils/typeUtils'
+
+import { useInstanceVar } from './useInstanceVar'
 
 type Size = SquareSizes | WidthSizes
 
@@ -40,7 +41,7 @@ const getNextImage =
     return imageSizes[next]
   }
 
-type UseImageSizeProps<
+type BaseUserImageSizeProps<
   ImageSize extends Size,
   ImageSizes extends ImageSizesObject<ImageSize>
 > = {
@@ -52,14 +53,20 @@ type UseImageSizeProps<
   id?: number | null | undefined | string
   // A flag (default = true) that will trigger the image load. Can be used to delay the load
   load?: boolean
-  // A flag that will cause the return value to be a function that will trigger the image load
-  onDemand?: boolean
   // The desired size of the image
   size: ImageSize
   // The available sizes of the image
   sizes: ImageSizes | null
   // Dispatch for current context. Fixes the issue when trying to use web dispatch in mobile context
   dispatch: Dispatch<any>
+}
+
+type UseImageSizeOnDemandProps<
+  ImageSize extends Size,
+  ImageSizes extends ImageSizesObject<ImageSize>
+> = BaseUserImageSizeProps<ImageSize, ImageSizes> & {
+  // A flag that will cause the return value to be a function that will trigger the image load
+  onDemand: true
 }
 
 /**
@@ -70,7 +77,15 @@ type UseImageSizeProps<
  * The desired size will be requested and returned when it becomes available
  *
  */
-export const useImageSize = <
+export function useImageSize<
+  ImageSize extends Size,
+  ImageSizes extends ImageSizesObject<ImageSize>
+>(props: UseImageSizeOnDemandProps<ImageSize, ImageSizes>): () => Maybe<string>
+export function useImageSize<
+  ImageSize extends Size,
+  ImageSizes extends ImageSizesObject<ImageSize>
+>(props: BaseUserImageSizeProps<ImageSize, ImageSizes>): Maybe<string>
+export function useImageSize<
   ImageSize extends Size,
   ImageSizes extends ImageSizesObject<ImageSize>
 >({
@@ -82,77 +97,121 @@ export const useImageSize = <
   onDemand,
   size,
   sizes
-}: UseImageSizeProps<ImageSize, ImageSizes>) => {
+}: BaseUserImageSizeProps<ImageSize, ImageSizes> & {
+  onDemand?: boolean
+}): Maybe<string> | (() => Maybe<string>) {
   const [getPreviousId, setPreviousId] = useInstanceVar<number | null>(null)
 
-  const fallbackImage = (url: URL) => {
-    setPreviousId(null)
-    return url
-  }
+  const getSmallerImage = useMemo(
+    () => getNextImage<ImageSize, ImageSizes>((a, b) => a < b),
+    []
+  )
+  const getLargerImage = useMemo(
+    () => getNextImage<ImageSize, ImageSizes>((a, b) => a > b),
+    []
+  )
 
-  const getSmallerImage = getNextImage<ImageSize, ImageSizes>((a, b) => a < b)
-  const getLargerImage = getNextImage<ImageSize, ImageSizes>((a, b) => a > b)
-
-  const getImageSize = (): Maybe<URL> => {
+  const getImageSize = useCallback((): { url: Maybe<URL>; type: string } => {
     if (id === null || id === undefined || typeof id === 'string') {
-      return ''
+      return { url: '', type: 'empty' }
+    }
+
+    const fallbackImage = (url: URL) => {
+      setPreviousId(null)
+      return url
     }
 
     // No image sizes object
     if (!sizes) {
-      return fallbackImage('')
+      return { url: fallbackImage(''), type: 'none' }
     }
 
     // An override exists
     if (DefaultSizes.OVERRIDE in sizes) {
       const override: Maybe<URL> = sizes[DefaultSizes.OVERRIDE]
       if (override) {
-        return fallbackImage(override)
+        return { url: fallbackImage(override), type: 'override' }
       }
 
-      return defaultImage
+      return { url: defaultImage, type: 'default' }
     }
 
     // The desired size exists
     if (size in sizes) {
       const desired: Maybe<URL> = sizes[size]
       if (desired) {
-        return desired
+        return { url: desired, type: 'desired' }
       }
 
-      return defaultImage
+      return { url: defaultImage, type: 'default' }
     }
 
     // A larger size exists
     const larger: Maybe<URL> = getLargerImage(sizes, size)
     if (larger) {
-      return fallbackImage(larger)
-    }
-
-    // If no larger size exists, dispatch to get the desired size
-    // Don't dispatch twice for the same id
-    if (load && getPreviousId() !== id) {
-      setPreviousId(id)
-      // Request the desired size
-      dispatch(action(id, size))
+      return { url: fallbackImage(larger), type: 'larger' }
     }
 
     // A smaller size exists
     const smaller: Maybe<URL> = getSmallerImage(sizes, size)
     if (smaller) {
-      return fallbackImage(smaller)
+      return { url: fallbackImage(smaller), type: 'smaller' }
     }
 
-    return undefined
+    return { url: undefined, type: 'undefined' }
+  }, [
+    defaultImage,
+    getLargerImage,
+    getSmallerImage,
+    id,
+    size,
+    sizes,
+    setPreviousId
+  ])
+
+  let imageUrl: Maybe<URL>
+  let imageType: Maybe<string>
+
+  if (!onDemand) {
+    const { url, type } = getImageSize()
+    imageUrl = url
+    imageType = type
   }
 
-  // TODO: sk - disambiguate the return value so it can be typed
-  if (!onDemand) return getImageSize() as any
-  return getImageSize as any
+  const previousId = getPreviousId()
+
+  const handleFetchLargeImage = useCallback(
+    (imageType) => {
+      if (
+        load &&
+        !(id === null || id === undefined || typeof id === 'string') &&
+        previousId !== id &&
+        (imageType === 'smaller' || imageType === 'undefined')
+      ) {
+        setPreviousId(id)
+        dispatch(action(id, size))
+      }
+    },
+    [load, id, previousId, action, dispatch, setPreviousId, size]
+  )
+
+  const handleOnDemandImage = useCallback(() => {
+    const { url, type } = getImageSize()
+    handleFetchLargeImage(type)
+    return url
+  }, [getImageSize, handleFetchLargeImage])
+
+  useEffect(() => {
+    if (!onDemand) {
+      handleFetchLargeImage(imageType)
+    }
+  }, [onDemand, handleFetchLargeImage, imageType])
+
+  if (!onDemand) return imageUrl
+  return handleOnDemandImage
 }
 
 const ARTWORK_HAS_LOADED_TIMEOUT = 1000
-
 // We don't want to indefinitely delay tile loading
 // waiting for the image, so set a timeout before
 // we call callback().

--- a/packages/common/src/hooks/useImageSize.ts
+++ b/packages/common/src/hooks/useImageSize.ts
@@ -69,6 +69,16 @@ type UseImageSizeOnDemandProps<
   onDemand: true
 }
 
+type ImageType =
+  | 'empty'
+  | 'none'
+  | 'override'
+  | 'default'
+  | 'desired'
+  | 'smaller'
+  | 'larger'
+  | 'undefined'
+
 /**
  * Custom hooks that allow a component to use an image size for a
  * track, collection, or user's image.
@@ -111,7 +121,10 @@ export function useImageSize<
     []
   )
 
-  const getImageSize = useCallback((): { url: Maybe<URL>; type: string } => {
+  const getImageSize = useCallback((): {
+    url: Maybe<URL>
+    type: ImageType
+  } => {
     if (id === null || id === undefined || typeof id === 'string') {
       return { url: '', type: 'empty' }
     }
@@ -181,7 +194,7 @@ export function useImageSize<
   const previousId = getPreviousId()
 
   const handleFetchLargeImage = useCallback(
-    (imageType) => {
+    (imageType: ImageType) => {
       if (
         load &&
         !(id === null || id === undefined || typeof id === 'string') &&

--- a/packages/common/src/hooks/useImageSize.ts
+++ b/packages/common/src/hooks/useImageSize.ts
@@ -215,7 +215,7 @@ export function useImageSize<
   }, [getImageSize, handleFetchLargeImage])
 
   useEffect(() => {
-    if (!onDemand) {
+    if (!onDemand && imageType !== undefined) {
       handleFetchLargeImage(imageType)
     }
   }, [onDemand, handleFetchLargeImage, imageType])

--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -12,8 +12,8 @@ import cn from 'classnames'
 
 import { useSelector } from 'common/hooks/useSelector'
 import { MountPlacement } from 'components/types'
-import { useUserCoverPhoto } from 'hooks/useUserCoverPhoto'
-import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
+import { useOnUserCoverPhoto } from 'hooks/useUserCoverPhoto'
+import { useOnUserProfilePicture } from 'hooks/useUserProfilePicture'
 
 import { ArtistCard } from './ArtistCard'
 import styles from './ArtistPopover.module.css'
@@ -60,19 +60,17 @@ export const ArtistPopover = ({
   )
   const userId = useSelector(getUserId)
 
-  const getCoverPhoto = useUserCoverPhoto(
+  const getCoverPhoto = useOnUserCoverPhoto(
     creator ? creator.user_id : null,
     creator ? creator._cover_photo_sizes : null,
     WidthSizes.SIZE_640,
-    undefined,
-    true
+    undefined
   )
-  const getProfilePicture = useUserProfilePicture(
+  const getProfilePicture = useOnUserProfilePicture(
     creator ? creator.user_id : null,
     creator ? creator._profile_picture_sizes : null,
     SquareSizes.SIZE_150_BY_150,
-    undefined,
-    true
+    undefined
   )
 
   const onMouseEnter = useCallback(() => {

--- a/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
+++ b/packages/web/src/components/notification/Notification/components/ProfilePicture.tsx
@@ -46,7 +46,6 @@ export const ProfilePicture = (props: ProfilePictureProps) => {
     _profile_picture_sizes,
     SquareSizes.SIZE_150_BY_150,
     undefined,
-    undefined,
     loadImage
   )
 

--- a/packages/web/src/components/remix-card/RemixCard.tsx
+++ b/packages/web/src/components/remix-card/RemixCard.tsx
@@ -13,8 +13,8 @@ const messages = {
 }
 
 type RemixCardProps = {
-  profilePictureImage: string
-  coverArtImage: string
+  profilePictureImage?: string
+  coverArtImage?: string
   coSign?: Remix | null
   artistName: string
   artistHandle: string

--- a/packages/web/src/hooks/useCollectionCoverArt.ts
+++ b/packages/web/src/hooks/useCollectionCoverArt.ts
@@ -13,9 +13,7 @@ export const useCollectionCoverArt = (
   collectionId: number | null | undefined,
   coverArtSizes: CoverArtSizes | null,
   size: SquareSizes,
-  defaultImage: string = imageEmpty as string,
-  onDemand = false,
-  load = true
+  defaultImage: string = imageEmpty as string
 ) => {
   const dispatch = useDispatch()
   return useImageSize({
@@ -24,8 +22,6 @@ export const useCollectionCoverArt = (
     sizes: coverArtSizes,
     size,
     action: fetchCoverArt,
-    defaultImage,
-    onDemand,
-    load
+    defaultImage
   })
 }

--- a/packages/web/src/hooks/useImageSize.test.tsx
+++ b/packages/web/src/hooks/useImageSize.test.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from 'react'
-
 import { DefaultSizes, SquareSizes, useImageSize } from '@audius/common'
 import { render } from '@testing-library/react'
 
@@ -172,60 +170,6 @@ describe('useImageSize', () => {
         render(<TestComponent {...props} action={action} />)
         expect(action).not.toHaveBeenCalled()
       })
-    })
-  })
-
-  describe('if onDemand is enabled', () => {
-    const OnDemandTestComponent = (props: {
-      useImageOptions: Parameters<typeof useImageSize>[0]
-      callFunction?: boolean
-    }) => {
-      const getImage = useImageSize(props.useImageOptions)
-
-      const image = useMemo(() => {
-        if (props.callFunction) {
-          return getImage()
-        }
-      }, [getImage, props.callFunction])
-
-      return <div>{image ?? 'nothing'}</div>
-    }
-
-    const props = {
-      id: 1,
-      size: SquareSizes.SIZE_1000_BY_1000,
-      sizes: {},
-      action: () => {},
-      defaultImage: 'default',
-      onDemand: true
-    }
-
-    it('does not dispatch the action if the returned function is not called', () => {
-      const action = jest.fn()
-      const dispatch = () => {}
-      const { getByText } = render(
-        <OnDemandTestComponent
-          // @ts-ignore
-          useImageOptions={{ ...props, dispatch, action }}
-          callFunction={false}
-        />
-      )
-      getByText('nothing')
-      expect(action).not.toHaveBeenCalled()
-    })
-
-    it('dispatches the action if the returned function is not called', () => {
-      const action = jest.fn()
-      const dispatch = () => {}
-      const { getByText } = render(
-        <OnDemandTestComponent
-          // @ts-ignore
-          useImageOptions={{ ...props, dispatch, action }}
-          callFunction={true}
-        />
-      )
-      getByText('nothing')
-      expect(action).toHaveBeenCalled()
     })
   })
 })

--- a/packages/web/src/hooks/useTrackCoverArt.ts
+++ b/packages/web/src/hooks/useTrackCoverArt.ts
@@ -13,9 +13,7 @@ export const useTrackCoverArt = (
   trackId: number | null | string | undefined,
   coverArtSizes: CoverArtSizes | null,
   size: SquareSizes,
-  defaultImage: string = imageEmpty as string,
-  onDemand = false,
-  load = true
+  defaultImage: string = imageEmpty as string
 ) => {
   const dispatch = useDispatch()
   return useImageSize({
@@ -24,8 +22,6 @@ export const useTrackCoverArt = (
     sizes: coverArtSizes,
     size,
     action: fetchCoverArt,
-    defaultImage,
-    onDemand,
-    load
+    defaultImage
   })
 }

--- a/packages/web/src/hooks/useUserCoverPhoto.ts
+++ b/packages/web/src/hooks/useUserCoverPhoto.ts
@@ -13,9 +13,25 @@ export const useUserCoverPhoto = (
   userId: number | null,
   coverPhotoSizes: CoverPhotoSizes | null,
   size: WidthSizes,
-  defaultImage: string = imageCoverPhotoBlank as string,
-  onDemand = false,
-  load = true
+  defaultImage: string = imageCoverPhotoBlank as string
+) => {
+  const dispatch = useDispatch()
+
+  return useImageSize({
+    dispatch,
+    id: userId,
+    sizes: coverPhotoSizes,
+    size,
+    action: fetchCoverPhoto,
+    defaultImage
+  })
+}
+
+export const useOnUserCoverPhoto = (
+  userId: number | null,
+  coverPhotoSizes: CoverPhotoSizes | null,
+  size: WidthSizes,
+  defaultImage: string = imageCoverPhotoBlank as string
 ) => {
   const dispatch = useDispatch()
 
@@ -26,7 +42,6 @@ export const useUserCoverPhoto = (
     size,
     action: fetchCoverPhoto,
     defaultImage,
-    onDemand,
-    load
+    onDemand: true
   })
 }

--- a/packages/web/src/hooks/useUserCoverPhoto.ts
+++ b/packages/web/src/hooks/useUserCoverPhoto.ts
@@ -27,6 +27,10 @@ export const useUserCoverPhoto = (
   })
 }
 
+/**
+ * Like useUserProfilePicture, but onDemand is set to true, which
+ * returns a callback that can be used to fetch the image on demand.
+ */
 export const useOnUserCoverPhoto = (
   userId: number | null,
   coverPhotoSizes: CoverPhotoSizes | null,

--- a/packages/web/src/hooks/useUserProfilePicture.ts
+++ b/packages/web/src/hooks/useUserProfilePicture.ts
@@ -28,6 +28,10 @@ export const useUserProfilePicture = (
   })
 }
 
+/**
+ * Like useUserProfilePicture, but onDemand is set to true, which
+ * returns a callback that can be used to fetch the image on demand.
+ */
 export const useOnUserProfilePicture = (
   userId: number | null,
   profilePictureSizes: ProfilePictureSizes | null,

--- a/packages/web/src/hooks/useUserProfilePicture.ts
+++ b/packages/web/src/hooks/useUserProfilePicture.ts
@@ -14,7 +14,6 @@ export const useUserProfilePicture = (
   profilePictureSizes: ProfilePictureSizes | null,
   size: SquareSizes,
   defaultImage: string = profilePicEmpty as string,
-  onDemand = false,
   load = true
 ) => {
   const dispatch = useDispatch()
@@ -25,7 +24,26 @@ export const useUserProfilePicture = (
     size,
     action: fetchProfilePicture,
     defaultImage,
-    onDemand,
     load
+  })
+}
+
+export const useOnUserProfilePicture = (
+  userId: number | null,
+  profilePictureSizes: ProfilePictureSizes | null,
+  size: SquareSizes,
+  defaultImage: string = profilePicEmpty as string,
+  load = true
+) => {
+  const dispatch = useDispatch()
+  return useImageSize({
+    dispatch,
+    id: userId,
+    sizes: profilePictureSizes,
+    size,
+    action: fetchProfilePicture,
+    defaultImage,
+    load,
+    onDemand: true
   })
 }


### PR DESCRIPTION
### Description

- Fixes pretty interesting/bad bug where we are dispatching fetch image actions in the render cycle by moving dispatch to useEffect/useCallback depending on onDemand value)
- Updates types to properly type useImage based on onDemand value
- Updates usages, particularly onDemand cases (in ArtistPopover) to use special hook rather than overloading useProfileImage and useCoverPhotoImage to match the useImage types in common

