### PR TITLE
[C-1323] Somewhat improve upload metrics

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -116,18 +116,23 @@ export enum Name {
   EMBED_OPEN = 'Embed: Open modal',
   EMBED_COPY = 'Embed: Copy',
 
-  // Upload
+  // Upload funnel / conversion
   TRACK_UPLOAD_OPEN = 'Track Upload: Open',
   TRACK_UPLOAD_START_UPLOADING = 'Track Upload: Start Upload',
   TRACK_UPLOAD_TRACK_UPLOADING = 'Track Upload: Track Uploading',
+  // Note that upload is considered complete if it is explicitly rejected
+  // by the node receiving the file (HTTP 403).
   TRACK_UPLOAD_COMPLETE_UPLOAD = 'Track Upload: Complete Upload',
   TRACK_UPLOAD_COPY_LINK = 'Track Upload: Copy Link',
   TRACK_UPLOAD_SHARE_WITH_FANS = 'Track Upload: Share with your fans',
   TRACK_UPLOAD_SHARE_SOUND_TO_TIKTOK = 'Track Upload: Share sound to TikTok',
   TRACK_UPLOAD_VIEW_TRACK_PAGE = 'Track Upload: View Track page',
+  TWEET_FIRST_UPLOAD = 'Tweet First Upload',
+
+  // Upload success tracking
   TRACK_UPLOAD_SUCCESS = 'Track Upload: Success',
   TRACK_UPLOAD_FAILURE = 'Track Upload: Failure',
-  TWEET_FIRST_UPLOAD = 'Tweet First Upload',
+  TRACK_UPLOAD_REJECTED = 'Track Upload: Rejected',
 
   // Trending
   TRENDING_CHANGE_VIEW = 'Trending: Change view',
@@ -687,6 +692,13 @@ type TrackUploadSuccess = {
 
 type TrackUploadFailure = {
   eventName: Name.TRACK_UPLOAD_FAILURE
+  endpoint: string
+  kind: 'single_track' | 'multi_track' | 'album' | 'playlist'
+  error?: string
+}
+
+type TrackUploadRejected = {
+  eventName: Name.TRACK_UPLOAD_REJECTED
   endpoint: string
   kind: 'single_track' | 'multi_track' | 'album' | 'playlist'
   error?: string
@@ -1395,6 +1407,7 @@ export type AllTrackingEvents =
   | TrackUploadCompleteUpload
   | TrackUploadSuccess
   | TrackUploadFailure
+  | TrackUploadRejected
   | TrackUploadCopyLink
   | TrackUploadShareWithFans
   | TrackUploadShareSoundToTikTok

--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -677,6 +677,9 @@ type TrackUploadTrackUploading = {
   genre: string
   mood: string
   downloadable: 'yes' | 'no' | 'follow'
+  size: number
+  type: string
+  name: string
 }
 type TrackUploadCompleteUpload = {
   eventName: Name.TRACK_UPLOAD_COMPLETE_UPLOAD

--- a/packages/web/src/pages/upload-page/store/sagas.js
+++ b/packages/web/src/pages/upload-page/store/sagas.js
@@ -456,6 +456,7 @@ export function* handleUploads({
   const trackIds = []
   const creatorNodeMetadata = []
   const failedRequests = [] // Array of shape [{ id, timeout, message }]
+  const rejectedRequests = [] // Array of shape [{ id, timeout, message }]
 
   // We should only stop the whole upload if a request fails
   // in the collection upload case.
@@ -483,8 +484,12 @@ export function* handleUploads({
         yield put(uploadActions.uploadSingleTrackFailed(index))
       }
 
-      // Save this out to the failedRequests array
-      failedRequests.push({ originalId, timeout, message, phase })
+      if (message === 'Request failed with status code 403') {
+        // This is a rejection not a failure, record it as so
+        rejectedRequests.push({ originalId, timeout, message, phase })
+      } else {
+        failedRequests.push({ originalId, timeout, message, phase })
+      }
       numOutstandingRequests -= 1
       continue
     }
@@ -527,6 +532,7 @@ export function* handleUploads({
     // Don't report non-uploaded tracks due to playlist upload abort
     numSuccess: numSuccessRequests,
     numFailure: failedRequests.length,
+    numRejected: rejectedRequests.length,
     errors: failedRequests.map((r) => r.message),
     uploadType
   })
@@ -926,15 +932,25 @@ function* uploadSingleTrack(track) {
   )
 
   const { confirmedTrack, error } = yield take(responseChan)
+  const isRejected = error === 'Request failed with status code 403'
 
   yield reportSuccessAndFailureEvents({
     numSuccess: error ? 0 : 1,
-    numFailure: error ? 1 : 0,
+    numFailure: error && !isRejected ? 1 : 0,
+    numRejected: isRejected ? 1 : 0,
     uploadType: 'single_track',
     errors: error ? [error] : []
   })
 
   if (error) {
+    if (isRejected) {
+      yield put(
+        make(Name.TRACK_UPLOAD_COMPLETE_UPLOAD, {
+          count: 1,
+          kind: 'tracks'
+        })
+      )
+    }
     return
   }
 
@@ -1089,52 +1105,6 @@ function* uploadTracksAsync(action) {
     )
   )
 
-  // If user already has creator_node_endpoint, do not reselect replica set
-  let newEndpoint = user.creator_node_endpoint || ''
-  if (!newEndpoint) {
-    const serviceSelectionStatus = yield select(getStatus)
-    if (serviceSelectionStatus === Status.ERROR) {
-      yield put(uploadActions.uploadTrackFailed())
-      yield put(
-        uploadActions.upgradeToCreatorError(
-          'Failed to find creator nodes to upload to'
-        )
-      )
-      return
-    }
-    // Wait for service selection to finish
-    const { selectedServices } = yield race({
-      selectedServices: call(
-        waitForValue,
-        getSelectedServices,
-        {},
-        (val) => val.length > 0
-      ),
-      failure: take(fetchServicesFailed.type)
-    })
-    if (!selectedServices) {
-      yield put(uploadActions.uploadTrackFailed())
-      yield put(
-        uploadActions.upgradeToCreatorError(
-          'Failed to find creator nodes to upload to, after taking a long time'
-        )
-      )
-      return
-    }
-    newEndpoint = selectedServices.join(',')
-  }
-
-  yield put(
-    cacheActions.update(Kind.USERS, [
-      {
-        id: user.user_id,
-        metadata: {
-          creator_node_endpoint: newEndpoint
-        }
-      }
-    ])
-  )
-
   const uploadType = (() => {
     switch (action.uploadType) {
       case UploadType.PLAYLIST:
@@ -1155,11 +1125,10 @@ function* uploadTracksAsync(action) {
   yield put(recordEvent)
 
   // Upload content.
-  if (
-    action.uploadType === UploadType.PLAYLIST ||
-    action.uploadType === UploadType.ALBUM
-  ) {
-    const isAlbum = action.uploadType === UploadType.ALBUM
+  const isPlaylist = action.uploadType === UploadType.PLAYLIST
+  const isAlbum = action.uploadType === UploadType.ALBUM
+  const isSingleTrack = action.tracks.length === 1
+  if (isPlaylist || isAlbum) {
     yield call(
       uploadCollection,
       action.tracks,
@@ -1167,12 +1136,10 @@ function* uploadTracksAsync(action) {
       action.metadata,
       isAlbum
     )
+  } else if (isSingleTrack) {
+    yield call(uploadSingleTrack, action.tracks[0])
   } else {
-    if (action.tracks.length === 1) {
-      yield call(uploadSingleTrack, action.tracks[0])
-    } else {
-      yield call(uploadMultipleTracks, action.tracks)
-    }
+    yield call(uploadMultipleTracks, action.tracks)
   }
 }
 

--- a/packages/web/src/pages/upload-page/store/sagas.js
+++ b/packages/web/src/pages/upload-page/store/sagas.js
@@ -1,7 +1,6 @@
 import {
   Kind,
   Name,
-  Status,
   makeUid,
   formatUrlName,
   accountSelectors,
@@ -10,8 +9,7 @@ import {
   cacheUsersSelectors,
   cacheActions,
   waitForAccount,
-  actionChannelDispatcher,
-  waitForValue
+  actionChannelDispatcher
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { range } from 'lodash'
@@ -25,7 +23,6 @@ import {
   fork,
   cancel,
   all,
-  race,
   getContext
 } from 'redux-saga/effects'
 
@@ -34,11 +31,6 @@ import { reformat } from 'common/store/cache/collections/utils'
 import { trackNewRemixEvent } from 'common/store/cache/tracks/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
-import {
-  getSelectedServices,
-  getStatus
-} from 'common/store/service-selection/selectors'
-import { fetchServicesFailed } from 'common/store/service-selection/slice'
 import UploadType from 'pages/upload-page/components/uploadType'
 import { getStems } from 'pages/upload-page/store/selectors'
 import { updateAndFlattenStems } from 'pages/upload-page/store/utils/stems'

--- a/packages/web/src/pages/upload-page/store/utils/sagaHelpers.ts
+++ b/packages/web/src/pages/upload-page/store/utils/sagaHelpers.ts
@@ -9,11 +9,13 @@ const getAccountUser = accountSelectors.getAccountUser
 export function* reportSuccessAndFailureEvents({
   numSuccess,
   numFailure,
+  numRejected,
   uploadType,
   errors
 }: {
   numSuccess: number
   numFailure: number
+  numRejected: number
   uploadType: 'single_track' | 'multi_track' | 'album' | 'playlist'
   errors: string[]
 }) {
@@ -37,5 +39,15 @@ export function* reportSuccessAndFailureEvents({
     })
   )
 
-  yield* all([...successEvents, ...failureEvents].map((e) => put(e)))
+  const rejectedEvents = range(numRejected).map((i) =>
+    make(Name.TRACK_UPLOAD_FAILURE, {
+      endpoint: primary,
+      kind: uploadType,
+      error: errors[i]
+    })
+  )
+
+  yield* all(
+    [...successEvents, ...failureEvents, ...rejectedEvents].map((e) => put(e))
+  )
 }

--- a/packages/web/src/pages/upload-page/store/utils/sagaHelpers.ts
+++ b/packages/web/src/pages/upload-page/store/utils/sagaHelpers.ts
@@ -40,7 +40,7 @@ export function* reportSuccessAndFailureEvents({
   )
 
   const rejectedEvents = range(numRejected).map((i) =>
-    make(Name.TRACK_UPLOAD_FAILURE, {
+    make(Name.TRACK_UPLOAD_REJECTED, {
       endpoint: primary,
       kind: uploadType,
       error: errors[i]

--- a/packages/web/src/pages/upload-page/store/utils/sagaHelpers.ts
+++ b/packages/web/src/pages/upload-page/store/utils/sagaHelpers.ts
@@ -6,7 +6,7 @@ import { make } from 'common/store/analytics/actions'
 import { waitForBackendAndAccount } from 'utils/sagaHelpers'
 const getAccountUser = accountSelectors.getAccountUser
 
-export function* reportSuccessAndFailureEvents({
+export function* reportResultEvents({
   numSuccess,
   numFailure,
   numRejected,


### PR DESCRIPTION
### Description

Upload flow is extremely difficult to reason with, but I did what I could here for now to hopefully get somewhat more useful metrics:
1. New metric for rejected in addition to success / failure. That will make this graph more useful: https://analytics.amplitude.com/audius/chart/b9jlu2b?linkingDashboardId=p8cbu9n. It should be 100% or something is broken and we don't understand why
2. In the single-track upload case COMPLETE_UPLOAD will get recorded if that single track was rejected (per what this ticket calls for). However, this is really tough to do in the case of playlists/albums where one of multiple tracks could get rejected and then it's really hard to determine how we should count those metrics. With this change, we will at least infer how many of the batch were rejected (which we're currently not doing).

I really think we should rewrite all this logic.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Uploaded a track against stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

