### PR TITLE
Fix password input clipping on mobile sign in/up C-1234

### DIFF
--- a/packages/mobile/src/screens/signon/CreatePassword.tsx
+++ b/packages/mobile/src/screens/signon/CreatePassword.tsx
@@ -80,8 +80,9 @@ const styles = StyleSheet.create({
     borderColor: defaultBorderColor,
     backgroundColor: '#FCFCFC',
     borderRadius: 4,
-    padding: 10,
     color: '#858199',
+    textAlignVertical: 'center',
+    justifyContent: 'center',
     fontFamily: 'AvenirNextLTPro-DemiBold',
     fontSize: 16
   },

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -166,8 +166,9 @@ const styles = StyleSheet.create({
     borderColor: defaultBorderColor,
     backgroundColor: '#FCFCFC',
     borderRadius: 4,
+    textAlignVertical: 'center',
+    justifyContent: 'center',
     marginTop: 16,
-    padding: 10,
     color: '#858199',
     fontFamily: 'AvenirNextLTPro-DemiBold',
     fontSize: 16


### PR DESCRIPTION
### Description
The bold Avenir LT Pro font isn't compatible with the text input for whatever reason (confirmed this by simply getting rid of the font family and everything worked as expected). In this gif you can see that the second character and on are still lower than the first character. But I at least could get rid of the clipping by getting rid of the vertical padding.

![clippy](https://user-images.githubusercontent.com/36916764/194437916-2411eb33-26e3-4087-8496-31b0e2dcf863.gif)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

