### PR TITLE
[C-1128] Add profile screen skeleton

### DIFF
--- a/packages/mobile/src/components/feed-tip-tile/FeedTipTileSkeleton.tsx
+++ b/packages/mobile/src/components/feed-tip-tile/FeedTipTileSkeleton.tsx
@@ -5,9 +5,8 @@ import { makeStyles } from 'app/styles'
 
 import { Tile } from '../core'
 
-const useStyles = makeStyles(({ spacing, palette }) => ({
+const useStyles = makeStyles(({ spacing }) => ({
   tile: {
-    display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
@@ -17,13 +16,11 @@ const useStyles = makeStyles(({ spacing, palette }) => ({
     paddingVertical: spacing(4)
   },
   header: {
-    display: 'flex',
     flexDirection: 'row',
     justifyContent: 'flex-start',
     alignItems: 'center'
   },
   metadata: {
-    display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-evenly'
   },

--- a/packages/mobile/src/components/skeleton/Skeleton.tsx
+++ b/packages/mobile/src/components/skeleton/Skeleton.tsx
@@ -17,6 +17,7 @@ type SkeletonProps = {
   height?: string
   // Optional style to pass in and override styles with
   style?: StyleProp<ViewStyle>
+  noShimmer?: boolean
 }
 
 const createStyles = (themeColors: ThemeColors) =>
@@ -34,14 +35,14 @@ const createStyles = (themeColors: ThemeColors) =>
     }
   })
 
-const Skeleton = ({ width, height, style }: SkeletonProps) => {
+const Skeleton = ({ width, height, style, noShimmer }: SkeletonProps) => {
   const styles = useThemedStyles(createStyles)
   const [shimmerWidth, setShimmerWidth] = useState(0)
   const [shimmerPos, setShimmerPos] = useState(new Animated.Value(0))
   const { skeleton, skeletonHighlight } = useThemeColors()
 
   useEffect(() => {
-    if (shimmerWidth !== 0) {
+    if (shimmerWidth !== 0 && !noShimmer) {
       Animated.loop(
         Animated.timing(shimmerPos, {
           toValue: 0,
@@ -51,12 +52,13 @@ const Skeleton = ({ width, height, style }: SkeletonProps) => {
         })
       ).start()
     }
-  }, [shimmerPos, shimmerWidth])
+  }, [shimmerPos, shimmerWidth, noShimmer])
 
   return (
     <View style={[styles.view, { height, width }, style]}>
       <Animated.View
         onLayout={(e) => {
+          if (noShimmer) return
           const { width } = e.nativeEvent.layout
           setShimmerWidth(width)
           setShimmerPos(new Animated.Value(-0.75 * width))

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -29,6 +29,7 @@ import { useThemeColors } from 'app/utils/theme'
 import type { ProfileTabScreenParamList } from '../app-screen/ProfileTabScreen'
 
 import { ProfileHeader } from './ProfileHeader'
+import { ProfileScreenSkeleton } from './ProfileScreenSkeleton'
 import { ProfileTabNavigator } from './ProfileTabNavigator'
 import { useSelectProfileRoot } from './selectors'
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
@@ -151,7 +152,9 @@ export const ProfileScreen = () => {
 
   return (
     <Screen topbarLeft={topbarLeft} topbarRight={topbarRight}>
-      {!profile ? null : (
+      {!profile ? (
+        <ProfileScreenSkeleton />
+      ) : (
         <>
           <View style={styles.navigator}>
             {isNotReachable ? (

--- a/packages/mobile/src/screens/profile-screen/ProfileScreenSkeleton.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreenSkeleton.tsx
@@ -1,0 +1,177 @@
+import { memo } from 'react'
+
+import { times, random } from 'lodash'
+import { View } from 'react-native'
+
+import { LineupTileSkeleton } from 'app/components/lineup-tile'
+import Skeleton from 'app/components/skeleton'
+import { makeStyles } from 'app/styles'
+
+const useStyles = makeStyles(({ palette, spacing }) => ({
+  root: {
+    marginBottom: 40
+  },
+  coverPhoto: {
+    height: 96
+  },
+  profilePicture: {
+    position: 'absolute',
+    top: 37,
+    left: 11,
+    zIndex: 101,
+
+    height: 82,
+    width: 82,
+    borderRadius: 1000,
+    borderWidth: 2,
+    borderStyle: 'solid',
+    borderColor: palette.white,
+    overflow: 'hidden',
+    backgroundColor: palette.neutralLight6
+  },
+  header: {
+    backgroundColor: palette.white,
+    paddingTop: spacing(8),
+    paddingHorizontal: spacing(3)
+  },
+  info: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: spacing(5)
+  },
+  name: {
+    height: spacing(5),
+    width: 100,
+    marginBottom: spacing(3)
+  },
+  handle: {
+    height: spacing(4),
+    width: 80
+  },
+  actionButton: {
+    height: 35,
+    width: 120
+  },
+  stats: {
+    flexDirection: 'row',
+    marginBottom: spacing(3)
+  },
+  stat: {
+    height: spacing(4),
+    width: 80,
+    marginRight: spacing(5)
+  },
+  bio: {
+    flexWrap: 'wrap',
+    flexDirection: 'row',
+    marginBottom: spacing(3)
+  },
+  tierAndSocials: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing(3)
+  },
+  tier: {
+    height: 50,
+    width: 100,
+    borderRadius: 12,
+    marginRight: spacing(10)
+  },
+  socialLinks: {
+    flexDirection: 'row',
+    alignSelf: 'center',
+    justifyContent: 'space-around',
+    flex: 4
+  },
+  socialLink: {
+    height: spacing(8),
+    width: spacing(8),
+    marginRight: spacing(3)
+  },
+  tabs: {
+    flexDirection: 'row',
+    justifyContent: 'space-evenly',
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: palette.neutralLight8,
+    backgroundColor: palette.white,
+    paddingVertical: spacing(3),
+    height: 50
+  },
+  tab: {
+    height: spacing(8),
+    width: spacing(15)
+  },
+  lineupTile: {
+    padding: spacing(3),
+    paddingBottom: 0
+  }
+}))
+
+const BioSkeleton = memo(() => {
+  const baseStyle = {
+    height: 12,
+    marginRight: 4,
+    marginBottom: 8
+  }
+  const elements = times(random(5, 15), () => random(20, 100))
+  return (
+    <>
+      {elements.map((elementWidth: number, i) => (
+        <Skeleton
+          key={i}
+          noShimmer
+          style={[baseStyle, { width: elementWidth }]}
+        />
+      ))}
+    </>
+  )
+})
+
+export const ProfileScreenSkeleton = memo(() => {
+  const styles = useStyles()
+
+  const statSkeleton = <Skeleton style={styles.stat} />
+
+  const lineupTile = (
+    <View style={styles.lineupTile}>
+      <LineupTileSkeleton />
+    </View>
+  )
+
+  return (
+    <View style={styles.root}>
+      <Skeleton style={styles.coverPhoto} />
+      <Skeleton style={styles.profilePicture} />
+      <View style={styles.header}>
+        <View style={styles.info}>
+          <View>
+            <Skeleton style={styles.name} />
+            <Skeleton style={styles.handle} />
+          </View>
+          <Skeleton style={styles.actionButton} />
+        </View>
+        <View style={styles.stats}>
+          {statSkeleton}
+          {statSkeleton}
+          {statSkeleton}
+        </View>
+        <View style={styles.bio}>
+          <BioSkeleton />
+        </View>
+        <View style={styles.tierAndSocials}>
+          <Skeleton style={styles.tier} />
+          <View style={styles.socialLinks}>
+            <Skeleton style={styles.socialLink} />
+            <Skeleton style={styles.socialLink} />
+            <Skeleton style={styles.socialLink} />
+          </View>
+        </View>
+      </View>
+      <View style={styles.tabs}></View>
+      {lineupTile}
+      {lineupTile}
+      {lineupTile}
+    </View>
+  )
+})


### PR DESCRIPTION
### Description

- Adds profile skeleton, which drastically improves UX for profiles loaded from search screen or deep-link, and other cases where the profile hasn't been fetched yet.
- Adds `noShimmer` option to `Skeleton` which is good for some skeletons that are small, like we have here for the bio element.
> Note: there is some lineup jank present when the profile data is first fetched present in this video. This will be addressed in a separate pr


https://user-images.githubusercontent.com/8230000/193168912-d12caf17-7979-4b25-b2ea-10f94ff9562a.mp4


