### PR TITLE
Fix play bar buttons target (Android) C-1264

### DIFF
--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBarButton.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBarButton.tsx
@@ -160,6 +160,7 @@ export const BottomTabBarButton = ({
   return (
     <AnimatedButton
       iconJSON={icons[route.name]}
+      hitSlop={{ top: 0, right: 0, bottom: 0, left: 0 }}
       isActive={isFocused}
       onLongPress={handleLongPress}
       onPress={handlePress}

--- a/packages/mobile/src/components/core/AnimatedButton.tsx
+++ b/packages/mobile/src/components/core/AnimatedButton.tsx
@@ -176,11 +176,11 @@ export const AnimatedButton = ({
 
   return iconJSON ? (
     <Pressable
+      hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}
       {...pressableProps}
       disabled={isDisabled}
       onPress={handlePress}
       onLongPress={handleLongPress}
-      hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}
       style={style}
     >
       {(pressableState) => (

--- a/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
@@ -14,6 +14,7 @@ import { FavoriteButton } from 'app/components/favorite-button'
 import Text from 'app/components/text'
 import { useTrackCoverArt } from 'app/hooks/useTrackCoverArt'
 import { makeStyles } from 'app/styles'
+import { zIndex } from 'app/utils/zIndex'
 
 import { PlayButton } from './PlayButton'
 import { TrackingBar } from './TrackingBar'
@@ -24,7 +25,8 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
   root: {
     width: '100%',
     height: PLAY_BAR_HEIGHT,
-    alignItems: 'center'
+    alignItems: 'center',
+    zIndex: zIndex.PLAY_BAR
   },
   container: {
     height: '100%',

--- a/packages/mobile/src/utils/zIndex.ts
+++ b/packages/mobile/src/utils/zIndex.ts
@@ -1,0 +1,3 @@
+export enum zIndex {
+  PLAY_BAR = 5
+}


### PR DESCRIPTION
### Description

-Improve now playing bar touch target by removing unnecessary hitslop from bottom buttons
-Fix favorite and play button touch targets on the now playing bar at the bottom by increasing the z-index of the play bar container

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

