### PR TITLE
Enable share to stories with dummy assets C-1412

### DIFF
--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -30,7 +30,8 @@ export enum FeatureFlags {
   MOBILE_NAV_OVERHAUL = 'mobile_nav_overhaul_final',
   MOBILE_UPLOAD = 'mobile_upload',
   STREAM_MP3 = 'stream_mp3',
-  READ_ARTIST_PICK_FROM_DISCOVERY = 'read_artist_pick_from_discovery'
+  READ_ARTIST_PICK_FROM_DISCOVERY = 'read_artist_pick_from_discovery',
+  SHARE_TO_STORY = 'share_to_story'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -82,5 +83,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.MOBILE_NAV_OVERHAUL]: false,
   [FeatureFlags.MOBILE_UPLOAD]: false,
   [FeatureFlags.STREAM_MP3]: false,
-  [FeatureFlags.READ_ARTIST_PICK_FROM_DISCOVERY]: false
+  [FeatureFlags.READ_ARTIST_PICK_FROM_DISCOVERY]: false,
+  [FeatureFlags.SHARE_TO_STORY]: false
 }

--- a/packages/mobile/ios/AudiusReactNative/Info.plist
+++ b/packages/mobile/ios/AudiusReactNative/Info.plist
@@ -39,6 +39,8 @@
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+    <string>instagram-stories</string>
+    <string>instagram</string>
 		<string>itms-apps</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -486,6 +486,8 @@ PODS:
   - RNSentry (3.2.8):
     - React-Core
     - Sentry (= 7.5.4)
+  - RNShare (8.0.0):
+    - React-Core
   - RNSVG (12.1.1):
     - React
   - Sentry (7.5.4):
@@ -567,6 +569,7 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNScrypt (from `../node_modules/react-native-scrypt`)
   - "RNSentry (from `../node_modules/@sentry/react-native`)"
