### PR TITLE
Remove track edit option from new dashboard table overflow menus

### DIFF
--- a/packages/web/src/components/test-table/components/OverflowMenuButton.tsx
+++ b/packages/web/src/components/test-table/components/OverflowMenuButton.tsx
@@ -13,6 +13,7 @@ type OverflowMenuButtonProps = {
   date?: any
   handle: string
   hiddenUntilHover?: boolean
+  includeEdit?: boolean
   index?: number
   isArtistPick?: boolean
   isDeleted?: boolean
@@ -33,6 +34,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
   const {
     className,
     date,
+    includeEdit = true,
     index,
     isFavorited,
     isOwnerDeactivated,
@@ -56,6 +58,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
     menu: {
       type: 'track' as MenuProps['menu']['type'],
       mount: 'page',
+      includeEdit,
       includeShare: true,
       ...props,
       extraMenuItems: onRemove ? [removeMenuItem] : []

--- a/packages/web/src/components/test-tracks-table/TestTracksTable.tsx
+++ b/packages/web/src/components/test-tracks-table/TestTracksTable.tsx
@@ -41,6 +41,7 @@ type TestTracksTableProps = {
   columns?: TracksTableColumn[]
   data: any[]
   defaultSorter?: (a: any, b: any) => number
+  disabledTrackEdit?: boolean
   fetchBatchSize?: number
   fetchMoreTracks?: (offset: number, limit: number) => void
   fetchPage?: (page: number) => void
@@ -91,6 +92,7 @@ export const TestTracksTable = ({
   columns = defaultColumns,
   data,
   defaultSorter,
+  disabledTrackEdit = false,
   isPaginated = false,
   isReorderable = false,
   fetchBatchSize,
@@ -307,6 +309,7 @@ export const TestTracksTable = ({
           <OverflowMenuButton
             className={styles.tableActionButton}
             isDeleted={deleted}
+            includeEdit={!disabledTrackEdit}
             onRemove={onClickRemove}
             removeText={removeText}
             handle={track.handle}
@@ -326,7 +329,7 @@ export const TestTracksTable = ({
         </div>
       )
     },
-    [onClickRemove, removeText, userId]
+    [disabledTrackEdit, onClickRemove, removeText, userId]
   )
 
   const renderTrackActions = useCallback(

--- a/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
+++ b/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.tsx
@@ -250,6 +250,7 @@ const TracksTableContainer = ({
         {isNewTablesEnabled && isNewArtistDashboardTableEnabled ? (
           <TestTracksTable
             data={filteredListedData}
+            disabledTrackEdit
             columns={tableColumns}
             onClickRow={onClickRow}
             onClickTrackName={onClickRow}
@@ -280,6 +281,7 @@ const TracksTableContainer = ({
         {isNewTablesEnabled && isNewArtistDashboardTableEnabled ? (
           <TestTracksTable
             data={filteredUnlistedData}
+            disabledTrackEdit
             columns={tableColumns}
             onClickRow={onClickRow}
             onClickTrackName={onClickRow}


### PR DESCRIPTION
### Description
Remove edit option so that things dont seem at broken

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

