### PR TITLE
[C-1284] Fix entropy sync for versions other than 1.1.29

### DIFF
--- a/packages/mobile/src/components/web-app-account-sync/WebAppAccountSync.tsx
+++ b/packages/mobile/src/components/web-app-account-sync/WebAppAccountSync.tsx
@@ -1,4 +1,5 @@
 import { getErrorMessage } from '@audius/common'
+import { CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY } from '@audius/sdk/dist/core'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { NativeSyntheticEvent } from 'react-native'
 import { Platform, View } from 'react-native'
@@ -66,6 +67,10 @@ export const WebAppAccountSync = (props: WebAppAccountSyncProps) => {
         const { entropy } = JSON.parse(event.nativeEvent.data)
         if (entropy) {
           await AsyncStorage.setItem(ENTROPY_KEY, entropy)
+          await AsyncStorage.setItem(
+            CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY,
+            'true'
+          )
         }
         // Once the check for entropy is complete
         // the backend setup can begin


### PR DESCRIPTION
### Description

* The account status was being set to ERROR because the account wasn't found in local storage and currentUserExists was also not in local storage https://github.com/AudiusProject/audius-client/blob/main/packages/web/src/common/store/account/sagas.js#L210
* Setting `CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY` to true when the entropy is synced fixes this issue

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?


| Release branch | Apple Store Version | |
|-----------------|--------------------|---|
| 1.3.3                   | 1.1.30                         | doesn't have native sagas, the entropy sync failed |
| 1.3.2                   | 1.1.29                         | has native sagas, the entropy sync worked |



Tested by confirming the bug when updating from 1.3.3 to main. Then applied fix and tested the update from 1.3.3 to main again, this time I was successfully signed in as soon as the app loaded

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

