### PR TITLE
[C-1443] Fix error page analytics

### DIFF
--- a/packages/web/src/store/errors/sagas.ts
+++ b/packages/web/src/store/errors/sagas.ts
@@ -21,17 +21,16 @@ function* handleError(action: errorActions.HandleErrorAction) {
   }
 
   if (action.shouldRedirect) {
-    if (action.redirectRoute) {
-      yield put(pushRoute(action.redirectRoute))
-    } else {
+    const redirectRoute = action.redirectRoute ?? ERROR_PAGE
+    if (redirectRoute === ERROR_PAGE) {
       yield put(
         make(Name.ERROR_PAGE, {
           error: action.message,
           name: action.name
         })
       )
-      yield put(pushRoute(ERROR_PAGE))
     }
+    yield put(pushRoute(redirectRoute))
   }
   if (action.shouldToast) {
     yield put(toast({ content: action.message }))


### PR DESCRIPTION
### Description

There has been a large drop off in error page analytics since february https://analytics.amplitude.com/audius/chart/hghn2r9/edit/hzfdg28?source=copy+url

`redirectRoute` is defaulted to `ERROR_PAGE`. But error page analytics were not being recorded when `redirectRoute` exists

* Update error saga logic so analytics are recorded when redirectRoute is `ERROR_PAGE`

### Dragons

Perhaps it would be better to have an effect in the error page component itself? Because currently these analytics are triggered on every error, so potentially multiple times even though the user is only seeing the error page once

### How Has This Been Tested?

Tested by throwing errors in react hierarchy and dispatching error actions in sagas. Also realized that actual errors getting thrown in sagas do not redirect to the error page (just get a blank screen)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

