### PR TITLE
[C-850, C-950] Add AudioTransactionsPage and display test data in AudioTransactionsTable

### DIFF
--- a/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.module.css
+++ b/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.module.css
@@ -1,0 +1,20 @@
+.textContainer {
+  position: relative;
+  display: inline-flex;
+  gap: 4px;
+  max-width: 100%;
+}
+
+.textCell {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+.changeCell.increase {
+  color: var(--accent-green);
+}
+.changeCell.decrease {
+  color: var(--accent-orange);
+}

--- a/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.tsx
+++ b/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useMemo } from 'react'
+
+import {
+  formatNumberCommas,
+  TransactionMethod,
+  TransactionType
+} from '@audius/common'
+import cn from 'classnames'
+import moment from 'moment'
+import { ColumnInstance } from 'react-table'
+
+import { AudioTransactionIcon } from 'components/audio-transaction-icon'
+import { TestTable } from 'components/test-table'
+
+import styles from './AudioTransactionsTable.module.css'
+
+const transactionTypeLabelMap: Record<TransactionType, string> = {
+  [TransactionType.TRANSFER]: '$AUDIO',
+  [TransactionType.CHALLENGE_REWARD]: '$AUDIO Reward Earned',
+  [TransactionType.TRENDING_REWARD]: 'Trending Competition Award',
+  [TransactionType.TIP]: 'Tip',
+  [TransactionType.PURCHASE]: 'Purchased $AUDIO'
+}
+
+const transactionMethodLabelMap: Record<TransactionMethod, string | null> = {
+  [TransactionMethod.COINBASE]: null,
+  [TransactionMethod.STRIPE]: null,
+  [TransactionMethod.RECEIVE]: 'Received',
+  [TransactionMethod.SEND]: 'Sent'
+}
+
+export type AudioTransactionsTableColumn =
+  | 'balance'
+  | 'change'
+  | 'date'
+  | 'transactionIcon'
+  | 'transactionType'
+  | 'spacer'
+  | 'spacer2'
+
+type AudioTransactionsTableProps = {
+  columns?: AudioTransactionsTableColumn[]
+  data: any[]
+  isVirtualized?: boolean
+  loading?: boolean
+  onClickRow?: (collectible: any, index: number) => void
+  tableClassName?: string
+  wrapperClassName?: string
+}
+
+const defaultColumns: AudioTransactionsTableColumn[] = [
+  'spacer',
+  'transactionIcon',
+  'transactionType',
+  'date',
+  'change',
+  'balance',
+  'spacer2'
+]
+
+export const AudioTransactionsTable = ({
+  columns = defaultColumns,
+  data,
+  isVirtualized = false,
+  loading = false,
+  onClickRow,
+  tableClassName,
+  wrapperClassName
+}: AudioTransactionsTableProps) => {
+  // Cell Render Functions
+  const renderTransactionIconCell = useCallback((cellInfo) => {
+    const { transactionType, method } = cellInfo.row.original
+    return <AudioTransactionIcon type={transactionType} method={method} />
+  }, [])
+
+  const renderTransactionTypeCell = useCallback((cellInfo) => {
+    const { transactionType, method } = cellInfo.row.original
+    const typeText = transactionTypeLabelMap[transactionType as TransactionType]
+    const methodText =
+      transactionMethodLabelMap[method as TransactionMethod] ?? ''
+
+    const isTransferType =
+      transactionType === TransactionType.TIP ||
+      transactionType === TransactionType.TRANSFER
+
+    return `${typeText} ${isTransferType ? methodText : ''}`.trim()
+  }, [])
+
+  const renderBalanceCell = useCallback((cellInfo) => {
+    const transaction = cellInfo.row.original
+    return formatNumberCommas(transaction.balance)
+  }, [])
+
+  const renderDateCell = useCallback((cellInfo) => {
+    const transaction = cellInfo.row.original
+    return moment(transaction.date).format('M/D/YY')
+  }, [])
+
+  const renderChangeCell = useCallback((cellInfo) => {
+    const { change } = cellInfo.row.original
+    return (
+      <div
+        className={cn(styles.changeCell, {
+          [styles.increase]: Number(change) > 0,
+          [styles.decrease]: Number(change) < 0
+        })}
+      >
+        {Number(change) > 0 ? '+' : ''}
+        {change}
+      </div>
+    )
+  }, [])
+
+  // Columns
+  const tableColumnMap: Record<
+    AudioTransactionsTableColumn,
+    Partial<ColumnInstance>
+  > = useMemo(
+    () => ({
+      transactionIcon: {
+        id: 'transactionIcon',
+        accessor: '',
+        Cell: renderTransactionIconCell,
+        minWidth: 64,
+        maxWidth: 64,
+        disableResizing: true,
+        disableSortBy: true
+      },
+      transactionType: {
+        id: 'transactionType',
+        Header: 'Transaction Type',
+        accessor: 'type',
+        Cell: renderTransactionTypeCell,
+        width: 150,
+        disableSortBy: true,
+        align: 'left'
+      },
+      date: {
+        id: 'date',
+        Header: 'Date',
+        accessor: 'date',
+        Cell: renderDateCell,
+        disableSortBy: true,
+        align: 'right'
+      },
+      change: {
+        id: 'change',
+        Header: 'Change',
+        accessor: 'change',
+        Cell: renderChangeCell,
+        disableSortBy: true,
+        align: 'right'
+      },
+      balance: {
+        id: 'balance',
+        Header: 'Balance',
+        accessor: 'balance',
+        Cell: renderBalanceCell,
+        disableSortBy: true,
+        align: 'right'
+      },
+      spacer: {
+        id: 'spacer',
+        maxWidth: 24,
+        minWidth: 24,
+        disableSortBy: true,
+        disableResizing: true
+      },
+      spacer2: {
+        id: 'spacer2',
+        maxWidth: 24,
+        minWidth: 24,
+        disableSortBy: true,
+        disableResizing: true
+      }
+    }),
+    [
+      renderTransactionIconCell,
+      renderTransactionTypeCell,
+      renderDateCell,
+      renderChangeCell,
+      renderBalanceCell
+    ]
+  )
+
+  const tableColumns = useMemo(
+    () => columns.map((id) => tableColumnMap[id]),
+    [columns, tableColumnMap]
+  )
+
+  const handleClickRow = useCallback(
+    (rowInfo, index: number) => {
+      const transaction = rowInfo.original
+      onClickRow?.(transaction, index)
+    },
+    [onClickRow]
+  )
+
+  const getRowClassName = useCallback(() => '', [])
+
+  return (
+    <TestTable
+      wrapperClassName={wrapperClassName}
+      tableClassName={tableClassName}
+      getRowClassName={getRowClassName}
+      columns={tableColumns}
+      data={data}
+      loading={loading}
+      onClickRow={handleClickRow}
+      isVirtualized={isVirtualized}
+    />
+  )
+}

