### PR TITLE
BuyAudio: Fix for if wallet has no transactions

### DIFF
--- a/packages/web/src/services/audius-backend/BuyAudio.ts
+++ b/packages/web/src/services/audius-backend/BuyAudio.ts
@@ -224,9 +224,6 @@ export const pollForNewTransaction = async ({
     limit: 1
   })
   let transaction = transactions?.[0]?.signature
-  if (initialTransaction === undefined) {
-    initialTransaction = transaction
-  }
   let retries = 0
   while (transaction === initialTransaction && retries++ < maxRetryCount) {
     console.debug(


### PR DESCRIPTION
### Description

If the wallet initially has no transactions, this code would set the initial transaction to the first transaction after the polling starts, which is already the purchase transaction in stripe's case, so the polling would timeout.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

