### PR TITLE
[PAY-705] Fix useLocalStorage hook to use getItem rather than getValue

### DIFF
--- a/packages/web/src/hooks/useLocalStorage.ts
+++ b/packages/web/src/hooks/useLocalStorage.ts
@@ -1,7 +1,7 @@
 import { createUseLocalStorageHook } from '@audius/common'
 
 const getJSONValue = (key: string) => {
-  const val = window.localStorage.getValue(key)
+  const val = window.localStorage.getItem(key)
   if (val) {
     try {
       const parsed = JSON.parse(val)


### PR DESCRIPTION
### Description

The only place this hook is used is on the `ReceiveBody.tsx` component, where it's used to acknowledge that the user has dismissed the warning around receiving $AUDIO. This bug manifests such that the user has to repeatedly acknowledge and click "I understand"

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

