### PR TITLE
[C-1316] Fix getState undefined crash when opening reopening app on android

### DIFF
--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -19,6 +19,7 @@ import {
   shareModalUIActions,
   RepostType
 } from '@audius/common'
+import { useNavigationState } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import type { LineupItemProps } from 'app/components/lineup-tile/types'
@@ -66,6 +67,7 @@ const TrackTileComponent = ({
 }: TrackTileProps) => {
   const dispatch = useDispatch()
   const navigation = useNavigation()
+  const currentScreen = useNavigationState((state) => state.history?.[0])
   const playingUid = useSelector(getUid)
   const isPlayingUid = playingUid === lineupTileProps.uid
 
@@ -81,7 +83,6 @@ const TrackTileComponent = ({
     track_id
   } = track
 
-  const currentScreen = navigation.getState().history?.[0]
   // @ts-expect-error -- history returning unknown[]
   const isOnArtistsTracksTab = currentScreen?.key.includes('Tracks')
 


### PR DESCRIPTION
### Description

`navigation.getState` is not defined for a brief period when reopening the app on android. Opted to use `useNavigationState` instead for safety

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

