### PR TITLE
[PAY-716] Go to Trending after BuyAudio flow if not opened from Tip

### DIFF
--- a/packages/common/src/store/ui/buy-audio/selectors.ts
+++ b/packages/common/src/store/ui/buy-audio/selectors.ts
@@ -17,8 +17,7 @@ export const getAudioPurchaseInfoStatus = (state: CommonState) =>
 
 export const getFeesCache = (state: CommonState) => state.ui.buyAudio.feesCache
 
-export const getOnSuccessAction = (state: CommonState) =>
-  state.ui.buyAudio.onSuccessAction
+export const getOnSuccess = (state: CommonState) => state.ui.buyAudio.onSuccess
 
 export const getStripeSessionStatus = (state: CommonState) =>
   state.ui.buyAudio.stripeSessionStatus

--- a/packages/common/src/store/ui/buy-audio/slice.ts
+++ b/packages/common/src/store/ui/buy-audio/slice.ts
@@ -42,6 +42,11 @@ type StripeSessionStatus =
   | 'fulfillment_processing'
   | 'fulfillment_complete'
 
+type OnSuccess = {
+  action?: Action
+  message?: string
+}
+
 type BuyAudioState = {
   stage: BuyAudioStage
   error?: boolean
@@ -52,7 +57,7 @@ type BuyAudioState = {
     transactionFees: number
   }
   provider: OnRampProvider
-  onSuccessAction?: Action
+  onSuccess?: OnSuccess
   stripeSessionStatus?: StripeSessionStatus
 }
 
@@ -116,13 +121,13 @@ const slice = createSlice({
       state,
       action: PayloadAction<{
         provider: OnRampProvider
-        onSuccessAction?: Action
+        onSuccess?: OnSuccess
       }>
     ) => {
       state.stage = BuyAudioStage.START
       state.error = undefined
       state.provider = action.payload.provider
-      state.onSuccessAction = action.payload.onSuccessAction
+      state.onSuccess = action.payload.onSuccess
     },
     onRampOpened: (state, _action: PayloadAction<PurchaseInfo>) => {
       state.stage = BuyAudioStage.PURCHASING

--- a/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
+++ b/packages/web/src/components/buy-audio-modal/components/SuccessPage.tsx
@@ -27,24 +27,24 @@ const messages = {
 const { getTransactionDetails } = transactionDetailsSelectors
 const { setModalClosedAction: setOnTransactionDetailsModalClosedAction } =
   transactionDetailsActions
-const { getOnSuccessAction } = buyAudioSelectors
+const { getOnSuccess } = buyAudioSelectors
 const { setVisibility } = modalsActions
 
 export const SuccessPage = () => {
   const dispatch = useDispatch()
   const transactionDetails = useSelector(getTransactionDetails)
-  const onSuccessAction = useSelector(getOnSuccessAction)
+  const onSuccess = useSelector(getOnSuccess)
   const [, setModalVisibility] = useModalState('BuyAudio')
   const [, setTransactionDetailsModalVisibility] =
     useModalState('TransactionDetails')
 
   const handleDoneClicked = useCallback(() => {
-    if (onSuccessAction) {
-      dispatch(onSuccessAction)
+    if (onSuccess?.action) {
+      dispatch(onSuccess.action)
       dispatch(setOnTransactionDetailsModalClosedAction())
     }
     setModalVisibility(false)
-  }, [dispatch, setModalVisibility, onSuccessAction])
+  }, [dispatch, setModalVisibility, onSuccess])
 
   const handleReviewTransactionClicked = useCallback(() => {
     dispatch(
@@ -84,7 +84,7 @@ export const SuccessPage = () => {
         </div>
       </div>
       <Button
-        text={messages.done}
+        text={onSuccess?.message ?? messages.done}
         type={ButtonType.PRIMARY_ALT}
         onClick={handleDoneClicked}
       />

--- a/packages/web/src/components/tipping/tip-audio/SendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/SendTip.tsx
@@ -145,7 +145,9 @@ export const SendTip = () => {
     dispatch(
       startBuyAudioFlow({
         provider: OnRampProvider.STRIPE,
-        onSuccessAction: beginTip({ user: receiver, source: 'buyAudio' })
+        onSuccess: {
+          action: beginTip({ user: receiver, source: 'buyAudio' })
+        }
       })
     )
     dispatch(resetSend())

--- a/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
+++ b/packages/web/src/components/tipping/tip-audio/TipAudio.module.css
@@ -76,7 +76,7 @@
   padding: 0 8px;
   font-size: var(--font-m);
   font-weight: var(--font-demi-bold);
-  color: var(--white);
+  color: var(--static-white);
   background: linear-gradient(
     315deg,
     var(--page-header-gradient-color-1) 0%,

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -31,6 +31,7 @@ import Tooltip from 'components/tooltip/Tooltip'
 import { useFlag, useRemoteVar } from 'hooks/useRemoteConfig'
 import { getLocation, Location } from 'services/Location'
 import { isMobile } from 'utils/clientUtil'
+import { pushUniqueRoute, TRENDING_PAGE } from 'utils/route'
 
 import TokenHoverTooltip from './TokenHoverTooltip'
 import styles from './WalletManagementTile.module.css'
@@ -62,7 +63,8 @@ const messages = {
     `Link by Stripe is not supported in the state of ${state}`,
   coinbaseStateNotSupported: (state: string) =>
     `Coinbase Pay is not supported in the state of ${state}`,
-  goldAudioToken: 'Gold $AUDIO token'
+  goldAudioToken: 'Gold $AUDIO token',
+  findArtists: 'Find Artists to Support on Trending'
 }
 
 const AdvancedWalletActions = () => {
@@ -223,11 +225,27 @@ export const WalletManagementTile = () => {
   }, [setOpen])
 
   const onBuyWithCoinbaseClicked = useCallback(() => {
-    dispatch(startBuyAudioFlow({ provider: OnRampProvider.COINBASE }))
+    dispatch(
+      startBuyAudioFlow({
+        provider: OnRampProvider.COINBASE,
+        onSuccess: {
+          action: pushUniqueRoute(TRENDING_PAGE),
+          message: messages.findArtists
+        }
+      })
+    )
   }, [dispatch])
 
   const onBuyWithStripeClicked = useCallback(() => {
-    dispatch(startBuyAudioFlow({ provider: OnRampProvider.STRIPE }))
+    dispatch(
+      startBuyAudioFlow({
+        provider: OnRampProvider.STRIPE,
+        onSuccess: {
+          action: pushUniqueRoute(TRENDING_PAGE),
+          message: messages.findArtists
+        }
+      })
+    )
   }, [dispatch])
 
   return (


### PR DESCRIPTION
### Description

Takes the user to the trending page to find an artist to support if they open the BuyAudio modal from the $AUDIO page. Also makes the topbanner in tips static white.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally against prod

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

