### PR TITLE
Dual write user subscriptions to discovery / identity

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2848,6 +2848,30 @@ export const audiusBackend = ({
     }
   }
 
+  async function subscribeToUser(userId: ID) {
+    try {
+      await waitForLibsInit()
+      const account = audiusLibs.Account.getCurrentUser()
+      if (!account) return
+      return await audiusLibs.User.addUserSubscribe(userId)
+    } catch (err) {
+      console.error(getErrorMessage(err))
+      throw err
+    }
+  }
+
+  async function unsubscribeFromUser(userId: ID) {
+    try {
+      await waitForLibsInit()
+      const account = audiusLibs.Account.getCurrentUser()
+      if (!account) return
+      return await audiusLibs.User.deleteUserSubscribe(userId)
+    } catch (err) {
+      console.error(getErrorMessage(err))
+      throw err
+    }
+  }
+
   async function updateUserLocationTimezone() {
     await waitForLibsInit()
     const account = audiusLibs.Account.getCurrentUser()
@@ -3481,6 +3505,8 @@ export const audiusBackend = ({
     updateUserEvent,
     updateUserLocationTimezone,
     updateUserSubscription,
+    subscribeToUser,
+    unsubscribeFromUser,
     upgradeToCreator,
     uploadImage,
     uploadTrack,

--- a/packages/common/src/store/social/users/actions.ts
+++ b/packages/common/src/store/social/users/actions.ts
@@ -11,6 +11,10 @@ export const UNFOLLOW_USER = 'SOCIAL/UNFOLLOW_USER'
 export const UNFOLLOW_USER_SUCCEEDED = 'SOCIAL/UNFOLLOW_USER_SUCCEEDED'
 export const UNFOLLOW_USER_FAILED = 'SOCIAL/UNFOLLOW_USER_FAILED'
 
+export const SUBSCRIBE_USER_FAILED = 'SOCIAL/SUBSCRIBE_USER_FAILED'
+
+export const UNSUBSCRIBE_USER_FAILED = 'SOCIAL/UNSUBSCRIBE_USER_FAILED'
+
 export const SHARE_USER = 'SOCIAL/SHARE_USER'
 
 export const followUser = createCustomAction(
@@ -40,6 +44,16 @@ export const unfollowUserSucceeded = createCustomAction(
 
 export const unfollowUserFailed = createCustomAction(
   UNFOLLOW_USER_FAILED,
+  (userId: ID, error: any) => ({ userId, error })
+)
+
+export const subscribeUserFailed = createCustomAction(
+  SUBSCRIBE_USER_FAILED,
+  (userId: ID, error: any) => ({ userId, error })
+)
+
+export const unsubscribeUserFailed = createCustomAction(
+  UNSUBSCRIBE_USER_FAILED,
   (userId: ID, error: any) => ({ userId, error })
 )
 

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -573,7 +573,7 @@ function* watchSetNotificationSubscription() {
     function* (action) {
       if (action.update) {
         try {
-          const getFeatureEnabled = yield* getContext('getFeatureEnabled')
+          const getFeatureEnabled = yield getContext('getFeatureEnabled')
 
           yield call(
             audiusBackendInstance.updateUserSubscription,

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -2,6 +2,7 @@ import {
   DefaultSizes,
   Kind,
   DoubleKeys,
+  FeatureFlags,
   makeUid,
   makeKindId,
   squashNewLines,
@@ -42,6 +43,10 @@ import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import feedSagas from 'common/store/pages/profile/lineups/feed/sagas.js'
 import tracksSagas from 'common/store/pages/profile/lineups/tracks/sagas.js'
+import {
+  subscribeToUserAsync,
+  unsubscribeFromUserAsync
+} from 'common/store/social/users/sagas'
 import { waitForBackendAndAccount } from 'utils/sagaHelpers'
 const { refreshSupport } = tippingActions
 const { getIsReachable } = reachabilitySelectors
@@ -568,11 +573,28 @@ function* watchSetNotificationSubscription() {
     function* (action) {
       if (action.update) {
         try {
+          const getFeatureEnabled = yield* getContext('getFeatureEnabled')
+
           yield call(
             audiusBackendInstance.updateUserSubscription,
             action.userId,
             action.isSubscribed
           )
+
+          // Dual write to discovery. Part of the migration of subscriptions
+          // from identity to discovery.
+          const socialFeatureEntityManagerEnabled =
+            (yield call(
+              getFeatureEnabled,
+              FeatureFlags.SOCIAL_FEATURE_ENTITY_MANAGER_ENABLED
+            )) ?? false
+          if (socialFeatureEntityManagerEnabled) {
+            if (action.isSubscribed) {
+              yield fork(subscribeToUserAsync, action.userId)
+            } else {
+              yield fork(unsubscribeFromUserAsync, action.userId)
+            }
+          }
         } catch (err) {
           const isReachable = yield select(getIsReachable)
           if (!isReachable) return

--- a/packages/web/src/common/store/social/users/errorSagas.ts
+++ b/packages/web/src/common/store/social/users/errorSagas.ts
@@ -9,7 +9,9 @@ type UserErrors =
 const errorSagas = createErrorSagas<UserErrors>({
   errorTypes: [
     socialUserActions.FOLLOW_USER_FAILED,
-    socialUserActions.UNFOLLOW_USER_FAILED
+    socialUserActions.UNFOLLOW_USER_FAILED,
+    socialUserActions.SUBSCRIBE_USER_FAILED,
+    socialUserActions.UNSUBSCRIBE_USER_FAILED
   ],
   getShouldRedirect: () => false,
   getShouldReport: () => true,

--- a/packages/web/src/common/store/social/users/sagas.ts
+++ b/packages/web/src/common/store/social/users/sagas.ts
@@ -265,6 +265,96 @@ export function* confirmUnfollowUser(userId: ID, accountId: ID) {
   )
 }
 
+/* SUBSCRIBE */
+
+export function* subscribeToUserAsync(userId: ID) {
+  yield* waitForBackendAndAccount()
+
+  const accountId = yield* select(getUserId)
+  if (!accountId) {
+    return
+  }
+
+  yield* call(confirmSubscribeToUser, userId, accountId)
+}
+
+export function* confirmSubscribeToUser(userId: ID, accountId: ID) {
+  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  yield* put(
+    confirmerActions.requestConfirmation(
+      makeKindId(Kind.USERS, userId),
+      function* () {
+        const { blockHash, blockNumber } = yield* call(
+          audiusBackendInstance.subscribeToUser,
+          userId
+        )
+        const confirmed = yield* call(
+          confirmTransaction,
+          blockHash,
+          blockNumber
+        )
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm subscribe to user for user id ${userId} and account id ${accountId}`
+          )
+        }
+        return accountId
+      },
+      function* () {},
+      function* ({ timeout, message }: { timeout: boolean; message: string }) {
+        yield* put(
+          socialActions.subscribeUserFailed(userId, timeout ? 'Timeout' : message)
+        )
+      }
+    )
+  )
+}
+
+export function* unsubscribeFromUserAsync(userId: ID) {
+  yield* waitForBackendAndAccount()
+
+  const accountId = yield* select(getUserId)
+  if (!accountId) {
+    return
+  }
+
+  yield* call(confirmUnsubscribeFromUser, userId, accountId)
+}
+
+export function* confirmUnsubscribeFromUser(userId: ID, accountId: ID) {
+  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
+  yield* put(
+    confirmerActions.requestConfirmation(
+      makeKindId(Kind.USERS, userId),
+      function* () {
+        const { blockHash, blockNumber } = yield* call(
+          audiusBackendInstance.unsubscribeFromUser,
+          userId
+        )
+        const confirmed = yield* call(
+          confirmTransaction,
+          blockHash,
+          blockNumber
+        )
+        if (!confirmed) {
+          throw new Error(
+            `Could not confirm unsubscribe from user for user id ${userId} and account id ${accountId}`
+          )
+        }
+        return accountId
+      },
+      function* () {},
+      function* ({ timeout, message }: { timeout: boolean; message: string }) {
+        yield* put(
+          socialActions.unsubscribeUserFailed(userId, timeout ? 'Timeout' : message)
+        )
+      }
+    )
+  )
+}
+
+/* SHARE */
+
 export function* watchShareUser() {
   yield* takeEvery(
     socialActions.SHARE_USER,

--- a/packages/web/src/common/store/social/users/sagas.ts
+++ b/packages/web/src/common/store/social/users/sagas.ts
@@ -303,7 +303,10 @@ export function* confirmSubscribeToUser(userId: ID, accountId: ID) {
       function* () {},
       function* ({ timeout, message }: { timeout: boolean; message: string }) {
         yield* put(
-          socialActions.subscribeUserFailed(userId, timeout ? 'Timeout' : message)
+          socialActions.subscribeUserFailed(
+            userId,
+            timeout ? 'Timeout' : message
+          )
         )
       }
     )
@@ -346,7 +349,10 @@ export function* confirmUnsubscribeFromUser(userId: ID, accountId: ID) {
       function* () {},
       function* ({ timeout, message }: { timeout: boolean; message: string }) {
         yield* put(
-          socialActions.unsubscribeUserFailed(userId, timeout ? 'Timeout' : message)
+          socialActions.unsubscribeUserFailed(
+            userId,
+            timeout ? 'Timeout' : message
+          )
         )
       }
     )


### PR DESCRIPTION
### Description
Part of migration of subscriptions from `identity` -> `discovery`. Write to discovery behind `social_feature_entity_manager_enabled` feature flag.

### Dragons

### How Has This Been Tested?
Manually tested. On both web and mobile:
- Click subscribe. See action in confirmer. Verify subscribe in discovery db
- " with unsubscribe
- View a profile while signed out. Make sure you're not able to click subscribe in the UI when not signed in.

### How will this change be monitored?
- Triggers sentries upon subscribe/unsubscribe failure
- Discprov logs

### Feature Flags ###

