### PR TITLE
Fix mac build

### DIFF
--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -41,6 +41,7 @@ web-init:
     - persist_to_workspace:
         root: ./
         paths:
+          - node_modules
           - packages/web/node_modules
           - packages/stems/node_modules
           - packages/stems/dist

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -104,9 +104,9 @@ jobs:
       context: Audius Client
       requires:
         - web-build-staging
-      filters:
-        branches:
-          only: /(^main)$/
+      # filters:
+      #   branches:
+      #     only: /(^main)$/
   - web-dist-win-staging:
       context: Audius Client
       requires:

--- a/.circleci/src/workflows/web.yml
+++ b/.circleci/src/workflows/web.yml
@@ -104,9 +104,9 @@ jobs:
       context: Audius Client
       requires:
         - web-build-staging
-      # filters:
-      #   branches:
-      #     only: /(^main)$/
+      filters:
+        branches:
+          only: /(^main)$/
   - web-dist-win-staging:
       context: Audius Client
       requires:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,7 +2589,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -64,7 +64,7 @@
     "@solana/spl-token": "0.1.8",
     "@solana/web3.js": "1.24.1",
     "react": "17.0.2",
-    "react-redux": "7.2.0",
+    "react-redux": "7.2.5",
     "redux": "4.0.5",
     "redux-saga": "1.1.3"
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -134,7 +134,7 @@
     "react-infinite-scroller": "1.2.4",
     "react-lottie": "1.2.3",
     "react-markdown": "4.3.1",
-    "react-redux": "7.2.0",
+    "react-redux": "7.2.5",
     "react-router-dom": "5.1.2",
     "react-router-last-location": "2.0.1",
     "react-scripts": "5.0.0",


### PR DESCRIPTION
### Description

- Persist root node modules to workspace so that npx lerna can work in subsequent steps.
- Use react-redux 7.2.5 everywhere (primarily for this change https://github.com/reduxjs/react-redux/releases/tag/v7.2.2)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

It works on CI & went thru previous 7.2.0-7.2.5 changelogs in react-redux. Only meaningful changes (albeit somewhat substantial) are improvements to useSelector edge-cases/rerenders that can happen. Good thing to look out for in future QA/releases, but should be ok

https://app.circleci.com/pipelines/github/AudiusProject/audius-client/9448/workflows/1bbf358c-417f-4391-9a05-68e6bef253d1/jobs/81678
(does not push because of the CSC pull req rule, but builds now)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

