### PR TITLE
[C-972] Fix go-to-definition for common/stems

### DIFF
--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -9,6 +9,7 @@
     "sourceMap": true,
     "allowJs": true,
     "declaration": true,
+    "declarationMap": true,
     "rootDirs": ["src"],
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/stems/tsconfig.json
+++ b/packages/stems/tsconfig.json
@@ -9,6 +9,7 @@
     "allowJs": false,
     "jsx": "react-jsx",
     "declaration": true,
+    "declarationMap": true,
     "moduleResolution": "node",
     "rootDirs": ["src"],
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
### Description

Fixes go-to-definition for built packages, leveraging a declarationMap ts feature, which proxies the d.ts file to the source code.
