### PR TITLE
[C-1411] Fix reachability issues with new splash screen

### DIFF
--- a/packages/common/src/store/reachability/reducer.ts
+++ b/packages/common/src/store/reachability/reducer.ts
@@ -12,11 +12,11 @@ const initialState = {
 const reducer = createReducer<ReachabilityState, ReachabilityActions>(
   initialState,
   {
-    [actions.SET_REACHABLE]() {
-      return { networkReachable: true }
+    [actions.SET_REACHABLE](state: ReachabilityState) {
+      return { ...state, networkReachable: true }
     },
-    [actions.SET_UNREACHABLE]() {
-      return { networkReachable: false }
+    [actions.SET_UNREACHABLE](state: ReachabilityState) {
+      return { ...state, networkReachable: false }
     }
   }
 )

--- a/packages/common/src/store/reachability/types.ts
+++ b/packages/common/src/store/reachability/types.ts
@@ -1,3 +1,3 @@
 export type ReachabilityState = {
-  networkReachable: boolean | null // null represents unknown/first load reachability
+  networkReachable: boolean
 }

--- a/packages/web/src/common/store/backend/reducer.ts
+++ b/packages/web/src/common/store/backend/reducer.ts
@@ -1,4 +1,4 @@
-import { SETUP_BACKEND_SUCCEEDED, SETUP_BACKEND_FAILED } from './actions'
+import { SETUP, SETUP_BACKEND_SUCCEEDED, SETUP_BACKEND_FAILED } from './actions'
 
 type BackendState = {
   isSetup: boolean
@@ -11,6 +11,12 @@ const initialState: BackendState = {
 }
 
 const actionsMap = {
+  [SETUP](state: BackendState) {
+    return {
+      ...state,
+      isSetup: false
+    }
+  },
   [SETUP_BACKEND_SUCCEEDED](
     state: BackendState,
     action: { web3Error: boolean }

--- a/packages/web/src/common/store/backend/selectors.ts
+++ b/packages/web/src/common/store/backend/selectors.ts
@@ -2,3 +2,4 @@
 import { AppState } from 'store/types'
 
 export const getWeb3Error = (state: AppState) => state.backend.web3Error
+export const getIsSetup = (state: AppState) => state.backend.isSetup

--- a/packages/web/src/common/store/pages/feed/lineup/sagas.ts
+++ b/packages/web/src/common/store/pages/feed/lineup/sagas.ts
@@ -88,6 +88,7 @@ function* getTracks({
       ? processedTracksMap[(m as LineupTrack).track_id]
       : processedCollectionsMap[(m as UserCollectionMetadata).playlist_id]
   )
+
   return processedFeed
 }
 


### PR DESCRIPTION
### Description

Fix reachability issues with new splash screen changes in 
https://github.com/AudiusProject/audius-client/pull/2289
that defaulted reachability state to `true` on app load.

Essentially the move here (as to the best of my ability) is to maintain some state for "failed backend set up" which allows our `waitForBackendSetup` hook to respect losing reachability mid setup and then wait for it to re-trigger.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

I tried to be pretty exhaustive and all did this with a "release mode build"

[x] open app when signed out
[x] open app when signed in
[x] open app in airplane mode => off airplane mode after 20s
[x] open app in airplane mode => off airplane mode quickly
[x] open app connected => airplane mode => off airplane mode
[x] open app signed out in airplane mode
[x] clear async storage and re-open app
[x] sign out and sign back in

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

