### PR TITLE
Fix logged out offline startup

### DIFF
--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -57,19 +57,17 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
     () => dispatch(enterBackground())
   )
 
+  const canDismissSplashScreen =
+    accountStatus === Status.SUCCESS || accountStatus === Status.ERROR
   return (
     <>
-      <SplashScreen
-        canDismiss={
-          accountStatus === Status.SUCCESS || accountStatus === Status.ERROR
-        }
-      />
+      <SplashScreen canDismiss={canDismissSplashScreen} />
       <Stack.Navigator
         screenOptions={{ gestureEnabled: false, headerShown: false }}
       >
         {updateRequired ? (
           <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
-        ) : !hasAccount ? (
+        ) : canDismissSplashScreen && !hasAccount ? (
           <Stack.Screen name='SignOnStack' component={SignOnScreen} />
         ) : (
           <Stack.Screen name='HomeStack' component={AppDrawerScreen} />

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -57,17 +57,17 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
     () => dispatch(enterBackground())
   )
 
-  const canDismissSplashScreen =
+  const accountFetchResolved =
     accountStatus === Status.SUCCESS || accountStatus === Status.ERROR
   return (
     <>
-      <SplashScreen canDismiss={canDismissSplashScreen} />
+      <SplashScreen canDismiss={accountFetchResolved} />
       <Stack.Navigator
         screenOptions={{ gestureEnabled: false, headerShown: false }}
       >
         {updateRequired ? (
           <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
-        ) : canDismissSplashScreen && !hasAccount ? (
+        ) : accountFetchResolved && !hasAccount ? (
           <Stack.Screen name='SignOnStack' component={SignOnScreen} />
         ) : (
           <Stack.Screen name='HomeStack' component={AppDrawerScreen} />


### PR DESCRIPTION
### Description

My understanding of how/why this happened is because the nav stack used to be not rendered until account came back as SUCCESS or ERROR. Since we always render it to have a faster startup time, we need to be careful around whether the sign on stack shows.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

I think this feels right -- I wasn't able to repro, but I also think the build version on the app store is different even than "Release mode" build from xcode.

https://user-images.githubusercontent.com/2731362/204440960-73fb98e0-dd77-4e35-a928-6c516ffa0100.MP4


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

