### PR TITLE
Add premium content default fields to track upload

### DIFF
--- a/packages/web/src/pages/upload-page/UploadPage.js
+++ b/packages/web/src/pages/upload-page/UploadPage.js
@@ -246,8 +246,17 @@ class Upload extends Component {
   }
 
   publish = () => {
+    // Set the premium content fields for the tracks
+    // so that libs track metadata validation passes.
+    // This will change once we introduce premium content UI
+    // in the track upload flow.
+    const tracks = [...this.state.tracks]
+    tracks.forEach((track) => {
+      track.metadata.is_premium = false
+      track.metadata.premium_conditions = null
+    })
     this.props.uploadTracks(
-      this.state.tracks,
+      tracks,
       this.state.metadata,
       this.state.uploadType,
       this.state.stems


### PR DESCRIPTION
### Description

Add is_premium and premium_conditions default values

### Dragons

Track upload flow should work.

### How Has This Been Tested?

Local client against stage. Uploaded track. Played it.

### How will this change be monitored?

n/a

### Feature Flags ###

none

