### PR TITLE
[C-1515] Allow repeat pushes via useNavigation inside nested navigator

### DIFF
--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -8,6 +8,8 @@ import { useNavigation as useNativeNavigation } from '@react-navigation/native'
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { isEqual } from 'lodash'
 
+import { getNearestStackNavigator } from 'app/utils/navigation'
+
 export type ContextualParams = {
   fromNotifications?: boolean
 }
@@ -48,16 +50,17 @@ export function useNavigation<
   const performCustomPush = useCallback(
     (...config: PerformNavigationConfig<ParamList>) => {
       if (!isEqual(lastNavAction.current, config)) {
-        ;(navigation as NativeStackNavigationProp<any>).push(...config)
-        lastNavAction.current = config
+        const stackNavigator: NativeStackNavigationProp<any> =
+          getNearestStackNavigator(navigation)
 
         // Reset lastNavAction when the transition ends
-        const unsubscribe = (
-          navigation as NativeStackNavigationProp<any>
-        ).addListener('transitionEnd', (e) => {
+        const unsubscribe = stackNavigator.addListener('transitionEnd', (e) => {
           lastNavAction.current = undefined
           unsubscribe()
         })
+
+        stackNavigator.push(...config)
+        lastNavAction.current = config
       }
     },
     [navigation, lastNavAction]

--- a/packages/mobile/src/hooks/useNavigation.ts
+++ b/packages/mobile/src/hooks/useNavigation.ts
@@ -50,17 +50,21 @@ export function useNavigation<
   const performCustomPush = useCallback(
     (...config: PerformNavigationConfig<ParamList>) => {
       if (!isEqual(lastNavAction.current, config)) {
-        const stackNavigator: NativeStackNavigationProp<any> =
-          getNearestStackNavigator(navigation)
+        const stackNavigator = getNearestStackNavigator(navigation)
 
-        // Reset lastNavAction when the transition ends
-        const unsubscribe = stackNavigator.addListener('transitionEnd', (e) => {
-          lastNavAction.current = undefined
-          unsubscribe()
-        })
+        if (stackNavigator) {
+          // Reset lastNavAction when the transition ends
+          const unsubscribe = stackNavigator.addListener(
+            'transitionEnd',
+            (e) => {
+              lastNavAction.current = undefined
+              unsubscribe()
+            }
+          )
 
-        stackNavigator.push(...config)
-        lastNavAction.current = config
+          stackNavigator.push(...config)
+          lastNavAction.current = config
+        }
       }
     },
     [navigation, lastNavAction]

--- a/packages/mobile/src/utils/navigation.ts
+++ b/packages/mobile/src/utils/navigation.ts
@@ -1,4 +1,4 @@
-import type { NavigationState } from '@react-navigation/native'
+import type { NavigationProp, NavigationState } from '@react-navigation/native'
 
 /**
  * Navigation state selector that selects the current route
@@ -20,4 +20,20 @@ export const getRoutePath = (state: NavigationState, routePath?: string[]) => {
 export const getPrimaryRoute = (state: NavigationState) => {
   // The route at index 2 is the primary route
   return getRoutePath(state)?.[2]
+}
+
+/**
+ * Given a navigator, get the nearest stack navigator in the hierarchy
+ */
+export const getNearestStackNavigator = (navigator: NavigationProp<any>) => {
+  if (navigator.getState?.()?.type === 'stack') {
+    return navigator
+  }
+  const parent = navigator.getParent()
+
+  if (!parent) {
+    return undefined
+  }
+
+  return getNearestStackNavigator(parent)
 }

--- a/packages/mobile/src/utils/navigation.ts
+++ b/packages/mobile/src/utils/navigation.ts
@@ -1,4 +1,6 @@
+import type { Maybe } from '@audius/common'
 import type { NavigationProp, NavigationState } from '@react-navigation/native'
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack'
 
 /**
  * Navigation state selector that selects the current route
@@ -25,9 +27,11 @@ export const getPrimaryRoute = (state: NavigationState) => {
 /**
  * Given a navigator, get the nearest stack navigator in the hierarchy
  */
-export const getNearestStackNavigator = (navigator: NavigationProp<any>) => {
+export const getNearestStackNavigator = (
+  navigator: NavigationProp<any>
+): Maybe<NativeStackNavigationProp<any>> => {
   if (navigator.getState?.()?.type === 'stack') {
-    return navigator
+    return navigator as unknown as NativeStackNavigationProp<any>
   }
   const parent = navigator.getParent()
 


### PR DESCRIPTION
### Description

Pushing via `useNavigation` inside a nested navigator (such as a tab navigator inside a stack navigator) was deduping any subsequent pushes to that same screen because the `transitionEnd` handler was being attached on the inner navigator instead of the stack navigator

* Add `getNearestStackNavigator` utility
* Use utility to push and attach the `transitionEnd` handler to the nearest stack instead of the nearest navigator

### Dragons

Slight perf implications. I considered computing the nearest stack navigator outside of the `performCustomPush` function but that would mean every instance of useNavigation is doing that work. I think computing it inside `performCustomPush` is better and in most cases it will only need to traverse one level up the navigation hierarchy anyway

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

