### PR TITLE
Queue optimizations; batch action for tracks

### DIFF
--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -35,6 +35,14 @@ const slice = createSlice({
     startDownload: (state, { payload: trackId }: PayloadAction<string>) => {
       state.downloadStatus[trackId] = OfflineTrackDownloadStatus.LOADING
     },
+    batchStartDownload: (
+      state,
+      { payload: trackIds }: PayloadAction<string[]>
+    ) => {
+      trackIds.forEach((trackId) => {
+        state.downloadStatus[trackId] = OfflineTrackDownloadStatus.LOADING
+      })
+    },
     completeDownload: (state, { payload: trackId }: PayloadAction<string>) => {
       state.downloadStatus[trackId] = OfflineTrackDownloadStatus.SUCCESS
     },
@@ -77,6 +85,7 @@ const slice = createSlice({
 
 export const {
   startDownload,
+  batchStartDownload,
   completeDownload,
   errorDownload,
   removeDownload,


### PR DESCRIPTION
### Description

Some fixes and optimizations for the download queue.

- Batch action for setting `LOADING` state on many tracks (lower redux overhead)
- Prune failed jobs from queue on startup
- Set `ERROR` state more reliably on failed jobs   


