### PR TITLE
[C-1467] Make previous button restart track within 3 seconds

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -14,7 +14,6 @@ import {
   playerSelectors,
   playerActions
 } from '@audius/common'
-import { play } from '@audius/common/dist/store/player/slice'
 import type {
   Animated,
   GestureResponderEvent,

--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -14,6 +14,7 @@ import {
   playerSelectors,
   playerActions
 } from '@audius/common'
+import { play } from '@audius/common/dist/store/player/slice'
 import type {
   Animated,
   GestureResponderEvent,
@@ -44,7 +45,7 @@ import { PlayBar } from './PlayBar'
 import { TitleBar } from './TitleBar'
 import { TrackInfo } from './TrackInfo'
 import { PLAY_BAR_HEIGHT } from './constants'
-const { seek } = playerActions
+const { seek, reset } = playerActions
 
 const { getPlaying, getCurrentTrack, getCounter } = playerSelectors
 const { next, previous } = queueActions
@@ -52,6 +53,8 @@ const { getUser } = cacheUsersSelectors
 
 const STATUS_BAR_FADE_CUTOFF = 0.6
 const SKIP_DURATION_SEC = 15
+const RESTART_THRESHOLD_SEC = 3
+
 // If the top screen inset is greater than this,
 // the status bar will be hidden when the drawer is open
 const INSET_STATUS_BAR_HIDE_THRESHOLD = 20
@@ -233,8 +236,14 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
         dispatch(seek({ seconds: Math.max(0, newPosition) }))
       }
     } else {
-      dispatch(previous())
-      setMediaKey((mediaKey) => mediaKey + 1)
+      const shouldGoToPrevious =
+        global.progress?.currentTime < RESTART_THRESHOLD_SEC
+      if (shouldGoToPrevious) {
+        dispatch(previous())
+        setMediaKey((mediaKey) => mediaKey + 1)
+      } else {
+        dispatch(reset({ shouldAutoplay: true }))
+      }
     }
   }, [dispatch, setMediaKey, track])
 


### PR DESCRIPTION
### Description

* Match behavior from web, pressing `previous` within 3 seconds of the beginning of a track will restart the track

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

