### PR TITLE
[C-854, C-1244] Update table styles to always display actions menu

### DIFF
--- a/packages/web/src/components/test-collectibles-playlist-table/TestCollectiblesPlaylistTable.tsx
+++ b/packages/web/src/components/test-collectibles-playlist-table/TestCollectiblesPlaylistTable.tsx
@@ -18,6 +18,7 @@ export type CollectiblesPlaylistTableColumn =
   | 'collectibleName'
   | 'length'
   | 'playButton'
+  | 'spacer'
 
 type TestCollectiblesPlaylistTableProps = {
   columns?: CollectiblesPlaylistTableColumn[]
@@ -36,7 +37,8 @@ const defaultColumns: CollectiblesPlaylistTableColumn[] = [
   'playButton',
   'collectibleName',
   'chain',
-  'length'
+  'length',
+  'spacer'
 ]
 
 export const TestCollectiblesPlaylistTable = ({
@@ -144,6 +146,13 @@ export const TestCollectiblesPlaylistTable = ({
         maxWidth: 160,
         disableSortBy: true,
         align: 'left'
+      },
+      spacer: {
+        id: 'spacer',
+        maxWidth: 24,
+        minWidth: 24,
+        disableSortBy: true,
+        disableResizing: true
       }
     }),
     [

--- a/packages/web/src/components/test-table/TestTable.module.css
+++ b/packages/web/src/components/test-table/TestTable.module.css
@@ -12,6 +12,7 @@
   position: relative;
   overflow: hidden;
   width: 100%;
+  min-width: 0px !important;
   background-color: var(--white);
   padding-bottom: 5px;
 
@@ -32,6 +33,22 @@
 
 .tableHeadRow {
   position: relative;
+  min-width: 0px !important;
+}
+
+.cellSection {
+  flex: 1 1 0;
+  position: relative;
+  display: flex;
+  overflow: hidden;
+}
+
+.cellSectionEnd {
+  position: relative;
+  flex: 0 0 144px;
+}
+.cellSectionEnd.menu {
+  flex: 0 0 64px;
 }
 
 .tableHeader {
@@ -160,7 +177,7 @@
 
 .tableBody {
   display: block;
-  overflow: auto;
+  overflow: hidden;
   background-color: var(--neutral-light-9);
 }
 
@@ -168,6 +185,7 @@
   display: flex;
   position: relative;
   background: var(--white);
+  min-width: 0px !important;
   color: var(--neutral);
   font-size: 14px;
   font-weight: 600;

--- a/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.module.css
+++ b/packages/web/src/pages/artist-dashboard-page/ArtistDashboardPage.module.css
@@ -114,6 +114,7 @@
   transition: all 0.5s ease-in-out;
   margin: 0px;
   flex-grow: 1;
+  min-width: 0px;
 }
 
 .overflowContainer {

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -253,7 +253,7 @@ const CollectionPage = ({
   >(
     () =>
       isNftPlaylist
-        ? ['playButton', 'collectibleName', 'chain', 'length']
+        ? ['playButton', 'collectibleName', 'chain', 'length', 'spacer']
         : [
             'playButton',
             'trackName',


### PR DESCRIPTION
### Description
Update the new tables to check for overflow menus and put them in a special div to not allow them to overflow off the side

### Dragons

Semi-hacky styling changes here. Should not affect the table's normal look and feel, but just wanted to flag that

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

