### PR TITLE
[C-1451] Use package.json version number in mobile updateRequired check

### DIFF
--- a/packages/mobile/src/hooks/useUpdateRequired.ts
+++ b/packages/mobile/src/hooks/useUpdateRequired.ts
@@ -1,12 +1,14 @@
 import { StringKeys } from '@audius/common'
-import VersionNumber from 'react-native-version-number'
 import semver from 'semver'
 
 import { useRemoteVar } from 'app/hooks/useRemoteConfig'
 
+import packageInfo from '../../package.json'
+
+const { version } = packageInfo
+
 export const useUpdateRequired = () => {
-  const { appVersion } = VersionNumber
   const minAppVersion = useRemoteVar(StringKeys.MIN_APP_VERSION)
 
-  return { updateRequired: semver.lt(appVersion, minAppVersion) }
+  return { updateRequired: semver.lt(version, minAppVersion) }
 }


### PR DESCRIPTION
### Description

* Updated optimizely `MIN_APP_VERSION` to 1.3.11 earlier and it bricked mobile because the `useUpdateRequired` hook is checking the mobile app version which is different on android/ios from web/desktop. Using the version in the package.json is more useful

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

