### PR TITLE
[C-481] Fix profile header loading jank

### DIFF
--- a/packages/mobile/src/components/top-tab-bar/CollapsibleTopTabNavigator.tsx
+++ b/packages/mobile/src/components/top-tab-bar/CollapsibleTopTabNavigator.tsx
@@ -70,6 +70,7 @@ type CollapsibleTabNavigatorProps = {
   initialScreenName?: string
   children: ReactNode
   screenOptions?: MaterialTopTabNavigationOptions
+  headerHeight?: number
 }
 
 export const CollapsibleTabNavigator = ({
@@ -77,11 +78,12 @@ export const CollapsibleTabNavigator = ({
   animatedValue,
   initialScreenName,
   children,
-  screenOptions
+  screenOptions,
+  headerHeight
 }: CollapsibleTabNavigatorProps) => {
   const collapsibleOptions = useMemo(
-    () => ({ renderHeader, disableSnap: true, animatedValue }),
-    [renderHeader, animatedValue]
+    () => ({ renderHeader, disableSnap: true, animatedValue, headerHeight }),
+    [renderHeader, animatedValue, headerHeight]
   )
 
   return (

--- a/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
@@ -107,6 +107,7 @@ export const ProfileTabNavigator = ({
       <CollapsibleTabNavigator
         renderHeader={renderHeader}
         animatedValue={animatedValue}
+        headerHeight={1000}
       >
         {trackScreen}
         {albumsScreen}
@@ -121,6 +122,7 @@ export const ProfileTabNavigator = ({
     <CollapsibleTabNavigator
       renderHeader={renderHeader}
       animatedValue={animatedValue}
+      headerHeight={1000}
     >
       {repostsScreen}
       {playlistsScreen}

--- a/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
@@ -21,6 +21,9 @@ import { TracksTab } from './TracksTab'
 import { useSelectProfile } from './selectors'
 import { useShouldShowCollectiblesTab } from './utils'
 
+// Height of a typical profile header
+const INITIAL_PROFILE_HEADER_HEIGHT = 1081
+
 type ProfileTabNavigatorProps = {
   /**
    * Function that renders the collapsible header
@@ -107,7 +110,7 @@ export const ProfileTabNavigator = ({
       <CollapsibleTabNavigator
         renderHeader={renderHeader}
         animatedValue={animatedValue}
-        headerHeight={1000}
+        headerHeight={INITIAL_PROFILE_HEADER_HEIGHT}
       >
         {trackScreen}
         {albumsScreen}
@@ -122,7 +125,7 @@ export const ProfileTabNavigator = ({
     <CollapsibleTabNavigator
       renderHeader={renderHeader}
       animatedValue={animatedValue}
-      headerHeight={1000}
+      headerHeight={INITIAL_PROFILE_HEADER_HEIGHT}
     >
       {repostsScreen}
       {playlistsScreen}


### PR DESCRIPTION
### Description

Fixes issue where profile lineups load underneath the profile header, and all the way at the top, then suddenly transition down. This is due to collapsible-tabs not knowing the height of the header on the first load. Adding a default value that is around the height of an average header.