### PR TITLE
[C-1236] Ensures refresh spinner does not float over content

### DIFF
--- a/packages/mobile/src/components/core/FlatList.tsx
+++ b/packages/mobile/src/components/core/FlatList.tsx
@@ -83,6 +83,7 @@ const AnimatedFlatList = forwardRef<RNFlatList, FlatListProps>(
             onRefresh={handleRefresh}
             scrollAnim={scrollAnim}
             isRefreshDisabled={isRefreshDisabled}
+            yOffsetDisappearance={-16}
           />
         ) : null}
         <Animated.FlatList

--- a/packages/mobile/src/components/core/PullToRefresh.tsx
+++ b/packages/mobile/src/components/core/PullToRefresh.tsx
@@ -41,7 +41,7 @@ const interpolateTranslateY = (scrollAnim: Animated.Value) =>
 
 const interpolateHitTopOpacity = (scrollAnim: Animated.Value, scrollDistance) =>
   scrollAnim.interpolate({
-    inputRange: [-60, scrollDistance, scrollDistance + 20],
+    inputRange: [-60, scrollDistance, scrollDistance + 12],
     outputRange: [1, 1, 0],
     extrapolateRight: 'clamp'
   })

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -154,9 +154,8 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
     () => dispatch(enterBackground())
   )
 
-  const isAccountLoading = ![Status.IDLE, Status.LOADING].includes(
-    accountStatus
-  )
+  const isAccountLoading =
+    accountStatus === Status.IDLE || accountStatus === Status.LOADING
 
   return (
     <>


### PR DESCRIPTION
### Description

There was a 6 pixel overlap where spinner was sometimes visible over its content.
