### PR TITLE
[PAY-739] Add view transactions button in Audio page

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -87,5 +87,6 @@ export const remoteConfigBooleanDefaults: {
   [BooleanKeys.DISPLAY_WEB3_PROVIDER_WALLET_LINK]: true,
   [BooleanKeys.DISPLAY_SOLANA_WEB3_PROVIDER_PHANTOM]: true,
   [BooleanKeys.SKIP_ROLLOVER_NODES_SANITY_CHECK]: false,
-  [BooleanKeys.USE_AMPLITUDE]: true
+  [BooleanKeys.USE_AMPLITUDE]: true,
+  [BooleanKeys.AUDIO_TRANSACTIONS_ENABLED]: false
 }

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -179,7 +179,12 @@ export enum BooleanKeys {
   /**
    * Boolean to use amplitude as the metrics tracking.
    */
-  USE_AMPLITUDE = 'USE_AMPLITUDE'
+  USE_AMPLITUDE = 'USE_AMPLITUDE',
+
+  /**
+   * Boolean to enable "Transactions" button on Audio page.
+   */
+  AUDIO_TRANSACTIONS_ENABLED = 'AUDIO_TRANSACTIONS_ENABLED'
 }
 
 export enum DoubleKeys {

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -10,17 +10,20 @@ import {
   buyAudioActions,
   OnRampProvider,
   FeatureFlags,
+  BooleanKeys,
   StringKeys
 } from '@audius/common'
 import { Button, ButtonType, IconInfo } from '@audius/stems'
 import BN from 'bn.js'
 import cn from 'classnames'
+import { push as pushRoute } from 'connected-react-router'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
 import { ReactComponent as IconReceive } from 'assets/img/iconReceive.svg'
 import { ReactComponent as IconSend } from 'assets/img/iconSend.svg'
 import { ReactComponent as IconSettings } from 'assets/img/iconSettings.svg'
+import { ReactComponent as IconTransaction } from 'assets/img/iconTransaction.svg'
 import IconGoldBadge from 'assets/img/tokenBadgeGold40@2x.png'
 import { useModalState } from 'common/hooks/useModalState'
 import { isMobileWeb } from 'common/utils/isMobileWeb'
@@ -31,7 +34,11 @@ import Tooltip from 'components/tooltip/Tooltip'
 import { useFlag, useRemoteVar } from 'hooks/useRemoteConfig'
 import { getLocation, Location } from 'services/Location'
 import { isMobile } from 'utils/clientUtil'
-import { pushUniqueRoute, TRENDING_PAGE } from 'utils/route'
+import {
+  AUDIO_TRANSACTIONS_PAGE,
+  pushUniqueRoute,
+  TRENDING_PAGE
+} from 'utils/route'
 
 import TokenHoverTooltip from './TokenHoverTooltip'
 import styles from './WalletManagementTile.module.css'
@@ -44,6 +51,7 @@ const { startBuyAudioFlow } = buyAudioActions
 const messages = {
   receiveLabel: 'Receive',
   sendLabel: 'Send',
+  transactionsLabel: 'View Transactions',
   audio: '$AUDIO',
   manageWallets: 'Manage Wallets',
   connectWallets: 'Connect Other Wallets',
@@ -74,6 +82,9 @@ const AdvancedWalletActions = () => {
   const [, openTransferDrawer] = useModalState('TransferAudioMobileWarning')
 
   const mobile = isMobile()
+  const isTransactionsEnabled = useRemoteVar(
+    BooleanKeys.AUDIO_TRANSACTIONS_ENABLED
+  )
   const onClickReceive = useCallback(() => {
     if (mobile) {
       openTransferDrawer(true)
@@ -90,6 +101,10 @@ const AdvancedWalletActions = () => {
     }
   }, [mobile, dispatch, openTransferDrawer])
   const [, setOpen] = useModalState('MobileConnectWalletsDrawer')
+
+  const onClickTransactions = useCallback(() => {
+    dispatch(pushRoute(AUDIO_TRANSACTIONS_PAGE))
+  }, [dispatch])
 
   const onClickConnectWallets = useCallback(() => {
     if (mobile) {
@@ -130,6 +145,17 @@ const AdvancedWalletActions = () => {
           type={ButtonType.GLASS}
           minWidth={200}
         />
+        {!mobile && isTransactionsEnabled && (
+          <Button
+            className={cn(styles.advancedButton)}
+            text={messages.transactionsLabel}
+            textClassName={styles.textClassName}
+            onClick={onClickTransactions}
+            leftIcon={<IconTransaction className={styles.iconStyle} />}
+            type={ButtonType.GLASS}
+            minWidth={200}
+          />
+        )}
         <Button
           className={cn(styles.advancedButton, styles.manageWalletsButton)}
           text={


### PR DESCRIPTION
### Description
Add button in Audio page that navigates to audio transactions page.

### Dragons

### How Has This Been Tested?

Tested locally using early access audience.

### How will this change be monitored?

### Feature Flags ###

AUDIO_TRANSACTIONS_ENABLED - boolean that enables/disables this button. Does not block `audio/transactions` route however.
