### PR TITLE
[C-1595] Fix sign out

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -863,18 +863,11 @@ export const audiusBackend = ({
     )
   }
 
-  async function getAccount(fromSource = false) {
+  async function getAccount() {
     await waitForLibsInit()
     try {
-      let account
-      if (fromSource) {
-        const wallet = audiusLibs.Account.getCurrentUser().wallet
-        account = await audiusLibs.discoveryProvider.getUserAccount(wallet)
-        audiusLibs.userStateManager.setCurrentUser(account)
-      } else {
-        account = audiusLibs.Account.getCurrentUser()
-        if (!account) return null
-      }
+      const account = audiusLibs.Account.getCurrentUser()
+      if (!account) return null
 
       // If reading the artist pick from discovery, set _artist_pick on
       // the user to the value from discovery (set in artist_pick_track_id

--- a/packages/common/src/utils/sagaHelpers.ts
+++ b/packages/common/src/utils/sagaHelpers.ts
@@ -122,6 +122,6 @@ export function* waitForAccount() {
     waitForValue,
     (state) => state.account.status,
     null,
-    (status) => status !== Status.LOADING
+    (status) => status !== Status.LOADING && status !== Status.IDLE
   )
 }

--- a/packages/mobile/src/components/sign-out-confirmation-drawer/SignOutConfirmationDrawer.tsx
+++ b/packages/mobile/src/components/sign-out-confirmation-drawer/SignOutConfirmationDrawer.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux'
 
 import { Button, Text } from 'app/components/core'
 import { AppDrawer, useDrawerState } from 'app/components/drawer/AppDrawer'
-import useSearchHistory from 'app/store/search/hooks'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
 const { signOut } = signOutActions
 
@@ -38,15 +38,18 @@ const useStyles = makeStyles(({ spacing }) => ({
 export const SignOutConfirmationDrawer = () => {
   const styles = useStyles()
   const dispatch = useDispatch()
-  const { clearHistory } = useSearchHistory()
+  const navigation = useNavigation()
 
   const { onClose } = useDrawerState(MODAL_NAME)
 
   const handleSignOut = useCallback(() => {
     dispatch(signOut())
-    clearHistory()
     onClose()
-  }, [dispatch, clearHistory, onClose])
+    navigation.reset({
+      index: 0,
+      routes: [{ name: 'SignOnStack' }]
+    })
+  }, [dispatch, onClose, navigation])
 
   return (
     <AppDrawer modalName={MODAL_NAME} title={messages.drawerTitle}>

--- a/packages/mobile/src/components/sign-out-confirmation-drawer/SignOutConfirmationDrawer.tsx
+++ b/packages/mobile/src/components/sign-out-confirmation-drawer/SignOutConfirmationDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 import { signOutActions } from '@audius/common'
 import { View } from 'react-native'
@@ -6,8 +6,9 @@ import { useDispatch } from 'react-redux'
 
 import { Button, Text } from 'app/components/core'
 import { AppDrawer, useDrawerState } from 'app/components/drawer/AppDrawer'
-import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
+
+import { WebAppAccountClear } from '../web-app-account-sync'
 const { signOut } = signOutActions
 
 const MODAL_NAME = 'SignOutConfirmation'
@@ -38,18 +39,15 @@ const useStyles = makeStyles(({ spacing }) => ({
 export const SignOutConfirmationDrawer = () => {
   const styles = useStyles()
   const dispatch = useDispatch()
-  const navigation = useNavigation()
+  const [clearWebApp, setClearWebApp] = useState(false)
 
   const { onClose } = useDrawerState(MODAL_NAME)
 
   const handleSignOut = useCallback(() => {
+    setClearWebApp(true)
     dispatch(signOut())
     onClose()
-    navigation.reset({
-      index: 0,
-      routes: [{ name: 'SignOnStack' }]
-    })
-  }, [dispatch, onClose, navigation])
+  }, [dispatch, onClose, setClearWebApp])
 
   return (
     <AppDrawer modalName={MODAL_NAME} title={messages.drawerTitle}>
@@ -80,6 +78,7 @@ export const SignOutConfirmationDrawer = () => {
           onPress={handleSignOut}
         />
       </View>
+      <WebAppAccountClear shouldClear={clearWebApp} />
     </AppDrawer>
   )
 }

--- a/packages/mobile/src/components/web-app-account-sync/WebAppAccountClear.tsx
+++ b/packages/mobile/src/components/web-app-account-sync/WebAppAccountClear.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react'
+
+import { getErrorMessage } from '@audius/common'
+import { Platform, View } from 'react-native'
+import RNFS from 'react-native-fs'
+import StaticServer from 'react-native-static-server'
+import { WebView } from 'react-native-webview'
+import { useAsync } from 'react-use'
+
+// Clear on any message
+const injected = `
+(function() {
+  document.addEventListener("message", (event) => {
+    window.localStorage.clear()
+  })
+})();
+`
+
+type WebAppAccountClearProps = {
+  shouldClear: boolean
+}
+
+/**
+ * Used to clear the entropy from the legacy WebView
+ */
+export const WebAppAccountClear = ({
+  shouldClear
+}: WebAppAccountClearProps) => {
+  const ref = useRef<WebView>(null)
+
+  const { value: uri, error } = useAsync(async () => {
+    const server =
+      Platform.OS === 'android'
+        ? new StaticServer(3100, RNFS.DocumentDirectoryPath, {
+            localOnly: true,
+            keepAlive: true
+          })
+        : new StaticServer(
+            // Hardcoding to prod port because ios crashes otherwise
+            3100,
+            {
+              localOnly: true,
+              keepAlive: true
+            }
+          )
+
+    return await server.start()
+  }, [])
+
+  useEffect(() => {
+    if (shouldClear) {
+      ref.current?.postMessage('clear')
+    }
+  }, [shouldClear])
+
+  if (error) {
+    console.error(
+      'WebAppAccountClear Error -- StaticServer: ',
+      getErrorMessage(error)
+    )
+  }
+
+  return uri ? (
+    <View style={{ display: 'none' }}>
+      <WebView ref={ref} injectedJavaScript={injected} source={{ uri }} />
+    </View>
+  ) : null
+}

--- a/packages/mobile/src/components/web-app-account-sync/index.ts
+++ b/packages/mobile/src/components/web-app-account-sync/index.ts
@@ -1,1 +1,2 @@
 export * from './WebAppAccountSync'
+export * from './WebAppAccountClear'

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -59,7 +59,6 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
     () => dispatch(enterBackground())
   )
 
-  console.reportErrorsAsExceptions = false
   useEffect(() => {
     if (
       !isLoaded &&

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { accountSelectors, Status } from '@audius/common'
+import { getHasAccount } from '@audius/common/dist/store/account/selectors'
 import type { NavigatorScreenParams } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
@@ -42,6 +43,7 @@ type RootScreenProps = {
 export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
   const dispatch = useDispatch()
   const accountStatus = useSelector(getAccountStatus)
+  const hasAccount = useSelector(getHasAccount)
   const { updateRequired } = useUpdateRequired()
   const [isLoaded, setIsLoaded] = useState(false)
 
@@ -81,7 +83,7 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
         >
           {updateRequired ? (
             <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
-          ) : accountStatus === Status.SUCCESS ? (
+          ) : hasAccount ? (
             <Stack.Screen name='HomeStack' component={AppDrawerScreen} />
           ) : (
             <Stack.Screen name='SignOnStack' component={SignOnScreen} />

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 
 import { accountSelectors, Status } from '@audius/common'
-import { getHasAccount } from '@audius/common/dist/store/account/selectors'
 import type { NavigatorScreenParams } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
@@ -20,7 +19,7 @@ import { AppDrawerScreen } from '../app-drawer-screen'
 
 import { ThemedStatusBar } from './StatusBar'
 
-const { getAccountStatus } = accountSelectors
+const { getAccountStatus, getHasAccount } = accountSelectors
 
 const IS_IOS = Platform.OS === 'ios'
 

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -1,15 +1,13 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { accountSelectors, Status } from '@audius/common'
 import type { NavigatorScreenParams } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
 import { Platform } from 'react-native'
-import * as BootSplash from 'react-native-bootsplash'
 import { useDispatch, useSelector } from 'react-redux'
 
 import useAppState from 'app/hooks/useAppState'
-import { useNavigation } from 'app/hooks/useNavigation'
 import { useUpdateRequired } from 'app/hooks/useUpdateRequired'
 import type { AppScreenParamList } from 'app/screens/app-screen'
 import { SignOnScreen } from 'app/screens/signon'
@@ -21,7 +19,7 @@ import { AppDrawerScreen } from '../app-drawer-screen'
 
 import { ThemedStatusBar } from './StatusBar'
 
-const { getAccountStatus, getHasAccount } = accountSelectors
+const { getAccountStatus } = accountSelectors
 
 const IS_IOS = Platform.OS === 'ios'
 
@@ -45,8 +43,7 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
   const dispatch = useDispatch()
   const accountStatus = useSelector(getAccountStatus)
   const { updateRequired } = useUpdateRequired()
-  const hasAccount = useSelector(getHasAccount)
-  const navigation = useNavigation()
+  const [isLoaded, setIsLoaded] = useState(false)
 
   useEffect(() => {
     // Setup the backend when ready
@@ -60,48 +57,37 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
     () => dispatch(enterBackground())
   )
 
-  const accountFetchResolved =
-    accountStatus === Status.SUCCESS || accountStatus === Status.ERROR
-
-  // Android does not use the SplashScreen component as different
-  // devices will render different sizes of the BootSplash.
-  // Instead of our custom SplashScreen, fade out the BootSplash screen.
+  console.reportErrorsAsExceptions = false
   useEffect(() => {
-    if (accountFetchResolved && !IS_IOS) {
-      BootSplash.hide({ fade: true })
+    if (
+      !isLoaded &&
+      (accountStatus === Status.SUCCESS || accountStatus === Status.ERROR)
+    ) {
+      setIsLoaded(true)
     }
-  }, [accountFetchResolved])
-
-  useEffect(() => {
-    if (accountFetchResolved) {
-      if (hasAccount) {
-        navigation.navigate('HomeStack')
-      } else {
-        navigation.navigate('SignOnStack')
-      }
-    }
-  }, [navigation, accountFetchResolved, hasAccount])
+  }, [accountStatus, setIsLoaded, isLoaded])
 
   return (
     <>
       {IS_IOS ? (
-        <SplashScreen canDismiss={accountFetchResolved} />
+        <SplashScreen canDismiss={isLoaded} />
       ) : (
-        <ThemedStatusBar onSignUpScreen={accountFetchResolved && !hasAccount} />
+        <ThemedStatusBar isAppLoaded={isLoaded} accountStatus={accountStatus} />
       )}
 
-      <Stack.Navigator
-        screenOptions={{ gestureEnabled: false, headerShown: false }}
-      >
-        {updateRequired ? (
-          <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
-        ) : (
-          <>
+      {isLoaded ? (
+        <Stack.Navigator
+          screenOptions={{ gestureEnabled: false, headerShown: false }}
+        >
+          {updateRequired ? (
+            <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
+          ) : accountStatus === Status.SUCCESS ? (
             <Stack.Screen name='HomeStack' component={AppDrawerScreen} />
+          ) : (
             <Stack.Screen name='SignOnStack' component={SignOnScreen} />
-          </>
-        )}
-      </Stack.Navigator>
+          )}
+        </Stack.Navigator>
+      ) : null}
     </>
   )
 }

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -9,6 +9,7 @@ import * as BootSplash from 'react-native-bootsplash'
 import { useDispatch, useSelector } from 'react-redux'
 
 import useAppState from 'app/hooks/useAppState'
+import { useNavigation } from 'app/hooks/useNavigation'
 import { useUpdateRequired } from 'app/hooks/useUpdateRequired'
 import type { AppScreenParamList } from 'app/screens/app-screen'
 import { SignOnScreen } from 'app/screens/signon'
@@ -45,6 +46,7 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
   const accountStatus = useSelector(getAccountStatus)
   const { updateRequired } = useUpdateRequired()
   const hasAccount = useSelector(getHasAccount)
+  const navigation = useNavigation()
 
   useEffect(() => {
     // Setup the backend when ready
@@ -70,6 +72,16 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
     }
   }, [accountFetchResolved])
 
+  useEffect(() => {
+    if (accountFetchResolved) {
+      if (hasAccount) {
+        navigation.navigate('HomeStack')
+      } else {
+        navigation.navigate('SignOnStack')
+      }
+    }
+  }, [navigation, accountFetchResolved, hasAccount])
+
   return (
     <>
       {IS_IOS ? (
@@ -83,10 +95,11 @@ export const RootScreen = ({ isReadyToSetupBackend }: RootScreenProps) => {
       >
         {updateRequired ? (
           <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
-        ) : accountFetchResolved && !hasAccount ? (
-          <Stack.Screen name='SignOnStack' component={SignOnScreen} />
         ) : (
-          <Stack.Screen name='HomeStack' component={AppDrawerScreen} />
+          <>
+            <Stack.Screen name='HomeStack' component={AppDrawerScreen} />
+            <Stack.Screen name='SignOnStack' component={SignOnScreen} />
+          </>
         )}
       </Stack.Navigator>
     </>

--- a/packages/mobile/src/screens/root-screen/StatusBar.tsx
+++ b/packages/mobile/src/screens/root-screen/StatusBar.tsx
@@ -1,13 +1,32 @@
+import { useEffect } from 'react'
+
+import { Status } from '@audius/common'
 import { NavigationBar, StatusBar } from 'react-native-bars'
+import * as BootSplash from 'react-native-bootsplash'
 
 import { Theme, useThemeVariant } from 'app/utils/theme'
 
 type ThemedStatusBarProps = {
-  onSignUpScreen: boolean
+  isAppLoaded: boolean
+  accountStatus: Status
 }
 
-export const ThemedStatusBar = ({ onSignUpScreen }: ThemedStatusBarProps) => {
+export const ThemedStatusBar = ({
+  isAppLoaded,
+  accountStatus
+}: ThemedStatusBarProps) => {
   const theme = useThemeVariant()
+
+  // Android does not use the SplashScreen component as different
+  // devices will render different sizes of the BootSplash.
+  // Instead of our custom SplashScreen, fade out the BootSplash screen.
+  useEffect(() => {
+    if (isAppLoaded) {
+      BootSplash.hide({ fade: true })
+    }
+  }, [isAppLoaded])
+
+  const onSignUpScreen = isAppLoaded && !(accountStatus === Status.SUCCESS)
   // Status & nav bar content (the buttons) should be light while in a dark theme or
   // the splash screen is still visible (it's purple and white-on-purple looks better)
   const statusBarStyle =

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -379,8 +379,12 @@ const SignOn = ({ navigation }: SignOnProps) => {
   useEffect(() => {
     if (signedIn && accountUser) {
       setIsWorking(false)
-      setEmail('')
-      setPassword('')
+
+      // Debounce resetting state
+      setTimeout(() => {
+        setEmail('')
+        setPassword('')
+      }, 1000)
 
       remindUserToTurnOnNotifications(dispatch)
     }

--- a/packages/mobile/src/store/notifications/sagas.ts
+++ b/packages/mobile/src/store/notifications/sagas.ts
@@ -1,14 +1,13 @@
 import {
   accountSelectors,
   notificationsActions as notificationActions,
-  getContext,
-  waitForValue
+  getContext
 } from '@audius/common'
-import { waitForBackendSetup } from 'audius-client/src/common/store/backend/sagas'
 import commonNotificationsSagas, {
   getNotifications,
   getPollingIntervalMs
 } from 'audius-client/src/common/store/notifications/sagas'
+import { waitForRead, waitForWrite } from 'audius-client/src/utils/sagaHelpers'
 import { AppState } from 'react-native'
 import { call, delay, select, takeEvery } from 'typed-redux-saga'
 
@@ -38,8 +37,7 @@ export function* markedAllNotificationsViewed() {
 
 function* notificationPollingDaemon() {
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
-  yield* call(waitForBackendSetup)
-  yield* call(waitForValue, getHasAccount, {})
+  yield* call(waitForRead)
 
   yield* takeEvery(ENTER_FOREGROUND, getNotifications, false)
 
@@ -57,7 +55,7 @@ function* notificationPollingDaemon() {
 
 // On enter foreground, clear the notification badges
 function* watchResetNotificationBadgeCount() {
-  yield* call(waitForBackendSetup)
+  yield* call(waitForWrite)
   yield* call(resetNotificationBadgeCount)
   yield* takeEvery(ENTER_FOREGROUND, resetNotificationBadgeCount)
 }

--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -75,7 +75,6 @@ export default function* rootSaga() {
     ...searchResultsSagas(),
 
     // Account
-
     ...accountSagas(),
     ...recoveryEmailSagas(),
     ...playlistLibrarySagas(),
@@ -125,7 +124,6 @@ export default function* rootSaga() {
     ...historySagas(),
     ...rewardsPageSagas(),
     ...settingsSagas(),
-    ...signOutSagas(),
 
     // Cast
     ...castSagas(),

--- a/packages/mobile/src/store/settings/sagas.ts
+++ b/packages/mobile/src/store/settings/sagas.ts
@@ -9,7 +9,7 @@ import {
   getContext,
   waitForValue
 } from '@audius/common'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
+import { waitForRead } from 'audius-client/src/utils/sagaHelpers'
 import commonSettingsSagas from 'common/store/pages/settings/sagas'
 import { select, call, put, takeEvery } from 'typed-redux-saga'
 
@@ -28,7 +28,7 @@ export function* disablePushNotifications() {
 function* watchGetPushNotificationSettings() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* takeEvery(actions.GET_PUSH_NOTIFICATION_SETTINGS, function* () {
-    yield* call(waitForBackendSetup)
+    yield* call(waitForRead)
     try {
       const settings = (yield* call(
         audiusBackendInstance.getPushNotificationSettings

--- a/packages/mobile/src/store/sign-out/sagas.ts
+++ b/packages/mobile/src/store/sign-out/sagas.ts
@@ -1,4 +1,5 @@
 import { Name, signOutActions, accountActions } from '@audius/common'
+import { setupBackend } from 'audius-client/src/common/store/backend/actions'
 import { make } from 'common/store/analytics/actions'
 import { takeLatest, put, call } from 'typed-redux-saga'
 
@@ -25,6 +26,12 @@ function* watchSignOut() {
     yield* put(resetAccount())
     yield* put(clearHistory())
     yield* put(resetOAuthState())
+
+    // On web we reload the page to get the app into a state
+    // where it is acting like first-load. On mobile, in order to
+    // get the same behavior, call to set up the backend again,
+    // which will discover that we have no account
+    yield* put(setupBackend())
   })
 }
 

--- a/packages/mobile/src/store/sign-out/sagas.ts
+++ b/packages/mobile/src/store/sign-out/sagas.ts
@@ -1,7 +1,8 @@
 import { Name, signOutActions, accountActions } from '@audius/common'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
+import { getIsSetup } from 'audius-client/src/common/store/backend/selectors'
 import { make } from 'common/store/analytics/actions'
-import { takeLatest, put, call } from 'typed-redux-saga'
+import { takeLatest, put, call, select, take } from 'typed-redux-saga'
 
 import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 import { localStorage } from 'app/services/local-storage'
@@ -16,16 +17,25 @@ const { signOut: signOutAction } = signOutActions
 function* watchSignOut() {
   yield* takeLatest(signOutAction.type, function* () {
     yield* put(make(Name.SETTINGS_LOG_OUT, {}))
+    // UX obstruction, but if the user somehow makes it
+    // all the way to the sign out flow before the
+    // backend has initted (e.g. there's still an account fetch)
+    // in-flight, we need to wait here.
+    const isBackendSetup = yield* select(getIsSetup)
+    if (!isBackendSetup) {
+      yield* take(accountActions.fetchAccountSucceeded.type)
+    }
+
+    yield* put(resetAccount())
+
+    yield* put(clearHistory())
+    yield* put(resetOAuthState())
 
     yield* call(disablePushNotifications)
     yield* call([localStorage, 'clearAudiusAccount'])
     yield* call([localStorage, 'clearAudiusAccountUser'])
     yield* call([audiusBackendInstance, 'signOut'])
     yield* call([localStorage, 'removeItem'], 'theme')
-
-    yield* put(resetAccount())
-    yield* put(clearHistory())
-    yield* put(resetOAuthState())
 
     // On web we reload the page to get the app into a state
     // where it is acting like first-load. On mobile, in order to

--- a/packages/mobile/src/store/sign-out/sagas.ts
+++ b/packages/mobile/src/store/sign-out/sagas.ts
@@ -6,7 +6,7 @@ import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 import { localStorage } from 'app/services/local-storage'
 
 import { resetOAuthState } from '../oauth/actions'
-import { setSearchHistory } from '../search/actions'
+import { clearHistory } from '../search/actions'
 import { disablePushNotifications } from '../settings/sagas'
 
 const { resetAccount } = accountActions
@@ -14,16 +14,16 @@ const { signOut: signOutAction } = signOutActions
 
 function* watchSignOut() {
   yield* takeLatest(signOutAction.type, function* () {
-    yield* put(resetAccount())
-    yield* call(disablePushNotifications)
     yield* put(make(Name.SETTINGS_LOG_OUT, {}))
 
+    yield* call(disablePushNotifications)
     yield* call([localStorage, 'clearAudiusAccount'])
     yield* call([localStorage, 'clearAudiusAccountUser'])
     yield* call([audiusBackendInstance, 'signOut'])
     yield* call([localStorage, 'removeItem'], 'theme')
 
-    yield* put(setSearchHistory([]))
+    yield* put(resetAccount())
+    yield* put(clearHistory())
     yield* put(resetOAuthState())
   })
 }

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -182,7 +182,7 @@ function* onSignedIn({ payload: { account, isSignUp = false } }) {
   }
 }
 
-export function* fetchAccountAsync({ fromSource = false, isSignUp = false }) {
+export function* fetchAccountAsync({ isSignUp = false }) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const remoteConfigInstance = yield getContext('remoteConfigInstance')
   const localStorage = yield getContext('localStorage')
@@ -192,11 +192,7 @@ export function* fetchAccountAsync({ fromSource = false, isSignUp = false }) {
 
   yield put(accountActions.fetchAccountRequested())
 
-  if (!fromSource) {
-    yield fetchLocalAccountAsync()
-  }
-
-  const account = yield call(audiusBackendInstance.getAccount, fromSource)
+  const account = yield call(audiusBackendInstance.getAccount)
   if (!account || account.is_deactivated) {
     yield put(
       fetchAccountFailed({

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -40,7 +40,6 @@ const {
 
 const {
   signedIn,
-  unsubscribeBrowserPushNotifications,
   showPushNotificationConfirmation,
   fetchAccountSucceeded,
   fetchAccountFailed,
@@ -185,7 +184,6 @@ function* onSignedIn({ payload: { account, isSignUp = false } }) {
 export function* fetchAccountAsync({ isSignUp = false }) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const remoteConfigInstance = yield getContext('remoteConfigInstance')
-  const localStorage = yield getContext('localStorage')
   const isNativeMobile = yield getContext('isNativeMobile')
   const isElectron = yield getContext('isElectron')
   const fingerprintClient = yield getContext('fingerprintClient')

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -193,19 +193,20 @@ export function* fetchAccountAsync({ isSignUp = false }) {
   yield put(accountActions.fetchAccountRequested())
 
   const account = yield call(audiusBackendInstance.getAccount)
-  if (!account || account.is_deactivated) {
+  if (!account) {
     yield put(
       fetchAccountFailed({
-        reason: account ? 'ACCOUNT_DEACTIVATED' : 'ACCOUNT_NOT_FOUND'
+        reason: 'ACCOUNT_NOT_FOUND'
       })
     )
-    // Clear local storage users if present
-    yield call([localStorage, 'clearAudiusAccount'])
-    yield call([localStorage, 'clearAudiusAccountUser'])
-
-    // If the user is not signed in
-    // Remove browser has requested push notifications.
-    yield put(unsubscribeBrowserPushNotifications())
+    return
+  }
+  if (account.is_deactivated) {
+    yield put(
+      fetchAccountFailed({
+        reason: 'ACCOUNT_DEACTIVATED'
+      })
+    )
     return
   }
 

--- a/packages/web/src/common/store/cache/tracks/sagas.js
+++ b/packages/web/src/common/store/cache/tracks/sagas.js
@@ -27,7 +27,6 @@ import {
 } from 'redux-saga/effects'
 
 import { make } from 'common/store/analytics/actions'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { fetchUsers } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
@@ -101,7 +100,7 @@ export function* trackNewRemixEvent(remixTrack) {
 }
 
 function* editTrackAsync(action) {
-  yield call(waitForBackendSetup)
+  yield call(waitForWrite)
   action.formFields.description = squashNewLines(action.formFields.description)
 
   const currentTrack = yield select(getTrack, { id: action.trackId })

--- a/packages/web/src/common/store/change-password/sagas.ts
+++ b/packages/web/src/common/store/change-password/sagas.ts
@@ -2,7 +2,7 @@ import { Name, changePasswordActions, getContext } from '@audius/common'
 import { call, put, takeEvery } from 'typed-redux-saga'
 
 import { make, TrackEvent } from 'common/store/analytics/actions'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
+import { waitForWrite } from 'utils/sagaHelpers'
 const {
   confirmCredentials,
   confirmCredentialsSucceeded,
@@ -17,7 +17,7 @@ function* handleConfirmCredentials(
 ) {
   const { email, password } = action.payload
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  yield* call(waitForBackendSetup)
+  yield* call(waitForWrite)
   try {
     const confirmed = yield* call(
       audiusBackendInstance.confirmCredentials,
@@ -37,7 +37,7 @@ function* handleConfirmCredentials(
 function* handleChangePassword(action: ReturnType<typeof changePassword>) {
   const { email, password, oldPassword } = action.payload
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  yield* call(waitForBackendSetup)
+  yield* call(waitForWrite)
   try {
     yield* call(
       audiusBackendInstance.changePassword,

--- a/packages/web/src/common/store/notifications/sagas.ts
+++ b/packages/web/src/common/store/notifications/sagas.ts
@@ -40,7 +40,6 @@ import {
 } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
 import { retrieveTracks } from 'common/store/cache/tracks/utils'
 import { fetchUsers } from 'common/store/cache/users/sagas'
@@ -48,7 +47,7 @@ import {
   subscribeToUserAsync,
   unsubscribeFromUserAsync
 } from 'common/store/social/users/sagas'
-import { waitForRead } from 'utils/sagaHelpers'
+import { waitForRead, waitForWrite } from 'utils/sagaHelpers'
 
 import { watchNotificationError } from './errorSagas'
 const { fetchReactionValues } = reactionsUIActions
@@ -638,13 +637,13 @@ export function* getNotifications(isFirstFetch: boolean) {
 
 export function* markAllNotificationsViewed() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  yield* call(waitForBackendSetup)
+  yield* call(waitForWrite)
   yield* call(audiusBackendInstance.markAllNotificationAsViewed)
   yield* put(notificationActions.markedAllAsViewed())
 }
 
 function* watchTogglePanel() {
-  yield* call(waitForBackendSetup)
+  yield* call(waitForWrite)
   yield* takeEvery(notificationActions.TOGGLE_NOTIFICATION_PANEL, function* () {
     const isOpen = yield* select(getNotificationPanelIsOpen)
     if (isOpen) {

--- a/packages/web/src/common/store/pages/explore/sagas.ts
+++ b/packages/web/src/common/store/pages/explore/sagas.ts
@@ -1,10 +1,10 @@
 import { ID, explorePageActions, getContext } from '@audius/common'
 import { call, put, takeEvery } from 'typed-redux-saga'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
 import { fetchUsers } from 'common/store/cache/users/sagas'
 import { STATIC_EXPLORE_CONTENT_URL } from 'utils/constants'
+import { waitForRead } from 'utils/sagaHelpers'
 const { fetchExplore, fetchExploreSucceeded, fetchExploreFailed } =
   explorePageActions
 
@@ -25,7 +25,7 @@ export const fetchExploreContent = async (
 
 function* watchFetchExplore() {
   yield* takeEvery(fetchExplore.type, function* () {
-    yield* call(waitForBackendSetup)
+    yield* call(waitForRead)
     const { EXPLORE_CONTENT_URL } = yield* getContext('env')
     try {
       const exploreContent = yield* call(

--- a/packages/web/src/common/store/pages/feed/sagas.ts
+++ b/packages/web/src/common/store/pages/feed/sagas.ts
@@ -8,13 +8,13 @@ import {
 } from '@audius/common'
 import { call, put, take, fork, takeEvery } from 'redux-saga/effects'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { fetchUsers } from 'common/store/cache/users/sagas'
 import feedSagas from 'common/store/pages/feed/lineup/sagas'
 import { fetchSuggestedFollowUserIds } from 'common/store/pages/signon/sagas'
+import { waitForRead, waitForWrite } from 'utils/sagaHelpers'
 
 function* fetchSuggestedFollowUsers() {
-  yield call(waitForBackendSetup)
+  yield call(waitForRead)
   try {
     const userIds: ID[] = yield call(fetchSuggestedFollowUserIds)
     yield put(discoverActions.setSuggestedFollows(userIds))
@@ -44,7 +44,7 @@ function* confirmFollowsAndRefresh(userIds: ID[]) {
 }
 
 function* followUsers(action: ReturnType<typeof discoverActions.followUsers>) {
-  yield call(waitForBackendSetup)
+  yield call(waitForWrite)
   try {
     yield put(feedActions.setLoading())
     yield fork(confirmFollowsAndRefresh, action.userIds)

--- a/packages/web/src/common/store/pages/remixes-page/sagas.ts
+++ b/packages/web/src/common/store/pages/remixes-page/sagas.ts
@@ -1,11 +1,11 @@
 import { TrackMetadata, remixesPageActions, Track } from '@audius/common'
 import { takeEvery, call, put } from 'redux-saga/effects'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import {
   retrieveTrackByHandleAndSlug,
   retrieveTracks
 } from 'common/store/cache/tracks/utils/retrieveTracks'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import tracksSagas from './lineups/tracks/sagas'
 
@@ -15,7 +15,7 @@ function* watchFetch() {
   yield takeEvery(
     fetchTrack.type,
     function* (action: ReturnType<typeof fetchTrack>) {
-      yield call(waitForBackendSetup)
+      yield call(waitForRead)
       const { handle, slug, id } = action.payload
       if (!id && (!handle || !slug)) {
         throw new Error(

--- a/packages/web/src/common/store/pages/search-page/sagas.js
+++ b/packages/web/src/common/store/pages/search-page/sagas.js
@@ -7,7 +7,6 @@ import {
 } from '@audius/common'
 import { select, call, takeLatest, put, getContext } from 'redux-saga/effects'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { processAndCacheCollections } from 'common/store/cache/collections/utils'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { fetchUsers } from 'common/store/cache/users/sagas'
@@ -46,7 +45,7 @@ export function* getTagSearchResults(tag, kind, limit, offset) {
 }
 
 export function* fetchSearchPageTags(action) {
-  yield call(waitForBackendSetup)
+  yield call(waitForRead)
   const query = trimToAlphaNumeric(action.tag)
 
   const rawResults = yield call(
@@ -117,7 +116,7 @@ export function* getSearchResults(searchText, kind, limit, offset) {
 }
 
 function* fetchSearchPageResults(action) {
-  yield call(waitForBackendSetup)
+  yield call(waitForRead)
 
   const rawResults = yield call(
     getSearchResults,

--- a/packages/web/src/common/store/pages/settings/sagas.ts
+++ b/packages/web/src/common/store/pages/settings/sagas.ts
@@ -5,7 +5,7 @@ import {
 } from '@audius/common'
 import { call, put, takeEvery } from 'typed-redux-saga'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 import errorSagas from './errorSagas'
 
@@ -13,7 +13,7 @@ function* watchGetSettings() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* takeEvery(actions.GET_NOTIFICATION_SETTINGS, function* () {
     try {
-      yield* call(waitForBackendSetup)
+      yield* call(waitForWrite)
       const emailSettings = yield* call(
         audiusBackendInstance.getEmailNotificationSettings
       )

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -35,7 +35,6 @@ import {
 import { fetchAccountAsync, reCacheAccount } from 'common/store/account/sagas'
 import { identify, make } from 'common/store/analytics/actions'
 import * as backendActions from 'common/store/backend/actions'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
 import { fetchUserByHandle, fetchUsers } from 'common/store/cache/users/sagas'
 import { processAndCacheUsers } from 'common/store/cache/users/utils'
@@ -48,7 +47,7 @@ import { isValidEmailString } from 'utils/email'
 import { withTimeout } from 'utils/network'
 import { restrictedHandles } from 'utils/restrictedHandles'
 import { ERROR_PAGE, FEED_PAGE, SIGN_IN_PAGE, SIGN_UP_PAGE } from 'utils/route'
-import { waitForRead } from 'utils/sagaHelpers'
+import { waitForRead, waitForWrite } from 'utils/sagaHelpers'
 
 import * as signOnActions from './actions'
 import { watchSignOnError } from './errorSagas'
@@ -111,7 +110,7 @@ function* getArtistsToFollow() {
 }
 
 function* fetchAllFollowArtist() {
-  yield call(waitForBackendSetup)
+  yield call(waitForRead)
   try {
     // Fetch Featured Follow artists first
     const suggestedUserFollowIds = yield call(fetchSuggestedFollowUserIds)
@@ -217,7 +216,7 @@ function* validateHandle(action) {
   const { handle, isOauthVerified, onValidate } = action
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const remoteConfigInstance = yield getContext('remoteConfigInstance')
-  yield call(waitForBackendSetup)
+  yield call(waitForWrite)
   try {
     if (handle.length > MAX_HANDLE_LENGTH) {
       yield put(signOnActions.validateHandleFailed('tooLong'))
@@ -326,7 +325,9 @@ function* signUp() {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const { waitForRemoteConfig } = yield getContext('remoteConfigInstance')
   const getFeatureEnabled = yield getContext('getFeatureEnabled')
-  yield call(waitForBackendSetup)
+
+  yield call(waitForWrite)
+
   const signOn = yield select(getSignOn)
   const location = yield call(getCityAndRegion)
   const createUserMetadata = {
@@ -504,7 +505,7 @@ function* signUp() {
 
 function* signIn(action) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  yield call(waitForBackendSetup)
+  yield call(waitForRead)
   try {
     const signOn = yield select(getSignOn)
     const signInResponse = yield call(
@@ -618,7 +619,7 @@ function* signIn(action) {
 }
 
 function* followCollections(collectionIds, favoriteSource) {
-  yield call(waitForBackendSetup)
+  yield call(waitForWrite)
   try {
     const result = yield retrieveCollections(null, collectionIds)
 
@@ -635,7 +636,7 @@ function* followCollections(collectionIds, favoriteSource) {
 
 function* followArtists() {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  yield call(waitForBackendSetup)
+  yield call(waitForWrite)
   try {
     // Auto-follow Hot & New Playlist
     if (IS_PRODUCTION) {

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -22,9 +22,9 @@ import {
   takeEvery
 } from 'redux-saga/effects'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { retrieveTracks } from 'common/store/cache/tracks/utils'
 import { retrieveTrackByHandleAndSlug } from 'common/store/cache/tracks/utils/retrieveTracks'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { NOT_FOUND_PAGE, trackRemixesPage } from '../../../../utils/route'
 
@@ -44,7 +44,7 @@ function* watchFetchTrackBadge() {
 
   yield takeEvery(trackPageActions.GET_TRACK_RANKS, function* (action) {
     try {
-      yield call(waitForBackendSetup)
+      yield call(waitForRead)
       yield call(remoteConfigInstance.waitForRemoteConfig)
       const TF = new Set(
         remoteConfigInstance.getRemoteVar(StringKeys.TF)?.split(',') ?? []

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -32,7 +32,6 @@ import {
   takeEvery
 } from 'redux-saga/effects'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import {
   fetchUsers,
   fetchUserByHandle,
@@ -48,7 +47,7 @@ import {
   subscribeToUserAsync,
   unsubscribeFromUserAsync
 } from 'common/store/social/users/sagas'
-import { waitForWrite } from 'utils/sagaHelpers'
+import { waitForRead, waitForWrite } from 'utils/sagaHelpers'
 const { refreshSupport } = tippingActions
 const { getIsReachable } = reachabilitySelectors
 const { getProfileUserId, getProfileFollowers, getProfileUser } =
@@ -315,7 +314,7 @@ function* fetchProfileAsync(action) {
 
 function* watchFetchFollowUsers(action) {
   yield takeEvery(profileActions.FETCH_FOLLOW_USERS, function* (action) {
-    yield call(waitForBackendSetup)
+    yield call(waitForRead)
     switch (action.followerGroup) {
       case FollowType.FOLLOWEE_FOLLOWS:
         yield call(fetchFolloweeFollows, action)

--- a/packages/web/src/common/store/search-bar/sagas.ts
+++ b/packages/web/src/common/store/search-bar/sagas.ts
@@ -2,7 +2,6 @@ import { Name, accountSelectors, getContext } from '@audius/common'
 import { call, cancel, fork, put, race, select, take } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { waitForRead } from 'utils/sagaHelpers'
 
 import * as searchActions from './actions'
@@ -38,7 +37,7 @@ export function* getSearchResults(searchText: string) {
 }
 
 function* fetchSearchAsync(action: searchActions.FetchSearchAction) {
-  yield* call(waitForBackendSetup)
+  yield* call(waitForRead)
   yield* put(searchActions.fetchSearchRequested(action.searchText))
   const search = yield* select(getSearch)
   if (action.searchText === search.searchText) {

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -22,7 +22,6 @@ import {
 import { call, select, takeEvery, put } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { adjustUserField } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
@@ -426,7 +425,7 @@ export function* watchUnsaveSmartCollection() {
 export function* unsaveSmartCollection(
   action: ReturnType<typeof socialActions.unsaveSmartCollection>
 ) {
-  yield* call(waitForBackendSetup)
+  yield* call(waitForWrite)
 
   const playlistLibrary = yield* select(getPlaylistLibrary)
   if (!playlistLibrary) return
@@ -447,7 +446,7 @@ export function* unsaveSmartCollection(
 export function* unsaveCollectionAsync(
   action: ReturnType<typeof socialActions.unsaveCollection>
 ) {
-  yield* call(waitForBackendSetup)
+  yield* call(waitForWrite)
   const collections = yield* select(getCollections, {
     ids: [action.collectionId]
   })

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -19,13 +19,12 @@ import { fork } from 'redux-saga/effects'
 import { call, select, takeEvery, put } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { adjustUserField } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
 import { updateProfileAsync } from 'common/store/profile/sagas'
-import { waitForWrite } from 'utils/sagaHelpers'
+import { waitForRead, waitForWrite } from 'utils/sagaHelpers'
 
 import watchTrackErrors from './errorSagas'
 const { updateOptimisticListenStreak } = audioRewardsPageActions
@@ -651,7 +650,7 @@ function* watchDownloadTrack() {
     socialActions.DOWNLOAD_TRACK,
     function* (action: ReturnType<typeof socialActions.downloadTrack>) {
       const trackDownload = yield* getContext('trackDownload')
-      yield* call(waitForBackendSetup)
+      yield* call(waitForRead)
 
       // Check if there is a logged in account and if not,
       // wait for one so we can trigger the download immediately after

--- a/packages/web/src/pages/artist-dashboard-page/store/sagas.js
+++ b/packages/web/src/pages/artist-dashboard-page/store/sagas.js
@@ -9,10 +9,10 @@ import { each } from 'lodash'
 import moment from 'moment'
 import { all, call, put, take, takeEvery, getContext } from 'redux-saga/effects'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import { retrieveUserTracks } from 'common/store/pages/profile/lineups/tracks/retrieveUserTracks'
 import { requiresAccount } from 'common/utils/requiresAccount'
 import { DASHBOARD_PAGE } from 'utils/route'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import * as dashboardActions from './actions'
 const { getBalance } = walletActions
@@ -47,7 +47,7 @@ function* fetchDashboardTracksAsync(action) {
 
 function* fetchDashboardAsync(action) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  yield call(waitForBackendSetup)
+  yield call(waitForRead)
 
   const account = yield call(waitForValue, getAccountUser)
   const { offset, limit } = action

--- a/packages/web/src/store/notifications/sagas.ts
+++ b/packages/web/src/store/notifications/sagas.ts
@@ -2,17 +2,17 @@ import { accountSelectors, getContext, waitForValue } from '@audius/common'
 import { eventChannel } from 'redux-saga'
 import { call, delay, fork, take } from 'typed-redux-saga'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
 import {
   getNotifications,
   getPollingIntervalMs
 } from 'common/store/notifications/sagas'
 import { isElectron } from 'utils/clientUtil'
+import { waitForRead } from 'utils/sagaHelpers'
 const { getHasAccount } = accountSelectors
 
 function* notificationPollingDaemon() {
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
-  yield* call(waitForBackendSetup)
+  yield* call(waitForRead)
   yield* call(waitForValue, getHasAccount, {})
 
   // Set up daemon that will watch for browser into focus and refetch notifications

--- a/packages/web/src/store/sign-out/sagas.ts
+++ b/packages/web/src/store/sign-out/sagas.ts
@@ -8,7 +8,7 @@ import { takeLatest, put } from 'redux-saga/effects'
 
 import { make } from 'common/store/analytics/actions'
 import { signOut } from 'store/sign-out/signOut'
-const { resetAccount } = accountActions
+const { resetAccount, unsubscribeBrowserPushNotifcations } = accountActions
 const { signOut: signOutAction } = signOutActions
 
 function* watchSignOut() {
@@ -16,6 +16,7 @@ function* watchSignOut() {
   const localStorage = yield* getContext('localStorage')
   yield takeLatest(signOutAction.type, function* () {
     yield put(resetAccount())
+    yield put(unsubscribeBrowserPushNotifcations())
     yield put(
       make(Name.SETTINGS_LOG_OUT, {
         callback: () => signOut(audiusBackendInstance, localStorage)

--- a/packages/web/src/store/sign-out/sagas.ts
+++ b/packages/web/src/store/sign-out/sagas.ts
@@ -8,7 +8,7 @@ import { takeLatest, put } from 'redux-saga/effects'
 
 import { make } from 'common/store/analytics/actions'
 import { signOut } from 'store/sign-out/signOut'
-const { resetAccount, unsubscribeBrowserPushNotifcations } = accountActions
+const { resetAccount, unsubscribeBrowserPushNotifications } = accountActions
 const { signOut: signOutAction } = signOutActions
 
 function* watchSignOut() {
@@ -16,7 +16,7 @@ function* watchSignOut() {
   const localStorage = yield* getContext('localStorage')
   yield takeLatest(signOutAction.type, function* () {
     yield put(resetAccount())
-    yield put(unsubscribeBrowserPushNotifcations())
+    yield put(unsubscribeBrowserPushNotifications())
     yield put(
       make(Name.SETTINGS_LOG_OUT, {
         callback: () => signOut(audiusBackendInstance, localStorage)


### PR DESCRIPTION
### Description
Fix sign out / sign in behavior. I felt like a small sensible refactor was due here -- I made SignOnScreen and HomeScreen both rendered at the same time so we can control via navigation what screen you're on as a user -- I think this is better? But open to feedback.

Some other issues:
- sign out sagas connected twice :oops:
- wait for account wasn't taking into consideration IDLE state
- sign out wasn't doing a page navigation but implicily relying on account state to change, which makes it hard to track
- sign in sometimes clears state before animations finish so you can see some error messages at the tail end of signing in sometimes in dev mode



### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

- sign in
- sign in & sign out & sign in
- sign in & sign out & sign in different account
- sign in & sign out & quit app & sign in
- sign in & quit app & open app


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

