### PR TITLE
[C-1166] Avoid only primary image

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -464,17 +464,15 @@ export const audiusBackend = ({
     const primary = creatorNodeGateways[0]
     const firstImageUrl = `${primary}${cid}`
 
-    if (disableImagePreload) {
-      return firstImageUrl
-    }
+    if (!disableImagePreload) {
+      if (primary) {
+        // Attempt to fetch/load the image using the first creator node gateway
+        const preloadedImageUrl = await preloadImage(firstImageUrl)
 
-    if (primary) {
-      // Attempt to fetch/load the image using the first creator node gateway
-      const preloadedImageUrl = await preloadImage(firstImageUrl)
-
-      // If the image is loaded, add to cache and return
-      if (preloadedImageUrl && cache) CIDCache.add(cid, preloadedImageUrl)
-      if (preloadedImageUrl) return preloadedImageUrl
+        // If the image is loaded, add to cache and return
+        if (preloadedImageUrl && cache) CIDCache.add(cid, preloadedImageUrl)
+        if (preloadedImageUrl) return preloadedImageUrl
+      }
     }
 
     await waitForLibsInit()

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -469,7 +469,6 @@ export const audiusBackend = ({
         try {
           const preloaded = await imagePreloader(firstImageUrl)
           if (preloaded) {
-            console.log('PRELOADED')
             return firstImageUrl
           }
         } catch (e) {

--- a/packages/mobile/src/services/audius-backend-instance.ts
+++ b/packages/mobile/src/services/audius-backend-instance.ts
@@ -1,6 +1,7 @@
 import { audiusBackend } from '@audius/common'
 import * as nativeLibs from '@audius/sdk/dist/native-libs'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Image } from 'react-native'
 import Config from 'react-native-config'
 import scrypt from 'react-native-scrypt'
 
@@ -132,5 +133,5 @@ export const audiusBackendInstance = audiusBackend({
   getLibs: async () => nativeLibs,
   waitForLibsInit,
   withEagerOption,
-  disableImagePreload: true
+  imagePreloader: (url: string) => Image.prefetch(url)
 })


### PR DESCRIPTION
### Description

The logic that handles fetching images from secondaries & legacy image formats is unfortunately split into two places:

Magic image component in native: https://github.com/AudiusProject/audius-client/blob/ee0b668b1165d7f980cf12b8fe59b8dfe5e77ece/packages/mobile/src/components/image/UserImage.tsx#L56

Libs: https://github.com/AudiusProject/audius-protocol/blob/6fdd8a88cb3d72da43743def17255c0fcc40edc7/libs/src/api/File.ts#L94

I think probably we want to move everything to magic image component in native, but this in the near-term makes all "Dynamic Images" work since the magic image thing in native isn't built to handle multiple sizes yet.

Curious for thoughts on this PR...!

At least this doesn't incur double fetch and we are doing some preloading!

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Simulator, prod 

![Simulator Screen Shot - iPhone 14 Pro - 2022-10-04 at 21 27 09](https://user-images.githubusercontent.com/2731362/193981666-b0220481-848c-4ad3-9990-b32fa2eec7d4.png)


*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

