### PR TITLE
[C-1302] Fix blank profile picture background color

### DIFF
--- a/packages/web/src/components/profile-picture/ProfilePicture.js
+++ b/packages/web/src/components/profile-picture/ProfilePicture.js
@@ -68,6 +68,7 @@ const ProfilePicture = ({
     >
       <div className={styles.profilePictureBackground}>
         <DynamicImage
+          usePlaceholder={false}
           image={updatedProfilePicture || image}
           skeletonClassName={styles.profilePictureSkeleton}
           wrapperClassName={styles.profilePicture}


### PR DESCRIPTION
### Description

Fixes issue where blank profile picture was using the default placeholder image, which did not provide enough contrast. 

Before: 
<img width="664" alt="image" src="https://user-images.githubusercontent.com/8230000/197673189-60dd7212-c9d6-41e2-8257-d983e1ece539.png">


After: 
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/8230000/197673087-8588611a-db93-45e3-accf-a69f2af7993a.png">


### Dragons

Do we want to apply `usePlaceholder={false}` for all `ProfilePicture` components?

