### PR TITLE
Fix userChallengePollingDaemon on web

### DIFF
--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -620,7 +620,7 @@ function* userChallengePollingDaemon() {
 
   yield take(fetchAccountSucceeded.type)
   if (!isNativeMobile) {
-    yield fork(function* () {
+    yield* fork(function* () {
       yield* call(visibilityPollingDaemon, fetchUserChallenges())
     })
   }


### PR DESCRIPTION
### Description

The visibility polling was blocking the execution of the method because we used `typed-redux-saga`s `fork()` but didn't `yield*` it, so the foreground poller never started.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested against stage locally

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

