### PR TITLE
[ARCH-1996] hotfix: takeLatest was registering after action already fired

### DIFF
--- a/packages/web/src/common/store/pages/saved/sagas.js
+++ b/packages/web/src/common/store/pages/saved/sagas.js
@@ -26,13 +26,13 @@ function* fetchTracksLineup() {
 }
 
 function* watchFetchSaves() {
-  yield waitForBackendAndAccount()
-  const apiClient = yield getContext('apiClient')
   let currentQuery = ''
   let currentSortMethod = ''
   let currentSortDirection = ''
 
   yield takeLatest(actions.FETCH_SAVES, function* (props) {
+    yield waitForBackendAndAccount()
+    const apiClient = yield getContext('apiClient')
     const account = yield call(waitForValue, getAccountUser)
     const userId = account.user_id
     const offset = props.offset ?? 0


### PR DESCRIPTION
### Description

The SavedPageProvider fires the fetch saves action before the saga is registered, since `takeLatest` is called only after waiting for the backend/client

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

tested locally against stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

