### PR TITLE
[C-1494] Listens not being recorded properly?

### DIFF
--- a/packages/common/src/store/player/slice.ts
+++ b/packages/common/src/store/player/slice.ts
@@ -106,6 +106,7 @@ const slice = createSlice({
       state.uid = uid || state.uid
       state.trackId = trackId || state.trackId
       state.collectible = null
+      state.counter = state.counter + 1
     },
     playCollectible: (
       _state,
@@ -140,7 +141,7 @@ const slice = createSlice({
       state.trackId = trackId
     },
     reset: (_state, _action: PayloadAction<ResetPayload>) => {},
-    resetSuceeded: (state, action: PayloadAction<ResetSucceededPayload>) => {
+    resetSucceeded: (state, action: PayloadAction<ResetSucceededPayload>) => {
       const { shouldAutoplay } = action.payload
       state.playing = shouldAutoplay
       state.counter = state.counter + 1
@@ -166,7 +167,7 @@ export const {
   setBuffering,
   set,
   reset,
-  resetSuceeded,
+  resetSucceeded,
   seek,
   error,
   incrementCount

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -346,7 +346,6 @@ function* recordListenWorker() {
     const position = audioPlayer.getPosition()
 
     const newPlay = lastSeenPlayCounter !== playCounter
-    console.log(lastSeenPlayCounter, playCounter)
 
     if (newPlay && position > RECORD_LISTEN_SECONDS) {
       if (trackId) yield* put(recordListen(trackId))

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -41,7 +41,7 @@ const {
   stop,
   setBuffering,
   reset,
-  resetSuceeded,
+  resetSucceeded,
   seek,
   error: errorAction
 } = playerActions
@@ -93,7 +93,6 @@ export function* watchPlay() {
       const track = yield* select(getTrack, { id: trackId })
       if (!track) return
       if (track.is_premium && !track.premium_content_signature) return
-
       const owner = yield* select(getUser, {
         id: track.owner_id
       })
@@ -230,7 +229,7 @@ export function* watchReset() {
         )
       }
     }
-    yield* put(resetSuceeded({ shouldAutoplay }))
+    yield* put(resetSucceeded({ shouldAutoplay }))
   })
 }
 
@@ -347,6 +346,7 @@ function* recordListenWorker() {
     const position = audioPlayer.getPosition()
 
     const newPlay = lastSeenPlayCounter !== playCounter
+    console.log(lastSeenPlayCounter, playCounter)
 
     if (newPlay && position > RECORD_LISTEN_SECONDS) {
       if (trackId) yield* put(recordListen(trackId))

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -93,6 +93,7 @@ export function* watchPlay() {
       const track = yield* select(getTrack, { id: trackId })
       if (!track) return
       if (track.is_premium && !track.premium_content_signature) return
+
       const owner = yield* select(getUser, {
         id: track.owner_id
       })


### PR DESCRIPTION
### Description

* Plays are being recorded for every play, but Listens are only being recorded for the first play in a session. The counter we are using to trigger the Listen is never being incremented. Not sure how this ever worked? Or is this how it's supposed to work?

https://user-images.githubusercontent.com/19916043/202252557-5b9908ef-995c-4bd9-9ea9-c179ea0ce277.mov

https://github.com/AudiusProject/audius-client/blob/main/packages/web/src/common/store/player/sagas.ts#L351

Fixed by incrementing the counter on playSuccessful. This also has the added benefit of triggering a scrubber reset on mobile when things are played, resolving the scrubber issues we've been seeing

### Dragons

Not sure what else this could break, did testing around all player actions on web and mobile but we will want to do a thorough pass if this is merged

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

