### PR TITLE
[Share to IG] Fix crash share to IG C-1612

### DIFF
--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -4,13 +4,13 @@ import EventEmitter from 'events'
 import path from 'path'
 
 import type { Color, Nullable, ShareModalContent } from '@audius/common'
-import { modalsActions, encodeHashId, ErrorLevel, uuid } from '@audius/common'
+import { encodeHashId, ErrorLevel, modalsActions, uuid } from '@audius/common'
 import {
   activateKeepAwake,
   deactivateKeepAwake
 } from '@sayem314/react-native-keep-awake'
 import type { FFmpegSession } from 'ffmpeg-kit-react-native'
-import { FFmpegKitConfig, FFmpegKit, ReturnCode } from 'ffmpeg-kit-react-native'
+import { FFmpegKit, FFmpegKitConfig, ReturnCode } from 'ffmpeg-kit-react-native'
 import { View } from 'react-native'
 import Config from 'react-native-config'
 import RNFS from 'react-native-fs'
@@ -21,7 +21,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import IconWavform from 'app/assets/images/iconWavform.svg'
 import { Button, LinearProgress, Text } from 'app/components/core'
 import { apiClient } from 'app/services/audius-api-client'
-import { getDominantColors } from 'app/services/threads/getDominantColors'
 import { setVisibility } from 'app/store/drawers/slice'
 import {
   getCancel,
@@ -37,6 +36,7 @@ import { convertRGBToHex } from 'app/utils/convertRGBtoHex'
 import { reportToSentry } from 'app/utils/reportToSentry'
 import { useThemeColors } from 'app/utils/theme'
 
+import { getDominantRgb } from '../../../threads/dominantColors.thread'
 import { NativeDrawer } from '../drawer'
 import { useTrackImage } from '../image/TrackImage'
 import { ToastContext } from '../toast/ToastContext'
@@ -179,7 +179,7 @@ export const useShareToStory = ({
       let dominantColorHex2: string
       if (trackImageUri) {
         try {
-          dominantColorsResult = await getDominantColors(trackImageUri)
+          dominantColorsResult = await getDominantRgb(trackImageUri)
         } catch (e) {
           handleError(
             e,
@@ -211,9 +211,9 @@ export const useShareToStory = ({
         }
         const totalVideoDuration = 10000
         const loadedSoFar = statistics.getTime()
-        const percentageLoaded = (loadedSoFar * 90) / totalVideoDuration
+        const percentageLoaded = (loadedSoFar * 80) / totalVideoDuration
         // Pad the result by 10% so the progress bar gets full before we get to IG
-        dispatch(setProgress(Math.min(10 + percentageLoaded + 10, 100)))
+        dispatch(setProgress(Math.min(20 + percentageLoaded + 10, 100)))
       })
       let session: FFmpegSession
 

--- a/packages/mobile/threads/dominantColors.thread.js
+++ b/packages/mobile/threads/dominantColors.thread.js
@@ -74,8 +74,8 @@ const findDominantColors = (selectFrom) => {
  * Returns the 3 dominant RGB colors of an image.
  * @param {string} imageUrl url of the image to use
  */
-const dominantRgb = (imageUrl) => {
-  Jimp.read(imageUrl)
+export const getDominantRgb = (imageUrl) => {
+  return Jimp.read(imageUrl)
     .then((img) => {
       img.posterize(15)
       const imageData = img.bitmap
@@ -114,14 +114,18 @@ const dominantRgb = (imageUrl) => {
       } else {
         result = findDominantColors(sortedResult)
       }
-
-      self.postMessage(JSON.stringify(result))
+      return result
     })
     .catch((err) => {
       console.error(imageUrl, err)
-      // eslint-disable-next-line
-      self.postMessage(DEFAULT_RGB)
+      return DEFAULT_RGB
     })
+}
+
+export const dominantRgb = (imageUrl) => {
+  getDominantRgb(imageUrl).then((result) => {
+    self.postMessage(JSON.stringify(result))
+  })
 }
 
 // listen for messages


### PR DESCRIPTION
### Description
Share to IG feature was crashing the app due to a memory issue: https://sentry.io/organizations/audius/issues/3491156239/?query=is%3Aunresolved&referrer=issue-stream
This was only happening on release builds which is why I didn't see it when developing locally.
Fixed by moving the dominant color calculation outside of a react-native-thread and into just a normal async function. Seemed to have no impact on the loading time or the UI interactions/music playback etc.

From react-native-thread repo:
```
The main tradeoff of using this library is memory usage, as creating new JS processes can have significant overhead. Be sure to benchmark your app's memory usage and other resources before using this library! Alternative solutions include using runAfterInteractions or the [Interaction Manager](https://facebook.github.io/react-native/docs/interactionmanager.html), and I recommend you investigate those thoroughly before using this library.
```
Maybe worth trying `runAfterInteractions` if we do end up seeing issues with this change.
I left the react-native-thread stuff in so we can get this feature into QA quicker and in case we want to figure out how to make it work.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

