### PR TITLE
[C-1185] Get user challenge polling daemon working in native

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -3206,7 +3206,7 @@ export const audiusBackend = ({
       address
     )
     if (!waudioBalance) {
-      console.error(`Failed to get waudio balance for address: ${address}`)
+      console.warn(`Failed to get waudio balance for address: ${address}`)
       return new BN('0')
     }
     return waudioBalance

--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -91,14 +91,14 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     alignItems: 'center'
   },
   tileHeader: {
-    fontFamiy: typography.fontByWeight.heavy,
+    fontFamily: typography.fontByWeight.heavy,
     fontSize: typography.fontSize.xxxxl,
     textTransform: 'uppercase',
     textAlign: 'center',
     marginBottom: 16
   },
   tileSubheader: {
-    fontFamiy: typography.fontByWeight.regular,
+    fontFamily: typography.fontByWeight.regular,
     fontSize: typography.fontSize.xs,
     lineHeight: spacing(5),
     textAlign: 'center'

--- a/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
+++ b/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import type {
   ChallengeRewardID,
@@ -13,6 +13,7 @@ import {
   audioRewardsPageSelectors,
   modalsActions
 } from '@audius/common'
+import { useFocusEffect } from '@react-navigation/native'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -86,10 +87,11 @@ export const ChallengeRewards = () => {
     }
   }, [userChallengesLoading, haveChallengesLoaded])
 
-  useEffect(() => {
-    // Refresh user challenges on load
-    dispatch(fetchUserChallenges())
-  }, [dispatch])
+  useFocusEffect(
+    useCallback(() => {
+      dispatch(fetchUserChallenges())
+    }, [dispatch])
+  )
 
   const openModal = (modalType: ChallengeRewardsModalType) => {
     dispatch(setChallengeRewardsModalType({ modalType }))

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -608,7 +608,6 @@ function* userChallengePollingDaemon() {
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
 
   const isNativeMobile = yield* getContext('isNativeMobile')
-  if (isNativeMobile) return
 
   yield* call(remoteConfigInstance.waitForRemoteConfig)
   const defaultChallengePollingTimeout = remoteConfigInstance.getRemoteVar(
@@ -620,9 +619,12 @@ function* userChallengePollingDaemon() {
     )!
 
   yield take(fetchAccountSucceeded.type)
-  yield fork(function* () {
-    yield* call(visibilityPollingDaemon, fetchUserChallenges())
-  })
+  if (!isNativeMobile) {
+    yield fork(function* () {
+      yield* call(visibilityPollingDaemon, fetchUserChallenges())
+    })
+  }
+
   yield* call(
     foregroundPollingDaemon,
     fetchUserChallenges(),


### PR DESCRIPTION
### Description

Polling daemon stuff is implemented using document event listeners.
Another solution here would be to supply the saga context with some sort of lifecycle hook, but that's somewhat of an involved change and think this is easier to at least make sure we have the same functionality!

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

1. Tested passive polling on interval behavior
2. Tested bringing app into foreground

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

