### PR TITLE
Disable dominant color on mobile

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/Artwork.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/Artwork.tsx
@@ -56,7 +56,7 @@ export const Artwork = ({ track }: ArtworkProps) => {
     })
   )
 
-  let shadowColor = 'rgba(0,0,0,0)'
+  let shadowColor = 'rgba(0,0,0,0.05)'
   const dominantColor = dominantColors ? dominantColors[0] : null
   if (dominantColor) {
     const { r, g, b } = dominantColor

--- a/packages/web/src/common/store/cache/tracks/sagas.js
+++ b/packages/web/src/common/store/cache/tracks/sagas.js
@@ -416,6 +416,8 @@ function* watchDeleteTrack() {
 
 function* watchFetchCoverArt() {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
+  const isNativeMobile = yield getContext('isNativeMobile')
+
   const inProgress = new Set()
   yield takeEvery(trackActions.FETCH_COVER_ART, function* ({ trackId, size }) {
     // Unique on id and size
@@ -457,14 +459,19 @@ function* watchFetchCoverArt() {
           gateways
         )
       }
-      const dominantColors = yield call(dominantColor, smallImageUrl)
 
-      yield put(
-        setDominantColors({
-          multihash,
-          colors: dominantColors
-        })
-      )
+      if (!isNativeMobile) {
+        // Disabling dominant color fetch on mobile because it requires WebWorker
+        // Can revisit this when doing glass morphism on NowPlaying
+        const dominantColors = yield call(dominantColor, smallImageUrl)
+
+        yield put(
+          setDominantColors({
+            multihash,
+            colors: dominantColors
+          })
+        )
+      }
     } catch (e) {
       console.error(`Unable to fetch cover art for track ${trackId}`)
     } finally {


### PR DESCRIPTION
### Description

This prevents crash on android. We can revisit dominant color when we tackle glass morphism on the NowPlaying drawer

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

