### PR TITLE
Use feature flag for mp3 stream toggle

### DIFF
--- a/packages/common/src/services/audio-player.ts
+++ b/packages/common/src/services/audio-player.ts
@@ -1,3 +1,4 @@
+import { TrackSegment } from '../models'
 import { Nullable } from '../utils'
 
 export type AudioInfo = {
@@ -16,7 +17,7 @@ export enum AudioError {
 export type AudioPlayer = {
   audio: HTMLAudioElement
   load: (
-    streamMp3Url: string,
+    segments: TrackSegment[],
     onEnd: () => void,
     prefetchedSegments: string[],
     gateways: string[],

--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -53,6 +53,7 @@ export const remoteConfigStringDefaults: {
   [StringKeys.REWARDS_TWEET_ID_TRACKS]: '1374856377651187713',
   [StringKeys.REWARDS_TWEET_ID_PLAYLISTS]: '1374856377651187713',
   [StringKeys.REWARDS_TWEET_ID_UNDERGROUND]: '1374856377651187713',
+  [StringKeys.FORCE_MP3_STREAM_TRACK_IDS]: null,
   [StringKeys.TF]: null,
   [StringKeys.TPF]: null,
   [StringKeys.UTF]: null,

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -29,7 +29,8 @@ export enum FeatureFlags {
   OFFLINE_MODE_ENABLED = 'offline_mode_enabled',
   AUTO_SUBSCRIBE_ON_FOLLOW = 'auto_subscribe_on_follow',
   MOBILE_NAV_OVERHAUL = 'mobile_nav_overhaul',
-  MOBILE_UPLOAD = 'mobile_upload'
+  MOBILE_UPLOAD = 'mobile_upload',
+  STREAM_MP3 = 'stream_mp3'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -76,5 +77,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.OFFLINE_MODE_ENABLED]: false,
   [FeatureFlags.AUTO_SUBSCRIBE_ON_FOLLOW]: false,
   [FeatureFlags.MOBILE_NAV_OVERHAUL]: false,
-  [FeatureFlags.MOBILE_UPLOAD]: false
+  [FeatureFlags.MOBILE_UPLOAD]: false,
+  [FeatureFlags.STREAM_MP3]: false
 }

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -256,6 +256,9 @@ export enum StringKeys {
   /** Embedded tweet for underground trending rewards UI  */
   REWARDS_TWEET_ID_UNDERGROUND = 'REWARDS_TWEET_ID_UNDERGROUND',
 
+  /** Audio that should be streamed via mp3 rather than HLS. Comma separated hash ids. */
+  FORCE_MP3_STREAM_TRACK_IDS = 'FORCE_MP3_STREAM_TRACK_IDS',
+
   /** TF */
   TF = 'TF',
   TPF = 'TPF',

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 
 import {
   accountSelectors,
   cacheUsersSelectors,
-  encodeHashId,
+  hlsUtils,
   Genre,
   playerSelectors,
   playerActions,
@@ -19,7 +19,7 @@ import Video from 'react-native-video'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useOfflineTrackUri } from 'app/hooks/useOfflineTrack'
-import { apiClient } from 'app/services/audius-api-client'
+import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 
 import { useChromecast } from './GoogleCast'
 import { logListen } from './listens'
@@ -332,20 +332,27 @@ export const Audio = () => {
     ]
   )
   const offlineTrackUri = useOfflineTrackUri(track)
-  const streamingUri = useMemo(() => {
-    return track
-      ? apiClient.makeUrl(`/tracks/${encodeHashId(track.track_id)}/stream`)
-      : null
-  }, [track])
 
   if (!track || track.is_delete) return null
+
+  const gateways = trackOwner
+    ? audiusBackendInstance.getCreatorNodeIPFSGateways(
+        trackOwner.creator_node_endpoint
+      )
+    : []
+
+  const m3u8 = hlsUtils.generateM3U8Variants({
+    segments: track.track_segments,
+    gateways
+  })
 
   let source
   if (offlineTrackUri) {
     source = { uri: offlineTrackUri }
-  } else if (streamingUri) {
+  } else if (m3u8) {
     source = {
-      uri: streamingUri
+      uri: m3u8,
+      type: 'm3u8'
     }
   }
 
@@ -353,6 +360,7 @@ export const Audio = () => {
     <View style={styles.backgroundVideo}>
       {source && (
         <Video
+          // @ts-ignore: type: m3u8 is actually a valid prop override
           source={source}
           ref={videoRef}
           playInBackground

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -21,6 +21,7 @@ import Video from 'react-native-video'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useOfflineTrackUri } from 'app/hooks/useOfflineTrack'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { apiClient } from 'app/services/audius-api-client'
 import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -1,5 +1,6 @@
 import {
   Kind,
+  StringKeys,
   encodeHashId,
   cacheTracksSelectors,
   cacheUsersSelectors,
@@ -50,11 +51,27 @@ const PLAYER_SUBSCRIBER_NAME = 'PLAYER'
 const RECORD_LISTEN_SECONDS = 1
 const RECORD_LISTEN_INTERVAL = 1000
 
+// Set of track ids that should be forceably streamed as mp3 rather than hls because
+// their hls maybe corrupt.
+let FORCE_MP3_STREAM_TRACK_IDS: Set<string> | null = null
+
 export function* watchPlay() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const apiClient = yield* getContext('apiClient')
+  const remoteConfigInstance = yield* getContext('remoteConfigInstance')
   yield* takeLatest(play.type, function* (action: ReturnType<typeof play>) {
     const { uid, trackId, onEnd } = action.payload ?? {}
+
+    if (!FORCE_MP3_STREAM_TRACK_IDS) {
+      FORCE_MP3_STREAM_TRACK_IDS = new Set(
+        (
+          remoteConfigInstance.getRemoteVar(
+            StringKeys.FORCE_MP3_STREAM_TRACK_IDS
+          ) || ''
+        ).split(',')
+      )
+    }
+
     const audioPlayer = yield* getContext('audioPlayer')
 
     if (trackId) {
@@ -73,7 +90,11 @@ export function* watchPlay() {
           )
         : []
       const encodedTrackId = encodeHashId(trackId)
-      const streamMp3Url = apiClient.makeUrl(`/tracks/${encodedTrackId}/stream`)
+      const forceStreamMp3 =
+        encodedTrackId && FORCE_MP3_STREAM_TRACK_IDS.has(encodedTrackId)
+      const forceStreamMp3Url = forceStreamMp3
+        ? apiClient.makeUrl(`/tracks/${encodedTrackId}/stream`)
+        : null
 
       const libs = yield* call(audiusBackendInstance.getAudiusLibs)
       const web3Manager = libs.web3Manager
@@ -85,7 +106,7 @@ export function* watchPlay() {
 
       const endChannel = eventChannel((emitter) => {
         audioPlayer.load(
-          streamMp3Url,
+          track.track_segments,
           () => {
             if (onEnd) {
               emitter(onEnd({}))
@@ -100,7 +121,8 @@ export function* watchPlay() {
             artist: owner?.name,
             artwork: '',
             premiumContentHeaders
-          }
+          },
+          forceStreamMp3Url
         )
         return () => {}
       })
@@ -125,7 +147,7 @@ export function* watchCollectiblePlay() {
       const audioPlayer = yield* getContext('audioPlayer')
       const endChannel = eventChannel((emitter) => {
         audioPlayer.load(
-          '',
+          [],
           () => {
             if (onEnd) {
               emitter(onEnd({}))


### PR DESCRIPTION
## To be cherry-picked onto https://github.com/AudiusProject/audius-client/tree/release-v1.3.11

### Description
This reverts https://github.com/AudiusProject/audius-client/pull/2147 and uses a feature flag to switch playback from hls to mp3.

Once this has been verified in prod, we can go back and rip out the unused hls code as originally done in https://github.com/AudiusProject/audius-client/pull/2147

See the non-revert commit [9313d83](https://github.com/AudiusProject/audius-client/pull/2202/commits/9313d83f0de8352f102584ca26327c430125c00d) for effective changes.

### Dragons

Affects all of track streaming.

### How Has This Been Tested?

Local web and sim
Tested with feature flag on and off. The correct endpoint was used in both cases

### How will this change be monitored?

Metrics for track play/listen will drop if malfunctioning

### Feature Flags ###

`STREAM_MP3`
- `true`: use mp3
- `false`: use hls