### PR TITLE
[C-1428] Fix tip reactions in notifications tab

### DIFF
--- a/packages/mobile/src/screens/account-screen/AccountDrawer.tsx
+++ b/packages/mobile/src/screens/account-screen/AccountDrawer.tsx
@@ -57,8 +57,8 @@ const accountStatHitSlop = {
 }
 
 type AccountDrawerProps = DrawerContentComponentProps & {
-  disableGestures: boolean
-  setDisableGestures: (disabled: boolean) => void
+  gesturesDisabled: boolean
+  setGesturesDisabled: (disabled: boolean) => void
 }
 
 const useStyles = makeStyles(({ spacing, palette }) => ({

--- a/packages/mobile/src/screens/notifications-screen/NotificationsDrawer.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationsDrawer.tsx
@@ -6,8 +6,8 @@ import { AppDrawerContextProvider } from '../app-drawer-screen'
 import { NotificationsDrawerScreen } from './NotificationsDrawerScreen'
 
 type NotificationDrawerContentsProps = DrawerContentComponentProps & {
-  disableGestures: boolean
-  setDisableGestures: (disabled: boolean) => void
+  gesturesDisabled: boolean
+  setGesturesDisabled: (disabled: boolean) => void
 }
 
 /**
@@ -16,8 +16,8 @@ type NotificationDrawerContentsProps = DrawerContentComponentProps & {
 export const NotificationsDrawer = (props: NotificationDrawerContentsProps) => {
   const {
     navigation: drawerHelpers,
-    disableGestures,
-    setDisableGestures
+    gesturesDisabled,
+    setGesturesDisabled
   } = props
   const drawerNavigation = useNavigation()
 
@@ -25,8 +25,8 @@ export const NotificationsDrawer = (props: NotificationDrawerContentsProps) => {
     <AppDrawerContextProvider
       drawerHelpers={drawerHelpers}
       drawerNavigation={drawerNavigation}
-      gesturesDisabled={disableGestures}
-      setGesturesDisabled={setDisableGestures}
+      gesturesDisabled={gesturesDisabled}
+      setGesturesDisabled={setGesturesDisabled}
     >
       <NotificationsDrawerScreen />
     </AppDrawerContextProvider>

--- a/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
@@ -52,24 +52,24 @@ export const Reaction = (props: ReactionProps) => {
   )
 
   const drawerStatus = useDrawerStatus()
-  const isOpen = isNavOverhaulEnabled ? true : drawerStatus === 'open'
+  const isFocused = isNavOverhaulEnabled ? true : drawerStatus === 'open'
 
   useEffect(() => {
     setStatus(statusProp)
   }, [statusProp])
 
   useEffect(() => {
-    if (status === 'unselected' || !isVisible || !isOpen) {
+    if (status === 'unselected' || !isVisible || !isFocused) {
       // Pause if off screen or unselected
       animationRef.current?.pause()
     } else if (isVisible && autoPlay) {
       animationRef.current?.play()
     }
-  }, [status, autoPlay, isVisible, isOpen])
+  }, [status, autoPlay, isVisible, isFocused])
 
   useEffect(() => {
-    if (ref.current && isOpen) {
-      // We need to wait until drawer finishes opening before calculating
+    if (ref.current && isFocused) {
+      // We need to wait until screen is focused before calculating
       // layout, otherwise we calculate off-screen values
       setTimeout(() => {
         ref.current?.measureInWindow((x, _, width) => {
@@ -78,7 +78,7 @@ export const Reaction = (props: ReactionProps) => {
       }, 500)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- onMeasure changes too much
-  }, [ref, isOpen])
+  }, [ref, isFocused])
 
   useEffect(() => {
     if (previousStatus !== 'interacting' && status === 'interacting') {

--- a/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { FeatureFlags } from '@audius/common'
 import { useDrawerStatus } from '@react-navigation/drawer'
 import type { AnimatedLottieViewProps } from 'lottie-react-native'
 import LottieView from 'lottie-react-native'
@@ -8,6 +9,7 @@ import { Animated } from 'react-native'
 import { usePrevious } from 'react-use'
 
 import { light, medium } from 'app/haptics'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { makeStyles } from 'app/styles'
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -45,9 +47,12 @@ export const Reaction = (props: ReactionProps) => {
   const ref = useRef<View | null>(null)
   const scale = useRef(new Animated.Value(1)).current
   const previousStatus = usePrevious(status)
+  const { isEnabled: isNavOverhaulEnabled } = useFeatureFlag(
+    FeatureFlags.MOBILE_NAV_OVERHAUL
+  )
 
   const drawerStatus = useDrawerStatus()
-  const isOpen = drawerStatus === 'open'
+  const isOpen = isNavOverhaulEnabled ? true : drawerStatus === 'open'
 
   useEffect(() => {
     setStatus(statusProp)


### PR DESCRIPTION
### Description

Fixes tip reactions in notification tab bar.
Issues due to `disabledGestures` not being propagated down correctly, so the drawer opens when interacting with reactions. additionally interaction can only occur when the reactions are visible and the tab bar / notif drawer is focused on screen