### PR TITLE
[C-1534] Use navigation.navigate for search

### DIFF
--- a/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
+++ b/packages/mobile/src/screens/app-screen/useAppScreenOptions.tsx
@@ -91,7 +91,7 @@ export const useAppScreenOptions = (
   }, [navigation])
 
   const handlePressSearch = useCallback(() => {
-    navigation.push('Search')
+    navigation.navigate('Search')
   }, [navigation])
 
   const { isEnabled: isEarlyAccess } = useFeatureFlag(FeatureFlags.EARLY_ACCESS)


### PR DESCRIPTION
### Description

Because of the navigation dedupe logic, opening search only works once. This is because the `useNavigation` hook used for opening search is in `useAppScreenOptions` which is outside of the actual stack navigator that gets navigated. Therefore the navigator that actually gets pushed to is not the same as the one we are listening for `transitionEnd` on.

Strangely this all works completely fine on prod, which has all the same code ???

The fix is simple, using `navigate` instead of our custom `push` for opening search

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested that stack behavior works normally around search

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

