### PR TITLE
[C-1399] Fix chromecast

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -272,7 +272,7 @@ export const Audio = () => {
         elapsedTime.current = seek
 
         // If we are casting, don't update the internal
-        // seek clock
+        // seek clock. This is already handled by the effect in GoogleCast.tsx
         if (!isCasting) {
           global.progress.currentTime = seek
         }
@@ -350,14 +350,23 @@ export const Audio = () => {
           setListenLoggedForTrack(false)
         )
       }
-      global.progress = progress
+
+      if (!isCasting) {
+        // If we aren't casting, update the progress
+        global.progress = progress
+      } else {
+        // If we are casting, only update the seekable duration
+        // The currentTime is set via the effect in GoogleCast.tsx
+        global.progress.seekableDuration = progress.seekableDuration
+      }
     },
     [
       track,
       currentUserId,
       listenLoggedForTrack,
       isOfflineModeEnabled,
-      isReachable
+      isReachable,
+      isCasting
     ]
   )
   const { value: offlineTrackUri, loading } = useOfflineTrackUri(

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -355,7 +355,7 @@ export const Audio = () => {
         // If we aren't casting, update the progress
         global.progress = progress
       } else {
-        // If we are casting, only update the seekable duration
+        // If we are casting, only update the seekableDuration
         // The currentTime is set via the effect in GoogleCast.tsx
         global.progress.seekableDuration = progress.seekableDuration
       }

--- a/packages/mobile/src/components/audio/GoogleCast.tsx
+++ b/packages/mobile/src/components/audio/GoogleCast.tsx
@@ -1,6 +1,12 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
-import { castActions, playerSelectors } from '@audius/common'
+import {
+  castActions,
+  encodeHashId,
+  playerSelectors,
+  cacheUsersSelectors,
+  SquareSizes
+} from '@audius/common'
 import {
   CastState,
   useCastState,
@@ -9,8 +15,13 @@ import {
 } from 'react-native-google-cast'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { apiClient } from 'app/services/audius-api-client'
+import { audiusBackendInstance } from 'app/services/audius-backend-instance'
+
 const { setIsCasting } = castActions
 const { getCurrentTrack, getPlaying, getSeek } = playerSelectors
+
+const { getUser } = cacheUsersSelectors
 
 export const useChromecast = () => {
   const dispatch = useDispatch()
@@ -20,34 +31,55 @@ export const useChromecast = () => {
   const playing = useSelector(getPlaying)
   const seek = useSelector(getSeek)
 
+  const owner = useSelector((state) =>
+    getUser(state, {
+      id: track?.owner_id
+    })
+  )
+
   // Cast hooks
   const client = useRemoteMediaClient()
   const castState = useCastState()
   const streamPosition = useStreamPosition(0.5)
 
+  const streamingUri = useMemo(() => {
+    return track
+      ? apiClient.makeUrl(`/tracks/${encodeHashId(track.track_id)}/stream`)
+      : null
+  }, [track])
+
   const loadCast = useCallback(
-    (track, startTime) => {
-      if (client && track) {
+    async (track, startTime) => {
+      if (client && track && owner && streamingUri) {
+        const gateways = audiusBackendInstance.getCreatorNodeIPFSGateways(
+          owner.creator_node_endpoint
+        )
+
+        const imageUrl = await audiusBackendInstance.getImageUrl(
+          track.cover_art_sizes,
+          SquareSizes.SIZE_1000_BY_1000,
+          gateways
+        )
+
         client.loadMedia({
           mediaInfo: {
-            contentUrl: track.uri,
-            contentType: 'application/vnd.apple.mpegurl',
+            contentUrl: streamingUri,
             metadata: {
               type: 'musicTrack',
               images: [
                 {
-                  url: track.largeArtwork
+                  url: imageUrl
                 }
               ],
               title: track.title,
-              artist: track.artist
+              artist: owner?.name
             }
           },
           startTime
         })
       }
     },
-    [client]
+    [client, streamingUri, owner]
   )
 
   const playCast = useCallback(() => {

--- a/packages/mobile/src/components/audio/GoogleCast.tsx
+++ b/packages/mobile/src/components/audio/GoogleCast.tsx
@@ -76,7 +76,7 @@ export const useChromecast = () => {
                 }
               ],
               title: track.title,
-              artist: owner?.name
+              artist: owner.name
             }
           },
           startTime


### PR DESCRIPTION
### Description

Chromecast was impressively broken, I'm not sure how it ever worked tbh

* Parts of the object being passed to `loadMedia` were undefined
  * `track.uri` - this might be because of the streaming change? Fixed this by using the same logic as in `Audio` to create the streaming endpoint
  * `track.largeArtwork` - straight up doesn't exist in the codebase, where did this go from? where did it go? something something cotton-eyed joe
  * `track.artist` also didn't exist on the track object. Fixed this by following the pattern in `Audio` and using the `getUser` selector to get the owner
* Scrubber position was being updated by both the GoogleCast client and the Audio player, resulting in flickering time values
* Time also wasn't resetting when the next queued track started playing. Fixed this by resetting the global currentTime when a new track starts in `GoogleCast.tsx`

May have a follow up pr to get rid of `global.progress` in favor of a context provider

### Dragons

Changes are relatively confined to casting

### How Has This Been Tested?

Tested casting on ios and android

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

