### PR TITLE
[C-1430] Stop propagation on repost button click in tracks tables

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -291,7 +291,10 @@ export const TracksTable = ({
               className={cn(styles.tableActionButton, {
                 [styles.active]: track.has_current_user_reposted
               })}
-              onClick={() => onClickRepost?.(track)}
+              onClick={(e) => {
+                onClickRepost?.(track)
+                e.stopPropagation()
+              }}
               reposted={track.has_current_user_reposted}
             />
           </div>


### PR DESCRIPTION
### Description
Stopping propagation so that clicking the repost button will not play/pause the track

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

