### PR TITLE
Add structured data and update head

### DIFF
--- a/packages/web/src/components/mobile-page-container/MobilePageContainer.tsx
+++ b/packages/web/src/components/mobile-page-container/MobilePageContainer.tsx
@@ -23,6 +23,7 @@ type OwnProps = {
   title?: string
   description?: string | null
   canonicalUrl?: string
+  structuredData?: Object | null
 
   children: ReactNode
 
@@ -58,6 +59,7 @@ const MobilePageContainer = ({
   title,
   description,
   canonicalUrl,
+  structuredData,
   children,
   backgroundClassName,
   containerClassName,
@@ -106,7 +108,7 @@ const MobilePageContainer = ({
 
   return (
     <>
-      <Helmet>
+      <Helmet encodeSpecialCharacters={false}>
         {title ? (
           <title>{`${title} ${messages.dotAudius}`}</title>
         ) : (
@@ -114,6 +116,11 @@ const MobilePageContainer = ({
         )}
         {description && <meta name='description' content={description} />}
         {canonicalUrl && <link rel='canonical' href={canonicalUrl} />}
+        {structuredData && (
+          <script type='application/ld+json'>
+            {JSON.stringify(structuredData)}
+          </script>
+        )}
       </Helmet>
       <div
         className={cn(styles.container, {

--- a/packages/web/src/components/page/Page.js
+++ b/packages/web/src/components/page/Page.js
@@ -109,7 +109,7 @@ export const Page = (props) => {
             [props.containerClassName]: !!props.containerClassName
           })}
         >
-          <Helmet>
+          <Helmet encodeSpecialCharacters={false}>
             {props.title ? (
               <title>{`${props.title} ${messages.dotAudius}`}</title>
             ) : (
@@ -120,6 +120,11 @@ export const Page = (props) => {
             ) : null}
             {props.canonicalUrl && (
               <link rel='canonical' href={props.canonicalUrl} />
+            )}
+            {props.structuredData && (
+              <script type='application/ld+json'>
+                {JSON.stringify(props.structuredData)}
+              </script>
             )}
           </Helmet>
           {props.header && (
@@ -167,6 +172,7 @@ Page.propTypes = {
   title: PropTypes.string,
   description: PropTypes.string,
   canonicalUrl: PropTypes.string,
+  structuredData: PropTypes.object,
   variant: PropTypes.oneOf(['inset', 'flush']),
   size: PropTypes.oneOf(['medium', 'large']),
   containerRef: PropTypes.node,

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -65,12 +65,12 @@ import {
   NOT_FOUND_PAGE,
   REPOSTING_USERS_ROUTE,
   FAVORITING_USERS_ROUTE,
-  fullPlaylistPage,
   playlistPage,
   albumPage,
   getPathname
 } from 'utils/route'
 import { parseCollectionRoute } from 'utils/route/collectionRouteParser'
+import { getCollectionPageSEOFields } from 'utils/seo'
 
 import { CollectionPageProps as DesktopCollectionPageProps } from './components/desktop/CollectionPage'
 import { CollectionPageProps as MobileCollectionPageProps } from './components/mobile/CollectionPage'
@@ -720,21 +720,24 @@ class CollectionPage extends Component<
 
     const { playlistId, allowReordering } = this.state
 
-    const title = metadata?.playlist_name ?? ''
-    const description = metadata?.description ?? ''
-    const canonicalUrl =
-      user && metadata
-        ? fullPlaylistPage(
-            user?.handle,
-            metadata?.playlist_name,
-            metadata?.playlist_id
-          )
-        : ''
+    const {
+      title = '',
+      description = '',
+      canonicalUrl = '',
+      structuredData
+    } = getCollectionPageSEOFields({
+      playlistName: metadata?.playlist_name,
+      playlistId: metadata?.playlist_id,
+      userName: user?.name,
+      userHandle: user?.handle,
+      isAlbum: metadata?.is_album
+    })
 
     const childProps = {
       title,
       description,
       canonicalUrl,
+      structuredData,
       playlistId: playlistId!,
       allowReordering,
       playing,
@@ -779,6 +782,7 @@ class CollectionPage extends Component<
           title={title}
           description={description}
           canonicalUrl={canonicalUrl}
+          structuredData={structuredData}
           playable={{
             metadata,
             type: metadata?.is_album

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -55,6 +55,7 @@ export type CollectionPageProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: Object
   playlistId: ID
   playing: boolean
   getPlayingUid: () => string | null
@@ -108,6 +109,7 @@ const CollectionPage = ({
   title,
   description: pageDescription,
   canonicalUrl,
+  structuredData,
   playlistId,
   allowReordering,
   playing,
@@ -271,6 +273,7 @@ const CollectionPage = ({
       title={title}
       description={pageDescription}
       canonicalUrl={canonicalUrl}
+      structuredData={structuredData}
       containerClassName={styles.pageContainer}
       scrollableSearch
     >

--- a/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
@@ -48,6 +48,7 @@ export type CollectionPageProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: Object
   playlistId: ID | SmartCollectionVariant
   playing: boolean
   getPlayingUid: () => string | null
@@ -84,6 +85,7 @@ const CollectionPage = ({
   title,
   description: pageDescription,
   canonicalUrl,
+  structuredData,
   playlistId,
   getPlayingUid,
   playing,
@@ -226,6 +228,7 @@ const CollectionPage = ({
         title={title}
         description={pageDescription}
         canonicalUrl={canonicalUrl}
+        structuredData={structuredData}
       >
         <div className={styles.collectionContent}>
           <div>

--- a/packages/web/src/pages/deleted-page/DeletedPage.tsx
+++ b/packages/web/src/pages/deleted-page/DeletedPage.tsx
@@ -10,6 +10,7 @@ type DeletedPageContentProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: Object
   playable: Playable
   user: User
   deletedByArtist?: boolean
@@ -19,6 +20,7 @@ const DeletedPage = ({
   title,
   description,
   canonicalUrl,
+  structuredData,
   playable,
   user,
   deletedByArtist = true
@@ -34,6 +36,7 @@ const DeletedPage = ({
       title={title}
       description={description}
       canonicalUrl={canonicalUrl}
+      structuredData={structuredData}
       playable={playable}
       user={user}
       deletedByArtist={deletedByArtist}

--- a/packages/web/src/pages/deleted-page/DeletedPageProvider.tsx
+++ b/packages/web/src/pages/deleted-page/DeletedPageProvider.tsx
@@ -28,6 +28,7 @@ type OwnProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: Object
   user: User
   playable: Playable
   deletedByArtist: boolean

--- a/packages/web/src/pages/deleted-page/components/desktop/DeletedPage.tsx
+++ b/packages/web/src/pages/deleted-page/components/desktop/DeletedPage.tsx
@@ -66,6 +66,7 @@ export type DeletedPageProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: Object
   deletedByArtist: boolean
 
   playable: Playable
@@ -85,6 +86,7 @@ const DeletedPage = g(
     title,
     description,
     canonicalUrl,
+    structuredData,
     playable,
     user,
     deletedByArtist = true,
@@ -172,6 +174,7 @@ const DeletedPage = g(
         title={title}
         description={description}
         canonicalUrl={canonicalUrl}
+        structuredData={structuredData}
         variant='flush'
         scrollableSearch
       >

--- a/packages/web/src/pages/deleted-page/components/mobile/DeletedPage.tsx
+++ b/packages/web/src/pages/deleted-page/components/mobile/DeletedPage.tsx
@@ -82,6 +82,7 @@ const DeletedPage = g(
     title,
     description,
     canonicalUrl,
+    structuredData,
     playable,
     deletedByArtist = true,
     user,
@@ -165,6 +166,7 @@ const DeletedPage = g(
         title={title}
         description={description}
         canonicalUrl={canonicalUrl}
+        structuredData={structuredData}
       >
         <div className={styles.contentWrapper}>
           {renderTile()}

--- a/packages/web/src/pages/deleted-page/components/mobile/DeletedPage.tsx
+++ b/packages/web/src/pages/deleted-page/components/mobile/DeletedPage.tsx
@@ -63,6 +63,7 @@ export type DeletedPageProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: Object
   deletedByArtist: boolean
 
   playable: Playable

--- a/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
+++ b/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
@@ -12,6 +12,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom'
 import { Dispatch } from 'redux'
 
 import { AppState } from 'store/types'
+import { createSeoDescription } from 'utils/seo'
 
 import { ExplorePageProps as DesktopExplorePageProps } from './components/desktop/ExplorePage'
 import { ExplorePageProps as MobileExplorePageProps } from './components/mobile/ExplorePage'
@@ -22,8 +23,7 @@ const getAccountUser = accountSelectors.getAccountUser
 const messages = {
   title: 'Explore',
   pageTitle: 'Explore featured content on Audius',
-  description:
-    'Explore featured content on Audius | Stream tracks, albums, playlists on desktop and mobile'
+  description: createSeoDescription('Explore featured content on Audius')
 }
 
 type OwnProps = {

--- a/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
+++ b/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
@@ -21,7 +21,9 @@ const getAccountUser = accountSelectors.getAccountUser
 
 const messages = {
   title: 'Explore',
-  description: 'Explore featured content on Audius'
+  pageTitle: 'Explore featured content on Audius',
+  description:
+    'Explore featured content on Audius | Stream tracks, albums, playlists on desktop and mobile'
 }
 
 type OwnProps = {
@@ -59,6 +61,7 @@ const ExplorePage = ({
 
   const childProps = {
     title: messages.title,
+    pageRitle: messages.pageTitle,
     description: messages.description,
     // Props from AppState
     account,

--- a/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
+++ b/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
@@ -61,7 +61,7 @@ const ExplorePage = ({
 
   const childProps = {
     title: messages.title,
-    pageRitle: messages.pageTitle,
+    pageTitle: messages.pageTitle,
     description: messages.description,
     // Props from AppState
     account,

--- a/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/ExplorePage.tsx
@@ -78,6 +78,7 @@ const lifestyle = [
 
 export type ExplorePageProps = {
   title: string
+  pageTitle: string
   description: string
   playlists: UserCollection[]
   profiles: User[]
@@ -87,6 +88,7 @@ export type ExplorePageProps = {
 
 const ExplorePage = ({
   title,
+  pageTitle,
   description,
   playlists,
   profiles,
@@ -115,7 +117,7 @@ const ExplorePage = ({
 
   return (
     <Page
-      title={title}
+      title={pageTitle}
       description={description}
       canonicalUrl={`${BASE_URL}${EXPLORE_PAGE}`}
       contentClassName={styles.page}

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
@@ -115,6 +115,7 @@ const tabHeaders = [
 
 export type ExplorePageProps = {
   title: string
+  pageTitle: string
   description: string
   playlists: UserCollection[]
   profiles: User[]
@@ -125,7 +126,7 @@ export type ExplorePageProps = {
 }
 
 const ExplorePage = ({
-  title,
+  pageTitle,
   description,
   playlists,
   profiles,
@@ -313,7 +314,7 @@ const ExplorePage = ({
 
   return (
     <MobilePageContainer
-      title={title}
+      title={pageTitle}
       description={description}
       canonicalUrl={`${BASE_URL}${EXPLORE_PAGE}`}
     >

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -41,11 +41,11 @@ import {
   albumPage,
   playlistPage,
   profilePage,
-  fullProfilePage,
   UPLOAD_PAGE,
   UPLOAD_ALBUM_PAGE,
   UPLOAD_PLAYLIST_PAGE
 } from 'utils/route'
+import { getUserPageSEOFields } from 'utils/seo'
 
 import { DeactivatedProfileTombstone } from '../DeactivatedProfileTombstone'
 
@@ -635,12 +635,18 @@ const ProfilePage = ({
     initialTab: activeTab || undefined,
     elements
   })
-
+  const {
+    title = '',
+    description = '',
+    canonicalUrl = '',
+    structuredData
+  } = getUserPageSEOFields({ handle, userName: name, bio })
   return (
     <Page
-      title={name && handle ? `${name} (${handle})` : ''}
-      description={bio}
-      canonicalUrl={fullProfilePage(handle)}
+      title={title}
+      description={description}
+      canonicalUrl={canonicalUrl}
+      structuredData={structuredData}
       variant='flush'
       contentClassName={styles.profilePageWrapper}
       scrollableSearch

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -40,7 +40,8 @@ import TierExplainerDrawer from 'components/user-badges/TierExplainerDrawer'
 import useAsyncPoll from 'hooks/useAsyncPoll'
 import useTabs from 'hooks/useTabs/useTabs'
 import { MIN_COLLECTIBLES_TIER } from 'pages/profile-page/ProfilePageProvider'
-import { albumPage, playlistPage, fullProfilePage } from 'utils/route'
+import { albumPage, playlistPage } from 'utils/route'
+import { getUserPageSEOFields } from 'utils/seo'
 import { withNullGuard } from 'utils/withNullGuard'
 
 import { DeactivatedProfileTombstone } from '../DeactivatedProfileTombstone'
@@ -615,6 +616,12 @@ const ProfilePage = g(
       variable: status,
       value: Status.SUCCESS
     })
+    const {
+      title = '',
+      description = '',
+      canonicalUrl = '',
+      structuredData
+    } = getUserPageSEOFields({ handle, userName: name, bio })
 
     return (
       <>
@@ -623,9 +630,10 @@ const ProfilePage = g(
           onDidRegainConnectivity={asyncRefresh}
         >
           <MobilePageContainer
-            title={name && handle ? `${name} (${handle})` : ''}
-            description={bio}
-            canonicalUrl={fullProfilePage(handle)}
+            title={title}
+            description={description}
+            canonicalUrl={canonicalUrl}
+            structuredData={structuredData}
             containerClassName={styles.container}
           >
             <PullToRefresh

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -14,8 +14,6 @@ import {
   Status,
   Track,
   Uid,
-  getCanonicalName,
-  formatSeconds,
   formatDate,
   accountSelectors,
   cacheTracksActions as cacheTrackActions,
@@ -61,11 +59,10 @@ import {
   FEED_PAGE,
   FAVORITING_USERS_ROUTE,
   REPOSTING_USERS_ROUTE,
-  fullTrackPage,
   trackRemixesPage
 } from 'utils/route'
 import { parseTrackRoute, TrackRouteParams } from 'utils/route/trackRouteParser'
-import { getTrackPageTitle, getTrackPageDescription } from 'utils/seo'
+import { getTrackPageSEOFields } from 'utils/seo'
 
 import StemsSEOHint from './components/StemsSEOHint'
 import { OwnProps as DesktopTrackPageProps } from './components/desktop/TrackPage'
@@ -415,22 +412,18 @@ class TrackPageProvider extends Component<
       onClickReposts: this.onClickReposts,
       onClickFavorites: this.onClickFavorites
     }
-
-    const title = getTrackPageTitle({
-      title: track ? track.title : '',
-      handle: user ? user.handle : ''
-    })
-
     const releaseDate = track ? track.release_date || track.created_at : ''
-    const description = getTrackPageDescription({
-      releaseDate: releaseDate ? formatDate(releaseDate) : '',
-      description: track?.description ?? '',
-      mood: track?.mood ?? '',
-      genre: track ? getCanonicalName(track.genre) : '',
-      duration: track ? formatSeconds(track.duration) : '',
-      tags: track ? (track.tags || '').split(',').filter(Boolean) : []
+    const {
+      title = '',
+      description = '',
+      canonicalUrl = '',
+      structuredData
+    } = getTrackPageSEOFields({
+      title: track?.title,
+      permalink: track?.permalink,
+      userName: user?.name,
+      releaseDate: releaseDate ? formatDate(releaseDate) : ''
     })
-    const canonicalUrl = user && track ? fullTrackPage(track.permalink) : ''
 
     // If the track has a remix parent and it's not deleted and the original's owner is not deactivated.
     const hasValidRemixParent =
@@ -449,6 +442,7 @@ class TrackPageProvider extends Component<
           title={title}
           description={description}
           canonicalUrl={canonicalUrl}
+          structuredData={structuredData}
           playable={{ metadata: track, type: PlayableType.TRACK }}
           user={user}
           deletedByArtist={deletedByArtist}
@@ -460,6 +454,7 @@ class TrackPageProvider extends Component<
       title,
       description,
       canonicalUrl,
+      structuredData,
       heroTrack: track,
       hasValidRemixParent,
       user,

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -34,6 +34,7 @@ export type OwnProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: Object
   // Hero Track Props
   heroTrack: Track | null
   hasValidRemixParent: boolean
@@ -76,6 +77,7 @@ const TrackPage = ({
   title,
   description,
   canonicalUrl,
+  structuredData,
   hasValidRemixParent,
   // Hero Track Props
   heroTrack,
@@ -215,6 +217,7 @@ const TrackPage = ({
       title={title}
       description={description}
       canonicalUrl={canonicalUrl}
+      structuredData={structuredData}
       variant='flush'
       scrollableSearch
     >

--- a/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
@@ -39,7 +39,7 @@ export type OwnProps = {
   title: string
   description: string
   canonicalUrl: string
-  structuredData?: object
+  structuredData?: Object
   hasValidRemixParent: boolean
   // Hero Track Props
   heroTrack: Track | null

--- a/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
@@ -39,6 +39,7 @@ export type OwnProps = {
   title: string
   description: string
   canonicalUrl: string
+  structuredData?: object
   hasValidRemixParent: boolean
   // Hero Track Props
   heroTrack: Track | null
@@ -80,6 +81,7 @@ const TrackPage = ({
   title,
   description,
   canonicalUrl,
+  structuredData,
   hasValidRemixParent,
   // Hero Track Props
   heroTrack,
@@ -179,6 +181,7 @@ const TrackPage = ({
         title={title}
         description={description}
         canonicalUrl={canonicalUrl}
+        structuredData={structuredData}
       >
         <div className={styles.trackContent}>
           <TrackPageHeader

--- a/packages/web/src/pages/trending-page/TrendingPageProvider.js
+++ b/packages/web/src/pages/trending-page/TrendingPageProvider.js
@@ -23,6 +23,7 @@ import { make } from 'common/store/analytics/actions'
 import { openSignOn } from 'common/store/pages/signon/actions'
 import { isMobile } from 'utils/clientUtil'
 import { getPathname, TRENDING_GENRES } from 'utils/route'
+import { createSeoDescription } from 'utils/seo'
 const { makeGetCurrent } = queueSelectors
 
 const { getBuffering, getPlaying } = playerSelectors
@@ -46,8 +47,9 @@ const getHasAccount = accountSelectors.getHasAccount
 const messages = {
   trendingTitle: 'Trending',
   pageTitle: "Listen to what's trending on the Audius platform",
-  trendingDescription:
-    "Listen to what's trending on the Audius platform | Stream tracks, albums, playlists on desktop and mobile"
+  trendingDescription: createSeoDescription(
+    "Listen to what's trending on the Audius platform"
+  )
 }
 
 // Dynamically dispatch call to a lineup action based on a timeRange

--- a/packages/web/src/pages/trending-page/TrendingPageProvider.js
+++ b/packages/web/src/pages/trending-page/TrendingPageProvider.js
@@ -45,7 +45,9 @@ const getHasAccount = accountSelectors.getHasAccount
 
 const messages = {
   trendingTitle: 'Trending',
-  trendingDescription: "Listen to what's trending on the Audius platform"
+  pageTitle: "Listen to what's trending on the Audius platform",
+  trendingDescription:
+    "Listen to what's trending on the Audius platform | Stream tracks, albums, playlists on desktop and mobile"
 }
 
 // Dynamically dispatch call to a lineup action based on a timeRange
@@ -178,6 +180,7 @@ class TrendingPageProvider extends PureComponent {
   render() {
     const childProps = {
       trendingTitle: messages.trendingTitle,
+      pageTitle: messages.pageTitle,
       trendingDescription: messages.trendingDescription,
       trending: this.props.trending,
       trendingWeek: this.props.trendingWeek,

--- a/packages/web/src/pages/trending-page/components/desktop/TrendingPageContent.tsx
+++ b/packages/web/src/pages/trending-page/components/desktop/TrendingPageContent.tsx
@@ -68,6 +68,7 @@ const getRangesToDisable = (timeRange: TimeRange) => {
 const TrendingPageContent = (props: TrendingPageContentProps) => {
   const {
     trendingTitle,
+    pageTitle,
     trendingDescription,
     trendingWeek,
     trendingMonth,
@@ -355,7 +356,7 @@ const TrendingPageContent = (props: TrendingPageContentProps) => {
   return (
     <>
       <Page
-        title={trendingTitle}
+        title={pageTitle}
         description={trendingDescription}
         size='large'
         header={header}

--- a/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.tsx
+++ b/packages/web/src/pages/trending-page/components/mobile/TrendingPageContent.tsx
@@ -54,7 +54,7 @@ const tabHeaders = [
 ]
 
 const TrendingPageMobileContent = ({
-  trendingTitle,
+  pageTitle,
   trendingDescription,
 
   trendingTimeRange,
@@ -268,7 +268,7 @@ const TrendingPageMobileContent = ({
 
   return (
     <MobilePageContainer
-      title={trendingTitle}
+      title={pageTitle}
       description={trendingDescription}
       canonicalUrl={`${BASE_URL}${TRENDING_PAGE}`}
     >

--- a/packages/web/src/pages/trending-page/types.ts
+++ b/packages/web/src/pages/trending-page/types.ts
@@ -4,6 +4,7 @@ type ExtraTrendingLineupProps = {}
 
 export interface TrendingPageContentProps {
   trendingTitle: string
+  pageTitle: string
   trendingDescription: string
   trending: Lineup<any>
   trendingWeek: Lineup<any, ExtraTrendingLineupProps>

--- a/packages/web/src/pages/trending-playlists/TrendingPlaylistPage.tsx
+++ b/packages/web/src/pages/trending-playlists/TrendingPlaylistPage.tsx
@@ -22,7 +22,8 @@ const { getLineup } = trendingPlaylistsPageLineupSelectors
 
 const messages = {
   trendingPlaylistTile: 'Trending Playlists',
-  description: 'Trending Playlists on Audius'
+  description:
+    'Trending Playlists on Audius | Stream tracks, albums, playlists on desktop and mobile'
 }
 
 /** Wraps useLineupProps to return trending playlist lineup props */

--- a/packages/web/src/pages/trending-playlists/TrendingPlaylistPage.tsx
+++ b/packages/web/src/pages/trending-playlists/TrendingPlaylistPage.tsx
@@ -16,14 +16,14 @@ import Page from 'components/page/Page'
 import RewardsBanner from 'pages/trending-page/components/RewardsBanner'
 import { isMobile } from 'utils/clientUtil'
 import { BASE_URL, TRENDING_PLAYLISTS_PAGE } from 'utils/route'
+import { createSeoDescription } from 'utils/seo'
 
 import styles from './TrendingPlaylistPage.module.css'
 const { getLineup } = trendingPlaylistsPageLineupSelectors
 
 const messages = {
   trendingPlaylistTile: 'Trending Playlists',
-  description:
-    'Trending Playlists on Audius | Stream tracks, albums, playlists on desktop and mobile'
+  description: createSeoDescription('Trending Playlists on Audius')
 }
 
 /** Wraps useLineupProps to return trending playlist lineup props */

--- a/packages/web/src/pages/trending-underground/TrendingUndergroundPage.tsx
+++ b/packages/web/src/pages/trending-underground/TrendingUndergroundPage.tsx
@@ -16,6 +16,7 @@ import Page from 'components/page/Page'
 import RewardsBanner from 'pages/trending-page/components/RewardsBanner'
 import { isMobile } from 'utils/clientUtil'
 import { BASE_URL, TRENDING_UNDERGROUND_PAGE } from 'utils/route'
+import { createSeoDescription } from 'utils/seo'
 
 import styles from './TrendingUndergroundPage.module.css'
 const { getLineup } = trendingUndergroundPageLineupSelectors
@@ -34,8 +35,9 @@ const useTrendingUndergroundLineup = (containerRef: HTMLElement) => {
 
 const messages = {
   trendingUndergroundTitle: 'Underground Trending',
-  description:
-    "Listen to what's trending on the Audius platform | Stream tracks, albums, playlists on desktop and mobile"
+  description: createSeoDescription(
+    "Listen to what's trending on the Audius platform"
+  )
 }
 
 type TrendingUndergroundPageProps = {

--- a/packages/web/src/pages/trending-underground/TrendingUndergroundPage.tsx
+++ b/packages/web/src/pages/trending-underground/TrendingUndergroundPage.tsx
@@ -34,7 +34,8 @@ const useTrendingUndergroundLineup = (containerRef: HTMLElement) => {
 
 const messages = {
   trendingUndergroundTitle: 'Underground Trending',
-  description: "Listen to what's trending on the Audius platform"
+  description:
+    "Listen to what's trending on the Audius platform | Stream tracks, albums, playlists on desktop and mobile"
 }
 
 type TrendingUndergroundPageProps = {

--- a/packages/web/src/utils/seo.ts
+++ b/packages/web/src/utils/seo.ts
@@ -9,6 +9,10 @@ import {
   fullTrackPage
 } from './route'
 
+export const createSeoDescription = (msg: string) => {
+  return `${msg} | Stream tracks, albums, playlists on desktop and mobile`
+}
+
 export const getUserPageSEOFields = ({
   handle,
   userName,
@@ -19,7 +23,9 @@ export const getUserPageSEOFields = ({
   bio: string
 }) => {
   const pageTitle = userName
-  const pageDescription = `Play ${userName} on Audius and discover followers on Audius | Stream tracks, albums, playlists on desktop and mobile`
+  const pageDescription = createSeoDescription(
+    `Play ${userName} on Audius and discover followers on Audius`
+  )
   const canonicalUrl = fullProfilePage(handle)
   const structuredData = {
     '@context': 'http://schema.googleapis.com/',
@@ -116,7 +122,9 @@ export const getCollectionPageSEOFields = ({
   if (!playlistName || !playlistId || !userName || !userHandle) return {}
 
   const pageTitle = `${playlistName} by ${userName}`
-  const pageDescription = `Listen to ${playlistName} by ${userName} on Audius | Stream tracks, albums, playlists on desktop and mobile`
+  const pageDescription = createSeoDescription(
+    `Listen to ${playlistName} by ${userName} on Audius`
+  )
   const canonicalUrl = isAlbum
     ? fullAlbumPage(userHandle, playlistName, playlistId)
     : fullPlaylistPage(userHandle, playlistName, playlistId)

--- a/packages/web/src/utils/seo.ts
+++ b/packages/web/src/utils/seo.ts
@@ -2,41 +2,151 @@
  * SEO Utlity functions to generate titles and descriptions
  */
 
-export const getTrackPageTitle = ({
-  title,
-  handle
+import {
+  fullAlbumPage,
+  fullPlaylistPage,
+  fullProfilePage,
+  fullTrackPage
+} from './route'
+
+export const getUserPageSEOFields = ({
+  handle,
+  userName,
+  bio
 }: {
-  title: string
   handle: string
+  userName: string
+  bio: string
 }) => {
-  if (!title) return ''
-  if (!handle) return title
-  return `${title} by ${handle}`
+  const pageTitle = userName
+  const pageDescription = `Play ${userName} on Audius and discover followers on Audius | Stream tracks, albums, playlists on desktop and mobile`
+  const canonicalUrl = fullProfilePage(handle)
+  const structuredData = {
+    '@context': 'http://schema.googleapis.com/',
+    '@type': 'MusicGroup',
+    '@id': canonicalUrl,
+    datePublished: null,
+    url: canonicalUrl,
+    name: userName,
+    description: bio || pageDescription,
+    potentialAction: {
+      '@type': 'ListenAction',
+      target: [
+        {
+          '@type': 'EntryPoint',
+          urlTemplate: canonicalUrl
+        }
+      ],
+      expectsAcceptanceOf: {
+        '@type': 'Offer',
+        category: 'free',
+        eligibleRegion: []
+      }
+    }
+  }
+
+  return {
+    title: pageTitle,
+    description: pageDescription,
+    canonicalUrl,
+    structuredData
+  }
 }
 
-type getTrackPageDescriptionProps = {
-  releaseDate: string
-  duration: string
-  tags: string[]
-  genre: string
-  mood: string
-  description: string
+export const getTrackPageSEOFields = ({
+  title,
+  userName,
+  permalink,
+  releaseDate
+}: {
+  title?: string
+  userName?: string
+  permalink?: string
+  releaseDate?: string
+}) => {
+  if (!title || !userName || !permalink) return {}
+  const pageTitle = `${title} by ${userName}`
+  const pageDescription = `Stream ${title} by ${userName} on Audius | Stream similar artists to ${userName} on desktop and mobile`
+  const canonicalUrl = fullTrackPage(permalink)
+  const structuredData = {
+    '@context': 'http://schema.googleapis.com/',
+    '@type': 'MusicRecording',
+    '@id': canonicalUrl,
+    url: canonicalUrl,
+    name: title,
+    description: pageDescription,
+    datePublished: releaseDate || null,
+    potentialAction: {
+      '@type': 'ListenAction',
+      target: [
+        {
+          '@type': 'EntryPoint',
+          urlTemplate: canonicalUrl
+        }
+      ],
+      expectsAcceptanceOf: {
+        '@type': 'Offer',
+        category: 'free',
+        eligibleRegion: []
+      }
+    }
+  }
+
+  return {
+    title: pageTitle,
+    description: pageDescription,
+    canonicalUrl,
+    structuredData
+  }
 }
-export const getTrackPageDescription = ({
-  releaseDate,
-  tags,
-  duration,
-  genre,
-  mood,
-  description
-}: getTrackPageDescriptionProps) => {
-  // Note, release date and duration will be defined if the track metadata is fetched.
-  if (!releaseDate) return ''
-  const tagText =
-    Array.isArray(tags) && tags.length > 0 ? ` | Tags: ${tags.join(', ')}` : ''
-  const genreText = genre ? ` | Genre: ${genre}` : ''
-  const durationText = duration ? ` | Duration: ${duration}` : ''
-  const moodText = mood ? ` | Mood: ${mood}` : ''
-  const descriptionText = description ? ` | ${description}` : ''
-  return `Released: ${releaseDate}${genreText}${moodText}${durationText}${tagText}${descriptionText}`
+
+export const getCollectionPageSEOFields = ({
+  playlistName,
+  playlistId,
+  userName,
+  userHandle,
+  isAlbum
+}: {
+  playlistName?: string
+  playlistId?: number
+  userName?: string
+  userHandle?: string
+  isAlbum?: boolean
+}) => {
+  if (!playlistName || !playlistId || !userName || !userHandle) return {}
+
+  const pageTitle = `${playlistName} by ${userName}`
+  const pageDescription = `Listen to ${playlistName} by ${userName} on Audius | Stream tracks, albums, playlists on desktop and mobile`
+  const canonicalUrl = isAlbum
+    ? fullAlbumPage(userHandle, playlistName, playlistId)
+    : fullPlaylistPage(userHandle, playlistName, playlistId)
+  const structuredData = {
+    '@context': 'http://schema.googleapis.com/',
+    '@type': 'MusicAlbum',
+    '@id': canonicalUrl,
+    url: canonicalUrl,
+    name: playlistName,
+    description: pageDescription,
+    potentialAction: {
+      '@type': 'ListenAction',
+      target: [
+        {
+          '@type': 'EntryPoint',
+          urlTemplate: canonicalUrl
+        }
+      ],
+      expectsAcceptanceOf: {
+        '@type': 'Offer',
+        category: 'free',
+        eligibleRegion: []
+      }
+    }
+  }
+
+  return {
+    title: pageTitle,
+    description: pageDescription,
+    canonicalUrl,
+    structuredData
+  }
 }


### PR DESCRIPTION
### Description
Pass at improving SEO on the client
* Adds Schema Structured Data
* Updates title and description on several pages: user/track/collection, trending, explore
* Fixed canonical url on album pages - there was a bug where we were using the /playlist instead of /album path

Fixes PLAT-325
Fixes PLAT-347
Fixes PLAT-346
Fixes PLAT-341

### Dragons

### How Has This Been Tested?
Ran the client locally against stage and inspected the page head

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

