### PR TITLE
Add rendering trace util

### DIFF
--- a/packages/mobile/devUtils/useRenderingTrace.ts
+++ b/packages/mobile/devUtils/useRenderingTrace.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Helps tracking the props changes made in a react functional component.
+ *
+ * Prints the name of the properties/states variables causing a render (or re-render).
+ * For debugging purposes only.
+ *
+ * @usage You can simply track the props of the components like this:
+ *  useRenderingTrace('MyComponent', props);
+ *
+ * @usage You can also track additional state like this:
+ *  const [someState] = useState(null);
+ *  useRenderingTrace('MyComponent', { ...props, someState });
+ *
+ * @param componentName Name of the component to display
+ * @param propsAndStates
+ * @param level
+ *
+ * @see https://stackoverflow.com/a/51082563/2391795
+ */
+export const useRenderingTrace = (
+  componentName: string,
+  propsAndStates: any
+) => {
+  const prev = useRef(propsAndStates)
+
+  useEffect(() => {
+    const changedProps: { [key: string]: { old: any; new: any } } =
+      Object.entries(propsAndStates).reduce(
+        (property: any, [key, value]: [string, any]) => {
+          if (prev.current[key] !== value) {
+            property[key] = {
+              old: prev.current[key],
+              new: value
+            }
+          }
+          return property
+        },
+        {}
+      )
+
+    if (Object.keys(changedProps).length > 0) {
+      console.log(`[${componentName}] changed props:`, changedProps)
+    }
+
+    prev.current = propsAndStates
+  })
+}

--- a/packages/web/devUtils/useRenderingTrace.ts
+++ b/packages/web/devUtils/useRenderingTrace.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Helps tracking the props changes made in a react functional component.
+ *
+ * Prints the name of the properties/states variables causing a render (or re-render).
+ * For debugging purposes only.
+ *
+ * @usage You can simply track the props of the components like this:
+ *  useRenderingTrace('MyComponent', props);
+ *
+ * @usage You can also track additional state like this:
+ *  const [someState] = useState(null);
+ *  useRenderingTrace('MyComponent', { ...props, someState });
+ *
+ * @param componentName Name of the component to display
+ * @param propsAndStates
+ * @param level
+ *
+ * @see https://stackoverflow.com/a/51082563/2391795
+ */
+export const useRenderingTrace = (
+  componentName: string,
+  propsAndStates: any
+) => {
+  const prev = useRef(propsAndStates)
+
+  useEffect(() => {
+    const changedProps: { [key: string]: { old: any; new: any } } =
+      Object.entries(propsAndStates).reduce(
+        (property: any, [key, value]: [string, any]) => {
+          if (prev.current[key] !== value) {
+            property[key] = {
+              old: prev.current[key],
+              new: value
+            }
+          }
+          return property
+        },
+        {}
+      )
+
+    if (Object.keys(changedProps).length > 0) {
+      console.log(`[${componentName}] changed props:`, changedProps)
+    }
+
+    prev.current = propsAndStates
+  })
+}


### PR DESCRIPTION
### Description
Add utility fn for determining why components rerendered.
This is a useful companion to the react profiler, since sometimes the profiler doesn't tell you exactly what caused the rerender.
Decided against putting this in common because mobile (react native) doesn't tree shake. That being said though, I don't think this is big enough to make a difference, so I'm down for either way!


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

