### PR TITLE
[C-1246] Fix smart collections

### DIFF
--- a/packages/common/src/store/pages/collection/actions.ts
+++ b/packages/common/src/store/pages/collection/actions.ts
@@ -1,4 +1,5 @@
 import { ID, SmartCollectionVariant, UID } from '../../../models'
+import { Nullable } from '../../../utils'
 
 export const FETCH_COLLECTION = 'FETCH_COLLECTION'
 export const FETCH_COLLECTION_SUCCEEDED = 'FETCH_COLLECTION_SUCCEEDED'
@@ -27,7 +28,10 @@ export const fetchCollectionFailed = (userUid: UID) => ({
   userUid
 })
 
-export const resetCollection = (collectionUid: UID, userUid: UID) => ({
+export const resetCollection = (
+  collectionUid: Nullable<UID>,
+  userUid: Nullable<UID>
+) => ({
   type: RESET_COLLECTION,
   collectionUid,
   userUid

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import type { Collection, User } from '@audius/common'
+import type { Collection, Nullable, User } from '@audius/common'
 import {
   removeNullable,
   FavoriteSource,
@@ -84,7 +84,7 @@ export const CollectionScreen = () => {
 
   const cachedCollection = useSelector((state) =>
     getCollection(state, { id })
-  ) as Collection
+  ) as Nullable<Collection>
 
   const cachedUser = useSelector((state) =>
     getUser(state, { id: cachedCollection?.playlist_owner_id })
@@ -94,9 +94,7 @@ export const CollectionScreen = () => {
   const user = cachedUser ?? searchCollection?.user
 
   if (!collection || !user) {
-    console.warn(
-      'Collection or user missing for CollectionScreen, preventing render'
-    )
+    // TODO: add collection-screen skeleton
     return null
   }
 

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import type { ID, UID } from '@audius/common'
+import type { ID, Maybe, UID } from '@audius/common'
 import {
   useProxySelector,
   collectionPageActions,
@@ -67,7 +67,7 @@ type CollectionScreenDetailsTileProps = {
 
 const getTracksLineup = makeGetTableMetadatas(getCollectionTracksLineup)
 
-const recordPlay = (id, play = true) => {
+const recordPlay = (id: Maybe<number>, play = true) => {
   track(
     make({
       eventName: play ? Name.PLAYBACK_PLAY : Name.PLAYBACK_PAUSE,
@@ -95,9 +95,7 @@ export const CollectionScreenDetailsTile = ({
   const numTracks = entries.length
 
   const resetCollectionLineup = useCallback(() => {
-    if (collectionUid && userUid) {
-      dispatch(resetCollection(collectionUid, userUid))
-    }
+    dispatch(resetCollection(collectionUid, userUid))
     dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch])


### PR DESCRIPTION
### Description

Basically the `resetCollection` action was incorrectly typed, requiring CID and userCID, but smart collections don't have CID. Updating type and updating useFocusEffect in collections-screen to call reset even if CID/userCID not there.

- Also updated the smart collection code to conform a bit more to our standards
- Removed the console.warn about missing user/collection for collection screen, since this is possible with normal behavior, we should add a skeleton eventually tho
