### PR TITLE
Prepare mobile-nav-overhaul for release

### DIFF
--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -28,7 +28,7 @@ export enum FeatureFlags {
   BUY_AUDIO_STRIPE_ENABLED = 'buy_audio_stripe_enabled',
   OFFLINE_MODE_ENABLED = 'offline_mode_enabled',
   AUTO_SUBSCRIBE_ON_FOLLOW = 'auto_subscribe_on_follow',
-  MOBILE_NAV_OVERHAUL = 'mobile_nav_overhaul',
+  MOBILE_NAV_OVERHAUL = 'mobile_nav_overhaul_final',
   MOBILE_UPLOAD = 'mobile_upload',
   STREAM_MP3 = 'stream_mp3'
 }
@@ -39,11 +39,15 @@ export const environmentFlagDefaults: Record<
   Environment,
   Partial<FlagDefaults>
 > = {
-  development: {},
+  development: {
+    [FeatureFlags.MOBILE_NAV_OVERHAUL]: true
+  },
   staging: {
     [FeatureFlags.MOBILE_NAV_OVERHAUL]: true
   },
-  production: {}
+  production: {
+    [FeatureFlags.MOBILE_NAV_OVERHAUL]: true
+  }
 }
 
 /**


### PR DESCRIPTION
### Description

Uses updated mobile-nav-overhaul value to ensure only this release will be affected when turning on mobile-nav feature flag

<img width="718" alt="image" src="https://user-images.githubusercontent.com/8230000/199311813-3678ba5e-121d-4eca-818b-e8245e26e386.png">

