### PR TITLE
Use confirmer wrapper when updating user

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2158,23 +2158,11 @@ export const audiusBackend = ({
 
   /**
    * Sets the artist pick for a user
-   * @param {User} userMetadata
-   * @param {number} userId
    * @param {number?} trackId if null, unsets the artist pick
    */
-  async function setArtistPick(
-    userMetadata: User,
-    userId: ID,
-    trackId: Nullable<ID> = null
-  ) {
+  async function setArtistPick(trackId: Nullable<ID> = null) {
     await waitForLibsInit()
     try {
-      // Dual write to the artist_pick_track_id field in the
-      // users table in the discovery DB. Part of the migration
-      // of the artist pick feature from the identity service
-      // to the entity manager in discovery.
-      updateCreator(userMetadata, userId)
-
       const { data, signature } = await signData()
       return await fetch(`${identityServiceUrl}/artist_pick`, {
         method: 'POST',

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -16,6 +16,7 @@ import {
   tracksSocialActions as socialActions,
   waitForValue
 } from '@audius/common'
+import { fork } from 'redux-saga/effects'
 import { call, select, takeEvery, put } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
@@ -24,6 +25,7 @@ import { adjustUserField } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
+import { updateProfileAsync } from 'common/store/profile/sagas'
 import { waitForBackendAndAccount } from 'utils/sagaHelpers'
 
 import watchTrackErrors from './errorSagas'
@@ -536,7 +538,11 @@ export function* watchSetArtistPick() {
     function* (action: ReturnType<typeof socialActions.setArtistPick>) {
       yield* waitForBackendAndAccount()
       const userId = yield* select(getUserId)
-      if (!userId) return
+
+      // Dual write to the artist_pick_track_id field in the
+      // users table in the discovery DB. Part of the migration
+      // of the artist pick feature from the identity service
+      // to the entity manager in discovery.
       yield* put(
         cacheActions.update(Kind.USERS, [
           {
@@ -548,13 +554,9 @@ export function* watchSetArtistPick() {
           }
         ])
       )
+      yield* call(audiusBackendInstance.setArtistPick, action.trackId)
       const user = yield* call(waitForValue, getUser, { id: userId })
-      yield* call(
-        audiusBackendInstance.setArtistPick,
-        user,
-        userId,
-        action.trackId
-      )
+      yield fork(updateProfileAsync, { metadata: user })
 
       const event = make(Name.ARTIST_PICK_SELECT_TRACK, { id: action.trackId })
       yield* put(event)
@@ -567,7 +569,11 @@ export function* watchUnsetArtistPick() {
   yield* takeEvery(socialActions.UNSET_ARTIST_PICK, function* (action) {
     yield* waitForBackendAndAccount()
     const userId = yield* select(getUserId)
-    if (!userId) return
+
+    // Dual write to the artist_pick_track_id field in the
+    // users table in the discovery DB. Part of the migration
+    // of the artist pick feature from the identity service
+    // to the entity manager in discovery.
     yield* put(
       cacheActions.update(Kind.USERS, [
         {
@@ -579,8 +585,9 @@ export function* watchUnsetArtistPick() {
         }
       ])
     )
+    yield* call(audiusBackendInstance.setArtistPick)
     const user = yield* call(waitForValue, getUser, { id: userId })
-    yield* call(audiusBackendInstance.setArtistPick, user, userId)
+    yield fork(updateProfileAsync, { metadata: user })
 
     const event = make(Name.ARTIST_PICK_SELECT_TRACK, { id: 'none' })
     yield* put(event)


### PR DESCRIPTION
### Description
Call `updateProfileAsync`, which wraps the call to `audiusBackendInstance.updateCreator` in confirmer logic, rather than calling `updateCreator` directly.

### Dragons

### How Has This Been Tested?
Open confirmer. For each of the following: verify confirmer action, verify change persistence via API
- Set artist pick
- Unset artist pick
- Delete track

### How will this change be monitored?
N/A

### Feature Flags ###
N/A
