### PR TITLE
[C-1278] Improve bottom-tab-bar performance

### DIFF
--- a/packages/mobile/index.js
+++ b/packages/mobile/index.js
@@ -1,6 +1,5 @@
 import 'react-native-gesture-handler'
 import { AppRegistry, LogBox } from 'react-native'
-import { enableFreeze } from 'react-native-screens'
 
 import { name as appName } from './app.json'
 
@@ -11,8 +10,6 @@ require('node-libs-react-native/globals')
 // Needed for @solana/web3.js to run correctly
 require('react-native-get-random-values')
 require('react-native-url-polyfill/auto')
-
-enableFreeze(true)
 
 const App = require('./src/App').default
 

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -138,7 +138,7 @@ export const useAppScreenOptions = (
           animation: isFromNotifs ? 'none' : 'default',
           gestureEnabled: !isFromNotifs,
           fullScreenGestureEnabled: true,
-          detachPreviousScreen: false,
+          freezeOnBlur: true,
           cardOverlayEnabled: true,
           cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
           headerShadowVisible: false,

--- a/packages/mobile/src/screens/root-screen/HomeScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/HomeScreen.tsx
@@ -78,7 +78,6 @@ export const HomeScreen = () => {
     <Drawer.Navigator
       // legacy implementation uses reanimated-v1
       useLegacyImplementation={true}
-      detachInactiveScreens={false}
       screenOptions={{
         drawerType: 'slide',
         headerShown: false,


### PR DESCRIPTION
### Description

Drastically improves bottom-bar performance by ensuring inactive tab-screens don't "freeze" https://github.com/software-mansion/react-freeze which requires a large remount when they become active again. This freeze behavior is great for stack-navs though since it prevents rerenders on deeply nested stacks. Luckily was able to remove the global freeze and still specify it for AppTab stacks
