### PR TITLE
Fix upload

### DIFF
--- a/packages/common/src/utils/sagaHelpers.ts
+++ b/packages/common/src/utils/sagaHelpers.ts
@@ -39,8 +39,10 @@ export function* batchYield(
  */
 export function* actionChannelDispatcher(channel: EventChannel<any>) {
   while (true) {
-    const action: Action<any> = yield take(channel)
-    yield put(action)
+    const action: Action<any> | undefined = yield take(channel)
+    if (action) {
+      yield put(action)
+    }
   }
 }
 

--- a/packages/web/src/pages/upload-page/store/sagas.js
+++ b/packages/web/src/pages/upload-page/store/sagas.js
@@ -659,8 +659,8 @@ export function* handleUploads({
 
   console.debug('Finished upload')
 
-  yield call(progressChan.close)
   yield cancel(actionDispatcherTask)
+  yield call(progressChan.close)
   return returnVal
 }
 

--- a/packages/web/src/pages/upload-page/store/sagas.js
+++ b/packages/web/src/pages/upload-page/store/sagas.js
@@ -659,8 +659,8 @@ export function* handleUploads({
 
   console.debug('Finished upload')
 
-  yield cancel(actionDispatcherTask)
   yield call(progressChan.close)
+  yield cancel(actionDispatcherTask)
   return returnVal
 }
 


### PR DESCRIPTION
### Description
Not sure how this was ever working before, but calling close on the progress channel puts an undefined action, so we would typically use the channelCanceller to close the channel because it would take the last undefined action and then call cancel
ref: https://github.com/AudiusProject/audius-client/blob/8cc3a29a7582323dbd19c1fa9a6ce0f45daf3c1b/packages/common/src/utils/sagaHelpers.ts#L47-L53
But since the current logic called close, the action channel dispatcher is called with an action of undefined which is put and then throws an error on the webpage
ref: https://github.com/AudiusProject/audius-client/blob/8cc3a29a7582323dbd19c1fa9a6ce0f45daf3c1b/packages/common/src/utils/sagaHelpers.ts#L40-L45


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Ran locally

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

