### PR TITLE
[C-1179] Fix edit-profile

### DIFF
--- a/packages/common/src/store/pages/profile/reducer.ts
+++ b/packages/common/src/store/pages/profile/reducer.ts
@@ -178,7 +178,11 @@ const actionsMap = {
     return updateProfile(state, action, { mostUsedTags })
   },
   [UPDATE_PROFILE](state, action) {
-    return updateProfile(state, action, { updating: true })
+    return updateProfile(state, action, {
+      updating: true,
+      updateSuccess: false,
+      updateError: false
+    })
   },
   [UPDATE_PROFILE_SUCCEEDED](state, action) {
     return updateProfile(state, action, {

--- a/packages/common/src/store/pages/profile/selectors.ts
+++ b/packages/common/src/store/pages/profile/selectors.ts
@@ -22,6 +22,16 @@ const emptyList: any[] = []
 // Profile selectors
 export const getProfileStatus = (state: CommonState, handle?: string) =>
   getProfile(state, handle)?.status ?? Status.IDLE
+export const getProfileEditStatus = (state: CommonState, handle?: string) => {
+  const profile = getProfile(state, handle)
+  if (!profile) return Status.IDLE
+  const { updating, updateError, updateSuccess } = profile
+  if (!updating && !updateError && !updateSuccess) return Status.IDLE
+  if (updating) return Status.LOADING
+  if (!updating && updateSuccess) return Status.SUCCESS
+  if (!updating && updateError) return Status.ERROR
+  return Status.IDLE
+}
 export const getProfileError = (state: CommonState, handle?: string) =>
   getProfile(state, handle)?.error
 export const getProfileUserId = (state: CommonState, handle?: string) =>

--- a/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
+++ b/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
@@ -1,11 +1,13 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import type { UserMetadata } from '@audius/common'
 import {
   accountSelectors,
   SquareSizes,
   WidthSizes,
-  profilePageActions
+  profilePageActions,
+  profilePageSelectors,
+  Status
 } from '@audius/common'
 import type { FormikProps } from 'formik'
 import { Formik } from 'formik'
@@ -19,14 +21,16 @@ import IconTikTokInverted from 'app/assets/images/iconTikTokInverted.svg'
 import IconTwitterBird from 'app/assets/images/iconTwitterBird.svg'
 import { FormTextInput, FormImageInput } from 'app/components/core'
 import { FormScreen } from 'app/components/form-screen'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { useUserCoverPhoto } from 'app/hooks/useUserCoverPhoto'
 import { useUserProfilePicture } from 'app/hooks/useUserProfilePicture'
 import { makeStyles } from 'app/styles'
 
 import type { ProfileValues, UpdatedProfile } from './types'
 
-const { getAccountUser } = accountSelectors
+const { getAccountUser, getUserHandle } = accountSelectors
 const { updateProfile } = profilePageActions
+const { getProfileEditStatus } = profilePageSelectors
 
 const useStyles = makeStyles(({ palette }) => ({
   coverPhoto: {
@@ -60,13 +64,23 @@ const useStyles = makeStyles(({ palette }) => ({
 const EditProfileForm = (props: FormikProps<ProfileValues>) => {
   const { handleSubmit, handleReset } = props
   const styles = useStyles()
+  const accountHandle = useSelector(getUserHandle)
+  const navigation = useNavigation()
+  const editStatus = useSelector((state) =>
+    getProfileEditStatus(state, accountHandle!)
+  )
+  useEffect(() => {
+    // Ensure we kick off the edit action before returning to profile screen
+    if (editStatus === Status.LOADING) {
+      navigation.goBack()
+    }
+  }, [editStatus, navigation])
 
   return (
     <FormScreen
       variant='secondary'
       onReset={handleReset}
       onSubmit={handleSubmit}
-      goBackOnSubmit
     >
       <FormImageInput
         name='cover_photo'

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -34,9 +34,9 @@ import { ProfileTabNavigator } from './ProfileTabNavigator'
 import { useSelectProfileRoot } from './selectors'
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { fetchProfile: fetchProfileAction } = profilePageActions
-const { getProfileStatus } = profilePageSelectors
+const { getProfileStatus, getProfileEditStatus } = profilePageSelectors
 const { getIsReachable } = reachabilitySelectors
-const getUserId = accountSelectors.getUserId
+const { getUserId } = accountSelectors
 
 const useStyles = makeStyles(({ spacing }) => ({
   navigator: {
@@ -76,10 +76,15 @@ export const ProfileScreen = () => {
   const { neutralLight4, accentOrange } = useThemeColors()
   const navigation = useNavigation<ProfileTabScreenParamList>()
   const isNotReachable = useSelector(getIsReachable) === false
+  const editStatus = useSelector((state) => getProfileEditStatus(state, handle))
 
   const fetchProfile = useCallback(() => {
-    dispatch(fetchProfileAction(handle, null, true, true, false))
-  }, [dispatch, handle])
+    // If we fetch when profile edit is being confirmed, we override
+    // optimistic writes
+    if (editStatus !== Status.LOADING) {
+      dispatch(fetchProfileAction(handle, null, true, true, false))
+    }
+  }, [dispatch, handle, editStatus])
 
   useFocusEffect(fetchProfile)
 

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -77,14 +77,14 @@ export const ProfileScreen = () => {
   const navigation = useNavigation<ProfileTabScreenParamList>()
   const isNotReachable = useSelector(getIsReachable) === false
   const editStatus = useSelector((state) => getProfileEditStatus(state, handle))
+  const isOwner = profile?.user_id === accountId
 
   const fetchProfile = useCallback(() => {
-    // If we fetch when profile edit is being confirmed, we override
-    // optimistic writes
-    if (editStatus !== Status.LOADING) {
-      dispatch(fetchProfileAction(handle, null, true, true, false))
-    }
-  }, [dispatch, handle, editStatus])
+    // When profile edited is being still confirmed, prevent fetch call so we
+    // don't override the optimistic profile metadata.
+    if (isOwner && editStatus === Status.LOADING) return
+    dispatch(fetchProfileAction(handle, null, true, true, false))
+  }, [dispatch, handle, isOwner, editStatus])
 
   useFocusEffect(fetchProfile)
 
@@ -120,8 +120,6 @@ export const ProfileScreen = () => {
       )
     }
   }, [profile, dispatch])
-
-  const isOwner = profile?.user_id === accountId
 
   const topbarLeft = isOwner ? (
     <View style={styles.topBarIcons}>

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -442,7 +442,6 @@ export function* updateProfileAsync(action) {
       }
     ])
   )
-  yield put(profileActions.updateProfileSucceeded(metadata.user_id))
 }
 
 function* confirmUpdateProfile(userId, metadata) {
@@ -507,6 +506,7 @@ function* confirmUpdateProfile(userId, metadata) {
             }
           ])
         )
+        yield put(profileActions.updateProfileSucceeded(metadata.user_id))
       },
       function* () {
         yield put(profileActions.updateProfileFailed())


### PR DESCRIPTION
### Description

Fixes edit-profile flow by adding a few improvements to profile state.
- Condenses three state variables, `updating`, `updateSuccess`, and `updateError` into an `updateStatus` variable that can be selected.
- Potentially improves the values of the various variables with the `updateProfile` `updateProfileSuccess` and updateProfileError` actions
- Moves `updateProfileSucceeded` to the onSuccess confirmer callback
- Updates profile screen to only fetch profile when we are not in "edit mode, ie waiting for edit confirmation, cause otherwise the values are overwritten

