### PR TITLE
[C-1347] Improve navigation performance

### DIFF
--- a/packages/common/src/utils/typeUtils.ts
+++ b/packages/common/src/utils/typeUtils.ts
@@ -29,3 +29,8 @@ export type Maybe<T> = T | undefined
  *
  */
 export type Brand<T, U extends string> = T & { _brand: U }
+
+type ParameterizedType<T> = T[]
+export type ExtractTypeParam<Type> = Type extends ParameterizedType<infer X>
+  ? X
+  : never

--- a/packages/common/src/utils/typeUtils.ts
+++ b/packages/common/src/utils/typeUtils.ts
@@ -29,8 +29,3 @@ export type Maybe<T> = T | undefined
  *
  */
 export type Brand<T, U extends string> = T & { _brand: U }
-
-type ParameterizedType<T> = T[]
-export type ExtractTypeParam<Type> = Type extends ParameterizedType<infer X>
-  ? X
-  : never

--- a/packages/mobile/src/components/empty-tile-cta/EmptyTileCTA.tsx
+++ b/packages/mobile/src/components/empty-tile-cta/EmptyTileCTA.tsx
@@ -3,8 +3,6 @@ import { useCallback } from 'react'
 import { Button, EmptyTile } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 
-import type { AppScreenParamList } from '../../screens/app-screen'
-
 const messages = {
   afterSaved: "Once you have, this is where you'll find them!",
   goToTrending: 'Go to Trending'
@@ -16,7 +14,7 @@ type EmptyTabProps = {
 
 export const EmptyTileCTA = (props: EmptyTabProps) => {
   const { message } = props
-  const navigation = useNavigation<AppScreenParamList>()
+  const navigation = useNavigation()
 
   const onPress = useCallback(() => {
     navigation.navigate('trending')

--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -30,6 +30,7 @@ import Drawer, {
 } from 'app/components/drawer'
 import { Scrubber } from 'app/components/scrubber'
 import { useDrawer } from 'app/hooks/useDrawer'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { AppDrawerContext } from 'app/screens/app-drawer-screen'
 import { AppTabNavigationContext } from 'app/screens/app-screen'
 import { getAndroidNavigationBarHeight } from 'app/store/mobileUi/selectors'
@@ -98,7 +99,10 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   props: NowPlayingDrawerProps
 ) {
   const { translationAnim } = props
-  const { navigation } = useContext(AppTabNavigationContext)
+  const { navigation: contextNavigation } = useContext(AppTabNavigationContext)
+  const navigation = useNavigation({
+    customNavigation: contextNavigation
+  })
   const dispatch = useDispatch()
   const insets = useSafeAreaInsets()
   const androidNavigationBarHeight = useSelector(getAndroidNavigationBarHeight)

--- a/packages/mobile/src/components/overflow-menu-drawer/CollectionOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/CollectionOverflowMenuDrawer.tsx
@@ -16,6 +16,7 @@ import {
 } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { useNavigation } from 'app/hooks/useNavigation'
 import { AppTabNavigationContext } from 'app/screens/app-screen'
 
 const { getMobileOverflowModal } = mobileOverflowMenuUISelectors
@@ -39,7 +40,8 @@ type Props = {
 
 const CollectionOverflowMenuDrawer = ({ render }: Props) => {
   const dispatch = useDispatch()
-  const { navigation } = useContext(AppTabNavigationContext)
+  const { navigation: contextNavigation } = useContext(AppTabNavigationContext)
+  const navigation = useNavigation({ customNavigation: contextNavigation })
   const { id: modalId } = useSelector(getMobileOverflowModal)
   const id = modalId as ID
 

--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -17,6 +17,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useDrawer } from 'app/hooks/useDrawer'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { AppTabNavigationContext } from 'app/screens/app-screen'
 
 const { getMobileOverflowModal } = mobileOverflowMenuUISelectors
@@ -33,7 +34,8 @@ type Props = {
 
 const TrackOverflowMenuDrawer = ({ render }: Props) => {
   const { onClose: closeNowPlayingDrawer } = useDrawer('NowPlaying')
-  const { navigation } = useContext(AppTabNavigationContext)
+  const { navigation: contextNavigation } = useContext(AppTabNavigationContext)
+  const navigation = useNavigation({ customNavigation: contextNavigation })
   const dispatch = useDispatch()
   const { id: modalId } = useSelector(getMobileOverflowModal)
   const id = modalId as ID

--- a/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
+++ b/packages/mobile/src/components/trending-rewards-drawer/TrendingRewardsDrawer.tsx
@@ -191,7 +191,7 @@ export const TrendingRewardsDrawer = () => {
 
   const handleGoToTrending = useCallback(() => {
     const [screen, params] = TRENDING_PAGES[modalType]
-    navigation.navigate(screen, params)
+    navigation.navigate(screen, params!)
     onClose()
   }, [modalType, navigation, onClose])
 

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -29,6 +29,17 @@ type UseNavigationOptions<NavigationProp extends RNNavigationProp<any>> = {
   customNavigation?: NavigationProp
 }
 
+/**
+ * Custom wrapper around react-navigation `useNavigation`
+ *
+ * Features:
+ * - Prevent duplicate navigation pushes
+ * - Apply contextual params to all routes
+ *
+ * Overloaded to support supplying only a ParamList type parameter
+ * or the entire NavigationProp itself
+ * @param options
+ */
 export function useNavigation<
   ParamList extends ParamListBase,
   NavigationProp extends RNNavigationProp<any> = NativeStackNavigationProp<ParamList>

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useRef } from 'react'
 
-import type { ExtractTypeParam } from '@audius/common'
 import type {
   ParamListBase,
   NavigationProp as RNNavigationProp
@@ -8,8 +7,6 @@ import type {
 import { useNavigation as useNativeNavigation } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { isEqual } from 'lodash'
-
-import type { AppTabScreenParamList } from 'app/screens/app-screen/AppTabScreen'
 
 export type ContextualParams = {
   fromNotifications?: boolean
@@ -20,8 +17,7 @@ export type ContextualizedParamList<ParamList extends ParamListBase> = {
 }
 
 type PerformNavigationConfig<
-  NavigationProp extends RNNavigationProp<any>,
-  ParamList = ExtractTypeParam<NavigationProp>,
+  ParamList extends ParamListBase,
   RouteName extends keyof ParamList = keyof ParamList
 > = [screen: RouteName, params?: ParamList[RouteName] & ContextualParams]
 
@@ -35,23 +31,14 @@ type UseNavigationOptions<NavigationProp extends RNNavigationProp<any>> = {
  * Features:
  * - Prevent duplicate navigation pushes
  * - Apply contextual params to all routes
- *
- * Overloaded to support supplying only a ParamList type parameter
- * or the entire NavigationProp itself
- * @param options
  */
 export function useNavigation<
   ParamList extends ParamListBase,
   NavigationProp extends RNNavigationProp<any> = NativeStackNavigationProp<ParamList>
->(options?: UseNavigationOptions<NavigationProp>): NavigationProp
-export function useNavigation<
-  NavigationProp extends RNNavigationProp<any> = NativeStackNavigationProp<
-    ContextualizedParamList<AppTabScreenParamList>
-  >
 >(options?: UseNavigationOptions<NavigationProp>): NavigationProp {
   const defaultNativeNavigation = useNativeNavigation<NavigationProp>()
 
-  const lastNavAction = useRef<PerformNavigationConfig<NavigationProp>>()
+  const lastNavAction = useRef<PerformNavigationConfig<ParamList>>()
 
   const nativeNavigation: NavigationProp =
     options?.customNavigation ?? defaultNativeNavigation
@@ -59,7 +46,7 @@ export function useNavigation<
   // Prevent duplicate pushes by de-duping
   // navigation actions
   const performCustomPush = useCallback(
-    (...config: PerformNavigationConfig<NavigationProp>) => {
+    (...config: PerformNavigationConfig<ParamList>) => {
       if (!isEqual(lastNavAction.current, config)) {
         ;(nativeNavigation as NativeStackNavigationProp<any>).push(...config)
         lastNavAction.current = config

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 
 import type { ExtractTypeParam } from '@audius/common'
 import type {
@@ -51,8 +51,7 @@ export function useNavigation<
 >(options?: UseNavigationOptions<NavigationProp>): NavigationProp {
   const defaultNativeNavigation = useNativeNavigation<NavigationProp>()
 
-  const [lastNavAction, setLastNavAction] =
-    useState<PerformNavigationConfig<NavigationProp>>()
+  const lastNavAction = useRef<PerformNavigationConfig<NavigationProp>>()
 
   const nativeNavigation: NavigationProp =
     options?.customNavigation ?? defaultNativeNavigation
@@ -61,10 +60,12 @@ export function useNavigation<
   // navigation actions
   const performCustomPush = useCallback(
     (...config: PerformNavigationConfig<NavigationProp>) => {
-      if (!isEqual(lastNavAction, config)) {
+      if (!isEqual(lastNavAction.current, config)) {
         ;(nativeNavigation as NativeStackNavigationProp<any>).push(...config)
-        setLastNavAction(config)
-        setTimeout(() => setLastNavAction(undefined), 500)
+        lastNavAction.current = config
+        setTimeout(() => {
+          lastNavAction.current = undefined
+        }, 500)
       }
     },
     [nativeNavigation, lastNavAction]

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -36,38 +36,38 @@ export function useNavigation<
   ParamList extends ParamListBase,
   NavigationProp extends RNNavigationProp<any> = NativeStackNavigationProp<ParamList>
 >(options?: UseNavigationOptions<NavigationProp>): NavigationProp {
-  const defaultNativeNavigation = useNativeNavigation<NavigationProp>()
+  const defaultNavigation = useNativeNavigation<NavigationProp>()
 
   const lastNavAction = useRef<PerformNavigationConfig<ParamList>>()
 
-  const nativeNavigation: NavigationProp =
-    options?.customNavigation ?? defaultNativeNavigation
+  const navigation: NavigationProp =
+    options?.customNavigation ?? defaultNavigation
 
   // Prevent duplicate pushes by de-duping
   // navigation actions
   const performCustomPush = useCallback(
     (...config: PerformNavigationConfig<ParamList>) => {
       if (!isEqual(lastNavAction.current, config)) {
-        ;(nativeNavigation as NativeStackNavigationProp<any>).push(...config)
+        ;(navigation as NativeStackNavigationProp<any>).push(...config)
         lastNavAction.current = config
         setTimeout(() => {
           lastNavAction.current = undefined
         }, 500)
       }
     },
-    [nativeNavigation, lastNavAction]
+    [navigation, lastNavAction]
   )
 
   return useMemo(
     () => ({
-      ...nativeNavigation,
+      ...navigation,
       push:
-        'push' in nativeNavigation
+        'push' in navigation
           ? performCustomPush
           : () => {
               console.error('Push is not implemented for this navigator')
             }
     }),
-    [nativeNavigation, performCustomPush]
+    [navigation, performCustomPush]
   )
 }

--- a/packages/mobile/src/screens/app-drawer-screen/useAppDrawerNavigation.ts
+++ b/packages/mobile/src/screens/app-drawer-screen/useAppDrawerNavigation.ts
@@ -1,12 +1,9 @@
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 
 import { FeatureFlags } from '@audius/common'
 
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
-
-import type { AppTabScreenParamList } from '../app-screen'
-import type { ProfileTabScreenParamList } from '../app-screen/ProfileTabScreen'
 
 import { AppDrawerContext } from '.'
 
@@ -20,27 +17,35 @@ export const useNotificationNavigation = () => {
     FeatureFlags.MOBILE_NAV_OVERHAUL
   )
 
-  const navigationOptions = isNavOverhaulEnabled
-    ? undefined
-    : {
-        customNativeNavigation: drawerHelpers
-      }
+  const navigation = useNavigation()
 
-  const navigation = useNavigation<
-    AppTabScreenParamList & ProfileTabScreenParamList
-  >(navigationOptions)
+  const notificationNavigation = useMemo(
+    () => ({
+      ...navigation,
+      ...drawerHelpers
+    }),
+    [drawerHelpers, navigation]
+  )
 
   if (isNavOverhaulEnabled) {
-    navigation.navigate = navigation.push
+    notificationNavigation.navigate = notificationNavigation.push as any
   }
 
-  return navigation
+  return notificationNavigation
 }
 
 export const useAppDrawerNavigation = () => {
   const { drawerHelpers } = useContext(AppDrawerContext)
 
-  return useNavigation<AppTabScreenParamList & ProfileTabScreenParamList>({
-    customNativeNavigation: drawerHelpers
-  })
+  const navigation = useNavigation()
+
+  const drawerNavigation = useMemo(
+    () => ({
+      ...navigation,
+      ...drawerHelpers
+    }),
+    [drawerHelpers, navigation]
+  )
+
+  return drawerNavigation
 }

--- a/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
@@ -27,6 +27,10 @@ export const SetAppTabNavigationContext =
 
 type AppTabNavigationProviderProps = { children: ReactNode }
 
+/**
+ * Context that provides the AppTabNavigation to any components
+ * that need it outside of the AppTabScreen stack context
+ */
 export const AppTabNavigationProvider = (
   props: AppTabNavigationProviderProps
 ) => {

--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -104,7 +104,7 @@ export const useAppScreenOptions = (
   const { accentOrangeLight1, neutralLight4 } = useThemeColors()
   const dispatch = useDispatch()
   const notificationCount = useSelector(getNotificationUnviewedCount)
-  const navigation = useNavigation<AppScreenParamList>()
+  const navigation = useNavigation()
   const { drawerHelpers } = useContext(AppDrawerContext)
 
   const handlePressNotification = useCallback(() => {

--- a/packages/mobile/src/screens/notifications-screen/Notification/UserNameLink.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/UserNameLink.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useContext } from 'react'
+import { useCallback } from 'react'
 
 import type { User as UserType } from '@audius/common'
 
 import type { TextProps } from 'app/components/core'
 import { Text } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { AppDrawerContext } from 'app/screens/app-drawer-screen'
 
 type UserNameLinkProps = TextProps & {
   user: UserType
@@ -13,8 +12,7 @@ type UserNameLinkProps = TextProps & {
 
 export const UserNameLink = (props: UserNameLinkProps) => {
   const { user, ...other } = props
-  const { drawerHelpers } = useContext(AppDrawerContext)
-  const navigation = useNavigation({ customNativeNavigation: drawerHelpers })
+  const navigation = useNavigation()
 
   const onPress = useCallback(() => {
     navigation.navigate('Profile', {


### PR DESCRIPTION
### Description

Reduces rerenders when navigating by updating our custom `useNavigation` hook to:
* Use react-navigation `useNavigation` instead of pulling the navigation from the AppTabScreen context
  > Components that need the context navigation now pass it to `useNavigation` as the customNavigation, so their pushes are also de-duped
* De-dupe navigation actions by saving the last action in a ref and comparing when a new action comes in. The saved action is reset after 500ms so that it can be performed again after the initial transition is complete. This worked better than trying to reset on `beforeRemove` because that attached a listener for every instance of the `useNavigation` hook
* Improve types

### Dragons

**This touches navigation so should be considered dangerous!**

### How Has This Been Tested?

Tested navigation:
* Navigation from the now playing drawer pushes to the correct stack
* Navigation from the notifications drawer pushes to the correct stack
* Navigation from Trending Playlists and other overflow menus push to the correct stack
* Duplicate navigation is prevented on all screens

Profiled performance
* Consumers of `useNavigation` do not rerender when a navigation occurs

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

