### PR TITLE
[C-1535] Add mobile-upload analytics, fix remix field

### DIFF
--- a/packages/common/src/schemas/index.ts
+++ b/packages/common/src/schemas/index.ts
@@ -127,7 +127,11 @@ export const newUserMetadata = (fields?: any, validate = false) => {
   }
 }
 
-export const createRemixOfMetadata = ({ parentTrackId }) => {
+export const createRemixOfMetadata = ({
+  parentTrackId
+}: {
+  parentTrackId: number
+}) => {
   return {
     tracks: [
       {

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -65,7 +65,10 @@ const NavigationContainer = (props: NavigationContainerProps) => {
                         Reposts: 'reposts',
                         Collectibles: 'collectibles'
                       }
-                    } as any // Nested navigator typing with own params is broken, see: https://github.com/react-navigation/react-navigation/issues/9897
+                    } as any, // Nested navigator typing with own params is broken, see: https://github.com/react-navigation/react-navigation/issues/9897
+                    Upload: {
+                      path: 'upload'
+                    }
                   }
                 },
                 trending: {

--- a/packages/mobile/src/screens/edit-track-screen/EditExistingTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditExistingTrackScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 
+import type { ExtendedTrackMetadata } from '@audius/common'
 import {
   cacheTracksActions,
   cacheTracksSelectors,
@@ -12,7 +13,6 @@ import { useRoute } from 'app/hooks/useRoute'
 import { useTrackCoverArt } from 'app/hooks/useTrackCoverArt'
 
 import { EditTrackScreen } from './EditTrackScreen'
-import type { FormValues } from './types'
 
 const { getTrack } = cacheTracksSelectors
 const { editTrack } = cacheTracksActions
@@ -36,8 +36,8 @@ export const EditExistingTrackScreen = () => {
   })
 
   const handleSubmit = useCallback(
-    (values: FormValues) => {
-      dispatch(editTrack(id, values))
+    (metadata: ExtendedTrackMetadata) => {
+      dispatch(editTrack(id, metadata))
       navigation.goBack()
     },
     [dispatch, id, navigation]

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackScreen.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import type { UploadTrack } from '@audius/common'
 import { Formik } from 'formik'
 import * as Yup from 'yup'
@@ -34,10 +36,22 @@ export const EditTrackScreen = (props: EditTrackScreenProps) => {
     }
   }
 
+  const handleSubmit = useCallback(
+    (values: FormValues) => {
+      const {
+        licenseType: ignoredLicenseType,
+        trackArtwork: ignoredTrackArtwork,
+        ...metadata
+      } = values
+      onSubmit(metadata)
+    },
+    [onSubmit]
+  )
+
   return (
     <Formik<FormValues>
       initialValues={initialValues}
-      onSubmit={onSubmit}
+      onSubmit={handleSubmit}
       validationSchema={EditTrackSchema}
     >
       {(formikProps) => (

--- a/packages/mobile/src/screens/edit-track-screen/fields/RemixSettingsField.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/fields/RemixSettingsField.tsx
@@ -1,4 +1,3 @@
-import type { Nullable } from '@audius/common'
 import { cacheUsersSelectors, cacheTracksSelectors } from '@audius/common'
 import { useField } from 'formik'
 import { View } from 'react-native'
@@ -9,6 +8,7 @@ import { Text, ContextualSubmenu } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 
 import { RemixTrackPill } from '../components'
+import type { RemixOfField } from '../types'
 const { getTrack } = cacheTracksSelectors
 const { getUser } = cacheUsersSelectors
 
@@ -30,13 +30,15 @@ type SelectMoodFieldProps = Partial<ContextualSubmenuProps>
 
 export const RemixSettingsField = (props: SelectMoodFieldProps) => {
   const styles = useStyles()
-  const [{ value: remixOf }] = useField<Nullable<string>>('remix_of')
+  const [{ value: remixOf }] = useField<RemixOfField>('remix_of')
   const [{ value: remixesVisible }] = useField<boolean>(
     'field_visibility.remixes'
   )
 
+  const parentTrackId = remixOf?.tracks[0].parent_track_id
+
   const parentTrack = useSelector((state) =>
-    getTrack(state, { permalink: remixOf ? new URL(remixOf).pathname : null })
+    getTrack(state, { id: parentTrackId })
   )
 
   const parentTrackUser = useSelector((state) =>

--- a/packages/mobile/src/screens/edit-track-screen/types.ts
+++ b/packages/mobile/src/screens/edit-track-screen/types.ts
@@ -1,4 +1,4 @@
-import type { ExtendedTrackMetadata } from '@audius/common'
+import type { ExtendedTrackMetadata, Nullable } from '@audius/common'
 import type { FormikProps } from 'formik'
 
 import type { ScreenProps } from 'app/components/core'
@@ -18,3 +18,5 @@ export type EditTrackScreenProps = {
 } & Partial<ScreenProps>
 
 export type EditTrackFormProps = FormikProps<FormValues> & Partial<ScreenProps>
+
+export type RemixOfField = Nullable<{ tracks: { parent_track_id }[] }>

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -1,10 +1,9 @@
 import { useCallback } from 'react'
 
-import type { UploadTrack } from '@audius/common'
+import type { ExtendedTrackMetadata, UploadTrack } from '@audius/common'
 import { useRoute } from '@react-navigation/native'
 
 import { useNavigation } from 'app/hooks/useNavigation'
-import type { FormValues } from 'app/screens/edit-track-screen/types'
 
 import { EditTrackScreen } from '../../edit-track-screen'
 import type { UploadParamList, UploadRouteProp } from '../types'
@@ -21,9 +20,9 @@ export const CompleteTrackScreen = () => {
   const navigation = useNavigation<UploadParamList>()
 
   const handleSubmit = useCallback(
-    (values: FormValues) => {
+    (metadata: ExtendedTrackMetadata) => {
       navigation.push('UploadingTracks', {
-        tracks: [{ file, preview: null, metadata: values }]
+        tracks: [{ file, preview: null, metadata }]
       })
     },
     [navigation, file]

--- a/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/CompleteTrackScreen.tsx
@@ -33,6 +33,7 @@ export const CompleteTrackScreen = () => {
       initialValues={metadata}
       onSubmit={handleSubmit}
       title={messages.title}
+      url='/complete-track'
     />
   )
 }

--- a/packages/mobile/src/screens/upload-screen/screens/SelectTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/SelectTrackScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
+import { Name } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import DocumentPicker from 'react-native-document-picker'
 import { useAsyncFn } from 'react-use'
@@ -9,6 +10,7 @@ import IconUpload from 'app/assets/images/iconUpload.svg'
 import { Button, ErrorText, Screen, Text, Tile } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { make, track as trackAnalytcs } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
@@ -73,6 +75,10 @@ export const SelectTrackScreen = () => {
     useCallback(() => {
       if (track) {
         setNavigatedBack(true)
+      } else {
+        trackAnalytcs(
+          make({ eventName: Name.TRACK_UPLOAD_OPEN, source: 'nav' })
+        )
       }
     }, [track])
   )
@@ -93,6 +99,7 @@ export const SelectTrackScreen = () => {
       topbarLeft={
         <TopBarIconButton icon={IconRemove} onPress={navigation.goBack} />
       }
+      url='/select-track'
     >
       <Tile styles={{ root: styles.tile, content: styles.tileContent }}>
         <IconUpload

--- a/packages/mobile/src/screens/upload-screen/screens/UploadCompleteScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadCompleteScreen.tsx
@@ -123,6 +123,7 @@ export const UploadCompleteScreen = () => {
       icon={IconUpload}
       variant='secondary'
       topbarLeft={null}
+      url='/upload-complete'
       bottomSection={
         <Button
           variant='primary'

--- a/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
@@ -90,6 +90,7 @@ export const UploadingTracksScreen = () => {
       icon={IconUpload}
       style={styles.root}
       topbarLeft={null}
+      url='/uploading-track'
     >
       <Tile styles={{ root: styles.tile, content: styles.tileContent }}>
         <View style={styles.title}>


### PR DESCRIPTION
### Description

Adds upload analytics to mimic existing desktop analytics.
Adds page-views for upload flow, to get another way to collect metrics about user's flow through upload
