### PR TITLE
[C-1239] Fix bottom-tab-bar highlighting

### DIFF
--- a/packages/mobile/src/components/core/AnimatedButton.tsx
+++ b/packages/mobile/src/components/core/AnimatedButton.tsx
@@ -191,6 +191,9 @@ export const AnimatedButton = ({
           <View style={wrapperStyle}>
             {/* The key is needed for animations to work on android  */}
             <LottieView
+              style={
+                !hasMultipleStates ? { opacity: isActive ? 1 : 0 } : undefined
+              }
               key={hasMultipleStates ? iconIndex : undefined}
               ref={(animation) => (animationRef.current = animation)}
               onAnimationFinish={handleAnimationFinish}
@@ -199,6 +202,16 @@ export const AnimatedButton = ({
               source={source}
               resizeMode={resizeMode}
             />
+            {!hasMultipleStates ? (
+              <LottieView
+                key={isActive ? 'active' : 'inactive'}
+                style={{ opacity: isActive ? 0 : 1 }}
+                progress={isActive ? 1 : 0}
+                loop={false}
+                source={source}
+                resizeMode={resizeMode}
+              />
+            ) : null}
           </View>
           {children}
         </>

--- a/packages/mobile/src/components/core/AnimatedButton.tsx
+++ b/packages/mobile/src/components/core/AnimatedButton.tsx
@@ -202,11 +202,16 @@ export const AnimatedButton = ({
               source={source}
               resizeMode={resizeMode}
             />
+            {/**
+             * Secondary animation that is visible when inactive. This ensures
+             * active->inactive transition is smooth, since Lottie onAnimationFinish
+             * does not do this smoothly and results in partially inactive states.
+             */}
             {!hasMultipleStates ? (
               <LottieView
                 key={isActive ? 'active' : 'inactive'}
                 style={{ opacity: isActive ? 0 : 1 }}
-                progress={isActive ? 1 : 0}
+                progress={0}
                 loop={false}
                 source={source}
                 resizeMode={resizeMode}


### PR DESCRIPTION
### Description

Fixes issue where multiple bottom-tab-bars can be highlighted at once. The issue is due to lottie not properly managing animation reset when "progress" prop also changes. 

To simplify things, we now have two lottie animations per button. Animation 1 is as it was before, which is to animate in when button becomes active. Animation two is a static/idle animation, which is visible when the button is inactive. Together, this ensures the inactive->active animation is smooth (only animation1 is visible), and active->inactive is immediate and smooth (only animation 2 is visible)
