### PR TITLE
[C-1205,C-1273] Improve splash screen animation, root screen management

### DIFF
--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -64,7 +64,7 @@ export const useNavigation = <
         return StackActions.push(screen as string, params)
       }
 
-      nativeNavigation?.dispatch(customPushAction)
+      nativeNavigation.dispatch(customPushAction)
     },
     [nativeNavigation]
   )

--- a/packages/mobile/src/screens/root-screen/HomeScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/HomeScreen.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react'
+
+import type { DrawerContentComponentProps } from '@react-navigation/drawer'
+import { createDrawerNavigator } from '@react-navigation/drawer'
+// eslint-disable-next-line import/no-unresolved
+import type { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
+import { useNavigation } from '@react-navigation/native'
+import { Dimensions } from 'react-native'
+
+import PushNotifications from 'app/notifications'
+import {
+  NotificationsScreen,
+  NotificationsDrawerNavigationContextProvider
+} from 'app/screens/notifications-screen'
+
+import { AppScreen } from '../app-screen'
+
+const SCREEN_WIDTH = Dimensions.get('window').width
+
+const Drawer = createDrawerNavigator()
+
+type AppTabScreenProps = {
+  navigation: DrawerNavigationHelpers
+}
+
+/**
+ * The app stack after signing up or signing in
+ */
+const AppStack = (props: AppTabScreenProps) => {
+  const { navigation: drawerHelpers } = props
+  const drawerNavigation = useNavigation()
+  return (
+    <NotificationsDrawerNavigationContextProvider
+      drawerNavigation={drawerNavigation}
+      drawerHelpers={drawerHelpers}
+    >
+      <AppScreen />
+    </NotificationsDrawerNavigationContextProvider>
+  )
+}
+
+type NotificationDrawerContentsProps = DrawerContentComponentProps & {
+  disableGestures: boolean
+  setDisableGestures: (disabled: boolean) => void
+}
+
+/**
+ * The content of the notifications drawer, which swipes in
+ */
+const NotificationDrawer = (props: NotificationDrawerContentsProps) => {
+  const {
+    navigation: drawerHelpers,
+    disableGestures,
+    setDisableGestures
+  } = props
+  const drawerNavigation = useNavigation()
+
+  useEffect(() => {
+    PushNotifications.setDrawerHelpers(drawerHelpers)
+  }, [drawerHelpers])
+
+  return (
+    <NotificationsDrawerNavigationContextProvider
+      drawerHelpers={drawerHelpers}
+      drawerNavigation={drawerNavigation}
+      gesturesDisabled={disableGestures}
+      setGesturesDisabled={setDisableGestures}
+    >
+      <NotificationsScreen />
+    </NotificationsDrawerNavigationContextProvider>
+  )
+}
+
+export const HomeScreen = () => {
+  const [disableGestures, setDisableGestures] = useState(false)
+
+  return (
+    <Drawer.Navigator
+      // legacy implementation uses reanimated-v1
+      useLegacyImplementation={true}
+      detachInactiveScreens={false}
+      screenOptions={{
+        drawerType: 'slide',
+        headerShown: false,
+        drawerStyle: {
+          width: '100%'
+        },
+        swipeEdgeWidth: SCREEN_WIDTH,
+        gestureHandlerProps: {
+          enabled: !disableGestures
+        }
+      }}
+      drawerContent={(props) => (
+        <NotificationDrawer
+          disableGestures={disableGestures}
+          setDisableGestures={setDisableGestures}
+          {...props}
+        />
+      )}
+    >
+      <Drawer.Screen name='App' component={AppStack} />
+    </Drawer.Navigator>
+  )
+}

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -1,31 +1,21 @@
 import { useEffect, useState } from 'react'
 
 import { accountSelectors, Status } from '@audius/common'
-import type { DrawerContentComponentProps } from '@react-navigation/drawer'
-import { createDrawerNavigator } from '@react-navigation/drawer'
-// eslint-disable-next-line import/no-unresolved
-import type { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
 import type { NavigatorScreenParams } from '@react-navigation/native'
-import { useNavigation } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
-import { Dimensions } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import useAppState from 'app/hooks/useAppState'
 import { useUpdateRequired } from 'app/hooks/useUpdateRequired'
-import PushNotifications from 'app/notifications'
 import type { AppScreenParamList } from 'app/screens/app-screen'
-import { AppScreen } from 'app/screens/app-screen'
-import {
-  NotificationsScreen,
-  NotificationsDrawerNavigationContextProvider
-} from 'app/screens/notifications-screen'
 import { SignOnScreen } from 'app/screens/signon'
 import { UpdateRequiredScreen } from 'app/screens/update-required-screen/UpdateRequiredScreen'
 import { enterBackground, enterForeground } from 'app/store/lifecycle/actions'
 
 import { SplashScreen } from '../splash-screen'
+
+import { HomeScreen } from './HomeScreen'
 
 const { getHasAccount, getAccountStatus } = accountSelectors
 
@@ -36,96 +26,7 @@ export type RootScreenParamList = {
   }>
 }
 
-const SCREEN_WIDTH = Dimensions.get('window').width
-
-const Drawer = createDrawerNavigator()
 const Stack = createNativeStackNavigator()
-
-/**
- * The sign up & sign in stack when not authenticated
- */
-const SignOnStack = () => {
-  return (
-    <Stack.Navigator
-      screenOptions={{ gestureEnabled: false, headerShown: false }}
-    >
-      <Stack.Screen name='SignOnStack' component={SignOnScreen} />
-    </Stack.Navigator>
-  )
-}
-
-/**
- * Update stack when the app is behind the minimum app version
- */
-const UpdateStack = () => {
-  return (
-    <Stack.Navigator
-      screenOptions={{ gestureEnabled: false, headerShown: false }}
-    >
-      <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
-    </Stack.Navigator>
-  )
-}
-
-type MainStackProps = {
-  navigation: DrawerNavigationHelpers
-}
-
-/**
- * The main stack after signing up or signing in
- */
-const MainStack = (props: MainStackProps) => {
-  const { navigation: drawerHelpers } = props
-  const drawerNavigation = useNavigation()
-  return (
-    <NotificationsDrawerNavigationContextProvider
-      drawerNavigation={drawerNavigation}
-      drawerHelpers={drawerHelpers}
-    >
-      <Stack.Navigator
-        screenOptions={{ gestureEnabled: false, headerShown: false }}
-      >
-        <Stack.Screen name='MainStack' component={AppScreen} />
-      </Stack.Navigator>
-    </NotificationsDrawerNavigationContextProvider>
-  )
-}
-
-type NotificationDrawerContentsProps = DrawerContentComponentProps & {
-  disableGestures: boolean
-  setDisableGestures: (disabled: boolean) => void
-}
-
-/**
- * The contents of the notifications drawer, which swipes in
- */
-const NotificationsDrawerContents = (
-  props: NotificationDrawerContentsProps
-) => {
-  const {
-    navigation: drawerHelpers,
-    disableGestures,
-    setDisableGestures,
-    state
-  } = props
-  const drawerNavigation = useNavigation()
-
-  useEffect(() => {
-    PushNotifications.setDrawerHelpers(drawerHelpers)
-  }, [drawerHelpers])
-
-  return (
-    <NotificationsDrawerNavigationContextProvider
-      drawerHelpers={drawerHelpers}
-      drawerNavigation={drawerNavigation}
-      gesturesDisabled={disableGestures}
-      setGesturesDisabled={setDisableGestures}
-      state={state}
-    >
-      <NotificationsScreen />
-    </NotificationsDrawerNavigationContextProvider>
-  )
-}
 
 type RootScreenProps = {
   isReadyToSetupBackend: boolean
@@ -139,7 +40,7 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
   const dispatch = useDispatch()
   const hasAccount = useSelector(getHasAccount)
   const accountStatus = useSelector(getAccountStatus)
-  const [disableGestures, setDisableGestures] = useState(false)
+  const [isInitting, setIsInittng] = useState(true)
   const { updateRequired } = useUpdateRequired()
 
   useEffect(() => {
@@ -154,41 +55,27 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
     () => dispatch(enterBackground())
   )
 
-  const isAccountLoading =
-    accountStatus === Status.IDLE || accountStatus === Status.LOADING
+  useEffect(() => {
+    if (accountStatus === Status.SUCCESS || accountStatus === Status.ERROR) {
+      setIsInittng(false)
+    }
+  }, [accountStatus])
 
   return (
     <>
       <SplashScreen />
-      {updateRequired ? <UpdateStack /> : null}
-      {isAccountLoading ? null : !hasAccount ? (
-        <SignOnStack />
-      ) : (
-        <Drawer.Navigator
-          // legacy implementation uses reanimated-v1
-          useLegacyImplementation={true}
-          detachInactiveScreens={false}
-          screenOptions={{
-            drawerType: 'slide',
-            headerShown: false,
-            drawerStyle: {
-              width: '100%'
-            },
-            swipeEdgeWidth: SCREEN_WIDTH,
-            gestureHandlerProps: {
-              enabled: !disableGestures
-            }
-          }}
-          drawerContent={(props) => (
-            <NotificationsDrawerContents
-              disableGestures={disableGestures}
-              setDisableGestures={setDisableGestures}
-              {...props}
-            />
-          )}
+      {isInitting && !hasAccount ? null : (
+        <Stack.Navigator
+          screenOptions={{ gestureEnabled: false, headerShown: false }}
         >
-          <Drawer.Screen name='App' component={MainStack} />
-        </Drawer.Navigator>
+          {updateRequired ? (
+            <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
+          ) : !hasAccount ? (
+            <Stack.Screen name='SignOnStack' component={SignOnScreen} />
+          ) : (
+            <Stack.Screen name='DrawerStack' component={HomeScreen} />
+          )}
+        </Stack.Navigator>
       )}
     </>
   )

--- a/packages/mobile/src/screens/splash-screen/SplashScreen.tsx
+++ b/packages/mobile/src/screens/splash-screen/SplashScreen.tsx
@@ -22,17 +22,25 @@ const styles = StyleSheet.create({
     bottom: 0,
     zIndex: 10,
     alignItems: 'center',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    opacity: 0.5
   }
 })
 
 export const SplashScreen = () => {
   const [animationFinished, setAnimationFinished] = useState(false)
   const accountStatus = useSelector(getAccountStatus)
+  const backgroundOpacityAnim = useRef(new Animated.Value(1))
 
   useEffect(() => {
     if (![Status.IDLE, Status.LOADING].includes(accountStatus)) {
       if (animationRef.current) {
+        Animated.timing(backgroundOpacityAnim.current, {
+          toValue: 0,
+          delay: 400,
+          duration: 300,
+          useNativeDriver: true
+        }).start()
         animationRef.current.play()
       }
     }
@@ -67,7 +75,8 @@ export const SplashScreen = () => {
     <Animated.View
       style={{
         ...styles.container,
-        transform: [{ scale: scaleAnim }]
+        transform: [{ scale: scaleAnim }],
+        opacity: backgroundOpacityAnim.current
       }}
     >
       <LottieView


### PR DESCRIPTION
### Description

After lots of testing, I believe the source of the white screen is due to the final frames of the splash being fully white, and lag associated with removing the Lottie animation from the view when animation is finished. When there is lag (due to so many things competing for main thread), the animation is paused in it's final frames, hence the white screen issue. To avoid this, I added an opacity animation that is delayed and quick on the back half of the animation, resulting in 0 opacity for the final frames of the lottie animation as it's being removed. It looks much better I think!

While experimenting with reducing the main thread churn as sign-in/feed is loading in (which could potentially improve speed at which the splash screen is removed from dom), I realized we could drastically improve animations from sign-in -> feed, and account-settings -> sign-out -> sign-in, by making a root stack that contains both of them, instead of conditional rendering outside nav flow. This flow is buttery smooth now, which is makes the app feel a lot more profesh, very stoked about this.

I also went ahead and cleaned up the RootScreen.tsx file and moved things to separate files as it was getting pretty overwhelming!
