### PR TITLE
[C-1145] Update favorites table to use client side sorting and filtering when all tracks are loaded

### DIFF
--- a/packages/web/src/components/table/Table.tsx
+++ b/packages/web/src/components/table/Table.tsx
@@ -89,6 +89,7 @@ type TableProps = {
   showMoreLimit?: number
   tableClassName?: string
   totalRowCount?: number
+  useLocalSort?: boolean
   wrapperClassName?: string
 }
 
@@ -116,6 +117,7 @@ export const Table = ({
   showMoreLimit,
   tableClassName,
   totalRowCount = 9999,
+  useLocalSort = false,
   wrapperClassName
 }: TableProps) => {
   const defaultColumn = useMemo(
@@ -166,7 +168,7 @@ export const Table = ({
   // NOTE: react-table allows for multple sorters, but we are only checking the first here
   // - This can be updated if we need multiple sorters in the future
   const handleSortChange = useCallback(() => {
-    if (isVirtualized) {
+    if (isVirtualized && !useLocalSort) {
       // Virtualized Table -> Pass back the selected column and direction for backend sorting
       if (sortBy.length === 0) return onSort?.('', '')
 
@@ -197,9 +199,9 @@ export const Table = ({
         onSort?.({ column: null, order })
       }
     }
-  }, [columns, defaultSorter, isVirtualized, onSort, sortBy])
+  }, [columns, defaultSorter, isVirtualized, onSort, sortBy, useLocalSort])
 
-  useEffect(handleSortChange, [handleSortChange, sortBy])
+  useEffect(handleSortChange, [sortBy])
 
   const renderTableHeader = useCallback((column) => {
     return (

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -72,6 +72,7 @@ type TracksTableProps = {
   showMoreLimit?: number
   tableClassName?: string
   totalRowCount?: number
+  useLocalSort?: boolean
   userId?: number | null
   wrapperClassName?: string
 }
@@ -118,6 +119,7 @@ export const TracksTable = ({
   showMoreLimit,
   tableClassName,
   totalRowCount,
+  useLocalSort = false,
   userId,
   wrapperClassName
 }: TracksTableProps) => {
@@ -176,7 +178,7 @@ export const TracksTable = ({
 
       return (
         <div className={styles.artistCellContainer}>
-          <ArtistPopover handle={track.user.handle}>
+          <ArtistPopover handle={track.user?.handle}>
             <div
               className={styles.textContainer}
               onClick={(e) => {
@@ -552,6 +554,7 @@ export const TracksTable = ({
       showMoreLimit={showMoreLimit}
       tableClassName={tableClassName}
       totalRowCount={totalRowCount}
+      useLocalSort={useLocalSort}
       wrapperClassName={wrapperClassName}
     />
   )

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -23,6 +23,7 @@ import FilterInput from 'components/filter-input/FilterInput'
 import Header from 'components/header/desktop/Header'
 import CardLineup from 'components/lineup/CardLineup'
 import Page from 'components/page/Page'
+import { dateSorter } from 'components/table'
 import { TracksTable, TracksTableColumn } from 'components/tracks-table'
 import EmptyTable from 'components/tracks-table/EmptyTable'
 import { useOrderedLoad } from 'hooks/useOrderedLoad'
@@ -70,6 +71,7 @@ export type SavedPageProps = {
   onSortTracks: (sorters: any) => void
   onChangeTab: (tab: ProfileTabs) => void
   formatCardSecondaryText: (saves: number, tracks: number) => string
+  allTracksFetched: boolean
   filterText: string
   initialOrder: UID[] | null
   currentTab: ProfileTabs
@@ -107,6 +109,7 @@ const SavedPage = ({
   onPlay,
   onFilterChange,
   onSortChange,
+  allTracksFetched,
   filterText,
   formatCardSecondaryText,
   onChangeTab,
@@ -244,6 +247,7 @@ const SavedPage = ({
         <TracksTable
           columns={tableColumns}
           data={dataSource}
+          defaultSorter={dateSorter('dateSaved')}
           fetchMoreTracks={fetchMoreTracks}
           isVirtualized
           key='favorites'
@@ -253,10 +257,11 @@ const SavedPage = ({
           onClickRepost={onClickRepost}
           onClickRow={onClickRow}
           onClickTrackName={onClickTrackName}
-          onSortTracks={onSortChange}
+          onSortTracks={allTracksFetched ? onSortTracks : onSortChange}
           playing={queuedAndPlaying}
           playingIndex={playingIndex}
           scrollRef={mainContentRef}
+          useLocalSort={allTracksFetched}
           totalRowCount={Math.min(
             dataSource.length,
             account?.track_save_count ?? Infinity


### PR DESCRIPTION
### Description
Add checks to use client-side sorting and filtering when all of the tracks have been fetched

### Dragons

Did a lot of testing, but there is the potential for a certain case where this breaks

### How Has This Been Tested?

Lots of manual testing

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

