### PR TITLE
Read artist pick from discovery behind feature flag

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -894,6 +894,10 @@ export const audiusBackend = ({
           (readArtistPickFromDiscoveryEnabled
             ? account.artist_pick_track_id
             : body.pinnedTrackId) || null
+        account.artist_pick_track_id =
+          (readArtistPickFromDiscoveryEnabled
+            ? account.artist_pick_track_id
+            : body.pinnedTrackId) || null
         account.twitterVerified = body.twitterVerified || false
         account.instagramVerified = body.instagramVerified || false
       } catch (e) {

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -873,6 +873,16 @@ export const audiusBackend = ({
         account = audiusLibs.Account.getCurrentUser()
         if (!account) return null
       }
+
+      // If reading the artist pick from discovery, set _artist_pick on
+      // the user to the value from discovery (set in artist_pick_track_id
+      // on the user).
+      // TODO after migration is complete: replace all usages of
+      // _artist_pick with artist_pick_track_id
+      const readArtistPickFromDiscoveryEnabled =
+        (await getFeatureEnabled(
+          FeatureFlags.READ_ARTIST_PICK_FROM_DISCOVERY
+        )) ?? false
       try {
         const body = await getCreatorSocialHandle(account.handle)
         account.twitter_handle = body.twitterHandle || null
@@ -880,7 +890,10 @@ export const audiusBackend = ({
         account.tiktok_handle = body.tikTokHandle || null
         account.website = body.website || null
         account.donation = body.donation || null
-        account._artist_pick = body.pinnedTrackId || null
+        account._artist_pick =
+          (readArtistPickFromDiscoveryEnabled
+            ? account.artist_pick_track_id
+            : body.pinnedTrackId) || null
         account.twitterVerified = body.twitterVerified || false
         account.instagramVerified = body.instagramVerified || false
       } catch (e) {

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -29,7 +29,8 @@ export enum FeatureFlags {
   AUTO_SUBSCRIBE_ON_FOLLOW = 'auto_subscribe_on_follow',
   MOBILE_NAV_OVERHAUL = 'mobile_nav_overhaul_final',
   MOBILE_UPLOAD = 'mobile_upload',
-  STREAM_MP3 = 'stream_mp3'
+  STREAM_MP3 = 'stream_mp3',
+  READ_ARTIST_PICK_FROM_DISCOVERY = 'read_artist_pick_from_discovery'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -80,5 +81,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.AUTO_SUBSCRIBE_ON_FOLLOW]: false,
   [FeatureFlags.MOBILE_NAV_OVERHAUL]: false,
   [FeatureFlags.MOBILE_UPLOAD]: false,
-  [FeatureFlags.STREAM_MP3]: false
+  [FeatureFlags.STREAM_MP3]: false,
+  [FeatureFlags.READ_ARTIST_PICK_FROM_DISCOVERY]: false
 }

--- a/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
@@ -9,9 +9,17 @@ import {
   profilePageTracksLineupActions as tracksActions,
   profilePageTracksLineupActions as lineupActions,
   tracksSocialActions,
-  waitForValue
+  waitForValue,
+  FeatureFlags
 } from '@audius/common'
-import { all, call, select, takeEvery, put } from 'redux-saga/effects'
+import {
+  all,
+  call,
+  select,
+  takeEvery,
+  put,
+  getContext
+} from 'redux-saga/effects'
 
 import { retrieveTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
@@ -43,8 +51,13 @@ function* getTracks({ offset, limit, payload, handle }) {
   )
   const sort = payload?.sort === TracksSortMode.POPULAR ? 'plays' : 'date'
   const getUnlisted = true
+  const getFeatureEnabled = yield getContext('getFeatureEnabled')
+  const readArtistPickFromDiscoveryEnabled = yield call(
+    getFeatureEnabled,
+    FeatureFlags.READ_ARTIST_PICK_FROM_DISCOVERY
+  ) ?? false
 
-  if (user._artist_pick) {
+  if (!readArtistPickFromDiscoveryEnabled && user._artist_pick) {
     let [pinnedTrack, processed] = yield all([
       call(retrieveTracks, { trackIds: [user._artist_pick] }),
       call(retrieveUserTracks, {

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -217,24 +217,6 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     }
   }
 
-  // Check that the sorted order has the _artist_pick track as the first
-  updateOrderArtistPickCheck = (tracks: Array<{ track_id: ID }>) => {
-    const {
-      profile: { profile }
-    } = this.props
-    if (!profile) return []
-    const artistPick = profile._artist_pick
-    const artistTrackIndex = tracks.findIndex(
-      (track) => track.track_id === artistPick
-    )
-    if (artistTrackIndex > -1) {
-      return [tracks[artistTrackIndex]]
-        .concat(tracks.slice(0, artistTrackIndex))
-        .concat(tracks.slice(artistTrackIndex + 1))
-    }
-    return tracks
-  }
-
   onFollow = () => {
     const {
       profile: { profile }


### PR DESCRIPTION
### Description
If the `READ_ARTIST_PICK_FROM_DISCOVERY` flag is on, read users' artist pick track ids from discovery instead of identity. I set `_artist_pick` on the user to the id from discovery when populating the user cache so that I didn't have to check the flag every time the artist pick value is accessed throughout the client code. Later, when everything is fully rolled out and we are ready to delete the dead code, I'll remove this switch and replace all references to `_artist_pick` with `artist_pick_track_id` throughout the client.

### Dragons
Do not turn this flag on until dual writes are on + backfill has been run.

### How Has This Been Tested?
On web and mobile:
Create divergence between discovery and identity artist pick track ids, insert debug statement when building user cache, make sure flag is on and artist pick is coming from discovery when loading your profile. Make sure artist pick is still 1st result in track lineup.
Turn off switch and refresh page, make sure artist pick and lineup reflect change.

### How will this change be monitored?

### Feature Flags ###
`READ_ARTIST_PICK_FROM_DISCOVERY`: enabled -> artist pick ids are read from discovery; disabled ->  artist pick ids are read from identity

