### PR TITLE
[PAY-679] Stop BuyAudio flow when user cancels the onramp

### DIFF
--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -554,7 +554,7 @@ function* purchaseStep({
   // If the user didn't complete the on ramp flow, return early
   if (result.canceled) {
     yield* put(make(Name.BUY_AUDIO_ON_RAMP_CANCELED, { provider }))
-    return
+    return {}
   }
   yield* put(make(Name.BUY_AUDIO_ON_RAMP_SUCCESS, { provider }))
 
@@ -854,6 +854,11 @@ function* doBuyAudio({
       retryDelayMs,
       maxRetryCount
     }) as unknown as ReturnType<typeof purchaseStep>)!
+
+    // If the user canceled the purchase, stop the flow
+    if (newBalance === undefined) {
+      return
+    }
 
     // Get dummy quote to calculate fees and get exchange amount
     const quote = yield* call(JupiterSingleton.getQuote, {


### PR DESCRIPTION
### Description

Stop the BuyAudio flow when the user cancels the third-party onramp

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

