### PR TITLE
[C-1261] Android sign on overflow

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:screenOrientation="portrait"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustPan">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -48,7 +48,6 @@ import { useThemeColors } from 'app/utils/theme'
 import type { SignOnStackParamList } from './types'
 
 const { getAccountUser } = accountSelectors
-const isAndroid = Platform.OS === 'android'
 const image = backgImage
 const windowWidth = Dimensions.get('window').width
 const defaultBorderColor = '#F2F2F4'
@@ -331,8 +330,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
   const [showInvalidEmailError, setShowInvalidEmailError] = useState(false)
   const [showEmptyPasswordError, setShowEmptyPasswordError] = useState(false)
   const [showDefaultError, setShowDefaultError] = useState(false)
-
-  const isKeyboardOpen = useSelector(getIsKeyboardOpen)
 
   const signOnStatus = useSelector(getStatus)
   const passwordField: EditableField = useSelector(getPasswordField)

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -18,7 +18,6 @@ import {
   Image,
   ImageBackground,
   Keyboard,
-  Platform,
   StyleSheet,
   Text,
   TextInput,
@@ -41,7 +40,6 @@ import { remindUserToTurnOnNotifications } from 'app/components/notification-rem
 import useAppState from 'app/hooks/useAppState'
 import { screen, track, make } from 'app/services/analytics'
 import { setVisibility } from 'app/store/drawers/slice'
-import { getIsKeyboardOpen } from 'app/store/keyboard/selectors'
 import { EventNames } from 'app/types/analytics'
 import { useThemeColors } from 'app/utils/theme'
 

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -27,6 +27,7 @@ import {
   View
 } from 'react-native'
 import RadialGradient from 'react-native-radial-gradient'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useSelector, useDispatch } from 'react-redux'
 
 import backgImage from 'app/assets/images/DJportrait.jpg'
@@ -72,22 +73,19 @@ const styles = StyleSheet.create({
     width: '100%',
     zIndex: 5,
     backgroundColor: 'white',
-    alignItems: 'center',
     borderBottomRightRadius: 40,
     borderBottomLeftRadius: 40,
     padding: 28,
-    paddingBottom: 38,
-    paddingTop: 80
+    paddingBottom: 38
   },
-
+  drawerContent: { width: '100%', alignItems: 'center' },
   containerCTA: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     width: '100%',
     zIndex: 4,
-    alignItems: 'center',
-    paddingBottom: 20
+    alignItems: 'center'
   },
   containerBack: {
     flex: 1,
@@ -135,7 +133,7 @@ const styles = StyleSheet.create({
   },
   signupCTAContainer: {
     flex: 1,
-    marginTop: 16
+    marginTop: 32
   },
   signupCTA: {
     resizeMode: 'contain',
@@ -732,46 +730,48 @@ const SignOn = ({ navigation }: SignOnProps) => {
               )
             }}
           >
-            <Image
-              source={audiusLogoHorizontal}
-              style={styles.audiusLogoHorizontal}
-            />
-            <FormTitle isSignin={isSignin} />
-            <TextInput
-              style={[styles.input, { borderColor: emailBorderColor }]}
-              placeholderTextColor='#C2C0CC'
-              underlineColorAndroid='transparent'
-              placeholder='Email'
-              keyboardType='email-address'
-              autoComplete='off'
-              autoCorrect={false}
-              autoCapitalize='none'
-              enablesReturnKeyAutomatically={true}
-              maxLength={100}
-              textContentType='emailAddress'
-              onChangeText={(newText) => {
-                setShowDefaultError(false)
-                const newEmail = newText.trim()
-                setEmail(newEmail)
-                if (newEmail !== '') {
-                  validateEmail(newEmail)
-                }
-              }}
-              onFocus={() => {
-                setEmailBorderColor('#7E1BCC')
-              }}
-              onBlur={() => {
-                setEmailBorderColor(defaultBorderColor)
-                if (email !== '') {
-                  setShowInvalidEmailError(!isValidEmailString(email))
-                  // wait a bit for email validation to come back
-                  setTimeout(() => setAttemptedEmail(true), 1000)
-                }
-              }}
-            />
-            {passwordInputField()}
-            {errorView()}
-            <MainButton isWorking={isWorking} isSignin={isSignin} />
+            <SafeAreaView edges={['top']} style={styles.drawerContent}>
+              <Image
+                source={audiusLogoHorizontal}
+                style={styles.audiusLogoHorizontal}
+              />
+              <FormTitle isSignin={isSignin} />
+              <TextInput
+                style={[styles.input, { borderColor: emailBorderColor }]}
+                placeholderTextColor='#C2C0CC'
+                underlineColorAndroid='transparent'
+                placeholder='Email'
+                keyboardType='email-address'
+                autoComplete='off'
+                autoCorrect={false}
+                autoCapitalize='none'
+                enablesReturnKeyAutomatically={true}
+                maxLength={100}
+                textContentType='emailAddress'
+                onChangeText={(newText) => {
+                  setShowDefaultError(false)
+                  const newEmail = newText.trim()
+                  setEmail(newEmail)
+                  if (newEmail !== '') {
+                    validateEmail(newEmail)
+                  }
+                }}
+                onFocus={() => {
+                  setEmailBorderColor('#7E1BCC')
+                }}
+                onBlur={() => {
+                  setEmailBorderColor(defaultBorderColor)
+                  if (email !== '') {
+                    setShowInvalidEmailError(!isValidEmailString(email))
+                    // wait a bit for email validation to come back
+                    setTimeout(() => setAttemptedEmail(true), 1000)
+                  }
+                }}
+              />
+              {passwordInputField()}
+              {errorView()}
+              <MainButton isWorking={isWorking} isSignin={isSignin} />
+            </SafeAreaView>
           </Animated.View>
         </TouchableWithoutFeedback>
         <Animated.View
@@ -782,10 +782,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
         >
           {Dimensions.get('window').height < 720 ? (
             <></>
-          ) : isAndroid && isKeyboardOpen ? (
-            // on android, if keyboard is showing and user is navigating away to the next screen
-            // the image below shows up above the keyboard and causes a weird transition */
-            <View style={styles.signupCTAContainer} />
           ) : (
             <View style={styles.signupCTAContainer}>
               <Image source={signupCTA} style={styles.signupCTA} />


### PR DESCRIPTION
### Description

* Improve layout of sign on screen so there is no overflow on android devices
* Update `windowSoftInputMode` so that the android keyboard overlays on top of the app, similar to ios

Before
<img width="1009" alt="before" src="https://user-images.githubusercontent.com/19916043/197865560-707df73b-6c41-4ad4-bf79-5e58bbb623c1.png">

After
<img width="975" alt="after" src="https://user-images.githubusercontent.com/19916043/197865580-23f801b6-8bd8-4971-aea2-b34e8561835c.png">

> Side note: does the space between the email input and the sign up button seem too large to anyone else?

### Dragons

THIS TOUCHES SIGN ON

Also changing the keyboard mode could be dangerous, but I thoroughly tested cases where it could be problematic (outlined below)

### How Has This Been Tested?

Tested on pixel 3 which was exhibiting the problem, as well as OnePlus 7T and ios devices

Tested scroll behavior on android with new keyboard mode on
* Search
* Edit Profile
* Create / edit playlist

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

