### PR TITLE
[C-1268] Fix height of remixes tile

### DIFF
--- a/packages/mobile/src/components/co-sign/CoSign.tsx
+++ b/packages/mobile/src/components/co-sign/CoSign.tsx
@@ -79,7 +79,7 @@ const CoSign = ({ size, children, style }: CoSignProps) => {
   const { size: iconSize, position } = layoutBySize[size]
 
   return (
-    <View style={[style, { flex: 1 }]}>
+    <View style={[{ flex: 1 }, style]}>
       <View>{children}</View>
       <View style={[styles.check, position]}>
         <IconCoSign fill={primary} fillSecondary={staticWhite} {...iconSize} />

--- a/packages/mobile/src/screens/track-screen/TrackScreenRemix.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenRemix.tsx
@@ -152,7 +152,13 @@ const TrackScreenRemixComponent = ({
   return (
     <View style={[styles.root, style, stylesProp?.root]}>
       <Pressable onPress={handlePressTrack}>
-        {_co_sign ? <CoSign size={Size.MEDIUM}>{images}</CoSign> : images}
+        {_co_sign ? (
+          <CoSign size={Size.MEDIUM} style={{ flex: 0 }}>
+            {images}
+          </CoSign>
+        ) : (
+          images
+        )}
       </Pressable>
       <Pressable style={styles.artist} onPress={handlePressArtist}>
         <View style={styles.name}>


### PR DESCRIPTION
### Description

* Fix styling of remixes tile on track screen by overriding `flex: 1` (which was added to position the cosign check icon on the track screen artwork)


![Simulator Screen Shot - iPhone 14 Pro - 2022-10-04 at 21 46 49](https://user-images.githubusercontent.com/19916043/193970158-ecb836af-8d0c-42e5-ad5d-aca98acbdeeb.png)
![Simulator Screen Shot - iPhone 14 Pro - 2022-10-04 at 21 47 16](https://user-images.githubusercontent.com/19916043/193970224-c8d08653-ee38-4768-b06b-c3b2a7ef5f1e.png)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*


### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

