### PR TITLE
Fix duplicate playlists once playlist is confirmed  / Await feature flag response in sagas C-1199

### DIFF
--- a/packages/common/src/store/pages/profile/selectors.ts
+++ b/packages/common/src/store/pages/profile/selectors.ts
@@ -75,7 +75,7 @@ export const getProfileCollections = createDeepEqualSelector(
       .filter((collection) => {
         if (collection) {
           const { is_delete, _marked_deleted, _moved } = collection
-          return !(is_delete || _marked_deleted) || _moved
+          return !(is_delete || _marked_deleted || _moved)
         }
         return false
       })
@@ -145,10 +145,10 @@ export const makeGetProfile = () => {
       // Filter out anything marked deleted on backend (is_delete) or locally (_marked_deleted)
       // Or locally moved playlists (_moved)
       let playlists = c.filter(
-        (c) => (!c.is_album && !(c.is_delete || c._marked_deleted)) || c._moved
+        (c) => !c.is_album && !(c.is_delete || c._marked_deleted) && !c._moved
       )
       let albums = c.filter(
-        (c) => (c.is_album && !(c.is_delete || c._marked_deleted)) || c._moved
+        (c) => c.is_album && !(c.is_delete || c._marked_deleted) && !c._moved
       )
 
       if (sortMode === CollectionSortMode.SAVE_COUNT) {

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -77,8 +77,10 @@ function* createPlaylistAsync(action) {
   const userId = yield select(getUserId)
   const uid = action.playlistId
   const getFeatureEnabled = yield getContext('getFeatureEnabled')
-  const playlistEntityManagerIsEnabled =
-    getFeatureEnabled(FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED) ?? false
+  const playlistEntityManagerIsEnabled = yield call(
+    getFeatureEnabled,
+    FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED
+  ) ?? false
   if (!userId) {
     yield put(signOnActions.openSignOn(false))
     return
@@ -220,6 +222,15 @@ function* confirmCreatePlaylist(
             }
           ])
         )
+        // yield put(
+        //   cacheActions.remove(Kind.COLLECTIONS, [
+        //     {
+        //       id: uid,
+        //       uid: subscribedUid,
+        //       metadata: reformattedPlaylist
+        //     }
+        //   ])
+        // )
         const user = yield select(getUser, { id: userId })
         yield put(
           cacheActions.update(Kind.USERS, [
@@ -308,6 +319,11 @@ function* editPlaylistAsync(action) {
 
   const playlist = { ...action.formFields }
 
+  // // For base64 images (coming from native), convert to a blob
+  // if (playlist.artwork?.type === 'base64') {
+  //   playlist.artwork.file = dataURLtoFile(playlist.artwork.file)
+  // }
+
   yield call(confirmEditPlaylist, action.playlistId, userId, playlist)
 
   playlist.playlist_id = action.playlistId
@@ -337,9 +353,10 @@ function* confirmEditPlaylist(playlistId, userId, formFields) {
       makeKindId(Kind.COLLECTIONS, playlistId),
       function* (confirmedPlaylistId) {
         const getFeatureEnabled = yield getContext('getFeatureEnabled')
-        const playlistEntityManagerIsEnabled =
-          getFeatureEnabled(FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED) ??
-          false
+        const playlistEntityManagerIsEnabled = yield call(
+          getFeatureEnabled,
+          FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED
+        ) ?? false
         if (!playlistEntityManagerIsEnabled) {
           playlistId = confirmedPlaylistId
         }
@@ -485,8 +502,10 @@ function* confirmAddTrackToPlaylist(
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const getFeatureEnabled = yield getContext('getFeatureEnabled')
 
-  const playlistEntityManagerIsEnabled =
-    getFeatureEnabled(FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED) ?? false
+  const playlistEntityManagerIsEnabled = yield call(
+    getFeatureEnabled,
+    FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED
+  ) ?? false
 
   yield put(
     confirmerActions.requestConfirmation(
@@ -687,8 +706,10 @@ function* confirmRemoveTrackFromPlaylist(
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const getFeatureEnabled = yield getContext('getFeatureEnabled')
 
-  const playlistEntityManagerIsEnabled =
-    getFeatureEnabled(FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED) ?? false
+  const playlistEntityManagerIsEnabled = yield call(
+    getFeatureEnabled,
+    FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED
+  ) ?? false
 
   yield put(
     confirmerActions.requestConfirmation(
@@ -841,9 +862,10 @@ function* confirmOrderPlaylist(userId, playlistId, trackIds, playlist) {
         const getFeatureEnabled = yield getContext('getFeatureEnabled')
         // NOTE: In an attempt to fix playlists in a corrupted state, only attempt the order playlist tracks once,
         // if it fails, check if the playlist is in a corrupted state and if so fix it before re-attempting to order playlist
-        const playlistEntityManagerIsEnabled =
-          getFeatureEnabled(FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED) ??
-          false
+        const playlistEntityManagerIsEnabled = yield call(
+          getFeatureEnabled,
+          FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED
+        ) ?? false
         if (!playlistEntityManagerIsEnabled) {
           playlistId = confirmedPlaylistId
         }
@@ -964,9 +986,10 @@ function* confirmPublishPlaylist(userId, playlistId, playlist) {
       makeKindId(Kind.COLLECTIONS, playlistId),
       function* (confirmedPlaylistId) {
         const getFeatureEnabled = yield getContext('getFeatureEnabled')
-        const playlistEntityManagerIsEnabled =
-          getFeatureEnabled(FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED) ??
-          false
+        const playlistEntityManagerIsEnabled = yield call(
+          getFeatureEnabled,
+          FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED
+        ) ?? false
         if (!playlistEntityManagerIsEnabled) {
           playlistId = confirmedPlaylistId
         }
@@ -1183,9 +1206,10 @@ function* confirmDeletePlaylist(userId, playlistId) {
       makeKindId(Kind.COLLECTIONS, playlistId),
       function* (confirmedPlaylistId) {
         const getFeatureEnabled = yield getContext('getFeatureEnabled')
-        const playlistEntityManagerIsEnabled =
-          getFeatureEnabled(FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED) ??
-          false
+        const playlistEntityManagerIsEnabled = yield call(
+          getFeatureEnabled,
+          FeatureFlags.PLAYLIST_ENTITY_MANAGER_ENABLED
+        ) ?? false
         if (!playlistEntityManagerIsEnabled) {
           playlistId = confirmedPlaylistId
         }

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -222,15 +222,6 @@ function* confirmCreatePlaylist(
             }
           ])
         )
-        // yield put(
-        //   cacheActions.remove(Kind.COLLECTIONS, [
-        //     {
-        //       id: uid,
-        //       uid: subscribedUid,
-        //       metadata: reformattedPlaylist
-        //     }
-        //   ])
-        // )
         const user = yield select(getUser, { id: userId })
         yield put(
           cacheActions.update(Kind.USERS, [
@@ -318,11 +309,6 @@ function* editPlaylistAsync(action) {
   )
 
   const playlist = { ...action.formFields }
-
-  // // For base64 images (coming from native), convert to a blob
-  // if (playlist.artwork?.type === 'base64') {
-  //   playlist.artwork.file = dataURLtoFile(playlist.artwork.file)
-  // }
 
   yield call(confirmEditPlaylist, action.playlistId, userId, playlist)
 

--- a/packages/web/src/common/store/pages/saved/sagas.js
+++ b/packages/web/src/common/store/pages/saved/sagas.js
@@ -41,7 +41,10 @@ function* watchFetchSaves() {
     const sortDirection = props.sortDirection ?? ''
     const saves = yield select(getSaves)
     const getFeatureEnabled = yield getContext('getFeatureEnabled')
-    const newTablesEnabled = getFeatureEnabled(FeatureFlags.NEW_TABLES) ?? false
+    const newTablesEnabled = yield call(
+      getFeatureEnabled,
+      FeatureFlags.NEW_TABLES
+    ) ?? false
 
     const isSameParams =
       query === currentQuery &&


### PR DESCRIPTION
### Description
Problems were:
1. Not awaiting the `getFeatureFlag` call in sagas
2. Not filtering out _moved playlists

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

