### PR TITLE
[C-1527] Hide tip tile when no tips

### DIFF
--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -597,6 +597,7 @@ function* fetchRecentTipsAsync(action: ReturnType<typeof fetchRecentTips>) {
   const userTips = yield* call([apiClient, apiClient.getTips], params)
 
   if (!userTips) {
+    yield put(hideTip())
     return
   }
 


### PR DESCRIPTION
### Description

* When no userTips exist (maybe due to network conditions, cloudflare rate limitting, WAF, whatever) hide the tip tile. Previously this just sat in an infinite skeleton state

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