--- a/packages/web/src/components/audio-transactions-table/index.ts
+++ b/packages/web/src/components/audio-transactions-table/index.ts
@@ -1,0 +1,1 @@
+export { AudioTransactionsTable } from './AudioTransactionsTable'

--- a/packages/web/src/components/test-table/TestTable.module.css
+++ b/packages/web/src/components/test-table/TestTable.module.css
@@ -199,6 +199,7 @@
   align-items: center;
   vertical-align: middle;
   justify-content: center;
+  height: 64px;
   padding: 20px 12px;
   background: transparent;
   user-select: none;

--- a/packages/web/src/components/tracks-table/TracksTable.js
+++ b/packages/web/src/components/tracks-table/TracksTable.js
@@ -87,7 +87,7 @@ const artistNameCell = (val, record, props) => {
     return `${record.user?.name} [Deactivated]`
   }
   return (
-    <ArtistPopover handle={record.handle}>
+    <ArtistPopover handle={record.handle ?? ''}>
       <div
         className={styles.textContainer}
         onClick={(e) => {
@@ -133,7 +133,7 @@ const optionsButtonCell = (
   props,
   storeActionButtonRefs
 ) => {
-  const deleted = record.is_delete || !!record.user.is_deactivated
+  const deleted = record.is_delete || !!record.user?.is_deactivated
   const optionsButtonRef = createRef()
   storeActionButtonRefs(record.key, optionsButtonRef)
 
@@ -150,8 +150,8 @@ const optionsButtonCell = (
         date={val.date}
         isFavorited={val.has_current_user_saved}
         isOwner={record.owner_id === props.userId}
-        isOwnerDeactivated={!!record.user.is_deactivated}
-        isArtistPick={val.user._artist_pick === val.track_id}
+        isOwnerDeactivated={!!record.user?.is_deactivated}
+        isArtistPick={val.user?._artist_pick === val.track_id}
         index={index}
         trackTitle={val.name}
         albumId={null}

--- a/packages/web/src/pages/App.js
+++ b/packages/web/src/pages/App.js
@@ -49,6 +49,7 @@ import TrendingGenreSelectionPage from 'components/trending-genre-selection/Tren
 import AnnouncementPage from 'pages/announcement-page/AnnoucementPage'
 import ArtistDashboardPage from 'pages/artist-dashboard-page/ArtistDashboardPage'
 import { AudioRewardsPage } from 'pages/audio-rewards-page/AudioRewardsPage'
+import { AudioTransactionsPage } from 'pages/audio-transactions-page'
 import CheckPage from 'pages/check-page/CheckPage'
 import CollectionPage from 'pages/collection-page/CollectionPage'
 import EmptyPage from 'pages/empty-page/EmptyPage'
@@ -100,6 +101,7 @@ import {
   HISTORY_PAGE,
   DASHBOARD_PAGE,
   AUDIO_PAGE,
+  AUDIO_TRANSACTIONS_PAGE,
   UPLOAD_PAGE,
   UPLOAD_ALBUM_PAGE,
   UPLOAD_PLAYLIST_PAGE,
@@ -782,6 +784,12 @@ class App extends Component {
                 path={AUDIO_PAGE}
                 isMobile={isMobileClient}
                 component={AudioRewardsPage}
+              />
+              <Route
+                exact
+                path={AUDIO_TRANSACTIONS_PAGE}
+                isMobile={isMobileClient}
+                component={AudioTransactionsPage}
               />
               <Route
                 exact

--- a/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.module.css
+++ b/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.module.css
@@ -1,0 +1,27 @@
+/* Body Content Wrapper */
+.bodyWrapper {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+/* Track Table */
+.bodyWrapper .tableWrapper {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px -2px var(--tile-shadow-3);
+  background-color: var(--white);
+  margin-bottom: 35px;
+  padding-bottom: 5px;
+  overflow: hidden;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto;
+}
+
+.spinner g path {
+  stroke: var(--secondary) !important;
+}

--- a/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
+++ b/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
@@ -1,0 +1,341 @@
+import {
+  accountSelectors,
+  FeatureFlags,
+  TransactionDetails,
+  TransactionMetadataType,
+  TransactionMethod,
+  TransactionType
+} from '@audius/common'
+import { useSelector } from 'react-redux'
+
+import { AudioTransactionsTable } from 'components/audio-transactions-table'
+import Header from 'components/header/desktop/Header'
+import Page from 'components/page/Page'
+import EmptyTable from 'components/tracks-table/EmptyTable'
+import TracksTable from 'components/tracks-table/TracksTable'
+import { useFlag } from 'hooks/useRemoteConfig'
+
+import styles from './AudioTransactionsPage.module.css'
+
+const { getUserId } = accountSelectors
+
+const messages = {
+  pageTitle: 'AudioTransactions',
+  pageDescription: 'View your listening history',
+  emptyTableText: 'You don’t have any $AUDIO transactions yet.',
+  emptyTableSecondaryText: 'Once you have, this is where you’ll find them!',
+  headerText: '$AUDIO Transactions'
+}
+
+export type AudioTransactionsPageProps = {}
+
+// Test Data for testing
+const data: TransactionDetails[] = [
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.SEND,
+    date: '6/23/2020',
+    change: '-100',
+    balance: '100000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.CHALLENGE_REWARD,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100000',
+    metadata: undefined
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.PURCHASE,
+    method: TransactionMethod.COINBASE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100000',
+    metadata: {
+      discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP,
+      usd: '0',
+      sol: '0',
+      audio: '0',
+      purchaseTransactionId: '0',
+      swapTransactionId: '0'
+    }
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.PURCHASE,
+    method: TransactionMethod.COINBASE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100000',
+    metadata: {
+      discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP,
+      usd: '0',
+      sol: '0',
+      audio: '0',
+      purchaseTransactionId: '0',
+      swapTransactionId: '0'
+    }
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.PURCHASE,
+    method: TransactionMethod.COINBASE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100100',
+    metadata: {
+      discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP,
+      usd: '0',
+      sol: '0',
+      audio: '0',
+      purchaseTransactionId: '0',
+      swapTransactionId: '0'
+    }
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.PURCHASE,
+    method: TransactionMethod.STRIPE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100200',
+    metadata: {
+      discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP,
+      usd: '0',
+      sol: '0',
+      audio: '0',
+      purchaseTransactionId: '0',
+      swapTransactionId: '0'
+    }
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.PURCHASE,
+    method: TransactionMethod.COINBASE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100300',
+    metadata: {
+      discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP,
+      usd: '0',
+      sol: '0',
+      audio: '0',
+      purchaseTransactionId: '0',
+      swapTransactionId: '0'
+    }
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.SEND,
+    date: '6/23/2020',
+    change: '-100',
+    balance: '1000000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TRANSFER,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '55',
+    balance: '1000000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TRENDING_REWARD,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '5',
+    balance: '1000000',
+    metadata: undefined
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '1000000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.PURCHASE,
+    method: TransactionMethod.STRIPE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100200',
+    metadata: {
+      discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP,
+      usd: '0',
+      sol: '0',
+      audio: '0',
+      purchaseTransactionId: '0',
+      swapTransactionId: '0'
+    }
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.SEND,
+    date: '6/23/2020',
+    change: '-100',
+    balance: '100000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TRENDING_REWARD,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '5',
+    balance: '1000000',
+    metadata: undefined
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.PURCHASE,
+    method: TransactionMethod.STRIPE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100200',
+    metadata: {
+      discriminator: TransactionMetadataType.PURCHASE_SOL_AUDIO_SWAP,
+      usd: '0',
+      sol: '0',
+      audio: '0',
+      purchaseTransactionId: '0',
+      swapTransactionId: '0'
+    }
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.SEND,
+    date: '6/23/2020',
+    change: '-100',
+    balance: '100000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TRENDING_REWARD,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '5',
+    balance: '1000000',
+    metadata: undefined
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.CHALLENGE_REWARD,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '1',
+    balance: '333333333',
+    metadata: undefined
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.SEND,
+    date: '6/23/2020',
+    change: '-100',
+    balance: '100000',
+    metadata: {}
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TRENDING_REWARD,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '5',
+    balance: '1000000',
+    metadata: undefined
+  },
+  {
+    signature: 'banana_bread',
+    transactionType: TransactionType.TIP,
+    method: TransactionMethod.RECEIVE,
+    date: '6/23/2020',
+    change: '100',
+    balance: '100000',
+    metadata: {}
+  }
+]
+
+export const AudioTransactionsPage = (props: AudioTransactionsPageProps) => {
+  const { isEnabled: isNewTablesEnabled } = useFlag(FeatureFlags.NEW_TABLES)
+  const tableLoading = !data.every((transaction: any) =>
+    Boolean(transaction.signature)
+  )
+  const isEmpty = data.length === 0
+
+  const userId = useSelector(getUserId)
+
+  return (
+    <Page
+      title={messages.pageTitle}
+      description={messages.pageDescription}
+      header={<Header primary={messages.headerText} />}
+    >
+      <div className={styles.bodyWrapper}>
+        {isEmpty && !tableLoading ? (
+          <EmptyTable
+            primaryText={messages.emptyTableText}
+            secondaryText={messages.emptyTableSecondaryText}
+          />
+        ) : isNewTablesEnabled ? (
+          <AudioTransactionsTable
+            key='audioTransactions'
+            data={data}
+            loading={tableLoading}
+          />
+        ) : (
+          <div className={styles.tableWrapper}>
+            <TracksTable
+              userId={userId}
+              loading={tableLoading}
+              loadingRowsCount={data.length}
+              dataSource={data}
+            />
+          </div>
+        )}
+      </div>
+    </Page>
+  )
+}

--- a/packages/web/src/pages/audio-transactions-page/index.ts
+++ b/packages/web/src/pages/audio-transactions-page/index.ts
@@ -1,0 +1,1 @@
+export { AudioTransactionsPage } from './AudioTransactionsPage'

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -67,6 +67,7 @@ export const FAVORITES_PAGE = '/favorites'
 export const HISTORY_PAGE = '/history'
 export const DASHBOARD_PAGE = '/dashboard'
 export const AUDIO_PAGE = '/audio'
+export const AUDIO_TRANSACTIONS_PAGE = '/audio/transactions'
 export const UPLOAD_PAGE = '/upload'
 export const UPLOAD_ALBUM_PAGE = '/upload/album'
 export const UPLOAD_PLAYLIST_PAGE = '/upload/playlist'
@@ -187,6 +188,7 @@ export const orderedRoutes = [
   HISTORY_PAGE,
   DASHBOARD_PAGE,
   AUDIO_PAGE,
+  AUDIO_TRANSACTIONS_PAGE,
   SETTINGS_PAGE,
   ACCOUNT_SETTINGS_PAGE,
   NOTIFICATION_SETTINGS_PAGE,
@@ -216,6 +218,7 @@ export const staticRoutes = new Set([
   HISTORY_PAGE,
   DASHBOARD_PAGE,
   AUDIO_PAGE,
+  AUDIO_TRANSACTIONS_PAGE,
   UPLOAD_PAGE,
   UPLOAD_ALBUM_PAGE,
   UPLOAD_PLAYLIST_PAGE,


### PR DESCRIPTION
### Description

* Add route for audio transactions page
* Add AudioTransactionsPageProvider and desktop page to add the scaffolding for later and display the test data
* Add the AudioTransactionsTable component to display the transaction detail rows

<img width="2103" alt="Screen Shot 2022-09-29 at 2 45 58 PM" src="https://user-images.githubusercontent.com/23732287/193117251-cf80eb26-af9f-44f3-b12c-2ceb34fa217e.png">

### Dragons

Needs to be updated when the backend is setup to return audio transaction information and pipe that into the table.
Table may need to be updated based on the actual data and based on sorting and filtering and things

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

