### PR TITLE
[C-1359] Prevent double navigation on android, plus StatusBar fixes

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -19,7 +19,7 @@ import type {
   GestureResponderEvent,
   PanResponderGestureState
 } from 'react-native'
-import { View, StatusBar, Pressable } from 'react-native'
+import { Platform, View, StatusBar, Pressable } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -150,7 +150,10 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   }, [staticTopInset, insets.top])
 
   useEffect(() => {
-    if (staticTopInset.current > INSET_STATUS_BAR_HIDE_THRESHOLD) {
+    if (
+      Platform.OS === 'ios' &&
+      staticTopInset.current > INSET_STATUS_BAR_HIDE_THRESHOLD
+    ) {
       if (isOpen) {
         StatusBar.setHidden(true, 'fade')
       } else {
@@ -165,7 +168,10 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
     (e: GestureResponderEvent, gestureState: PanResponderGestureState) => {
       // Do not hide the status bar for smaller insets
       // This is to prevent layout shift which breaks the animation
-      if (staticTopInset.current > INSET_STATUS_BAR_HIDE_THRESHOLD) {
+      if (
+        Platform.OS === 'ios' &&
+        staticTopInset.current > INSET_STATUS_BAR_HIDE_THRESHOLD
+      ) {
         if (gestureState.vy > 0) {
           // Dragging downwards
           if (drawerPercentOpen.current < STATUS_BAR_FADE_CUTOFF) {

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import type {
   ParamListBase,
@@ -50,9 +50,14 @@ export function useNavigation<
       if (!isEqual(lastNavAction.current, config)) {
         ;(navigation as NativeStackNavigationProp<any>).push(...config)
         lastNavAction.current = config
-        setTimeout(() => {
+
+        // Reset lastNavAction when the transition ends
+        const unsubscribe = (
+          navigation as NativeStackNavigationProp<any>
+        ).addListener('transitionEnd', (e) => {
           lastNavAction.current = undefined
-        }, 500)
+          unsubscribe()
+        })
       }
     },
     [navigation, lastNavAction]

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 
 import type {
   ParamListBase,

--- a/packages/mobile/src/store/mobileUi/sagas.ts
+++ b/packages/mobile/src/store/mobileUi/sagas.ts
@@ -11,12 +11,12 @@ function* calculateAndroidNavigationBarHeight() {
 
     // Account for statusBar height because it is translucent and `getNavigationbarHeight`
     // does not account for it
-    const statusBarHeight = StatusBar.currentHeight
+    const statusBarHeight = StatusBar.currentHeight ?? 0
 
     yield* put(
       setAndroidNavigationBarHeight({
         androidNavigationBarHeight:
-          navigationBarHeight / scale - (statusBarHeight ?? 0)
+          navigationBarHeight / scale - statusBarHeight
       })
     )
   }

--- a/packages/mobile/src/store/mobileUi/sagas.ts
+++ b/packages/mobile/src/store/mobileUi/sagas.ts
@@ -1,4 +1,4 @@
-import { Dimensions, Platform } from 'react-native'
+import { Dimensions, Platform, StatusBar } from 'react-native'
 import { getNavigationBarHeight } from 'react-native-android-navbar-height'
 import { call, put } from 'typed-redux-saga'
 
@@ -9,9 +9,14 @@ function* calculateAndroidNavigationBarHeight() {
     const scale = Dimensions.get('screen').scale
     const navigationBarHeight = yield* call(getNavigationBarHeight)
 
+    // Account for statusBar height because it is translucent and `getNavigationbarHeight`
+    // does not account for it
+    const statusBarHeight = StatusBar.currentHeight
+
     yield* put(
       setAndroidNavigationBarHeight({
-        androidNavigationBarHeight: navigationBarHeight / scale
+        androidNavigationBarHeight:
+          navigationBarHeight / scale - (statusBarHeight ?? 0)
       })
     )
   }


### PR DESCRIPTION
### Description

* Fix double navigation on android by listening to the `transitionEnd` event on the current navigator
* Fix now playing bar offset by accounting for the translucent status bar
* Don't hide status bar when now playing drawer is open on android. Showing/hiding the status bar on android causes a lot of UI shift

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

