### PR TITLE
Update push notificaiton navigation to work when the app is closed

### DIFF
--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -3,9 +3,9 @@ import { useRef } from 'react'
 
 import { accountSelectors } from '@audius/common'
 import {
-  useNavigationContainerRef,
   getStateFromPath,
-  NavigationContainer as RNNavigationContainer
+  NavigationContainer as RNNavigationContainer,
+  createNavigationContainerRef
 } from '@react-navigation/native'
 import { useSelector } from 'react-redux'
 
@@ -20,6 +20,9 @@ const { getAccountUser } = accountSelectors
 type NavigationContainerProps = {
   children: ReactNode
 }
+
+export const navigationRef = createNavigationContainerRef()
+
 /**
  * NavigationContainer contains the react-navigation context
  * and configures linking
@@ -29,7 +32,6 @@ const NavigationContainer = (props: NavigationContainerProps) => {
   const theme = useThemeVariant()
   const account = useSelector(getAccountUser)
 
-  const navigationRef = useNavigationContainerRef()
   const routeNameRef = useRef<string>()
 
   const linking = {

--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -62,7 +62,11 @@ class PushNotifications {
 
   onNotification = (notification: any) => {
     console.info(`Received notification ${JSON.stringify(notification)}`)
-    if (Platform.OS === 'android' || !notification.foreground) {
+    if (
+      Platform.OS === 'android' ||
+      notification.userInteration ||
+      !notification.foreground
+    ) {
       track(
         make({
           eventName: EventNames.NOTIFICATIONS_OPEN_PUSH_NOTIFICATION,
@@ -77,6 +81,16 @@ class PushNotifications {
 
       this.navigation?.navigate(notification.data.data)
     }
+  }
+
+  // Method used to open the push notification that the user pressed while the app was closed
+  openInitialNotification = () => {
+    PushNotification.popInitialNotification((notification) => {
+      if (notification) {
+        console.log('Opening initial notification')
+        this.onNotification(notification)
+      }
+    })
   }
 
   async onRegister(token: Token) {

--- a/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabNavigationProvider.tsx
@@ -2,7 +2,9 @@ import type { ReactNode } from 'react'
 import { useEffect, useMemo, createContext, useState } from 'react'
 
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
+import { useInterval } from 'react-use'
 
+import { navigationRef } from 'app/components/navigation-container/NavigationContainer'
 import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
 import PushNotifications from 'app/notifications'
 
@@ -30,6 +32,8 @@ export const SetAppTabNavigationContext =
 
 type AppTabNavigationProviderProps = { children: ReactNode }
 
+const checkNavReadyInterval = 1000
+
 /**
  * Context that provides the AppTabNavigation to any components
  * that need it outside of the AppTabScreen stack context
@@ -40,6 +44,7 @@ export const AppTabNavigationProvider = (
   const { children } = props
   const [navigation, setNavigation] = useState({} as AppTabNavigation)
   const notifNavigation = useNotificationNavigation()
+  const [isNavigationReady, setIsNavigationReady] = useState(false)
 
   const navigationContext = useMemo(
     () => ({ navigation, setNavigation }),
@@ -54,6 +59,16 @@ export const AppTabNavigationProvider = (
   useEffect(() => {
     PushNotifications.setNavigation(notifNavigation)
   }, [notifNavigation])
+
+  useInterval(
+    () => {
+      if (navigationRef.isReady()) {
+        PushNotifications.openInitialNotification()
+        setIsNavigationReady(true)
+      }
+    },
+    isNavigationReady ? null : checkNavReadyInterval
+  )
 
   return (
     <AppTabNavigationContext.Provider value={navigationContext}>


### PR DESCRIPTION
### Description
Updates to allow the app to check for and open the pressed push notification when the app is opened

### Dragons

There may be issues with updating how the ref is created in the NavigationContainer component

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

