### PR TITLE
Remove getLatest track id

### DIFF
--- a/packages/common/src/services/explore/Explore.ts
+++ b/packages/common/src/services/explore/Explore.ts
@@ -200,17 +200,6 @@ export class Explore {
     }
   }
 
-  async getLatestTrackID(): Promise<number> {
-    try {
-      const libs = await this.audiusBackendInstance.getAudiusLibs()
-      const latestTrackID = await libs.discoveryProvider.getLatest('track')
-      return latestTrackID
-    } catch (e) {
-      console.error(e)
-      return 0
-    }
-  }
-
   /** PLAYLIST ENDPOINTS */
   async getTopCollections(
     type?: 'playlist' | 'album',


### PR DESCRIPTION
### Description
We need to remove discoveryProvider.getLatest because entity manager creates random IDs. I don't think this is being used anywhere. 

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