+  - RNShare (from `../node_modules/react-native-share`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - SRSRadialGradient (from `../node_modules/react-native-radial-gradient/ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -731,6 +734,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-scrypt"
   RNSentry:
     :path: "../node_modules/@sentry/react-native"
+  RNShare:
+    :path: "../node_modules/react-native-share"
   RNSVG:
     :path: "../node_modules/react-native-svg"
   SRSRadialGradient:
@@ -825,6 +830,7 @@ SPEC CHECKSUMS:
   RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
   RNScrypt: 5090216bbf2ebb7baea2f42fdd26011dc2c4c7b1
   RNSentry: fe878ca3982d7871e502ccbb90072fe764c8d07d
+  RNShare: 36aa3e6958373a0ad1c95a1c960adef589da3794
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   Sentry: 5c5dd4005f3b7b9765d5a8871232cddbd0d888b7
   SRSRadialGradient: 71378a83e52b616c40367c37ee7cb6865f9f7c6e

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -8304,7 +8304,7 @@
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -9924,7 +9924,7 @@
     "dedent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
-      "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s="
+      "integrity": "sha512-cSfRWjXJtZQeRuZGVvDrJroCR5V2UvBNUMHsPCdNYzuAG8b9V8aAy3KUcdQrGQPXs17Y+ojbPh1aOCplg9YR9g=="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -17357,7 +17357,7 @@
     "murmurhash": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-0.0.2.tgz",
-      "integrity": "sha512-LKlwdZKWzvCQpMszb2HO5leJ7P9T4m5XuDKku8bM0uElrzqK9cn0+iozwQS8jO4SNjrp4w7olalgd8WgsIjhWA=="
+      "integrity": "sha1-bwe9ihEF5wnCb8iUIMtZMMJFhf4="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -19386,6 +19386,11 @@
       "requires": {
         "polished": "^4.1.3"
       }
+    },
+    "react-native-share": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-share/-/react-native-share-8.0.0.tgz",
+      "integrity": "sha512-IFUKcWQ1/VgtsQmuC3EKaIPMhKqssTblwCojtTB4dehWJ2ZUPsIstPXJGqcmWqg7/S3cLNfCLvxf/tVaZvptxw=="
     },
     "react-native-static-server": {
       "version": "github:futurepress/react-native-static-server#034c04e7a2999ae11a799fb68266c94389fc61bf",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -113,6 +113,7 @@
     "react-native-screens": "3.17.0",
     "react-native-scrypt": "1.2.1",
     "react-native-shadow-2": "6.0.1",
+    "react-native-share": "8.0.0",
     "react-native-static-server": "github:futurepress/react-native-static-server.git#034c04e7a2999ae11a799fb68266c94389fc61bf",
     "react-native-svg": "12.1.1",
     "react-native-svg-transformer": "0.14.3",

--- a/packages/mobile/src/components/share-drawer/messages.ts
+++ b/packages/mobile/src/components/share-drawer/messages.ts
@@ -11,6 +11,7 @@ const shareTypeMap: Record<ShareType, string> = {
 export const messages = {
   modalTitle: (asset: ShareType) => `Share ${shareTypeMap[asset]}`,
   twitter: 'Share to Twitter',
+  instagramStory: 'Share to Instagram Story',
   tikTok: 'Share Sound to TikTok',
   copyLink: (asset: ShareType) => `Copy Link to ${shareTypeMap[asset]}`,
   shareSheet: (asset: ShareType) => `Share ${asset} via...`,

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -12214,7 +12214,7 @@
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -13256,7 +13256,7 @@
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -13808,7 +13808,7 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA=="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "earcut": {
       "version": "2.2.3",
@@ -16770,12 +16770,12 @@
         "Base64": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-          "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg="
+          "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw=="
         },
         "JSONStream": {
           "version": "0.8.4",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-          "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
+          "integrity": "sha512-l0NN3IcqrZfZBJp7JWDJIHsnPV7yzJWqsYxQzL8Fwdx1BmEMjLuvtYkv+P9pbvpyfP75/f4MeDZhWNU4is32uA==",
           "requires": {
             "jsonparse": "0.0.5",
             "through": ">=2.2.7 <3"
@@ -16784,7 +16784,7 @@
         "acorn": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+          "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug=="
         },
         "acorn-node": {
           "version": "1.8.2",
@@ -16816,7 +16816,7 @@
         "align-text": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -16826,7 +16826,7 @@
         "amdefine": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+          "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
         },
         "asn1.js": {
           "version": "5.4.1",
@@ -16849,7 +16849,7 @@
         "assert": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
-          "integrity": "sha1-raoExGu1jG3R8pTaPrJuYijrbkQ=",
+          "integrity": "sha512-pSLN/C6u6JFR8L+0TzQ0Elc+VboxUXFtNw11RI1UcTcHEktQqIKIKK5S4nAZX4j8mpTpnCtmqpR+thPfqT11Kg==",
           "requires": {
             "util": "0.10.3"
           },
@@ -16857,12 +16857,12 @@
             "inherits": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+              "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
             },
             "util": {
               "version": "0.10.3",
               "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+              "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
               "requires": {
                 "inherits": "2.0.1"
               }
@@ -16872,7 +16872,7 @@
         "astw": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-          "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
+          "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
           "requires": {
             "acorn": "^4.0.3"
           }
@@ -16880,7 +16880,7 @@
         "async": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+          "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
         },
         "balanced-match": {
           "version": "1.0.2",
@@ -16890,7 +16890,7 @@
         "base64-js": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+          "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
         },
         "bn.js": {
           "version": "5.2.1",
@@ -16909,12 +16909,12 @@
         "brorand": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+          "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
         },
         "browser-pack": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
-          "integrity": "sha1-+qHLxBSHsazEdH43PhFIrf/Q4tk=",
+          "integrity": "sha512-BHla5EbbxjNyLMFUMamVjeTY+q1QwHbrYNXlWOkw71QcBqAQF7maJyNh3OI/V0d5YyNdMYD6tiPhJB9ukBo99Q==",
           "requires": {
             "JSONStream": "~0.8.4",
             "combine-source-map": "~0.3.0",
@@ -16927,7 +16927,7 @@
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -16938,7 +16938,7 @@
             "through2": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+              "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
               "requires": {
                 "readable-stream": "~1.0.17",
                 "xtend": "~3.0.0"
@@ -16957,14 +16957,14 @@
             "resolve": {
               "version": "1.1.7",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+              "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
             }
           }
         },
         "browserify": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/browserify/-/browserify-7.1.0.tgz",
-          "integrity": "sha1-FmB3XJPD7+rrQvPGY4psTCtBTxQ=",
+          "integrity": "sha512-BHHshSNeACBbVMAo/QCeJ4chEVOfrF1S4/8YTdNPnmP4GmuyS+RmZKHcKD0SmjJjvjBiHsT4eYuv/VUA0/9XnA==",
           "requires": {
             "JSONStream": "~0.8.3",
             "assert": "~1.1.0",
@@ -17099,7 +17099,7 @@
         "browserify-zlib": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+          "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
           "requires": {
             "pako": "~0.2.0"
           }
@@ -17117,34 +17117,34 @@
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+              "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
             }
           }
         },
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+          "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
         },
         "builtins": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-          "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo="
+          "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw=="
         },
         "callsite": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-          "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+          "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ=="
         },
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+          "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g=="
         },
         "center-align": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
           "requires": {
             "align-text": "^0.1.3",
             "lazy-cache": "^1.0.3"
@@ -17162,7 +17162,7 @@
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
           "requires": {
             "center-align": "^0.1.1",
             "right-align": "^0.1.1",
@@ -17172,14 +17172,14 @@
             "wordwrap": {
               "version": "0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
             }
           }
         },
         "combine-source-map": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
-          "integrity": "sha1-2edPWT2c1DgHMSy12EbUUe+qnrc=",
+          "integrity": "sha512-HRKa6g9SC1xd6ifto8ay6SxvyHaaQ50/8NO1ZONXx2hsIF9t/52qXa7Eeivaf5KFOSowK7Nm8TkIL/VC4khdBA==",
           "requires": {
             "convert-source-map": "~0.3.0",
             "inline-source-map": "~0.3.0",
@@ -17189,12 +17189,12 @@
         "commondir": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-          "integrity": "sha1-ifAP3NUbUZxXhzP+xWPmptp/W+I="
+          "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg=="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "concat-stream": {
           "version": "1.4.11",
@@ -17214,12 +17214,12 @@
         "constants-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-          "integrity": "sha1-kld9tSe6bEzwpFaNhLwDH0QeIfI="
+          "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA=="
         },
         "convert-source-map": {
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-          "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
+          "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg=="
         },
         "core-util-is": {
           "version": "1.0.3",
@@ -17288,22 +17288,22 @@
         "decamelize": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
         },
         "deep-equal": {
           "version": "0.2.2",
           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+          "integrity": "sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ=="
         },
         "defined": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-          "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4="
+          "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg=="
         },
         "deps-sort": {
           "version": "1.3.9",
           "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
-          "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
+          "integrity": "sha512-aEnmQuu/Hf5h8akL8QshYWzk9MVBg/JYMyNq/Lz68i69nR17tunjP6o/AC6Tn48c8ayzG6aeKs6OoFOtVCtvrQ==",
           "requires": {
             "JSONStream": "^1.0.3",
             "shasum": "^1.0.0",
@@ -17323,7 +17323,7 @@
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
             }
           }
         },
@@ -17353,7 +17353,7 @@
             "defined": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
             }
           }
         },
@@ -17377,12 +17377,12 @@
         "domain-browser": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-          "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
+          "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q=="
         },
         "duplexer2": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
           "requires": {
             "readable-stream": "~1.1.9"
           }
@@ -17411,7 +17411,7 @@
         "events": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
-          "integrity": "sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ="
+          "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ=="
         },
         "evp_bytestokey": {
           "version": "1.0.3",
@@ -17430,7 +17430,7 @@
         "glob": {
           "version": "4.5.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -17488,7 +17488,7 @@
         "hmac-drbg": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-          "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+          "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -17498,7 +17498,7 @@
         "http-browserify": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
+          "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
           "requires": {
             "Base64": "~0.2.0",
             "inherits": "~2.0.1"
@@ -17507,7 +17507,7 @@
         "https-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-          "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+          "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ=="
         },
         "ieee754": {
           "version": "1.2.1",
@@ -17517,12 +17517,12 @@
         "indexof": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-          "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+          "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -17536,7 +17536,7 @@
         "inline-source-map": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-          "integrity": "sha1-pSi1FOaJ/OkNswiehw2S9Sestes=",
+          "integrity": "sha512-RNlldBXZ7BBcVm3HjXIXiwKxih1lnuKbzeLBRDSB/qaqk8/g4JEZBjxpBQMhqEthQyGv7ycu8r/8PKGgBdIqrA==",
           "requires": {
             "source-map": "~0.3.0"
           },
@@ -17544,7 +17544,7 @@
             "source-map": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-              "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
+              "integrity": "sha512-jz8leTIGS8+qJywWiO9mKza0hJxexdeIYXhDHw9avTQcXSNAGk3hiiRMpmI2Qf9dOrZDrDpgH9VNefzuacWC9A==",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -17554,7 +17554,7 @@
         "insert-module-globals": {
           "version": "6.6.3",
           "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
-          "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
+          "integrity": "sha512-ryk8hTKUZCc300SPOOwx30WhE5oRUssPDVlIoO8vtoMNBy5HGeesVRl3HF7ra4ll42T0IdnwD9XR9svh6+RRhg==",
           "requires": {
             "JSONStream": "^1.0.3",
             "combine-source-map": "~0.6.1",
@@ -17578,7 +17578,7 @@
             "combine-source-map": {
               "version": "0.6.1",
               "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
-              "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
+              "integrity": "sha512-XKRNtuZRlVDTuSGKsfZpXYz80y0XDbYS4a+FzafTgmYHy/ckruFBx7Nd6WaQnFHVI3O6IseWVdXUvZutMpjSkQ==",
               "requires": {
                 "convert-source-map": "~1.1.0",
                 "inline-source-map": "~0.5.0",
@@ -17589,12 +17589,12 @@
             "convert-source-map": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-              "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
+              "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg=="
             },
             "inline-source-map": {
               "version": "0.5.0",
               "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
-              "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
+              "integrity": "sha512-2WtHG0qX9OH9TVcxsLVfq3Tzr+qtL6PtWgoh0XAAKe4KkdA/57Q+OGJuRJHA4mZ2OZnkJ/ZAaXf9krLB12/nIg==",
               "requires": {
                 "source-map": "~0.4.0"
               }
@@ -17602,17 +17602,17 @@
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
             },
             "process": {
               "version": "0.11.10",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
             },
             "source-map": {
               "version": "0.4.4",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -17640,12 +17640,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
         },
         "json-stable-stringify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-          "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+          "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
           "requires": {
             "jsonify": "~0.0.0"
           }
@@ -17653,17 +17653,17 @@
         "jsonify": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+          "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA=="
         },
         "jsonparse": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
-          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
+          "integrity": "sha512-fw7Q/8gFR8iSekUi9I+HqWIap6mywuoe7hQIg3buTVjuZgALKj4HAmm0X6f+TaL4c9NJbvyFQdaI2ppr5p6dnQ=="
         },
         "kind-of": {
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -17671,7 +17671,7 @@
         "labeled-stream-splicer": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
-          "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
+          "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
           "requires": {
             "inherits": "^2.0.1",
             "isarray": "~0.0.1",
@@ -17681,12 +17681,12 @@
         "lazy-cache": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+          "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="
         },
         "lexical-scope": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-          "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
+          "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
           "requires": {
             "astw": "^2.0.0"
           }
@@ -17694,12 +17694,12 @@
         "lodash.memoize": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-          "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8="
+          "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A=="
         },
         "longest": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+          "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg=="
         },
         "md5.js": {
           "version": "1.3.5",
@@ -17735,12 +17735,12 @@
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+          "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
         },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
           "requires": {
             "brace-expansion": "^1.0.0"
           }
@@ -17753,7 +17753,7 @@
         "module-deps": {
           "version": "3.9.1",
           "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
-          "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
+          "integrity": "sha512-EbWWlSGaCVidEsLsSzkY6l/jm0IcGDSQ8tGwtjM8joTrxqxP0om02Px9Np8D7FMZ/vZFdsOGbio+WqkKQxYuTA==",
           "requires": {
             "JSONStream": "^1.0.3",
             "browser-resolve": "^1.7.0",
@@ -17783,17 +17783,17 @@
             "defined": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
             },
             "jsonparse": {
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+              "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
             },
             "parents": {
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-              "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+              "integrity": "sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==",
               "requires": {
                 "path-platform": "~0.11.15"
               }
@@ -17818,7 +17818,7 @@
         "once": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
           "requires": {
             "wrappy": "1"
           }
@@ -17826,7 +17826,7 @@
         "optimist": {
           "version": "0.3.7",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+          "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
           "requires": {
             "wordwrap": "~0.0.2"
           }
@@ -17834,17 +17834,17 @@
         "os-browserify": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-          "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ="
+          "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA=="
         },
         "pako": {
           "version": "0.2.9",
           "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+          "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
         },
         "parents": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
-          "integrity": "sha1-+iEvAk2fpjGNu2tM5nbIvkk7nEM=",
+          "integrity": "sha512-ASkdjFPS2nrxujzSBZGt8ZCKeG0/K2ZZVKveqXt7XGtXfu+ssnk4DQhnK91KRvt83f36LjfxOfwi0cv1+Re0eA==",
           "requires": {
             "path-platform": "^0.0.1"
           },
@@ -17852,7 +17852,7 @@
             "path-platform": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
-              "integrity": "sha1-tVhdfDxGPYmqAGDYZhHPGv1hfio="
+              "integrity": "sha512-ydK1VKZFYwy0mT2JvimJfxt5z6Z6sjBbLfsFMoJczbwZ/ul0AjgpXLHinUzclf4/XYC8mtsWGuFERZ95Rnm8wA=="
             }
           }
         },
@@ -17881,7 +17881,7 @@
         "path-platform": {
           "version": "0.11.15",
           "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-          "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I="
+          "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg=="
         },
         "pbkdf2": {
           "version": "3.1.2",
@@ -17898,7 +17898,7 @@
         "process": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz",
-          "integrity": "sha1-e7r3GH/m3tP9W+DLYQP7qcrLl5g="
+          "integrity": "sha512-g7Lv2/7sZaS5oNElebRqsd40W/k0QCTmq8WeNZ/w3PVTqRsz0giER3sMsFQXobi+/Gmuy/qbnksrh76o21DEDA=="
         },
         "public-encrypt": {
           "version": "4.0.3",
@@ -17923,17 +17923,17 @@
         "punycode": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
-          "integrity": "sha1-VACKyXKux0F13vnLpt9/qdORh0A="
+          "integrity": "sha512-h/vscxLPvI2l7k/0dFUKZ5I5TgMCJ/Pl+J6rw77PDuQM6UApf/GaRVkjv/YSm2k+fbp7Yw8dxsoe29DolT7h7w=="
         },
         "querystring": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
         },
         "querystring-es3": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-          "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+          "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="
         },
         "randombytes": {
           "version": "2.1.0",
@@ -17955,7 +17955,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -17966,7 +17966,7 @@
         "readable-wrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-          "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
+          "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
           "requires": {
             "readable-stream": "^1.1.13-1"
           }
@@ -17974,17 +17974,17 @@
         "repeat-string": {
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+          "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
         },
         "resolve": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-          "integrity": "sha1-OVqe+ehz+/4SvRRAi9kbuTYAPWk="
+          "integrity": "sha512-zxmAcifDjKxmUbk7chQdKhDSn8ml08g+MYyU37xhEXBp+N81cfbYsm4e0Gn9jtLbAvbR8w8Ox09xqUZtPuCoeA=="
         },
         "rfile": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-          "integrity": "sha1-WXCM+Qyh50xUw8/Fw2/bmBBDUmE=",
+          "integrity": "sha512-aNeTpY8g6DYmqPvakau22B0SipQTskO8FtYXzn8qg4X4bN9ExIH8VAhq/L9w7N8HvESYeSSwk3e4GmW+rLLAxQ==",
           "requires": {
             "callsite": "~1.0.0",
             "resolve": "~0.3.0"
@@ -17993,14 +17993,14 @@
             "resolve": {
               "version": "0.3.1",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-              "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ="
+              "integrity": "sha512-mxx/I/wLjxtryDBtrrb0ZNzaYERVWaHpJ0W0Arm8N4l8b+jiX/U5yKcsj0zQpF9UuKN1uz80EUTOudON6OPuaQ=="
             }
           }
         },
         "right-align": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
           "requires": {
             "align-text": "^0.1.1"
           }
@@ -18017,7 +18017,7 @@
         "ruglify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-          "integrity": "sha1-3Ikw4qlUSidDAcyZcldMDQmGtnU=",
+          "integrity": "sha512-XfRj1YJdm/gnZNvmpQ5L+2YGRHglDGMPgJRbitgCxC3GzKVQF/t+ij1aNcNg2AnEXGtLHJDwoSWrAq3TUm0EVg==",
           "requires": {
             "rfile": "~1.0",
             "uglify-js": "~2.2"
@@ -18026,7 +18026,7 @@
             "uglify-js": {
               "version": "2.2.5",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-              "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
+              "integrity": "sha512-viLk+/8G0zm2aKt1JJAVcz5J/5ytdiNaIsKgrre3yvSUjwVG6ZUujGH7E2TiPigZUwLYCe7eaIUEP2Zka2VJPA==",
               "requires": {
                 "optimist": "~0.3.5",
                 "source-map": "~0.1.7"
@@ -18056,12 +18056,12 @@
         "shallow-copy": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-          "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
+          "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
         },
         "shasum": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-          "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+          "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
           "requires": {
             "json-stable-stringify": "~0.0.0",
             "sha.js": "~2.4.4"
@@ -18070,12 +18070,12 @@
         "shell-quote": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
-          "integrity": "sha1-GkEZbzwDM8SCMjWT1ohuzxU92YY="
+          "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ=="
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -18083,7 +18083,7 @@
         "stream-browserify": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
+          "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
           "requires": {
             "inherits": "~2.0.1",
             "readable-stream": "^1.0.27-1"
@@ -18092,7 +18092,7 @@
         "stream-combiner2": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
-          "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
+          "integrity": "sha512-7DO1SfBVnyIyo9ytUjSyVojT5bp1ZY6h3pj7HUs6PwcRSd/r8mBOHbRwYC7nbHRakKzMKyNp5HWJRv4GgVherA==",
           "requires": {
             "duplexer2": "~0.0.2",
             "through2": "~0.5.1"
@@ -18101,7 +18101,7 @@
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -18112,7 +18112,7 @@
             "through2": {
               "version": "0.5.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+              "integrity": "sha512-zexCrAOTbjkBCXGyozn7hhS3aEaqdrc59mAD2E3dKYzV1vFuEGQ1hEDJN2oQMQFwy4he2zyLqPZV+AlfS8ZWJA==",
               "requires": {
                 "readable-stream": "~1.0.17",
                 "xtend": "~3.0.0"
@@ -18123,7 +18123,7 @@
         "stream-splicer": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-          "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
+          "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
           "requires": {
             "indexof": "0.0.1",
             "inherits": "^2.0.1",
@@ -18136,12 +18136,12 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
         },
         "subarg": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-          "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+          "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
           "requires": {
             "minimist": "^1.1.0"
           }
@@ -18162,12 +18162,12 @@
         "through": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+          "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
         },
         "through2": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
+          "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
           "requires": {
             "readable-stream": ">=1.1.13-1 <1.2.0-0",
             "xtend": ">=4.0.0 <4.1.0-0"
@@ -18183,7 +18183,7 @@
         "timers-browserify": {
           "version": "1.4.2",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-          "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+          "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
           "requires": {
             "process": "~0.11.0"
           },
@@ -18191,7 +18191,7 @@
             "process": {
               "version": "0.11.10",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
             }
           }
         },
@@ -18203,12 +18203,12 @@
         "typedarray": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+          "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
         },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
           "requires": {
             "source-map": "~0.5.1",
             "uglify-to-browserify": "~1.0.0",
@@ -18218,12 +18218,12 @@
             "source-map": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+              "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
             },
             "yargs": {
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
               "requires": {
                 "camelcase": "^1.0.2",
                 "cliui": "^2.1.0",
@@ -18236,12 +18236,12 @@
         "uglify-to-browserify": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+          "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q=="
         },
         "umd": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-          "integrity": "sha1-SmMHt2LxfwLSAbX6FU5nM5bCY88=",
+          "integrity": "sha512-mEAJeceExHnblcAwN3BQtDPYOrTy4ALeBh6nQ9KW0cUCd0UU714jAfil2jvq09b67IizwJIiTVFOjE+/52Dyvw==",
           "requires": {
             "rfile": "~1.0.0",
             "ruglify": "~1.0.0",
@@ -18252,7 +18252,7 @@
             "source-map": {
               "version": "0.1.34",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-              "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
+              "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
               "requires": {
                 "amdefine": ">=0.0.4"
               }
@@ -18260,7 +18260,7 @@
             "uglify-js": {
               "version": "2.4.24",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-              "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
+              "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
               "requires": {
                 "async": "~0.2.6",
                 "source-map": "0.1.34",
@@ -18273,7 +18273,7 @@
         "url": {
           "version": "0.10.3",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
           "requires": {
             "punycode": "1.3.2",
             "querystring": "0.2.0"
@@ -18282,7 +18282,7 @@
             "punycode": {
               "version": "1.3.2",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-              "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+              "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
             }
           }
         },
@@ -18297,19 +18297,19 @@
             "inherits": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+              "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
             }
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "vm-browserify": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+          "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
           "requires": {
             "indexof": "0.0.1"
           }
@@ -18317,27 +18317,27 @@
         "window-size": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+          "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg=="
         },
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
         },
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "xtend": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+          "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg=="
         },
         "yargs": {
           "version": "3.5.4",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
+          "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
           "requires": {
             "camelcase": "^1.0.2",
             "decamelize": "^1.0.0",
@@ -18348,7 +18348,7 @@
             "wordwrap": {
               "version": "0.0.2",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
             }
           }
         }
@@ -22605,7 +22605,7 @@
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ=="
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -22681,7 +22681,7 @@
     "json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
       "requires": {
         "string-convert": "^0.2.0"
       }
@@ -26149,7 +26149,7 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA=="
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -29061,7 +29061,7 @@
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-      "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "requires": {
         "lowercase-keys": "^1.0.0"
       }
@@ -30429,7 +30429,7 @@
     "string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-length": {
       "version": "4.0.2",
@@ -32670,7 +32670,7 @@
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "requires": {
         "prepend-http": "^2.0.0"
       }


### PR DESCRIPTION
https://user-images.githubusercontent.com/36916764/200700808-45fa7ea5-659b-4c66-97b4-c770b4692aa6.mov

### Description
Set up share to IG story feature using react-native-share. Tested by using a base64 image string for the sticker and a base64 video for the background locally, but removed those assets from this PR to prevent needlessly increasing the app size.

Also verified that the audio from the video makes it to the IG story :).

There's gonna be a lot of logic to generate the assets before initiating the share, so the handler code will likely be moved out later.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*
Should be a no op with the feature flag off.
 
### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

