### PR TITLE
Fix tracks/reposts lineups for artist with handles with capitials

### DIFF
--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -15,14 +15,18 @@ const { getProfileFeedLineup } = profilePageSelectors
 
 export const RepostsTab = () => {
   const { handle } = useSelectProfile(['handle'])
+  const handleLower = handle.toLowerCase()
 
   const lineup = useProxySelector(
-    (state) => getProfileFeedLineup(state, handle),
-    [handle]
+    (state) => getProfileFeedLineup(state, handleLower),
+    [handleLower]
   )
   const { repost_count } = useSelectProfile(['repost_count'])
 
-  const extraFetchOptions = useMemo(() => ({ handle }), [handle])
+  const extraFetchOptions = useMemo(
+    () => ({ handle: handleLower }),
+    [handleLower]
+  )
 
   if (!lineup) return null
 

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -24,9 +24,11 @@ export const TracksTab = () => {
     '_artist_pick'
   ])
 
+  const handleLower = handle.toLowerCase()
+
   const lineup = useProxySelector(
-    (state) => getProfileTracksLineup(state, handle),
-    [handle]
+    (state) => getProfileTracksLineup(state, handleLower),
+    [handleLower]
   )
 
   useEffect(() => {
@@ -37,11 +39,11 @@ export const TracksTab = () => {
           undefined,
           undefined,
           { userId: user_id },
-          { handle }
+          { handle: handleLower }
         )
       )
     }
-  }, [dispatch, isProfileLoaded, user_id, handle])
+  }, [dispatch, isProfileLoaded, user_id, handleLower])
 
   const loadMore = useCallback(
     (offset: number, limit: number) => {

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -59,7 +59,9 @@ export const getIsOwner = createSelector(
 export const useIsProfileLoaded = () => {
   const { params } = useRoute<'Profile'>()
   const { handle } = params
-  const profileStatus = useSelector((state) => getProfileStatus(state, handle))
+  const profileStatus = useSelector((state) =>
+    getProfileStatus(state, handle.toLowerCase())
+  )
 
   return handle === 'accountUser' || profileStatus === Status.SUCCESS
 }


### PR DESCRIPTION
### Description

Fixes mobile tracks/reposts by ensuring handle is lowerCased, which we need since the profile state references lowercase handles. Ultimately i think we should move all the `.toLowerCase` code to the actions/reducers/selectors so the consumer doesn't have to think about this. This pr unblocks tho.