### PR TITLE
[C-1254] Fix debounced navigation

### DIFF
--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -1,11 +1,10 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 // eslint-disable-next-line import/no-unresolved
 import type { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
 import type { ParamListBase } from '@react-navigation/native'
 import { useNavigation as useNavigationNative } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
-import { throttle } from 'lodash'
 
 import type { AppTabScreenParamList } from 'app/screens/app-screen/AppTabScreen'
 
@@ -27,35 +26,30 @@ export const useNavigation = <
     useNavigationNative<NativeStackNavigationProp<ParamList>>()
   const nativeNavigation = customNativeNavigation || defaultNativeNavigation
 
-  const performNavigation = useMemo(
-    () =>
-      throttle(
-        (method) =>
-          <RouteName extends keyof ParamList>(
-            ...config: UseNavigationConfig<ParamList, RouteName>
-          ) => {
-            const [screen, params] = config
-            method(screen, params)
-          },
-        1000,
-        { leading: true }
-      ),
+  const performNavigation = useCallback(
+    (method) =>
+      <RouteName extends keyof ParamList>(
+        ...config: UseNavigationConfig<ParamList, RouteName>
+      ) => {
+        const [screen, params] = config
+        method(screen, params)
+      },
     []
   )
 
   return useMemo(
     () => ({
       ...nativeNavigation,
-      navigate: performNavigation(nativeNavigation.navigate)!,
+      navigate: performNavigation(nativeNavigation.navigate),
       push:
         'push' in nativeNavigation
-          ? performNavigation!(nativeNavigation.push)!
+          ? performNavigation(nativeNavigation.push)
           : () => {
               console.error('Push is not implemented for this navigator')
             },
       replace:
         'replace' in nativeNavigation
-          ? performNavigation(nativeNavigation.replace)!
+          ? performNavigation(nativeNavigation.replace)
           : () => {
               console.error('Replace is not implemented for this navigator')
             },

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -1,11 +1,15 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 
 // eslint-disable-next-line import/no-unresolved
 import type { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
-import type { ParamListBase } from '@react-navigation/native'
-import { useNavigation as useNavigationNative } from '@react-navigation/native'
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import type {
+  ParamListBase,
+  StackNavigationState
+} from '@react-navigation/native'
+import { StackActions, CommonActions } from '@react-navigation/native'
+import { isEqual } from 'lodash'
 
+import { AppTabNavigationContext } from 'app/screens/app-screen'
 import type { AppTabScreenParamList } from 'app/screens/app-screen/AppTabScreen'
 
 export type ContextualParams = { fromNotifications?: boolean }
@@ -15,16 +19,21 @@ type UseNavigationConfig<
   RouteName extends keyof ParamList
 > = [screen: RouteName, params?: ParamList[RouteName] & ContextualParams]
 
+type UseNavigationOptions = {
+  customNativeNavigation?: DrawerNavigationHelpers
+}
+
 export const useNavigation = <
   ParamList extends ParamListBase = AppTabScreenParamList
->({
-  customNativeNavigation
-}: {
-  customNativeNavigation?: DrawerNavigationHelpers
-} = {}) => {
-  const defaultNativeNavigation =
-    useNavigationNative<NativeStackNavigationProp<ParamList>>()
-  const nativeNavigation = customNativeNavigation || defaultNativeNavigation
+>(
+  options?: UseNavigationOptions
+) => {
+  const { navigation: defaultNativeNavigation } = useContext(
+    AppTabNavigationContext
+  )
+
+  const nativeNavigation =
+    options?.customNativeNavigation || defaultNativeNavigation
 
   const performNavigation = useCallback(
     (method) =>
@@ -37,13 +46,36 @@ export const useNavigation = <
     []
   )
 
+  const performCustomPush = useCallback(
+    <RouteName extends keyof ParamList>(
+      ...config: UseNavigationConfig<ParamList, RouteName>
+    ) => {
+      const [screen, params] = config
+
+      const customPushAction = (state: StackNavigationState<ParamList>) => {
+        const lastRoute = state.routes[state.routes.length - 1]
+        if (
+          (screen as string) === lastRoute.name &&
+          isEqual(params, lastRoute.params)
+        ) {
+          // react-navigation considers this a no-op
+          return CommonActions.navigate(lastRoute)
+        }
+        return StackActions.push(screen as string, params)
+      }
+
+      nativeNavigation?.dispatch(customPushAction)
+    },
+    [nativeNavigation]
+  )
+
   return useMemo(
     () => ({
       ...nativeNavigation,
       navigate: performNavigation(nativeNavigation.navigate),
       push:
         'push' in nativeNavigation
-          ? performNavigation(nativeNavigation.push)
+          ? performCustomPush
           : () => {
               console.error('Push is not implemented for this navigator')
             },
@@ -58,6 +90,6 @@ export const useNavigation = <
       // is handled in `createStackScreen`
       goBack: nativeNavigation.goBack
     }),
-    [nativeNavigation, performNavigation]
+    [nativeNavigation, performNavigation, performCustomPush]
   )
 }

--- a/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
@@ -1,20 +1,19 @@
 import type { ReactNode } from 'react'
 import { useMemo, createContext, useState } from 'react'
 
-import type { Nullable } from '@audius/common'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 
 import type { AppTabScreenParamList } from './AppTabScreen'
 
-type AppTabNavigation = NativeStackNavigationProp<AppTabScreenParamList>
+export type AppTabNavigation = NativeStackNavigationProp<AppTabScreenParamList>
 
 type AppTabNavigationContextValue = {
-  navigation: Nullable<AppTabNavigation>
+  navigation: AppTabNavigation
 }
 
 export const AppTabNavigationContext =
   createContext<AppTabNavigationContextValue>({
-    navigation: null
+    navigation: {} as AppTabNavigation
   })
 
 type SetAppTabNavigationContextValue = {
@@ -32,7 +31,7 @@ export const AppTabNavigationProvider = (
   props: AppTabNavigationProviderProps
 ) => {
   const { children } = props
-  const [navigation, setNavigation] = useState<Nullable<AppTabNavigation>>(null)
+  const [navigation, setNavigation] = useState({} as AppTabNavigation)
 
   const navigationContext = useMemo(
     () => ({ navigation, setNavigation }),


### PR DESCRIPTION
### Description

Refactors debounced navigation solution with a custom push function.
Inspiration here: https://github.com/react-navigation/react-navigation/issues/3839#issuecomment-377159605
dispatch docs: https://reactnavigation.org/docs/navigation-prop/#dispatch

### Dragons
Instead of using the nearest navigator, we are defaulting to the AppStack Navigator, which should result in consistent behavior. Without this, when we were in a collapsible tab bar, we didn't have access to the previous route, so it wouldn't work.

