### PR TITLE
[C-977] Add Screen change analytics

### DIFF
--- a/packages/mobile/src/components/core/Screen.tsx
+++ b/packages/mobile/src/components/core/Screen.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react'
-import { useLayoutEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 
 import type { Nullable } from '@audius/common'
 import { useNavigation } from '@react-navigation/native'
@@ -7,6 +7,7 @@ import { pickBy, negate, isUndefined } from 'lodash'
 import type { Animated, StyleProp, ViewStyle } from 'react-native'
 import { View } from 'react-native'
 
+import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 
 const removeUndefined = (object: Record<string, unknown>) =>
@@ -33,6 +34,8 @@ export type ScreenProps = {
   title?: Nullable<ReactNode>
   headerTitle?: ReactNode
   style?: StyleProp<ViewStyle>
+  // url used for screen view analytics
+  url?: string
   variant?: 'primary' | 'secondary' | 'white'
 }
 
@@ -45,11 +48,21 @@ export const Screen = (props: ScreenProps) => {
     headerTitle,
     topbarRightStyle,
     topbarLeftStyle,
+    url,
     variant = 'primary',
     style
   } = props
   const styles = useStyles({ variant })
   const navigation = useNavigation()
+
+  // Record screen view
+  useEffect(() => {
+    if (url) {
+      screen({
+        route: url
+      })
+    }
+  }, [url])
 
   useLayoutEffect(() => {
     navigation.setOptions(

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -171,7 +171,7 @@ const NavigationContainer = (props: NavigationContainerProps) => {
       onReady={() => {
         routeNameRef.current = getPrimaryRoute(navigationRef.getRootState())
       }}
-      onStateChange={async () => {
+      onStateChange={() => {
         // Record screen views for the primary routes
         // Secondary routes (e.g. Track, Collection, Profile) are recorded via
         // an effect in the corresponding component

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react'
 import { useRef } from 'react'
 
 import { accountSelectors } from '@audius/common'
-import type { LinkingOptions } from '@react-navigation/native'
 import {
   useNavigationContainerRef,
   getStateFromPath,
@@ -11,9 +10,8 @@ import {
 import { useSelector } from 'react-redux'
 
 import { AppTabNavigationProvider } from 'app/screens/app-screen'
-import type { RootScreenParamList } from 'app/screens/root-screen/RootScreen'
 import { screen } from 'app/services/analytics'
-import { getPrimaryRoute, getRoutePath } from 'app/utils/navigation'
+import { getPrimaryRoute } from 'app/utils/navigation'
 import { useThemeVariant } from 'app/utils/theme'
 
 import { navigationThemes } from './navigationThemes'
@@ -34,7 +32,7 @@ const NavigationContainer = (props: NavigationContainerProps) => {
   const navigationRef = useNavigationContainerRef()
   const routeNameRef = useRef<string>()
 
-  const linking: LinkingOptions<RootScreenParamList> = {
+  const linking = {
     prefixes: [
       'https://audius.co',
       'http://audius.co',
@@ -44,10 +42,9 @@ const NavigationContainer = (props: NavigationContainerProps) => {
     // configuration for matching screens with paths
     config: {
       screens: {
-        App: {
+        HomeStack: {
           screens: {
-            MainStack: {
-              initialRouteName: 'feed',
+            App: {
               screens: {
                 feed: {
                   initialRouteName: 'Feed',

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -288,7 +288,8 @@ export const Slider = memo(
     useEffect(() => {
       if (previousAppState === 'background' && appState === 'active') {
         const { currentTime } = global.progress
-        const percentComplete = currentTime / durationRef.current
+        const percentComplete =
+          durationRef.current === 0 ? 0 : currentTime / durationRef.current
         translationAnim.setValue(percentComplete * railWidth)
 
         setHandlePosition(percentComplete * railWidth)

--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -35,7 +35,6 @@ import {
   Tile
 } from 'app/components/core'
 import { Header } from 'app/components/header'
-import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -174,13 +173,6 @@ export const AudioScreen = () => {
   const { tierNumber } = getTierAndNumberForBalance(totalBalanceWei)
 
   const hasMultipleWallets = useSelector(getHasAssociatedWallets)
-
-  // Record screen view
-  useFocusEffect(() => {
-    screen({
-      route: `/audio`
-    })
-  })
 
   const onPressWalletInfo = useCallback(() => {
     dispatch(setVisibility({ modal: 'AudioBreakdown', visible: true }))
@@ -439,7 +431,7 @@ export const AudioScreen = () => {
   }
 
   return (
-    <Screen>
+    <Screen url='/audio'>
       <Header text={messages.title} />
       <ScrollView style={styles.tiles}>
         {renderAudioTile()}

--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -35,6 +35,7 @@ import {
   Tile
 } from 'app/components/core'
 import { Header } from 'app/components/header'
+import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -173,6 +174,13 @@ export const AudioScreen = () => {
   const { tierNumber } = getTierAndNumberForBalance(totalBalanceWei)
 
   const hasMultipleWallets = useSelector(getHasAssociatedWallets)
+
+  // Record screen view
+  useFocusEffect(() => {
+    screen({
+      route: `/audio`
+    })
+  })
 
   const onPressWalletInfo = useCallback(() => {
     dispatch(setVisibility({ modal: 'AudioBreakdown', visible: true }))

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import type { Collection, User } from '@audius/common'
 import {
+  encodeUrlName,
   removeNullable,
   FavoriteSource,
   RepostSource,
@@ -28,6 +29,7 @@ import { Screen, VirtualizedScrollView } from 'app/components/core'
 import { useCollectionCoverArt } from 'app/hooks/useCollectionCoverArt'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
+import { screen } from 'app/services/analytics'
 import type { SearchPlaylist, SearchUser } from 'app/store/search/types'
 import { makeStyles } from 'app/styles'
 
@@ -130,6 +132,15 @@ const CollectionScreenComponent = ({
     save_count,
     updated_at
   } = collection
+
+  // Record screen view
+  useEffect(() => {
+    screen({
+      route: `/${encodeUrlName(user.handle)}/${
+        is_album ? 'album' : 'playlist'
+      }/${encodeUrlName(playlist_name)}-${playlist_id}`
+    })
+  }, [user.handle, is_album, playlist_name, playlist_id])
 
   const imageUrl = useCollectionCoverArt({
     id: playlist_id,

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -133,13 +133,10 @@ const CollectionScreenComponent = ({
     updated_at
   } = collection
 
-  // Record screen view
-  useEffect(() => {
-    screen({
-      route: `/${encodeUrlName(user.handle)}/${
-        is_album ? 'album' : 'playlist'
-      }/${encodeUrlName(playlist_name)}-${playlist_id}`
-    })
+  const url = useMemo(() => {
+    return `/${encodeUrlName(user.handle)}/${
+      is_album ? 'album' : 'playlist'
+    }/${encodeUrlName(playlist_name)}-${playlist_id}`
   }, [user.handle, is_album, playlist_name, playlist_id])
 
   const imageUrl = useCollectionCoverArt({
@@ -222,7 +219,7 @@ const CollectionScreenComponent = ({
   }, [dispatch, playlist_id, navigation])
 
   return (
-    <Screen>
+    <Screen url={url}>
       <VirtualizedScrollView
         listKey={`playlist-${collection.playlist_id}`}
         style={styles.root}

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import type { Collection, User } from '@audius/common'
 import {
@@ -29,7 +29,6 @@ import { Screen, VirtualizedScrollView } from 'app/components/core'
 import { useCollectionCoverArt } from 'app/hooks/useCollectionCoverArt'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
-import { screen } from 'app/services/analytics'
 import type { SearchPlaylist, SearchUser } from 'app/store/search/types'
 import { makeStyles } from 'app/styles'
 

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -24,7 +24,6 @@ import { useNavigation } from 'app/hooks/useNavigation'
 import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
 import { useRoute } from 'app/hooks/useRoute'
 import { TopBarIconButton } from 'app/screens/app-screen'
-import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles/makeStyles'
 import { useThemeColors } from 'app/utils/theme'
 

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -7,7 +7,8 @@ import {
   profilePageSelectors,
   profilePageActions,
   reachabilitySelectors,
-  shareModalUIActions
+  shareModalUIActions,
+  encodeUrlName
 } from '@audius/common'
 import { PortalHost } from '@gorhom/portal'
 import { useFocusEffect } from '@react-navigation/native'
@@ -23,6 +24,7 @@ import { useNavigation } from 'app/hooks/useNavigation'
 import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
 import { useRoute } from 'app/hooks/useRoute'
 import { TopBarIconButton } from 'app/screens/app-screen'
+import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles/makeStyles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -103,6 +105,15 @@ export const ProfileScreen = () => {
       setIsRefreshing(false)
     }
   }, [status])
+
+  // Record screen view
+  useEffect(() => {
+    if (handle) {
+      screen({
+        route: `/${encodeUrlName(handle)}`
+      })
+    }
+  }, [handle])
 
   const handlePressSettings = useCallback(() => {
     navigation.push('SettingsScreen')

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -106,15 +106,6 @@ export const ProfileScreen = () => {
     }
   }, [status])
 
-  // Record screen view
-  useEffect(() => {
-    if (handle) {
-      screen({
-        route: `/${encodeUrlName(handle)}`
-      })
-    }
-  }, [handle])
-
   const handlePressSettings = useCallback(() => {
     navigation.push('SettingsScreen')
   }, [navigation])
@@ -168,7 +159,11 @@ export const ProfileScreen = () => {
   )
 
   return (
-    <Screen topbarLeft={topbarLeft} topbarRight={topbarRight}>
+    <Screen
+      topbarLeft={topbarLeft}
+      topbarRight={topbarRight}
+      url={handle && `/${encodeUrlName(handle)}`}
+    >
       {!profile ? (
         <ProfileScreenSkeleton />
       ) : (

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { accountSelectors, Status } from '@audius/common'
 import type { NavigatorScreenParams } from '@react-navigation/native'
+import { useNavigationState } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
 import { useDispatch, useSelector } from 'react-redux'
@@ -20,9 +21,8 @@ import { HomeScreen } from './HomeScreen'
 const { getHasAccount, getAccountStatus } = accountSelectors
 
 export type RootScreenParamList = {
-  signOn: undefined
-  App: NavigatorScreenParams<{
-    MainStack: NavigatorScreenParams<AppScreenParamList>
+  HomeStack: NavigatorScreenParams<{
+    App: NavigatorScreenParams<AppScreenParamList>
   }>
 }
 
@@ -42,6 +42,8 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
   const accountStatus = useSelector(getAccountStatus)
   const [isInitting, setIsInittng] = useState(true)
   const { updateRequired } = useUpdateRequired()
+  const navState = useNavigationState((x) => x)
+  console.log(navState)
 
   useEffect(() => {
     // Setup the backend when ready
@@ -73,7 +75,7 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
           ) : !hasAccount ? (
             <Stack.Screen name='SignOnStack' component={SignOnScreen} />
           ) : (
-            <Stack.Screen name='DrawerStack' component={HomeScreen} />
+            <Stack.Screen name='HomeStack' component={HomeScreen} />
           )}
         </Stack.Navigator>
       )}

--- a/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react'
 
-import { useFocusEffect } from '@react-navigation/native'
 import { Image, Platform } from 'react-native'
 
 import audiusLogoHorizontal from 'app/assets/images/Horizontal-Logo-Full-Color.png'
@@ -9,7 +8,6 @@ import Headphone from 'app/assets/images/emojis/headphone.png'
 import SpeechBalloon from 'app/assets/images/emojis/speech-balloon.png'
 import { Screen, ScrollView } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { Theme } from 'app/utils/theme'
 

--- a/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import { useFocusEffect } from '@react-navigation/native'
 import { Image, Platform } from 'react-native'
 
 import audiusLogoHorizontal from 'app/assets/images/Horizontal-Logo-Full-Color.png'
@@ -8,6 +9,7 @@ import Headphone from 'app/assets/images/emojis/headphone.png'
 import SpeechBalloon from 'app/assets/images/emojis/speech-balloon.png'
 import { Screen, ScrollView } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { Theme } from 'app/utils/theme'
 
@@ -43,6 +45,13 @@ export const SettingsScreen = () => {
   const styles = useStyles()
 
   const navigation = useNavigation<ProfileTabScreenParamList>()
+
+  // Record screen view
+  useFocusEffect(() => {
+    screen({
+      route: `/settings`
+    })
+  })
 
   const handlePressHistory = useCallback(() => {
     navigation.push('ListeningHistoryScreen')

--- a/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
@@ -46,13 +46,6 @@ export const SettingsScreen = () => {
 
   const navigation = useNavigation<ProfileTabScreenParamList>()
 
-  // Record screen view
-  useFocusEffect(() => {
-    screen({
-      route: `/settings`
-    })
-  })
-
   const handlePressHistory = useCallback(() => {
     navigation.push('ListeningHistoryScreen')
   }, [navigation])
@@ -66,7 +59,12 @@ export const SettingsScreen = () => {
   }, [navigation])
 
   return (
-    <Screen title={messages.title} topbarRight={null} variant='secondary'>
+    <Screen
+      title={messages.title}
+      topbarRight={null}
+      variant='secondary'
+      url='/settings'
+    >
       <ScrollView>
         <Image source={audiusLogoHorizontal} style={styles.logo} />
         <AccountSettingsRow />

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -38,7 +38,7 @@ import Button from 'app/components/button'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { remindUserToTurnOnNotifications } from 'app/components/notification-reminder/NotificationReminder'
 import useAppState from 'app/hooks/useAppState'
-import { track, make } from 'app/services/analytics'
+import { screen, track, make } from 'app/services/analytics'
 import { setVisibility } from 'app/store/drawers/slice'
 import { getIsKeyboardOpen } from 'app/store/keyboard/selectors'
 import { EventNames } from 'app/types/analytics'
@@ -365,6 +365,13 @@ const SignOn = ({ navigation }: SignOnProps) => {
       useNativeDriver: true
     }).start()
   }, [opacityCTA])
+
+  // Record screen view
+  useEffect(() => {
+    screen({
+      route: `/${isSignin ? 'signin' : 'signup'}`
+    })
+  }, [isSignin])
 
   useEffect(() => {
     setShowInvalidEmailError(attemptedEmail && !emailIsValid)

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 
 import {
   trackPageLineupActions,
@@ -15,7 +15,6 @@ import { Button, Screen } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
-import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 
 import { TrackScreenMainContent } from './TrackScreenMainContent'
@@ -78,13 +77,6 @@ export const TrackScreen = () => {
 
   useFocusEffect(handleFetchTrack)
 
-  // Record screen view
-  useEffect(() => {
-    if (track?.permalink) {
-      screen({ route: track?.permalink })
-    }
-  }, [track?.permalink])
-
   if (!track || !user) {
     console.warn(
       'Track, user, or lineup missing for TrackScreen, preventing render'
@@ -121,7 +113,7 @@ export const TrackScreen = () => {
   )
 
   return (
-    <Screen>
+    <Screen url={track?.permalink}>
       <Lineup
         actions={tracksActions}
         count={6}

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import {
   trackPageLineupActions,
@@ -15,6 +15,7 @@ import { Button, Screen } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
+import { screen } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 
 import { TrackScreenMainContent } from './TrackScreenMainContent'
@@ -76,6 +77,13 @@ export const TrackScreen = () => {
   }, [dispatch, canBeUnlisted, id, slug, handle, user?.handle])
 
   useFocusEffect(handleFetchTrack)
+
+  // Record screen view
+  useEffect(() => {
+    if (track?.permalink) {
+      screen({ route: track?.permalink })
+    }
+  }, [track?.permalink])
 
   if (!track || !user) {
     console.warn(

--- a/packages/mobile/src/utils/navigation.ts
+++ b/packages/mobile/src/utils/navigation.ts
@@ -12,3 +12,12 @@ export const getRoutePath = (state: NavigationState, routePath?: string[]) => {
   const { state: subState, name } = state.routes[state.index]
   return getRoutePath(subState as NavigationState, [...(routePath ?? []), name])
 }
+
+/**
+ * Navigation state selector that selects the primary route
+ * e.g. 'feed', 'trending', 'profile', etc
+ */
+export const getPrimaryRoute = (state: NavigationState) => {
+  // The route at index 2 is the primary route
+  return getRoutePath(state)?.[2]
+}


### PR DESCRIPTION
### Description

* Add analytics on screen change on mobile
* Primary routes are recorded via the NavigationContainer `onStateChange`
* Secondary routes are recorded via effects in the corresponding components
   This is necessary because in some cases the data needed to build the url is not available in the navigation state. Track screen for example records a url like this: `/KSHMRmusic/anywheres-home` but we only have track id available in the navigation state

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

