### PR TITLE
Fix navigation context scope and setting

### DIFF
--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -8,6 +8,7 @@ import {
 } from '@react-navigation/native'
 import { useSelector } from 'react-redux'
 
+import { AppTabNavigationProvider } from 'app/screens/app-screen'
 import type { RootScreenParamList } from 'app/screens/root-screen/RootScreen'
 import { useThemeVariant } from 'app/utils/theme'
 
@@ -152,7 +153,7 @@ const NavigationContainer = (props: NavigationContainerProps) => {
 
   return (
     <RNNavigationContainer linking={linking} theme={navigationThemes[theme]}>
-      {children}
+      <AppTabNavigationProvider>{children}</AppTabNavigationProvider>
     </RNNavigationContainer>
   )
 }

--- a/packages/mobile/src/hooks/usePopToTopOnDrawerOpen.ts
+++ b/packages/mobile/src/hooks/usePopToTopOnDrawerOpen.ts
@@ -1,12 +1,27 @@
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import { useNavigation } from '@react-navigation/core'
 import { useDrawerStatus } from '@react-navigation/drawer'
+import { useFocusEffect } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { usePrevious } from 'react-use'
 
 import type { AppTabScreenParamList } from 'app/screens/app-screen'
 import { AppTabNavigationContext } from 'app/screens/app-screen'
+
+type AppTabNavigation = NativeStackNavigationProp<AppTabScreenParamList>
+
+// Sets the navigation context so drawers can push onto current app-tab stack
+const useSetAppTabNavigationContext = () => {
+  const navigation = useNavigation<AppTabNavigation>()
+  const { setNavigation } = useContext(AppTabNavigationContext)
+
+  const handleSetNavigation = useCallback(() => {
+    setNavigation(navigation)
+  }, [setNavigation, navigation])
+
+  useFocusEffect(handleSetNavigation)
+}
 
 /**
  * Hook for use in top level stack screens that will reset the stack when the notifications drawer opens.
@@ -14,16 +29,11 @@ import { AppTabNavigationContext } from 'app/screens/app-screen'
  * When closing the notification drawer the stack will be back at the base screen
  */
 export const usePopToTopOnDrawerOpen = () => {
-  const navigation =
-    useNavigation<NativeStackNavigationProp<AppTabScreenParamList>>()
+  const navigation = useNavigation<AppTabNavigation>()
   const isDrawerOpen = useDrawerStatus() === 'open'
   const wasDrawerOpen = usePrevious(isDrawerOpen)
-  const { setNavigation } = useContext(AppTabNavigationContext)
 
-  // Sets the navigation context so drawers can push onto current app-tab stack
-  useEffect(() => {
-    setNavigation(navigation)
-  }, [setNavigation, navigation])
+  useSetAppTabNavigationContext()
 
   useEffect(() => {
     if (!wasDrawerOpen && isDrawerOpen) {

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -16,7 +16,7 @@ import useAppState from 'app/hooks/useAppState'
 import { useUpdateRequired } from 'app/hooks/useUpdateRequired'
 import PushNotifications from 'app/notifications'
 import type { AppScreenParamList } from 'app/screens/app-screen'
-import { AppScreen, AppTabNavigationProvider } from 'app/screens/app-screen'
+import { AppScreen } from 'app/screens/app-screen'
 import {
   NotificationsScreen,
   NotificationsDrawerNavigationContextProvider

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -78,18 +78,16 @@ const MainStack = (props: MainStackProps) => {
   const { navigation: drawerHelpers } = props
   const drawerNavigation = useNavigation()
   return (
-    <AppTabNavigationProvider>
-      <NotificationsDrawerNavigationContextProvider
-        drawerNavigation={drawerNavigation}
-        drawerHelpers={drawerHelpers}
+    <NotificationsDrawerNavigationContextProvider
+      drawerNavigation={drawerNavigation}
+      drawerHelpers={drawerHelpers}
+    >
+      <Stack.Navigator
+        screenOptions={{ gestureEnabled: false, headerShown: false }}
       >
-        <Stack.Navigator
-          screenOptions={{ gestureEnabled: false, headerShown: false }}
-        >
-          <Stack.Screen name='MainStack' component={AppScreen} />
-        </Stack.Navigator>
-      </NotificationsDrawerNavigationContextProvider>
-    </AppTabNavigationProvider>
+        <Stack.Screen name='MainStack' component={AppScreen} />
+      </Stack.Navigator>
+    </NotificationsDrawerNavigationContextProvider>
   )
 }
 


### PR DESCRIPTION
### Description

A few mistakes with the new app-tab-navigation-context: 
- It was too low in the stack so modals didn't have access to it
- It wasn't updating correctly since useEffect was only running the first time a tab is rendered, but we want to update whenever it's active
