### PR TITLE
Pass retry through for client handle validation

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -225,6 +225,7 @@ type GetUserArgs = {
 type GetUserByHandleArgs = {
   handle: string
   currentUserId: Nullable<ID>
+  retry?: boolean
 }
 
 type GetUserTracksByHandleArgs = {
@@ -966,7 +967,11 @@ export class AudiusAPIClient {
     return adapted
   }
 
-  async getUserByHandle({ handle, currentUserId }: GetUserByHandleArgs) {
+  async getUserByHandle({
+    handle,
+    currentUserId,
+    retry = true
+  }: GetUserByHandleArgs) {
     const encodedCurrentUserId = encodeHashId(currentUserId)
     this._assertInitialized()
     const params = {
@@ -975,7 +980,8 @@ export class AudiusAPIClient {
 
     const response: Nullable<APIResponse<APIUser[]>> = await this._getResponse(
       FULL_ENDPOINT_MAP.userByHandle(handle),
-      params
+      params,
+      retry
     )
 
     if (!response) return []

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -233,7 +233,17 @@ function* validateHandle(action) {
     }
     yield delay(300) // Wait 300 ms to debounce user input
 
-    const user = yield call(fetchUserByHandle, handle)
+    // Call fetch user by handle and do not retry if the user is not created, it will
+    // return 404 and force discovery reselection
+    const user = yield call(
+      fetchUserByHandle,
+      handle,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false
+    )
     const handleInUse = !isEmpty(user)
 
     if (IS_PRODUCTION_BUILD || IS_PRODUCTION) {


### PR DESCRIPTION
### Description
Iteration on #2183
Because `404` response codes trigger a discovery node reelection, the check for user not existing will trigger this logic and results in longer method response times. 
This change is to pass along a flag for `retry` so that checking for an existing handle will not trigger reslection and be instant!
Not sure if there's a mobile component to this that I'm missing @sliptype 

Fixes PLAT-432

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Ran locally against stage and validated that no re-selection were happening for non-existent handles. 

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

