### PR TITLE
Add notification navigation hook and update profile screen to accept id param

### DIFF
--- a/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
+++ b/packages/mobile/src/components/bottom-tab-bar/BottomTabBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 
 import type { BottomTabBarProps as RNBottomTabBarProps } from '@react-navigation/bottom-tabs'
 import type { BottomTabNavigationEventMap } from '@react-navigation/bottom-tabs/lib/typescript/src/types'
@@ -8,7 +8,6 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { FULL_DRAWER_HEIGHT } from 'app/components/drawer'
 import { PLAY_BAR_HEIGHT } from 'app/components/now-playing-drawer'
-import PushNotifications from 'app/notifications'
 import { makeStyles } from 'app/styles'
 
 import { bottomTabBarButtons } from './bottom-tab-bar-buttons'
@@ -74,14 +73,6 @@ export const BottomTabBar = (props: BottomTabBarProps) => {
   const { translationAnim, navigation, state } = props
   const { routes, index: activeIndex } = state
   const insets = useSafeAreaInsets()
-
-  // Provide PushNotification the bottom-bar navigation context to
-  // switch to notification stack
-  useEffect(() => {
-    if (navigation) {
-      PushNotifications.setBottomTabNavigation(navigation as any)
-    }
-  }, [navigation])
 
   const handlePress = useCallback(
     (isFocused: boolean, routeName: string, routeKey: string) => {

--- a/packages/mobile/src/hooks/useNotificationNavigation.ts
+++ b/packages/mobile/src/hooks/useNotificationNavigation.ts
@@ -1,0 +1,191 @@
+import { useCallback, useMemo } from 'react'
+
+import type {
+  AddTrackToPlaylistNotification,
+  AnnouncementNotification,
+  ChallengeRewardNotification,
+  FavoriteNotification,
+  FollowNotification,
+  MilestoneNotification,
+  ReactionNotification,
+  RemixCosignNotification,
+  RemixCreateNotification,
+  RepostNotification,
+  SupporterDethronedNotification,
+  SupporterRankUpNotification,
+  SupportingRankUpNotification,
+  TierChangeNotification,
+  TipReceiveNotification,
+  TipSendNotification,
+  TrendingTrackNotification,
+  UserSubscriptionNotification
+} from '@audius/common'
+import {
+  notificationsUserListActions,
+  tippingActions,
+  Achievement,
+  Entity,
+  NotificationType
+} from '@audius/common'
+import type { AppState } from 'audius-client/src/store/types'
+import { useDispatch, useStore } from 'react-redux'
+
+import { useNavigation } from './useNavigation'
+
+const { setNotificationId } = notificationsUserListActions
+const { beginTip } = tippingActions
+
+/**
+ * Navigator for notifications
+ *
+ * Uses the useNavigation hook under the hood
+ */
+export const useNotificationNavigation = () => {
+  const navigation = useNavigation()
+  const dispatch = useDispatch()
+  const store = useStore<AppState>()
+
+  const socialActionHandler = useCallback(
+    (
+      notification:
+        | FollowNotification
+        | RepostNotification
+        | FavoriteNotification
+    ) => {
+      const { id, type, userIds } = notification
+      const firstUserId = userIds[0]
+      const isMultiUser = userIds.length > 1
+
+      if (isMultiUser) {
+        dispatch(setNotificationId(id))
+        navigation.navigate('NotificationUsers', {
+          id,
+          notificationType: type,
+          count: userIds.length
+        })
+      } else if (firstUserId) {
+        navigation.push('Profile', {
+          id: firstUserId
+        })
+      }
+    },
+    [dispatch, navigation]
+  )
+
+  const notificationTypeHandlerMap = useMemo(
+    () => ({
+      [NotificationType.AddTrackToPlaylist]: (
+        notification: AddTrackToPlaylistNotification
+      ) => {
+        navigation.navigate('Collection', { id: notification.playlistId })
+      },
+      [NotificationType.Announcement]: (
+        notification: AnnouncementNotification
+      ) => {
+        navigation.navigate('Feed')
+      },
+      [NotificationType.ChallengeReward]: (
+        notification: ChallengeRewardNotification
+      ) => {
+        navigation.navigate('AudioScreen')
+      },
+      [NotificationType.Favorite]: (notification: FavoriteNotification) => {
+        socialActionHandler(notification)
+      },
+      [NotificationType.Follow]: (notification: FollowNotification) => {
+        socialActionHandler(notification)
+      },
+      [NotificationType.Milestone]: (notification: MilestoneNotification) => {
+        if (notification.achievement === Achievement.Followers) {
+          navigation.navigate('Profile', { id: notification.entityId })
+        } else {
+          navigation.navigate(
+            notification.entityType === Entity.Track ? 'Track' : 'Collection',
+            { id: notification.entityId }
+          )
+        }
+      },
+      [NotificationType.Reaction]: (notification: ReactionNotification) => {
+        navigation.navigate('Profile', { id: notification.entityId })
+      },
+      [NotificationType.RemixCosign]: (
+        notification: RemixCosignNotification
+      ) => {
+        navigation.navigate('Track', {
+          // @ts-ignore - Identity notification used entityId
+          id: notification.childTrackId ?? notification.entityId
+        })
+      },
+      [NotificationType.RemixCreate]: (
+        notification: RemixCreateNotification
+      ) => {
+        navigation.navigate('Track', {
+          // @ts-ignore - Identity notification used entityId
+          id: notification.childTrackId ?? notification.entityId
+        })
+      },
+      [NotificationType.Repost]: (notification: RepostNotification) => {
+        socialActionHandler(notification)
+      },
+      [NotificationType.SupporterDethroned]: (
+        notification: SupporterDethronedNotification
+      ) => {
+        const { supportedUserId } = notification
+        const supportedUser = store.getState().users.entries[supportedUserId]
+
+        dispatch(
+          beginTip({ user: supportedUser?.metadata, source: 'dethroned' })
+        )
+        navigation.navigate('TipArtist')
+      },
+      [NotificationType.SupporterRankUp]: (
+        notification: SupporterRankUpNotification
+      ) => {
+        navigation.navigate('Profile', { id: notification.entityId })
+      },
+      [NotificationType.SupportingRankUp]: (
+        notification: SupportingRankUpNotification
+      ) => {
+        navigation.navigate('Profile', { id: notification.entityId })
+      },
+      [NotificationType.TierChange]: (notification: TierChangeNotification) => {
+        navigation.navigate('AudioScreen')
+      },
+      [NotificationType.TipReceive]: (notification: TipReceiveNotification) => {
+        navigation.navigate('Profile', { id: notification.entityId })
+      },
+      [NotificationType.TipSend]: (notification: TipSendNotification) => {
+        navigation.navigate('Profile', { id: notification.entityId })
+      },
+      [NotificationType.TrendingTrack]: (
+        notification: TrendingTrackNotification
+      ) => {
+        navigation.navigate('Track', { id: notification.entityId })
+      },
+      [NotificationType.UserSubscription]: (
+        notification: UserSubscriptionNotification
+      ) => {
+        const multiUpload = notification.entityIds.length > 1
+
+        if (notification.entityType === Entity.Track && multiUpload) {
+          navigation.navigate('Profile', { id: notification.userId })
+        } else {
+          navigation.navigate(
+            notification.entityType === Entity.Track ? 'Track' : 'Collection',
+            { id: notification.entityIds[0] }
+          )
+        }
+      }
+    }),
+    [dispatch, navigation, socialActionHandler, store]
+  )
+
+  const handleNavigate = useCallback(
+    (notification: any) => {
+      notificationTypeHandlerMap[notification.type]?.(notification)
+    },
+    [notificationTypeHandlerMap]
+  )
+
+  return useMemo(() => ({ navigate: handleNavigate }), [handleNavigate])
+}

--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -13,6 +13,8 @@ type Token = {
   os: string
 }
 
+type NotificationNavigation = { navigate: (notification: any) => void }
+
 // Set to true while the push notification service is registering with the os
 let isRegistering = false
 
@@ -43,7 +45,7 @@ const getPlatformConfiguration = () => {
 class PushNotifications {
   lastId: number
   token: Token | null
-  navigation: any | null
+  navigation: NotificationNavigation | null
 
   // onNotification is a function passed in that is to be called when a
   // notification is to be emitted.
@@ -54,7 +56,7 @@ class PushNotifications {
     this.navigation = null
   }
 
-  setNavigation = (navigation: any) => {
+  setNavigation = (navigation: NotificationNavigation) => {
     this.navigation = navigation
   }
 

--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -1,9 +1,4 @@
-import type { Nullable } from '@audius/common'
-import { FeatureFlags } from '@audius/common'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs'
-import type { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types'
-import type { ParamListBase } from '@react-navigation/native'
 import type { PushNotificationPermissions } from 'react-native'
 import { Platform } from 'react-native'
 import Config from 'react-native-config'
@@ -11,18 +6,12 @@ import Config from 'react-native-config'
 import PushNotification from 'react-native-push-notification'
 
 import { track, make } from 'app/services/analytics'
-import {
-  getFeatureEnabled,
-  remoteConfigInstance
-} from 'app/services/remote-config'
 import { EventNames } from 'app/types/analytics'
 
 type Token = {
   token: string
   os: string
 }
-
-type BottomTabNavigation = BottomTabNavigationProp<ParamListBase>
 
 // Set to true while the push notification service is registering with the os
 let isRegistering = false
@@ -54,8 +43,7 @@ const getPlatformConfiguration = () => {
 class PushNotifications {
   lastId: number
   token: Token | null
-  drawerHelpers: DrawerNavigationHelpers | null
-  bottomTabNavigation: Nullable<BottomTabNavigation>
+  navigation: any | null
 
   // onNotification is a function passed in that is to be called when a
   // notification is to be emitted.
@@ -63,18 +51,14 @@ class PushNotifications {
     this.configure()
     this.lastId = 0
     this.token = null
-    this.bottomTabNavigation = null
+    this.navigation = null
   }
 
-  setDrawerHelpers(helpers: DrawerNavigationHelpers) {
-    this.drawerHelpers = helpers
+  setNavigation = (navigation: any) => {
+    this.navigation = navigation
   }
 
-  setBottomTabNavigation = (bottomTabNavigation: BottomTabNavigation) => {
-    this.bottomTabNavigation = bottomTabNavigation
-  }
-
-  onNotification = async (notification: any) => {
+  onNotification = (notification: any) => {
     console.info(`Received notification ${JSON.stringify(notification)}`)
     if (notification.userInteraction || Platform.OS === 'android') {
       track(
@@ -82,23 +66,14 @@ class PushNotifications {
           eventName: EventNames.NOTIFICATIONS_OPEN_PUSH_NOTIFICATION,
           ...(notification.message
             ? {
-                title: notification.message.title,
-                body: notification.message.body
+                title: notification.message.title ?? notification.title,
+                body: notification.message.body ?? notification.message
               }
             : {})
         })
       )
 
-      await remoteConfigInstance.waitForRemoteConfig()
-      const isNavOverhaulEnabled = await getFeatureEnabled(
-        FeatureFlags.MOBILE_NAV_OVERHAUL
-      )
-
-      if (isNavOverhaulEnabled) {
-        this.bottomTabNavigation?.navigate('notifications')
-      } else {
-        this.drawerHelpers?.openDrawer()
-      }
+      this.navigation?.navigate(notification.data.data)
     }
   }
 

--- a/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from 'react'
-import { useMemo, createContext, useState } from 'react'
+import { useEffect, useMemo, createContext, useState } from 'react'
 
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
+
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
+import PushNotifications from 'app/notifications'
 
 import type { AppTabScreenParamList } from './AppTabScreen'
 
@@ -36,6 +39,7 @@ export const AppTabNavigationProvider = (
 ) => {
   const { children } = props
   const [navigation, setNavigation] = useState({} as AppTabNavigation)
+  const notifNavigation = useNotificationNavigation()
 
   const navigationContext = useMemo(
     () => ({ navigation, setNavigation }),
@@ -46,6 +50,10 @@ export const AppTabNavigationProvider = (
     () => ({ setNavigation }),
     [setNavigation]
   )
+
+  useEffect(() => {
+    PushNotifications.setNavigation(notifNavigation)
+  }, [notifNavigation])
 
   return (
     <AppTabNavigationContext.Provider value={navigationContext}>

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -63,7 +63,7 @@ export type AppTabScreenParamList = {
     slug?: string
   }
   TrackRemixes: { id: ID }
-  Profile: { handle: string }
+  Profile: { handle: string; id?: ID } | { handle?: string; id: ID }
   Collection: {
     id?: ID
     collectionName?: string

--- a/packages/mobile/src/screens/notifications-screen/Notifications/AddTrackToPlaylistNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/AddTrackToPlaylistNotification.tsx
@@ -5,8 +5,8 @@ import { useProxySelector, notificationsSelectors } from '@audius/common'
 import { View } from 'react-native'
 
 import IconPlaylists from 'app/assets/images/iconPlaylists.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
-import { useNotificationNavigation } from '../../app-drawer-screen'
 import {
   NotificationHeader,
   NotificationText,
@@ -16,7 +16,6 @@ import {
   UserNameLink,
   ProfilePicture
 } from '../Notification'
-import { getEntityScreen } from '../Notification/utils'
 const { getNotificationEntities } = notificationsSelectors
 
 const messages = {
@@ -32,6 +31,7 @@ export const AddTrackToPlaylistNotification = (
   props: AddTrackToPlaylistNotificationProps
 ) => {
   const { notification } = props
+  const navigation = useNotificationNavigation()
   const entities = useProxySelector(
     (state) => getNotificationEntities(state, notification),
     [notification]
@@ -39,14 +39,11 @@ export const AddTrackToPlaylistNotification = (
   const { track, playlist } = entities
   const playlistOwner = playlist.user
 
-  const navigation = useNotificationNavigation()
-
   const handlePress = useCallback(() => {
     if (playlist) {
-      const [screen, params] = getEntityScreen(playlist)
-      navigation.navigate(screen, params)
+      navigation.navigate(notification)
     }
-  }, [playlist, navigation])
+  }, [playlist, navigation, notification])
 
   return (
     <NotificationTile notification={notification} onPress={handlePress}>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/ChallengeRewardNotification.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import type {
   ChallengeRewardID,
   ChallengeRewardNotification as ChallengeRewardNotificationType
@@ -5,6 +7,7 @@ import type {
 import { Platform } from 'react-native'
 
 import IconAudius from 'app/assets/images/iconAudius.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
 import {
   NotificationTile,
@@ -83,10 +86,17 @@ export const ChallengeRewardNotification = (
   const { notification } = props
   const { challengeId } = notification
   const info = challengeInfoMap[challengeId]
+  const navigation = useNotificationNavigation()
+
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
+
   if (!info) return null
   const { title, amount, iosTitle } = info
+
   return (
-    <NotificationTile notification={notification}>
+    <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={IconAudius}>
         <NotificationTitle>
           {Platform.OS === 'ios' && iosTitle != null ? iosTitle : title}

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteNotification.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import type { FavoriteNotification as FavoriteNotificationType } from '@audius/common'
 import {
   formatCount,
@@ -6,6 +8,7 @@ import {
 } from '@audius/common'
 
 import IconHeart from 'app/assets/images/iconHeart.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
 import {
   NotificationHeader,
@@ -17,7 +20,6 @@ import {
   EntityLink
 } from '../Notification'
 
-import { useSocialActionHandler } from './useSocialActionHandler'
 const { getNotificationEntity, getNotificationUsers } = notificationsSelectors
 
 const messages = {
@@ -33,6 +35,7 @@ type FavoriteNotificationProps = {
 export const FavoriteNotification = (props: FavoriteNotificationProps) => {
   const { notification } = props
   const { userIds, entityType } = notification
+  const navigation = useNotificationNavigation()
 
   const users = useProxySelector(
     (state) => getNotificationUsers(state, notification, USER_LENGTH_LIMIT),
@@ -47,7 +50,9 @@ export const FavoriteNotification = (props: FavoriteNotificationProps) => {
     [notification]
   )
 
-  const handlePress = useSocialActionHandler(notification, users)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   if (!users || !firstUser || !entity) return null
 

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FollowNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FollowNotification.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import type { FollowNotification as FollowNotificationType } from '@audius/common'
 import {
   useProxySelector,
@@ -6,6 +8,7 @@ import {
 } from '@audius/common'
 
 import IconUser from 'app/assets/images/iconUser.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
 import {
   NotificationHeader,
@@ -16,7 +19,6 @@ import {
   NotificationText
 } from '../Notification'
 
-import { useSocialActionHandler } from './useSocialActionHandler'
 const { getNotificationUsers } = notificationsSelectors
 
 const messages = {
@@ -32,6 +34,8 @@ type FollowNotificationProps = {
 export const FollowNotification = (props: FollowNotificationProps) => {
   const { notification } = props
   const { userIds } = notification
+  const navigation = useNotificationNavigation()
+
   const users = useProxySelector(
     (state) => getNotificationUsers(state, notification, USER_LENGTH_LIMIT),
     [notification]
@@ -39,7 +43,9 @@ export const FollowNotification = (props: FollowNotificationProps) => {
   const firstUser = users?.[0]
   const otherUsersCount = userIds.length - 1
 
-  const handlePress = useSocialActionHandler(notification, users)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   if (!users || !firstUser) return null
 

--- a/packages/mobile/src/screens/notifications-screen/Notifications/MilestoneNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/MilestoneNotification.tsx
@@ -15,11 +15,11 @@ import { fullProfilePage } from 'audius-client/src/utils/route'
 import { useSelector } from 'react-redux'
 
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 import { formatCount } from 'app/utils/format'
 
-import { useNotificationNavigation } from '../../app-drawer-screen'
 import {
   EntityLink,
   NotificationHeader,
@@ -28,7 +28,7 @@ import {
   NotificationTitle,
   NotificationTwitterButton
 } from '../Notification'
-import { getEntityRoute, getEntityScreen } from '../Notification/utils'
+import { getEntityRoute } from '../Notification/utils'
 const { getNotificationEntity, getNotificationUser } = notificationsSelectors
 
 const messages = {
@@ -104,20 +104,8 @@ export const MilestoneNotification = (props: MilestoneNotificationProps) => {
   const navigation = useNotificationNavigation()
 
   const handlePress = useCallback(() => {
-    if (achievement === Achievement.Followers) {
-      if (user) {
-        navigation.navigate('Profile', {
-          handle: user.handle,
-          fromNotifications: true
-        })
-      }
-    } else {
-      if (entity) {
-        const [screen, params] = getEntityScreen(entity)
-        navigation.navigate(screen, params)
-      }
-    }
-  }, [achievement, user, navigation, entity])
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   const renderBody = () => {
     const { achievement, value } = notification

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RemixCosignNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RemixCosignNotification.tsx
@@ -10,11 +10,11 @@ import { View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import IconRemix from 'app/assets/images/iconRemix.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 import { getTrackRoute } from 'app/utils/routes'
 
-import { useNotificationNavigation } from '../../app-drawer-screen'
 import {
   NotificationHeader,
   NotificationText,
@@ -60,12 +60,9 @@ export const RemixCosignNotification = (
 
   const handlePress = useCallback(() => {
     if (childTrack) {
-      navigation.navigate('Track', {
-        id: childTrack.track_id,
-        fromNotifications: true
-      })
+      navigation.navigate(notification)
     }
-  }, [childTrack, navigation])
+  }, [childTrack, navigation, notification])
 
   const handleTwitterShareData = useCallback(
     (handle: string | undefined) => {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RemixCreateNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RemixCreateNotification.tsx
@@ -9,11 +9,11 @@ import { useProxySelector, notificationsSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import IconRemix from 'app/assets/images/iconRemix.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 import { getTrackRoute } from 'app/utils/routes'
 
-import { useNotificationNavigation } from '../../app-drawer-screen'
 import {
   NotificationHeader,
   NotificationText,
@@ -61,12 +61,9 @@ export const RemixCreateNotification = (
 
   const handlePress = useCallback(() => {
     if (childTrack) {
-      navigation.navigate('Track', {
-        id: childTrack.track_id,
-        fromNotifications: true
-      })
+      navigation.navigate(notification)
     }
-  }, [childTrack, navigation])
+  }, [childTrack, navigation, notification])
 
   const handleTwitterShareData = useCallback(
     (handle: string | undefined) => {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RepostNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RepostNotification.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import type { RepostNotification as RepostNotificationType } from '@audius/common'
 import {
   useProxySelector,
@@ -6,6 +8,7 @@ import {
 } from '@audius/common'
 
 import IconRepost from 'app/assets/images/iconRepost.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
 import {
   NotificationHeader,
@@ -17,7 +20,6 @@ import {
   EntityLink
 } from '../Notification'
 
-import { useSocialActionHandler } from './useSocialActionHandler'
 const { getNotificationEntity, getNotificationUsers } = notificationsSelectors
 
 const messages = {
@@ -33,6 +35,8 @@ type RepostNotificationProps = {
 export const RepostNotification = (props: RepostNotificationProps) => {
   const { notification } = props
   const { userIds, entityType } = notification
+  const navigation = useNotificationNavigation()
+
   const users = useProxySelector(
     (state) => getNotificationUsers(state, notification, USER_LENGTH_LIMIT),
     [notification]
@@ -45,7 +49,9 @@ export const RepostNotification = (props: RepostNotificationProps) => {
     [notification]
   )
 
-  const handlePress = useSocialActionHandler(notification, users)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   if (!users || !firstUser || !entity) return null
 

--- a/packages/mobile/src/screens/notifications-screen/Notifications/SupporterDethronedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/SupporterDethronedNotification.tsx
@@ -1,19 +1,15 @@
 import { useCallback } from 'react'
 
-import {
-  cacheUsersSelectors,
-  notificationsSelectors,
-  tippingActions
-} from '@audius/common'
+import { cacheUsersSelectors, notificationsSelectors } from '@audius/common'
 import type {
   Nullable,
   SupporterDethronedNotification as SupporterDethroned
 } from '@audius/common'
 import { Platform } from 'react-native'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 
 import IconCrownSource from 'app/assets/images/crown2x.png'
-import { useNavigation } from 'app/hooks/useNavigation'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 
@@ -30,7 +26,6 @@ import {
 
 const { getUser } = cacheUsersSelectors
 const { getNotificationUser } = notificationsSelectors
-const { beginTip } = tippingActions
 
 type SupporterDethronedNotificationProps = {
   notification: SupporterDethroned
@@ -51,8 +46,7 @@ export const SupporterDethronedNotification = (
 ) => {
   const { notification } = props
   const { supportedUserId } = notification
-  const dispatch = useDispatch()
-  const navigation = useNavigation()
+  const navigation = useNotificationNavigation()
   const usurpingUser = useSelector((state) =>
     getNotificationUser(state, notification)
   )
@@ -62,9 +56,8 @@ export const SupporterDethronedNotification = (
   )
 
   const handlePress = useCallback(() => {
-    dispatch(beginTip({ user: supportedUser, source: 'dethroned' }))
-    navigation.navigate('TipArtist')
-  }, [dispatch, supportedUser, navigation])
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   const handleShare = useCallback(
     (usurpingHandle: string, supportingHandle?: Nullable<string>) => {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TierChangeNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TierChangeNotification.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import type { TierChangeNotification as TierChangeNotificationType } from '@audius/common'
 import { cacheUsersSelectors } from '@audius/common'
 import { fullProfilePage } from 'audius-client/src/utils/route'
@@ -7,6 +9,7 @@ import IconBronzeBadge from 'app/assets/images/IconBronzeBadge.svg'
 import IconGoldBadge from 'app/assets/images/IconGoldBadge.svg'
 import IconPlatinumBadge from 'app/assets/images/IconPlatinumBadge.svg'
 import IconSilverBadge from 'app/assets/images/IconSilverBadge.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
 import {
   NotificationTile,
@@ -65,13 +68,18 @@ type TierChangeNotificationProps = {
 export const TierChangeNotification = (props: TierChangeNotificationProps) => {
   const { notification } = props
   const { tier, userId } = notification
+  const navigation = useNotificationNavigation()
   const user = useSelector((state) => getUser(state, { id: userId }))
   const { icon, label, amount, twitterIcon } = tierInfoMap[tier]
+
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   if (!user) return null
 
   return (
-    <NotificationTile notification={notification}>
+    <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={icon}>
         <NotificationTitle style={{ textTransform: 'uppercase' }}>
           {label} {messages.unlocked}

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipReactionNotification.tsx
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux'
 
 import IconTip from 'app/assets/images/iconTip.svg'
 import UserBadges from 'app/components/user-badges'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { EventNames } from 'app/types/analytics'
@@ -27,7 +28,6 @@ import {
 } from '../Notification'
 import { reactionMap } from '../Reaction'
 
-import { useGoToProfile } from './useGoToProfile'
 const { getNotificationUser } = notificationsSelectors
 
 const messages = {
@@ -79,12 +79,15 @@ export const TipReactionNotification = (
     reactedToEntity: { amount }
   } = notification
 
+  const navigation = useNotificationNavigation()
   const uiAmount = useUIAudio(amount)
   const styles = useStyles()
 
   const user = useSelector((state) => getNotificationUser(state, notification))
 
-  const handlePress = useGoToProfile(user)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   const handleTwitterShare = useCallback((handle: string) => {
     const shareText = messages.twitterShare(handle, Platform.OS === 'ios')

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipReceivedNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipReceivedNotification.tsx
@@ -18,6 +18,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import Checkmark from 'app/assets/images/emojis/white-heavy-check-mark.png'
 import IconTip from 'app/assets/images/iconTip.svg'
 import { Text } from 'app/components/core'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 
@@ -34,7 +35,6 @@ import {
 } from '../Notification'
 import { ReactionList } from '../Reaction'
 
-import { useGoToProfile } from './useGoToProfile'
 const { writeReactionValue } = reactionsUIActions
 const { makeGetReactionForSignature } = reactionsUISelectors
 const { getNotificationUser } = notificationsSelectors
@@ -78,6 +78,7 @@ export const TipReceivedNotification = (
   const { notification, isVisible } = props
   const { amount, tipTxSignature } = notification
   const uiAmount = useUIAudio(amount)
+  const navigation = useNotificationNavigation()
 
   const user = useSelector((state) => getNotificationUser(state, notification))
 
@@ -85,7 +86,9 @@ export const TipReceivedNotification = (
 
   const setReactionValue = useSetReaction(tipTxSignature)
 
-  const handlePress = useGoToProfile(user)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   const handleTwitterShare = useCallback(
     (senderHandle: string) => {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TipSentNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TipSentNotification.tsx
@@ -6,6 +6,7 @@ import { Platform, View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import IconTip from 'app/assets/images/iconTip.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 
@@ -20,7 +21,6 @@ import {
 import { TipText } from '../Notification/TipText'
 import { UserNameLink } from '../Notification/UserNameLink'
 
-import { useGoToProfile } from './useGoToProfile'
 const { getNotificationUser } = notificationsSelectors
 
 const messages = {
@@ -48,10 +48,13 @@ export const TipSentNotification = (props: TipSentNotificationProps) => {
 
   const { amount } = notification
   const uiAmount = useUIAudio(amount)
+  const navigation = useNotificationNavigation()
 
   const user = useSelector((state) => getNotificationUser(state, notification))
 
-  const handlePress = useGoToProfile(user)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   const handleTwitterShare = useCallback(
     (senderHandle: string) => {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TopSupporterNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TopSupporterNotification.tsx
@@ -5,13 +5,13 @@ import { notificationsSelectors } from '@audius/common'
 import { Platform } from 'react-native'
 import { useSelector } from 'react-redux'
 
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 
 import { NotificationTile, NotificationTwitterButton } from '../Notification'
 
 import { SupporterAndSupportingNotificationContent } from './SupporterAndSupportingNotificationContent'
-import { useGoToProfile } from './useGoToProfile'
 const { getNotificationUser } = notificationsSelectors
 
 const messages = {
@@ -34,10 +34,13 @@ export const TopSupporterNotification = (
 ) => {
   const { notification } = props
   const { rank } = notification
+  const navigation = useNotificationNavigation()
 
   const user = useSelector((state) => getNotificationUser(state, notification))
 
-  const handlePress = useGoToProfile(user)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   const handleTwitterShare = useCallback(
     (handle: string) => {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TopSupportingNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TopSupportingNotification.tsx
@@ -5,13 +5,13 @@ import { notificationsSelectors } from '@audius/common'
 import { Platform } from 'react-native'
 import { useSelector } from 'react-redux'
 
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import { make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
 
 import { NotificationTile, NotificationTwitterButton } from '../Notification'
 
 import { SupporterAndSupportingNotificationContent } from './SupporterAndSupportingNotificationContent'
-import { useGoToProfile } from './useGoToProfile'
 const { getNotificationUser } = notificationsSelectors
 
 const messages = {
@@ -34,10 +34,13 @@ export const TopSupportingNotification = (
 ) => {
   const { notification } = props
   const { rank } = notification
+  const navigation = useNotificationNavigation()
 
   const user = useSelector((state) => getNotificationUser(state, notification))
 
-  const handlePress = useGoToProfile(user)
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   const handleTwitterShare = useCallback(
     (handle: string) => {

--- a/packages/mobile/src/screens/notifications-screen/Notifications/TrendingTrackNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/TrendingTrackNotification.tsx
@@ -9,8 +9,8 @@ import { notificationsSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import IconTrending from 'app/assets/images/iconTrending.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
-import { useNotificationNavigation } from '../../app-drawer-screen'
 import {
   EntityLink,
   NotificationHeader,
@@ -51,9 +51,9 @@ export const TrendingTrackNotification = (
 
   const handlePress = useCallback(() => {
     if (track) {
-      navigation.navigate('Track', { id: track.track_id })
+      navigation.navigate(notification)
     }
-  }, [navigation, track])
+  }, [navigation, notification, track])
 
   if (!track) return null
 

--- a/packages/mobile/src/screens/notifications-screen/Notifications/UserSubscriptionNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/UserSubscriptionNotification.tsx
@@ -1,17 +1,13 @@
 import { useCallback } from 'react'
 
 import type { UserSubscriptionNotification as UserSubscriptionNotificationType } from '@audius/common'
-import {
-  useProxySelector,
-  notificationsSelectors,
-  Entity
-} from '@audius/common'
+import { useProxySelector, notificationsSelectors } from '@audius/common'
 import { View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import IconStars from 'app/assets/images/iconStars.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 
-import { useNotificationNavigation } from '../../app-drawer-screen'
 import {
   NotificationHeader,
   NotificationText,
@@ -21,7 +17,6 @@ import {
   UserNameLink,
   ProfilePicture
 } from '../Notification'
-import { getEntityScreen } from '../Notification/utils'
 const { getNotificationEntities, getNotificationUser } = notificationsSelectors
 
 const messages = {
@@ -50,21 +45,8 @@ export const UserSubscriptionNotification = (
   const isSingleUpload = uploadCount === 1
 
   const handlePress = useCallback(() => {
-    if (entityType === Entity.Track && !isSingleUpload) {
-      if (user) {
-        navigation.navigate('Profile', {
-          handle: user.handle,
-          fromNotifications: true
-        })
-      }
-    } else {
-      if (entities) {
-        const [entity] = entities
-        const [screen, params] = getEntityScreen(entity)
-        navigation.navigate(screen, params)
-      }
-    }
-  }, [entityType, isSingleUpload, navigation, user, entities])
+    navigation.navigate(notification)
+  }, [navigation, notification])
 
   if (!user || !entities) return null
 

--- a/packages/mobile/src/screens/notifications-screen/NotificationsDrawer.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationsDrawer.tsx
@@ -1,9 +1,5 @@
-import { useEffect } from 'react'
-
 import type { DrawerContentComponentProps } from '@react-navigation/drawer'
 import { useNavigation } from '@react-navigation/native'
-
-import PushNotifications from 'app/notifications'
 
 import { AppDrawerContextProvider } from '../app-drawer-screen'
 
@@ -24,10 +20,6 @@ export const NotificationsDrawer = (props: NotificationDrawerContentsProps) => {
     setDisableGestures
   } = props
   const drawerNavigation = useNavigation()
-
-  useEffect(() => {
-    PushNotifications.setDrawerHelpers(drawerHelpers)
-  }, [drawerHelpers])
 
   return (
     <AppDrawerContextProvider

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -60,16 +60,15 @@ export const ProfileScreen = () => {
   usePopToTopOnDrawerOpen()
   const styles = useStyles()
   const { params } = useRoute<'Profile'>()
+  const { handle: userHandle, id } = params
   const profile = useSelectProfileRoot([
     'user_id',
     'handle',
     'does_current_user_follow'
   ])
   const handle =
-    params.handle && params.handle !== 'accountUser'
-      ? params.handle
-      : profile?.handle
-  const handleLower = handle?.toLowerCase()
+    userHandle && userHandle !== 'accountUser' ? userHandle : profile?.handle
+  const handleLower = handle ? handle?.toLowerCase() : ''
   const accountId = useSelector(getUserId)
   const dispatch = useDispatch()
   const status = useSelector((state) => getProfileStatus(state, handleLower))
@@ -83,8 +82,10 @@ export const ProfileScreen = () => {
   )
 
   const fetchProfile = useCallback(() => {
-    dispatch(fetchProfileAction(handleLower, null, true, true, false))
-  }, [dispatch, handleLower])
+    dispatch(
+      fetchProfileAction(handleLower ?? null, id ?? null, true, true, false)
+    )
+  }, [dispatch, handleLower, id])
 
   useEffect(() => {
     fetchProfile()

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -68,7 +68,7 @@ export const ProfileScreen = () => {
   ])
   const handle =
     userHandle && userHandle !== 'accountUser' ? userHandle : profile?.handle
-  const handleLower = handle ? handle?.toLowerCase() : ''
+  const handleLower = handle?.toLowerCase() ?? ''
   const accountId = useSelector(getUserId)
   const dispatch = useDispatch()
   const status = useSelector((state) => getProfileStatus(state, handleLower))

--- a/packages/mobile/src/screens/profile-screen/selectors.ts
+++ b/packages/mobile/src/screens/profile-screen/selectors.ts
@@ -60,7 +60,7 @@ export const useIsProfileLoaded = () => {
   const { params } = useRoute<'Profile'>()
   const { handle } = params
   const profileStatus = useSelector((state) =>
-    getProfileStatus(state, handle.toLowerCase())
+    getProfileStatus(state, handle?.toLowerCase())
   )
 
   return handle === 'accountUser' || profileStatus === Status.SUCCESS


### PR DESCRIPTION
### Description
Add notification navigation hook to be used by notification components and push notifications

This can be updated to have separate handlers for each notification type, but wanted to get the basics down

### Dragons

The structure of notifications coming back from identity is not the same as client side, so need to do a lot of verification to make sure that this will work for push notifications

### How Has This Been Tested?

Manually tested with a lot of notif types, but need to do testing on device to work out the kinks with push notifications

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

