### PR TITLE
[C-1200] Improve lineup and bottom-tab perf

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -186,7 +186,6 @@ export const Lineup = ({
 
   const handleInView = useCallback(() => {
     dispatch(actions.setInView(true))
-    return () => dispatch(actions.setInView(false))
   }, [dispatch, actions])
 
   useFocusEffect(handleInView)

--- a/packages/mobile/src/hooks/usePopToTopOnDrawerOpen.ts
+++ b/packages/mobile/src/hooks/usePopToTopOnDrawerOpen.ts
@@ -7,14 +7,14 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { usePrevious } from 'react-use'
 
 import type { AppTabScreenParamList } from 'app/screens/app-screen'
-import { AppTabNavigationContext } from 'app/screens/app-screen'
+import { SetAppTabNavigationContext } from 'app/screens/app-screen'
 
 type AppTabNavigation = NativeStackNavigationProp<AppTabScreenParamList>
 
 // Sets the navigation context so drawers can push onto current app-tab stack
 const useSetAppTabNavigationContext = () => {
   const navigation = useNavigation<AppTabNavigation>()
-  const { setNavigation } = useContext(AppTabNavigationContext)
+  const { setNavigation } = useContext(SetAppTabNavigationContext)
 
   const handleSetNavigation = useCallback(() => {
     setNavigation(navigation)

--- a/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
@@ -10,12 +10,19 @@ type AppTabNavigation = NativeStackNavigationProp<AppTabScreenParamList>
 
 type AppTabNavigationContextValue = {
   navigation: Nullable<AppTabNavigation>
-  setNavigation: (navigation: AppTabNavigation) => void
 }
 
 export const AppTabNavigationContext =
   createContext<AppTabNavigationContextValue>({
-    navigation: null,
+    navigation: null
+  })
+
+type SetAppTabNavigationContextValue = {
+  setNavigation: (navigation: AppTabNavigation) => void
+}
+
+export const SetAppTabNavigationContext =
+  createContext<SetAppTabNavigationContextValue>({
     setNavigation: () => {}
   })
 
@@ -27,14 +34,21 @@ export const AppTabNavigationProvider = (
   const { children } = props
   const [navigation, setNavigation] = useState<Nullable<AppTabNavigation>>(null)
 
-  const context = useMemo(
+  const navigationContext = useMemo(
     () => ({ navigation, setNavigation }),
     [navigation, setNavigation]
   )
 
+  const setNavigationContext = useMemo(
+    () => ({ setNavigation }),
+    [setNavigation]
+  )
+
   return (
-    <AppTabNavigationContext.Provider value={context}>
-      {children}
+    <AppTabNavigationContext.Provider value={navigationContext}>
+      <SetAppTabNavigationContext.Provider value={setNavigationContext}>
+        {children}
+      </SetAppTabNavigationContext.Provider>
     </AppTabNavigationContext.Provider>
   )
 }


### PR DESCRIPTION
### Description

- Improves all lineup perf by ensuring we don't trigger a full rerender on it when we are out of view. This significantly improves navigating to profile from feed.
- Improves bottom-tab-navigation by splitting up the reading of bottom-bar-navigation object, and setting of it. Having them together meant that each bottom bar would trigger a full rerender on the one that was being left, slowing that initial navigation.
