### PR TITLE
[C-1309] Fix playlists/collectibles not loading

### DIFF
--- a/packages/common/src/store/pages/profile/selectors.ts
+++ b/packages/common/src/store/pages/profile/selectors.ts
@@ -12,7 +12,7 @@ import { initialState as initialTracksState } from './lineups/tracks/reducer'
 import { CollectionSortMode } from './types'
 
 const getProfile = (state: CommonState, handle?: string) => {
-  const profileHandle = handle ?? state.pages.profile.currentUser
+  const profileHandle = handle?.toLowerCase() ?? state.pages.profile.currentUser
   if (!profileHandle) return null
   return state.pages.profile.entries[profileHandle]
 }


### PR DESCRIPTION
### Description

Fixes issue where users with captials in their handle mess up with some of our selectors. By updating our profile selectors to always `toLowerCase`, this fixes any other issues.


I may remove some cases where we are manually `toLowerCase`ing things in the client, but this ultimately should fix things

### Dragons
Looking at clayton's account, his collectibles only have one entry. is this expected?
