### PR TITLE
[C-1514] Prevent next track playing when playback is paused

### DIFF
--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -385,9 +385,8 @@ export class AudioPlayer {
     if (this.audioCtx && IS_CHROME_LIKE) {
       // See comment above in the `play()` method.
       this.source!.disconnect()
-    } else {
-      this.audio.pause()
     }
+    this.audio.pause()
   }
 
   stop = () => {


### PR DESCRIPTION
### Description

The extra things happening in `_initContext` due to these changes https://github.com/AudiusProject/audius-client/pull/2259 have made it so simply doing `this.source!.disconnect()` doesn't properly pause the audio context. This resulted in the next track playing even when playback is paused.

The fix is to always do `this.audio.pause()`, even in a chrome-like browser. I tested to make sure the playback speed was correct after backgrounding/foregrounding the tab

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

