### PR TITLE
Fix profile reposts loading issue

### DIFF
--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -1024,7 +1024,6 @@ function mapDispatchToProps(dispatch: Dispatch, props: RouteComponentProps) {
       id: ID,
       sort: TracksSortMode
     ) => {
-      console.log('refetch tracks', offset, limit, id, sort)
       dispatch(
         tracksActions.fetchLineupMetadatas(
           offset,

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -551,7 +551,7 @@ const ProfilePage = ({
     const elements = [
       <div key={ProfilePageTabs.REPOSTS} className={styles.tiles}>
         {renderProfileCompletionCard()}
-        {(userFeed.status !== Status.LOADING &&
+        {(userFeed.status === Status.SUCCESS &&
           userFeed.entries.length === 0) ||
         profile.repost_count === 0 ? (
           <EmptyTab


### PR DESCRIPTION
### Description

Fixes issue where non artist profile's reposts tab was not rendering. This regression occured because the initialState of lineups has changed from Status.LOADING to Status.IDLE