### PR TITLE
[C-1624] Fix eager load

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -112,6 +112,7 @@
     "idb-keyval": "3.2.0",
     "inherits": "2.0.4",
     "jimp": "0.6.8",
+    "js-sha3": "0.8.0",
     "js-yaml": "3.13.1",
     "jsmediatags": "3.8.1",
     "lerp": "1.0.3",

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -21,7 +21,7 @@ import { identify } from 'common/store/analytics/actions'
 import { retrieveCollections } from 'common/store/cache/collections/utils'
 import { addPlaylistsNotInLibrary } from 'common/store/playlist-library/sagas'
 import { updateProfileAsync } from 'common/store/profile/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite, waitForRead } from 'utils/sagaHelpers'
 
 import disconnectedWallets from './disconnected_wallet_fix.json'
 
@@ -283,7 +283,7 @@ export function* reCacheAccount() {
 
 function* associateTwitterAccount(action) {
   const { uuid, profile } = action.payload
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   try {
     const userId = yield select(getUserId)
@@ -337,7 +337,7 @@ function* associateInstagramAccount(action) {
 }
 
 function* fetchSavedAlbumsAsync() {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
   const cachedSavedAlbums = yield select(getAccountAlbumIds)
   if (cachedSavedAlbums.length > 0) {
     yield call(retrieveCollections, null, cachedSavedAlbums)
@@ -345,7 +345,7 @@ function* fetchSavedAlbumsAsync() {
 }
 
 function* fetchSavedPlaylistsAsync() {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
 
   // Fetch other people's playlists you've saved
   yield fork(function* () {

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -46,6 +46,13 @@ export function* waitForBackendSetup() {
   }
 }
 
+export function* waitForReachability() {
+  const isReachable = yield* select(getIsReachable)
+  if (!isReachable) {
+    yield* all([take(reachabilityActions.SET_REACHABLE)])
+  }
+}
+
 function* awaitReachability() {
   const isNativeMobile = yield* getContext('isNativeMobile')
   const isReachable = yield* select(getIsReachable)

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -34,7 +34,7 @@ import { fetchUsers } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 import { reformat } from './utils'
 import {
@@ -64,7 +64,7 @@ function* watchCreatePlaylist() {
 }
 
 function* createPlaylistAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   // Potentially grab artwork from the initializing track.
   if (action.initTrackId) {
     const track = yield select(getTrack, { id: action.initTrackId })
@@ -288,7 +288,7 @@ function* watchEditPlaylist() {
 }
 
 function* editPlaylistAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   action.formFields.description = squashNewLines(action.formFields.description)
 
   const userId = yield select(getUserId)
@@ -403,7 +403,7 @@ function* watchAddTrackToPlaylist() {
 }
 
 function* addTrackToPlaylistAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const userId = yield select(getUserId)
   if (!userId) {
     yield put(signOnActions.openSignOn(false))
@@ -588,7 +588,7 @@ function* watchRemoveTrackFromPlaylist() {
 }
 
 function* removeTrackFromPlaylistAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const userId = yield select(getUserId)
   if (!userId) {
     yield put(signOnActions.openSignOn(false))
@@ -650,7 +650,7 @@ function* removeTrackFromPlaylistAsync(action) {
 
 // Removes the invalid track ids from the playlist by calling `dangerouslySetPlaylistOrder`
 function* fixInvalidTracksInPlaylist(playlistId, userId, invalidTrackIds) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const apiClient = yield getContext('apiClient')
   const removedTrackIds = new Set(invalidTrackIds)
@@ -794,7 +794,7 @@ function* watchOrderPlaylist() {
 }
 
 function* orderPlaylistAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const userId = yield select(getUserId)
   if (!userId) {
     yield put(signOnActions.openSignOn(false))
@@ -933,7 +933,7 @@ function* watchPublishPlaylist() {
 }
 
 function* publishPlaylistAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const userId = yield select(getUserId)
   if (!userId) {
     yield put(signOnActions.openSignOn(false))
@@ -1023,7 +1023,7 @@ function* watchDeletePlaylist() {
 }
 
 function* deletePlaylistAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const userId = yield select(getUserId)
   if (!userId) {
     yield put(signOnActions.openSignOn(false))

--- a/packages/web/src/common/store/cache/collections/utils/addUsersFromCollections.ts
+++ b/packages/web/src/common/store/cache/collections/utils/addUsersFromCollections.ts
@@ -10,7 +10,7 @@ import { uniqBy } from 'lodash'
 import { put, select } from 'typed-redux-saga'
 
 import { reformat as reformatUser } from 'common/store/cache/users/utils'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const getAccountUser = accountSelectors.getAccountUser
 
@@ -22,7 +22,7 @@ const getAccountUser = accountSelectors.getAccountUser
 export function* addUsersFromCollections(
   metadataArray: Array<UserCollectionMetadata>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const accountUser = yield* select(getAccountUser)
   const currentUserId = accountUser?.user_id

--- a/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
+++ b/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
@@ -16,7 +16,7 @@ import { call, select } from 'typed-redux-saga'
 
 import { retrieve } from 'common/store/cache/sagas'
 import { retrieveTracks } from 'common/store/cache/tracks/utils'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { addTracksFromCollections } from './addTracksFromCollections'
 import { addUsersFromCollections } from './addUsersFromCollections'
@@ -89,7 +89,7 @@ export function* retrieveTracksForCollections(
  * Retrieves a single collection via API client
  */
 export function* retrieveCollection(playlistId: ID) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const userId = yield* select(getUserId)
   const playlists = yield* call([apiClient, 'getPlaylist'], {

--- a/packages/web/src/common/store/cache/tracks/sagas.js
+++ b/packages/web/src/common/store/cache/tracks/sagas.js
@@ -34,7 +34,7 @@ import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
 import { updateProfileAsync } from 'common/store/profile/sagas'
 import { dominantColor } from 'utils/imageProcessingUtil'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 const { getUser } = cacheUsersSelectors
 const { getTrack } = cacheTracksSelectors
@@ -170,7 +170,7 @@ function* confirmEditTrack(
   isNowListed,
   currentTrack
 ) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const apiClient = yield getContext('apiClient')
   yield put(
@@ -257,7 +257,7 @@ function* watchEditTrack() {
 
 function* deleteTrackAsync(action) {
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const userId = yield select(getUserId)
   if (!userId) {
     yield put(signOnActions.openSignOn(false))
@@ -302,7 +302,7 @@ function* deleteTrackAsync(action) {
 }
 
 function* confirmDeleteTrack(trackId) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const apiClient = yield getContext('apiClient')
   yield put(

--- a/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessRemixes.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessRemixes.ts
@@ -11,7 +11,7 @@ import {
 } from '@audius/common'
 import { select, call, put } from 'typed-redux-saga'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { processAndCacheTracks } from './processAndCacheTracks'
 const { getTrack } = cacheTracksSelectors
@@ -27,7 +27,7 @@ const INITIAL_FETCH_LIMIT = 6
  * @param trackId the parent track for which to fetch remixes
  */
 export function* fetchAndProcessRemixes(trackId: ID) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const currentUserId = yield* select(getUserId)
   const {
@@ -80,7 +80,7 @@ export function* fetchAndProcessRemixes(trackId: ID) {
  * @param trackId the track for which to fetch remix parents
  */
 export function* fetchAndProcessRemixParents(trackId: ID) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const currentUserId = yield* select(getUserId)
   const remixParents = (yield* call([apiClient, 'getRemixing'], {

--- a/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessStems.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/fetchAndProcessStems.ts
@@ -11,7 +11,7 @@ import {
 } from '@audius/common'
 import { call, put } from 'redux-saga/effects'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { processAndCacheTracks } from './processAndCacheTracks'
 const { getTrack } = cacheTracksSelectors
@@ -24,7 +24,7 @@ const { getTrack } = cacheTracksSelectors
  * @param trackId the parent track for which to fetch stems
  */
 export function* fetchAndProcessStems(trackId: ID) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
 
   const stems: StemTrackMetadata[] = yield call(

--- a/packages/web/src/common/store/cache/tracks/utils/helpers.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/helpers.ts
@@ -11,7 +11,7 @@ import { uniqBy } from 'lodash'
 import { put, select } from 'typed-redux-saga'
 
 import { reformat as reformatUser } from 'common/store/cache/users/utils'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const getAccountUser = accountSelectors.getAccountUser
 
 /**
@@ -22,7 +22,7 @@ const getAccountUser = accountSelectors.getAccountUser
 export function* addUsersFromTracks<T extends TrackMetadata & { user?: User }>(
   metadataArray: T[]
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const accountUser = yield* select(getAccountUser)
   const currentUserId = accountUser?.user_id

--- a/packages/web/src/common/store/cache/tracks/utils/processAndCacheTracks.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/processAndCacheTracks.ts
@@ -8,7 +8,7 @@ import {
 } from '@audius/common'
 import { put, call } from 'typed-redux-saga'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { addUsersFromTracks } from './helpers'
 import { reformat } from './reformat'
@@ -20,7 +20,7 @@ import { reformat } from './reformat'
 export function* processAndCacheTracks<T extends TrackMetadata>(
   tracks: T[]
 ): Generator<any, Track[], any> {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   // Add users
   yield* call(addUsersFromTracks, tracks)

--- a/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
@@ -15,7 +15,7 @@ import {
 import { call, put, select, spawn } from 'typed-redux-saga'
 
 import { retrieve } from 'common/store/cache/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import {
   fetchAndProcessRemixes,
@@ -65,7 +65,7 @@ export function* retrieveTrackByHandleAndSlug({
         return track
       },
       retrieveFromSource: function* (permalinks: string[]) {
-        yield* waitForBackendAndAccount()
+        yield* waitForRead()
         const apiClient = yield* getContext('apiClient')
         const userId = yield* select(getUserId)
         const track = yield* call((args) => {
@@ -153,7 +153,7 @@ export function* retrieveTracks({
   withRemixes = false,
   withRemixParents = false
 }: RetrieveTracksArgs) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId = yield* select(getUserId)
 
   // In the case of unlisted tracks, trackIds contains metadata used to fetch tracks
@@ -217,7 +217,7 @@ export function* retrieveTracks({
       return selected
     },
     retrieveFromSource: function* (ids: ID[] | UnlistedTrackRequest[]) {
-      yield* waitForBackendAndAccount()
+      yield* waitForRead()
       const apiClient = yield* getContext('apiClient')
       let fetched: UserTrackMetadata | UserTrackMetadata[] | null | undefined
       if (canBeUnlisted) {

--- a/packages/web/src/common/store/cache/users/sagas.js
+++ b/packages/web/src/common/store/cache/users/sagas.js
@@ -30,7 +30,7 @@ import {
   getStatus
 } from 'common/store/service-selection/selectors'
 import { fetchServicesFailed } from 'common/store/service-selection/slice'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite, waitForRead } from 'utils/sagaHelpers'
 
 import { pruneBlobValues, reformat } from './utils'
 const { removePlaylistLibraryTempPlaylists } = playlistLibraryHelpers
@@ -42,7 +42,7 @@ const { getAccountUser, getUserId } = accountSelectors
  * If the user is not a creator, upgrade the user to a creator node.
  */
 export function* upgradeToCreator() {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const user = yield select(getAccountUser)
 
@@ -118,7 +118,7 @@ export function* fetchUsers(
 }
 
 function* retrieveUserByHandle(handle, retry) {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
   const apiClient = yield getContext('apiClient')
   const userId = yield select(getUserId)
   if (Array.isArray(handle)) {

--- a/packages/web/src/common/store/cache/users/utils/processAndCacheUsers.ts
+++ b/packages/web/src/common/store/cache/users/utils/processAndCacheUsers.ts
@@ -1,12 +1,12 @@
 import { User, Kind, makeUid, getContext, cacheActions } from '@audius/common'
 import { put } from 'typed-redux-saga'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { reformat } from './reformat'
 
 export function* processAndCacheUsers(users: User[]) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const reformattedUser = users.map((user) => {
     return reformat(user, audiusBackendInstance)

--- a/packages/web/src/common/store/notifications/sagas.ts
+++ b/packages/web/src/common/store/notifications/sagas.ts
@@ -48,7 +48,7 @@ import {
   subscribeToUserAsync,
   unsubscribeFromUserAsync
 } from 'common/store/social/users/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { watchNotificationError } from './errorSagas'
 const { fetchReactionValues } = reactionsUIActions
@@ -195,7 +195,7 @@ export function* fetchNotifications(action: FetchNotifications) {
 export function* parseAndProcessNotifications(
   notifications: Notification[]
 ): Generator<any, Notification[], any> {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   /**
    * Parse through the notifications & collect user /track / collection IDs
    * that the notification references to fetch

--- a/packages/web/src/common/store/pages/audio-rewards/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-rewards/sagas.ts
@@ -37,7 +37,7 @@ import {
 } from 'typed-redux-saga'
 
 import { AUDIO_PAGE } from 'utils/route'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 import {
   foregroundPollingDaemon,
   visibilityPollingDaemon
@@ -436,7 +436,7 @@ function* watchClaimChallengeReward() {
 }
 
 function* fetchUserChallengesAsync() {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const currentUserId = yield* select(getUserId)
   if (!currentUserId) return

--- a/packages/web/src/common/store/pages/deactivate-account/sagas.ts
+++ b/packages/web/src/common/store/pages/deactivate-account/sagas.ts
@@ -12,7 +12,7 @@ import { make } from 'common/store/analytics/actions'
 import { requestConfirmation } from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import { getConfirmCalls } from 'common/store/confirmer/selectors'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 const { afterDeactivationSignOut, deactivateAccount, deactivateAccountFailed } =
   deactivateAccountActions
@@ -24,7 +24,7 @@ const DEACTIVATE_CONFIRMATION_UID = 'DEACTIVATE'
 function* handleDeactivateAccount() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   try {
-    yield* waitForBackendAndAccount()
+    yield* waitForWrite()
 
     const accountUserId = yield* select(getUserId)
     const userMetadata = yield* select(getAccountUser)

--- a/packages/web/src/common/store/pages/explore/exploreCollections/sagas.ts
+++ b/packages/web/src/common/store/pages/explore/exploreCollections/sagas.ts
@@ -9,7 +9,7 @@ import { takeEvery, call, put } from 'typed-redux-saga'
 import { processAndCacheCollections } from 'common/store/cache/collections/utils'
 import { requiresAccount } from 'common/utils/requiresAccount'
 import { EXPLORE_PAGE } from 'utils/route'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const { fetch, fetchSucceeded } = explorePageCollectionsActions
 
 function* fetchLetThemDJ() {
@@ -49,7 +49,7 @@ const fetchMap = {
 
 function* watchFetch() {
   yield* takeEvery(fetch.type, function* (action: ReturnType<typeof fetch>) {
-    yield* waitForBackendAndAccount()
+    yield* waitForRead()
 
     const { variant, moods } = action.payload
 

--- a/packages/web/src/common/store/pages/feed/lineup/sagas.ts
+++ b/packages/web/src/common/store/pages/feed/lineup/sagas.ts
@@ -20,7 +20,7 @@ import { processAndCacheCollections } from 'common/store/cache/collections/utils
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
 import { getFollowIds } from 'common/store/pages/signon/selectors'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const { getFeedFilter } = feedPageSelectors
 const getAccountUser = accountSelectors.getAccountUser
 
@@ -39,7 +39,7 @@ function* getTracks({
   offset: number
   limit: number
 }): Generator<any, FeedItem[], any> {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUser = yield select(getAccountUser)
   const filterEnum: FeedFilter = yield select(getFeedFilter)
   const apiClient = yield* getContext('apiClient')

--- a/packages/web/src/common/store/pages/history/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/history/lineups/sagas.js
@@ -8,12 +8,12 @@ import { call, getContext, select } from 'redux-saga/effects'
 
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const { getUserId } = accountSelectors
 const { prefix: PREFIX } = tracksActions
 
 function* getHistoryTracks() {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
 
   const apiClient = yield getContext('apiClient')
   try {

--- a/packages/web/src/common/store/pages/profile/lineups/feed/retrieveUserReposts.ts
+++ b/packages/web/src/common/store/pages/profile/lineups/feed/retrieveUserReposts.ts
@@ -9,7 +9,7 @@ import { all } from 'redux-saga/effects'
 
 import { processAndCacheCollections } from 'common/store/cache/collections/utils'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const getTracksAndCollections = (
   feed: (UserTrackMetadata | UserCollection)[]
@@ -41,7 +41,7 @@ export function* retrieveUserReposts({
   offset,
   limit
 }: RetrieveUserRepostsArgs): Generator<any, Track[], any> {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const reposts = yield apiClient.getUserRepostsByHandle({
     handle,

--- a/packages/web/src/common/store/pages/profile/lineups/feed/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/feed/sagas.js
@@ -15,7 +15,7 @@ import { select, call, takeEvery, put } from 'redux-saga/effects'
 
 import { getConfirmCalls } from 'common/store/confirmer/selectors'
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { retrieveUserReposts } from './retrieveUserReposts'
 const { getProfileUserId, getProfileFeedLineup } = profilePageSelectors
@@ -24,7 +24,7 @@ const { getCollections } = cacheCollectionsSelectors
 const { getUserId, getUserHandle } = accountSelectors
 
 function* getReposts({ offset, limit, handle }) {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
 
   const profileId = yield select((state) => getProfileUserId(state, handle))
 

--- a/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
+++ b/packages/web/src/common/store/pages/profile/lineups/tracks/sagas.js
@@ -23,7 +23,7 @@ import {
 
 import { retrieveTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { retrieveUserTracks } from './retrieveUserTracks'
 const { SET_ARTIST_PICK } = tracksSocialActions
@@ -35,7 +35,7 @@ const { getUserId, getUserHandle } = accountSelectors
 const PREFIX = tracksActions.prefix
 
 function* getTracks({ offset, limit, payload, handle }) {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
   const currentUserId = yield select(getUserId)
   const profileHandle = handle.toLowerCase()
 

--- a/packages/web/src/common/store/pages/remixes-page/lineups/tracks/sagas.ts
+++ b/packages/web/src/common/store/pages/remixes-page/lineups/tracks/sagas.ts
@@ -10,7 +10,7 @@ import { call, put, select } from 'typed-redux-saga'
 
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const { getTrackId, getLineup } = remixesPageSelectors
 const { setCount } = remixesPageActions
 const getUserId = accountSelectors.getUserId
@@ -27,7 +27,7 @@ function* getTracks({
   const apiClient = yield* getContext('apiClient')
   const { trackId } = payload
   if (!trackId) return []
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
 
   const currentUserId = yield* select(getUserId)
   const { tracks, count } = yield* call([apiClient, 'getRemixes'], {

--- a/packages/web/src/common/store/pages/saved/sagas.js
+++ b/packages/web/src/common/store/pages/saved/sagas.js
@@ -15,7 +15,7 @@ import {
 } from 'redux-saga/effects'
 
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import tracksSagas from './lineups/sagas'
 const { getSaves } = savedPageSelectors
@@ -31,7 +31,7 @@ function* watchFetchSaves() {
   let currentSortDirection = ''
 
   yield takeLatest(actions.FETCH_SAVES, function* (props) {
-    yield waitForBackendAndAccount()
+    yield waitForRead()
     const apiClient = yield getContext('apiClient')
     const account = yield call(waitForValue, getAccountUser)
     const userId = account.user_id
@@ -94,7 +94,7 @@ function* watchFetchSaves() {
 }
 
 function* watchFetchMoreSaves() {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
   const apiClient = yield getContext('apiClient')
   yield takeLatest(actions.FETCH_MORE_SAVES, function* (props) {
     const account = yield call(waitForValue, getAccountUser)

--- a/packages/web/src/common/store/pages/search-page/sagas.js
+++ b/packages/web/src/common/store/pages/search-page/sagas.js
@@ -13,7 +13,7 @@ import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { fetchUsers } from 'common/store/cache/users/sagas'
 import { processAndCacheUsers } from 'common/store/cache/users/utils'
 import tracksSagas from 'common/store/pages/search-page/lineups/tracks/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const getUserId = accountSelectors.getUserId
 
@@ -90,7 +90,7 @@ export function* fetchSearchPageTags(action) {
 }
 
 export function* getSearchResults(searchText, kind, limit, offset) {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
 
   const apiClient = yield getContext('apiClient')
   const userId = yield select(getUserId)

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -48,7 +48,7 @@ import { isValidEmailString } from 'utils/email'
 import { withTimeout } from 'utils/network'
 import { restrictedHandles } from 'utils/restrictedHandles'
 import { ERROR_PAGE, FEED_PAGE, SIGN_IN_PAGE, SIGN_UP_PAGE } from 'utils/route'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import * as signOnActions from './actions'
 import { watchSignOnError } from './errorSagas'
@@ -154,7 +154,7 @@ function* fetchFollowArtistGenre(followArtistCategory) {
 }
 
 function* fetchReferrer(action) {
-  yield waitForBackendAndAccount()
+  yield waitForRead()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const { handle } = action
   if (handle) {

--- a/packages/web/src/common/store/pages/token-dashboard/sagas.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/sagas.ts
@@ -11,7 +11,7 @@ import {
   fetchOpenSeaAssetsForWallets,
   fetchSolanaCollectiblesForWallets
 } from 'common/store/profile/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const { fetchAssociatedWallets, setAssociatedWallets } =
   tokenDashboardPageActions
@@ -63,7 +63,7 @@ function* fetchSplWalletInfo(wallets: string[]) {
 }
 
 function* fetchAccountAssociatedWallets() {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const accountUserId = yield* select(getUserId)
   if (!accountUserId) return

--- a/packages/web/src/common/store/pages/track/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/track/lineups/sagas.ts
@@ -9,7 +9,7 @@ import { call, select } from 'typed-redux-saga'
 
 import { LineupSagas } from 'common/store/lineup/sagas'
 import { retrieveUserTracks } from 'common/store/pages/profile/lineups/tracks/retrieveUserTracks'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const { PREFIX, tracksActions } = trackPageLineupActions
 const { getLineup, getSourceSelector: sourceSelector } = trackPageSelectors
 const { getTrack } = cacheTracksSelectors
@@ -29,7 +29,7 @@ function* getTracks({
   limit?: number
 }) {
   const { ownerHandle, heroTrackPermalink } = payload
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId = yield* select(getUserId)
 
   const lineup = []

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -11,6 +11,7 @@ import {
   reachabilitySelectors
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
+import { keccak_256 } from 'js-sha3'
 import moment from 'moment'
 import {
   call,
@@ -37,11 +38,9 @@ const { getUsers } = cacheUsersSelectors
 
 export const TRENDING_BADGE_LIMIT = 10
 
-function* watchTrackBadge() {
+function* watchFetchTrackBadge() {
   const apiClient = yield getContext('apiClient')
   const remoteConfigInstance = yield getContext('remoteConfigInstance')
-  const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  const web3 = yield call(audiusBackendInstance.getWeb3)
 
   yield takeEvery(trackPageActions.GET_TRACK_RANKS, function* (action) {
     try {
@@ -57,15 +56,15 @@ function* watchTrackBadge() {
         })
         if (TF.size > 0) {
           trendingRanks.week = trendingRanks.week.filter((i) => {
-            const shaId = web3.utils.sha3(i.toString())
+            const shaId = keccak_256(i.toString())
             return !TF.has(shaId)
           })
           trendingRanks.month = trendingRanks.month.filter((i) => {
-            const shaId = web3.utils.sha3(i.toString())
+            const shaId = keccak_256(i.toString())
             return !TF.has(shaId)
           })
           trendingRanks.year = trendingRanks.year.filter((i) => {
-            const shaId = web3.utils.sha3(i.toString())
+            const shaId = keccak_256(i.toString())
             return !TF.has(shaId)
           })
         }
@@ -267,7 +266,7 @@ export default function sagas() {
     watchFetchTrack,
     watchFetchTrackSucceeded,
     watchRefetchLineup,
-    watchTrackBadge,
+    watchFetchTrackBadge,
     watchTrackPageMakePublic,
     watchGoToRemixesOfParentPage
   ]

--- a/packages/web/src/common/store/pages/trending-playlists/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/trending-playlists/lineups/sagas.ts
@@ -6,20 +6,19 @@ import {
   trendingPlaylistsPageLineupActions,
   getContext
 } from '@audius/common'
+import { keccak_256 } from 'js-sha3'
 import { call, select } from 'typed-redux-saga'
 
 import { processAndCacheCollections } from 'common/store/cache/collections/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const { getLineup } = trendingPlaylistsPageLineupSelectors
 const getUserId = accountSelectors.getUserId
 
 function* getPlaylists({ limit, offset }: { limit: number; offset: number }) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const web3 = yield* call(audiusBackendInstance.getWeb3)
 
   yield* call(remoteConfigInstance.waitForRemoteConfig)
 
@@ -43,7 +42,7 @@ function* getPlaylists({ limit, offset }: { limit: number; offset: number }) {
 
   if (TF.size > 0) {
     playlists = playlists.filter((p) => {
-      const shaId = web3.utils.sha3(p.playlist_id.toString())
+      const shaId = keccak_256(p.playlist_id.toString())
       return !TF.has(shaId)
     })
   }

--- a/packages/web/src/common/store/pages/trending-underground/lineups/sagas.ts
+++ b/packages/web/src/common/store/pages/trending-underground/lineups/sagas.ts
@@ -5,11 +5,12 @@ import {
   trendingUndergroundPageLineupActions,
   getContext
 } from '@audius/common'
+import { keccak_256 } from 'js-sha3'
 import { call, select } from 'typed-redux-saga'
 
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const { getLineup } = trendingUndergroundPageLineupSelectors
 const getUserId = accountSelectors.getUserId
@@ -21,11 +22,9 @@ function* getTrendingUnderground({
   limit: number
   offset: number
 }) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const web3 = yield* call(audiusBackendInstance.getWeb3)
 
   yield call(remoteConfigInstance.waitForRemoteConfig)
 
@@ -43,7 +42,7 @@ function* getTrendingUnderground({
 
   if (TF.size > 0) {
     tracks = tracks.filter((t) => {
-      const shaId = web3.utils.sha3(t.track_id.toString())
+      const shaId = keccak_256(t.track_id.toString())
       return !TF.has(shaId)
     })
   }

--- a/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
+++ b/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
@@ -12,11 +12,12 @@ import {
   trendingPageSelectors,
   getContext
 } from '@audius/common'
+import { keccak_256 } from 'js-sha3'
 import { call, put, select } from 'redux-saga/effects'
 
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { AppState } from 'store/types'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const { getLastFetchedTrendingGenre, getTrendingGenre } = trendingPageSelectors
 const { setLastFetchedTrendingGenre } = trendingPageActions
 const { getTrendingEntries } = trendingPageLineupSelectors
@@ -37,11 +38,9 @@ export function* retrieveTrending({
   limit,
   currentUserId
 }: RetrieveTrendingArgs): Generator<any, Track[], any> {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
-  const audiusBackendInstance = yield* getContext('audiusBackendInstance')
-  const web3 = yield call(audiusBackendInstance.getWeb3)
 
   yield call(remoteConfigInstance.waitForRemoteConfig)
   const TF = new Set(
@@ -75,7 +74,7 @@ export function* retrieveTrending({
 
   if (TF.size > 0) {
     apiTracks = apiTracks.filter((t) => {
-      const shaId = web3.utils.sha3(t.track_id.toString())
+      const shaId = keccak_256(t.track_id.toString())
       return !TF.has(shaId)
     })
   }

--- a/packages/web/src/common/store/pages/trending/lineups/trending/sagas.js
+++ b/packages/web/src/common/store/pages/trending/lineups/trending/sagas.js
@@ -7,7 +7,7 @@ import {
 import { select } from 'redux-saga/effects'
 
 import { LineupSagas } from 'common/store/lineup/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { retrieveTrending } from './retrieveTrending'
 const { getTrendingGenre } = trendingPageSelectors
@@ -23,7 +23,7 @@ const getUserId = accountSelectors.getUserId
 
 function getTracks(timeRange) {
   return function* ({ offset, limit }) {
-    yield waitForBackendAndAccount()
+    yield waitForRead()
     const genreAtStart = yield select(getTrendingGenre)
     const userId = yield select(getUserId)
     try {

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -27,7 +27,7 @@ import {
   delay
 } from 'typed-redux-saga'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 import errorSagas from './errorSagas'
 
@@ -61,7 +61,7 @@ const RECORD_LISTEN_INTERVAL = 1000
 let FORCE_MP3_STREAM_TRACK_IDS: Set<string> | null = null
 
 export function* watchPlay() {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const apiClient = yield* getContext('apiClient')
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')

--- a/packages/web/src/common/store/playlist-library/sagas.ts
+++ b/packages/web/src/common/store/playlist-library/sagas.ts
@@ -25,7 +25,7 @@ import {
 
 import { getResult } from 'common/store/confirmer/selectors'
 import { updateProfileAsync } from 'common/store/profile/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 const { update } = playlistLibraryActions
 const {
@@ -72,7 +72,7 @@ function* watchUpdatePlaylistLibrary() {
   yield takeEvery(
     update.type,
     function* updatePlaylistLibrary(action: ReturnType<typeof update>) {
-      yield* waitForBackendAndAccount()
+      yield* waitForWrite()
       const { playlistLibrary } = action.payload
 
       const account: User = yield select(getAccountUser)
@@ -113,7 +113,7 @@ function* watchUpdatePlaylistLibraryWithTempPlaylist() {
   yield takeLatest(
     TEMP_PLAYLIST_UPDATE_HELPER,
     function* makeUpdate(action: ReturnType<typeof update>) {
-      yield* waitForBackendAndAccount()
+      yield* waitForWrite()
       const { playlistLibrary: rawPlaylistLibrary } = action.payload
       const playlistLibrary =
         removePlaylistLibraryDuplicates(rawPlaylistLibrary)

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -17,7 +17,7 @@ import {
 } from '@audius/common'
 import { takeLatest, select, call, put } from 'typed-redux-saga'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 const {
   updatePremiumContentSignatures,
@@ -169,7 +169,7 @@ function* updateNFTGatedTrackAccess(
     | ReturnType<typeof cacheActions.add>
 ) {
   // Halt if premium content not enabled
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
   if (!getFeatureEnabled(FeatureFlags.PREMIUM_CONTENT_ENABLED)) {
     return

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -48,7 +48,7 @@ import {
   subscribeToUserAsync,
   unsubscribeFromUserAsync
 } from 'common/store/social/users/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 const { refreshSupport } = tippingActions
 const { getIsReachable } = reachabilitySelectors
 const { getProfileUserId, getProfileFollowers, getProfileUser } =
@@ -396,7 +396,7 @@ function* watchUpdateProfile() {
 }
 
 export function* updateProfileAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   let metadata = { ...action.metadata }
   metadata.bio = squashNewLines(metadata.bio)
@@ -471,7 +471,7 @@ export function* updateProfileAsync(action) {
 }
 
 function* confirmUpdateProfile(userId, metadata) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const apiClient = yield getContext('apiClient')
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const localStorage = yield getContext('localStorage')

--- a/packages/web/src/common/store/search-bar/sagas.ts
+++ b/packages/web/src/common/store/search-bar/sagas.ts
@@ -3,7 +3,7 @@ import { call, cancel, fork, put, race, select, take } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
 import { waitForBackendSetup } from 'common/store/backend/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import * as searchActions from './actions'
 import { getSearch } from './selectors'
@@ -11,7 +11,7 @@ import { getSearch } from './selectors'
 const getUserId = accountSelectors.getUserId
 
 export function* getSearchResults(searchText: string) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
 
   const apiClient = yield* getContext('apiClient')
   const userId = yield* select(getUserId)

--- a/packages/web/src/common/store/service-selection/sagas.ts
+++ b/packages/web/src/common/store/service-selection/sagas.ts
@@ -8,7 +8,7 @@ import {
 } from '@audius/common'
 import { all, fork, call, put, select, takeEvery } from 'typed-redux-saga'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite, waitForRead } from 'utils/sagaHelpers'
 
 import { watchServiceSelectionErrors } from './errorSagas'
 import { getSecondaries, getSelectedServices } from './selectors'
@@ -27,7 +27,7 @@ const getAccountUser = accountSelectors.getAccountUser
 export function* watchFetchServices() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* takeEvery(fetchServices.type, function* () {
-    yield* waitForBackendAndAccount()
+    yield* waitForRead()
 
     const currentUser = yield* call(waitForValue, getAccountUser)
 
@@ -112,7 +112,7 @@ function* watchSetSelected() {
   yield* takeEvery(
     setSelected.type,
     function* (action: ReturnType<typeof setSelected>) {
-      yield* waitForBackendAndAccount()
+      yield* waitForWrite()
 
       const user = yield* call(waitForValue, getAccountUser)
 

--- a/packages/web/src/common/store/smart-collection/sagas.ts
+++ b/packages/web/src/common/store/smart-collection/sagas.ts
@@ -14,7 +14,7 @@ import { takeEvery, put, call, select } from 'typed-redux-saga'
 import { processAndCacheTracks } from 'common/store/cache/tracks/utils'
 import { fetchUsers as retrieveUsers } from 'common/store/cache/users/sagas'
 import { requiresAccount } from 'common/utils/requiresAccount'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 import { EXPLORE_PAGE } from '../../../utils/route'
 
@@ -63,7 +63,7 @@ function* fetchHeavyRotation() {
 
 function* fetchBestNewReleases() {
   const explore = yield* getContext('explore')
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId = yield* select(getUserId)
   if (currentUserId == null) {
     return
@@ -114,7 +114,7 @@ function* fetchUnderTheRadar() {
 }
 
 function* fetchMostLoved() {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId = yield* select(getUserId)
   if (currentUserId == null) {
     return
@@ -140,7 +140,7 @@ function* fetchMostLoved() {
 }
 
 function* fetchFeelingLucky() {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId = yield* select(getUserId)
   const explore = yield* getContext('explore')
 
@@ -162,7 +162,7 @@ function* fetchFeelingLucky() {
 
 function* fetchRemixables() {
   const explore = yield* getContext('explore')
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId = yield* select(getUserId)
   if (currentUserId == null) {
     return
@@ -233,7 +233,7 @@ function* watchFetch() {
   yield takeEvery(
     fetchSmartCollection.type,
     function* (action: ReturnType<typeof fetchSmartCollection>) {
-      yield* waitForBackendAndAccount()
+      yield* waitForRead()
 
       const { variant } = action.payload
 

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -28,7 +28,7 @@ import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
 import { albumPage, audioNftPlaylistPage, playlistPage } from 'utils/route'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 import watchCollectionErrors from './errorSagas'
 const { update: updatePlaylistLibrary } = playlistLibraryActions
@@ -47,7 +47,7 @@ export function* watchRepostCollection() {
 export function* repostCollectionAsync(
   action: ReturnType<typeof socialActions.repostCollection>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.openSignOn(false))
@@ -153,7 +153,7 @@ export function* watchUndoRepostCollection() {
 export function* undoRepostCollectionAsync(
   action: ReturnType<typeof socialActions.undoRepostCollection>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.openSignOn(false))
@@ -269,7 +269,7 @@ export function* watchSaveSmartCollection() {
 export function* saveSmartCollection(
   action: ReturnType<typeof socialActions.saveSmartCollection>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.showRequiresAccountModal())
@@ -301,7 +301,7 @@ export function* saveSmartCollection(
 export function* saveCollectionAsync(
   action: ReturnType<typeof socialActions.saveCollection>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.showRequiresAccountModal())

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -25,7 +25,7 @@ import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
 import { updateProfileAsync } from 'common/store/profile/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 import watchTrackErrors from './errorSagas'
 const { updateOptimisticListenStreak } = audioRewardsPageActions
@@ -42,7 +42,7 @@ export function* watchRepostTrack() {
 export function* repostTrackAsync(
   action: ReturnType<typeof socialActions.repostTrack>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.openSignOn(false))
@@ -186,7 +186,7 @@ export function* watchUndoRepostTrack() {
 export function* undoRepostTrackAsync(
   action: ReturnType<typeof socialActions.undoRepostTrack>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.openSignOn(false))
@@ -299,7 +299,7 @@ export function* watchSaveTrack() {
 export function* saveTrackAsync(
   action: ReturnType<typeof socialActions.saveTrack>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.showRequiresAccountModal())
@@ -439,7 +439,7 @@ export function* watchUnsaveTrack() {
 export function* unsaveTrackAsync(
   action: ReturnType<typeof socialActions.unsaveTrack>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const userId = yield* select(getUserId)
   if (!userId) {
     yield* put(signOnActions.openSignOn(false))
@@ -556,7 +556,7 @@ export function* watchSetArtistPick() {
   yield* takeEvery(
     socialActions.SET_ARTIST_PICK,
     function* (action: ReturnType<typeof socialActions.setArtistPick>) {
-      yield* waitForBackendAndAccount()
+      yield* waitForWrite()
       const userId = yield* select(getUserId)
 
       // Dual write to the artist_pick_track_id field in the
@@ -587,7 +587,7 @@ export function* watchSetArtistPick() {
 export function* watchUnsetArtistPick() {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* takeEvery(socialActions.UNSET_ARTIST_PICK, function* (action) {
-    yield* waitForBackendAndAccount()
+    yield* waitForWrite()
     const userId = yield* select(getUserId)
 
     // Dual write to the artist_pick_track_id field in the
@@ -625,7 +625,7 @@ export function* watchRecordListen() {
       if (isNativeMobile) return
       console.debug('Listen recorded for track', action.trackId)
 
-      yield* waitForBackendAndAccount()
+      yield* waitForWrite()
       const userId = yield* select(getUserId)
       const track = yield* select(getTrack, { id: action.trackId })
       if (!userId || !track) return

--- a/packages/web/src/common/store/social/users/sagas.ts
+++ b/packages/web/src/common/store/social/users/sagas.ts
@@ -19,7 +19,7 @@ import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
 import { profilePage } from 'utils/route'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 import errorSagas from './errorSagas'
 const { getUsers, getUser } = cacheUsersSelectors
@@ -35,7 +35,7 @@ export function* watchFollowUser() {
 export function* followUser(
   action: ReturnType<typeof socialActions.followUser>
 ) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
 
   const accountId = yield* select(getUserId)
@@ -156,7 +156,7 @@ export function* unfollowUser(
   action: ReturnType<typeof socialActions.unfollowUser>
 ) {
   /* Make Async Backend Call */
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const accountId = yield* select(getUserId)
   if (!accountId) {
     yield* put(signOnActions.openSignOn(false))
@@ -268,7 +268,7 @@ export function* confirmUnfollowUser(userId: ID, accountId: ID) {
 /* SUBSCRIBE */
 
 export function* subscribeToUserAsync(userId: ID) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
 
   const accountId = yield* select(getUserId)
   if (!accountId) {
@@ -314,7 +314,7 @@ export function* confirmSubscribeToUser(userId: ID, accountId: ID) {
 }
 
 export function* unsubscribeFromUserAsync(userId: ID) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
 
   const accountId = yield* select(getUserId)
   if (!accountId) {

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -43,7 +43,7 @@ import {
 
 import { make } from 'common/store/analytics/actions'
 import { fetchUsers } from 'common/store/cache/users/sagas'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite, waitForRead } from 'utils/sagaHelpers'
 
 import { updateTipsStorage } from './storageUtils'
 const { decreaseBalance } = walletActions
@@ -200,7 +200,7 @@ function* sendTipAsync() {
   const { waitForRemoteConfig } = yield* getContext('remoteConfigInstance')
   const isNativeMobile = yield* getContext('isNativeMobile')
   yield call(waitForRemoteConfig)
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
 
   const device = isNativeMobile ? 'native' : 'web'
 
@@ -319,7 +319,7 @@ function* refreshSupportAsync({
   payload: RefreshSupportPayloadAction
   type: string
 }) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
 
   const supportingParams: GetSupportingArgs = {
@@ -405,7 +405,7 @@ function* fetchSupportingForUserAsync({
   payload: { userId: ID }
   type: string
 }) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
 
   /**

--- a/packages/web/src/common/store/ui/artist-recommendations/sagas.ts
+++ b/packages/web/src/common/store/ui/artist-recommendations/sagas.ts
@@ -11,12 +11,12 @@ import { shuffle } from 'lodash'
 import { call, put, select, takeEvery } from 'redux-saga/effects'
 
 import { processAndCacheUsers } from 'common/store/cache/users/utils'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const getUserId = accountSelectors.getUserId
 
 export function* fetchRelatedArtists(action: Action) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const remoteConfigInstance = yield* getContext('remoteConfigInstance')
   if (artistRecommendationsActions.fetchRelatedArtists.match(action)) {
@@ -55,7 +55,7 @@ export function* fetchRelatedArtists(action: Action) {
 }
 
 function* fetchTopArtists() {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const apiClient = yield* getContext('apiClient')
   const currentUserId: ID = yield select(getUserId)
   const topArtists: User[] = yield apiClient.getTopArtists({
@@ -74,7 +74,7 @@ function* fetchTopArtists() {
 }
 
 function* cacheUsers(users: User[]) {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId: ID = yield select(getUserId)
   // Filter out the current user from the list to cache
   yield processAndCacheUsers(

--- a/packages/web/src/common/store/upload/sagaHelpers.ts
+++ b/packages/web/src/common/store/upload/sagaHelpers.ts
@@ -3,7 +3,7 @@ import { range } from 'lodash'
 import { all, put, select } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 const { getAccountUser } = accountSelectors
 
 export function* reportResultEvents({
@@ -19,7 +19,7 @@ export function* reportResultEvents({
   uploadType: 'single_track' | 'multi_track' | 'album' | 'playlist'
   errors: string[]
 }) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const accountUser = yield* select(getAccountUser)
   if (!accountUser) return
   const primary = accountUser.creator_node_endpoint?.split(',')[0]

--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -37,7 +37,7 @@ import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import { updateAndFlattenStems } from 'pages/upload-page/store/utils/stems'
 import { ERROR_PAGE } from 'utils/route'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 import { getTempPlaylistId } from 'utils/tempPlaylistId'
 
 import { watchUploadErrors } from './errorSagas'
@@ -829,7 +829,7 @@ function* uploadCollection(tracks, userId, collectionMetadata, isAlbum) {
 }
 
 function* uploadSingleTrack(track) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const apiClient = yield getContext('apiClient')
   // Need an object to hold phase error info that
@@ -888,7 +888,7 @@ function* uploadSingleTrack(track) {
           throw new Error(error)
         }
 
-        yield waitForBackendAndAccount()
+        yield waitForWrite()
         const userId = yield select(getUserId)
         const handle = yield select(getUserHandle)
         const confirmed = yield call(confirmTransaction, blockHash, blockNumber)
@@ -1093,7 +1093,7 @@ function* uploadMultipleTracks(tracks) {
 }
 
 function* uploadTracksAsync(action) {
-  yield waitForBackendAndAccount()
+  yield waitForWrite()
   const user = yield select(getAccountUser)
   yield put(
     uploadActions.uploadTracksRequested(

--- a/packages/web/src/common/store/user-list/utils.ts
+++ b/packages/web/src/common/store/user-list/utils.ts
@@ -11,7 +11,7 @@ import { call, select } from 'typed-redux-saga'
 
 import { processAndCacheUsers } from 'common/store/cache/users/utils'
 import { AppState } from 'store/types'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const { getAccountUser, getUserId } = accountSelectors
 
@@ -73,7 +73,7 @@ export function createUserListProvider<T, U = void>({
     currentPage: number
     pageSize: number
   }) {
-    yield* waitForBackendAndAccount()
+    yield* waitForRead()
     const audiusBackendInstance = yield* getContext('audiusBackendInstance')
     const apiClient = yield* getContext('apiClient')
     const existingEntity: T | null = yield* select(getExistingEntity, { id })

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -20,7 +20,7 @@ import { all, call, put, take, takeEvery, select } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
 import { SETUP_BACKEND_SUCCEEDED } from 'common/store/backend/actions'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite, waitForRead } from 'utils/sagaHelpers'
 
 const ATA_SIZE = 165 // Size allocated for an associated token account
 
@@ -64,7 +64,7 @@ function* getIsBalanceFrozen() {
 function* sendAsync({
   payload: { recipientWallet, amount: weiAudioAmount, chain }
 }: ReturnType<typeof send>) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const walletClient = yield* getContext('walletClient')
 
   const account = yield* select(getAccountUser)
@@ -171,7 +171,7 @@ function* getWalletBalanceAndWallets() {
 }
 
 function* fetchBalanceAsync() {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const walletClient = yield* getContext('walletClient')
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
 

--- a/packages/web/src/pages/deleted-page/store/lineups/more-by/sagas.ts
+++ b/packages/web/src/pages/deleted-page/store/lineups/more-by/sagas.ts
@@ -8,7 +8,7 @@ import {
   moreByActions
 } from 'pages/deleted-page/store/lineups/more-by/actions'
 import { getLineup } from 'pages/deleted-page/store/selectors'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 const getUserId = accountSelectors.getUserId
 
 function* getTracks({
@@ -20,7 +20,7 @@ function* getTracks({
 }) {
   const { handle } = payload
 
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const currentUserId = yield* select(getUserId)
   const processed = yield* call(retrieveUserTracks, {
     handle,

--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -63,7 +63,7 @@ import {
 import { JupiterSingleton } from 'services/audius-backend/Jupiter'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { reportToSentry } from 'store/errors/reportToSentry'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 const {
   calculateAudioPurchaseInfo,
@@ -961,7 +961,7 @@ function* recoverPurchaseIfNecessary() {
   let recoveredAudio: null | number = null
   try {
     // Bail if not enabled
-    yield* call(waitForBackendAndAccount)
+    yield* call(waitForWrite)
     const getFeatureEnabled = yield* getContext('getFeatureEnabled')
     if (!getFeatureEnabled(FeatureFlags.BUY_AUDIO_ENABLED)) {
       return

--- a/packages/web/src/store/token-dashboard/getAccountMetadataCID.ts
+++ b/packages/web/src/store/token-dashboard/getAccountMetadataCID.ts
@@ -1,12 +1,12 @@
 import { accountSelectors, getContext } from '@audius/common'
 import { select, call } from 'typed-redux-saga'
 
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForRead } from 'utils/sagaHelpers'
 
 const { getUserId } = accountSelectors
 
 export function* getAccountMetadataCID() {
-  yield* waitForBackendAndAccount()
+  yield* waitForRead()
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const accountUserId = yield* select(getUserId)
   if (!accountUserId) return null

--- a/packages/web/src/store/token-dashboard/sagas.ts
+++ b/packages/web/src/store/token-dashboard/sagas.ts
@@ -31,7 +31,7 @@ import {
   loadBitski,
   loadWalletConnect
 } from 'services/web3-modal'
-import { waitForBackendAndAccount } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 import { watchConnectNewWallet } from './connectNewWalletSaga'
 import { getAccountMetadataCID } from './getAccountMetadataCID'
@@ -119,7 +119,7 @@ function* confirmSendAsync() {
 }
 
 function* removeWallet(action: ConfirmRemoveWalletAction) {
-  yield* waitForBackendAndAccount()
+  yield* waitForWrite()
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   try {
     const removeWallet = action.payload.wallet

--- a/packages/web/src/utils/sagaHelpers.ts
+++ b/packages/web/src/utils/sagaHelpers.ts
@@ -1,9 +1,23 @@
 import { waitForAccount } from '@audius/common'
 import { call } from 'typed-redux-saga'
 
-import { waitForBackendSetup } from 'common/store/backend/sagas'
+import {
+  waitForBackendSetup,
+  waitForReachability
+} from 'common/store/backend/sagas'
 
-export function* waitForBackendAndAccount() {
+/**
+ * Required for all writes
+ */
+export function* waitForWrite() {
   yield* call(waitForBackendSetup)
+  yield* call(waitForAccount)
+}
+
+/**
+ * Required for all reads
+ */
+export function* waitForRead() {
+  yield* call(waitForReachability)
   yield* call(waitForAccount)
 }


### PR DESCRIPTION
### Description

Fix eager load so that feed/trending/whatever loads quickly on your first app open
This change is big, but not that scary. It does 3 things:
- Rename `waitForAccountAndBackend` to be `waitForWrite` -- you need this to write data
- Add a new `waitForAccountAndReachability` (no backend) and calls it `waitForRead` -- you need this to read data
- Changes web3.utils.sha3 to use a (tiny 3kb gzip) js-sha3 library to not block on libs init for trending/track ranks


https://user-images.githubusercontent.com/2731362/205843733-7dbc0ac4-f8d5-4c83-b070-b37afc8f3243.MP4



### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Release build on phone, tested offline mode usual behaviors as well.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

