### PR TITLE
[PAY-677] Prevent multiple recovery flow triggers

### DIFF
--- a/packages/common/src/store/ui/buy-audio/slice.ts
+++ b/packages/common/src/store/ui/buy-audio/slice.ts
@@ -60,12 +60,6 @@ const slice = createSlice({
   name: 'ui/buy-audio',
   initialState,
   reducers: {
-    setProvider: (
-      state,
-      action: PayloadAction<{ provider: OnRampProvider }>
-    ) => {
-      state.provider = action.payload.provider
-    },
     calculateAudioPurchaseInfo: (
       state,
       _action: PayloadAction<CalculateAudioPurchaseInfoPayload>
@@ -141,12 +135,14 @@ const slice = createSlice({
     },
     buyAudioFlowFailed: (state) => {
       state.error = true
+    },
+    startRecoveryIfNecessary: () => {
+      // Triggers saga
     }
   }
 })
 
 export const {
-  setProvider,
   calculateAudioPurchaseInfo,
   calculateAudioPurchaseInfoSucceeded,
   calculateAudioPurchaseInfoFailed,
@@ -160,7 +156,8 @@ export const {
   swapStarted,
   swapCompleted,
   transferStarted,
-  transferCompleted
+  transferCompleted,
+  startRecoveryIfNecessary
 } = slice.actions
 
 export default slice.reducer

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -1081,6 +1081,10 @@ function* watchStartBuyAudioFlow() {
 }
 
 function* watchRecovery() {
+  // Use takeLeading since:
+  // 1) We don't want to run more than one recovery flow at a time (so not takeEvery)
+  // 2) We don't need to interrupt if already running (so not takeLatest)
+  // 3) We do want to be able to trigger more than one time per session in case of same-session failures (so not take)
   yield takeLeading(startRecoveryIfNecessary, recoverPurchaseIfNecessary)
 }
 


### PR DESCRIPTION
### Description

- Remove unused setProvider action
- Add action to trigger recovery flow, use `takeLeading` to process the first action

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

It hasn't yet

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

