### PR TITLE
[C-1563] Fetch and download all paginated track favorites

### DIFF
--- a/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
+++ b/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
@@ -5,11 +5,15 @@ import { useAsync } from 'react-use'
 
 import { apiClient } from 'app/services/audius-api-client'
 
+import { useIsOfflineModeEnabled } from './useIsOfflineModeEnabled'
+
 const { getUserId } = accountSelectors
 
 export const useFetchAllFavoritedTrackIds = () => {
   const currentUserId = useSelector(getUserId)
+  const isOfflineModeEnabled = useIsOfflineModeEnabled()
   return useAsync(async () => {
+    if (!isOfflineModeEnabled) return []
     let trackIds: number[] = []
     let loadMore = true
     let offset = 0

--- a/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
+++ b/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
@@ -1,10 +1,5 @@
 import type { APIFavorite } from '@audius/common'
-import {
-  FavoriteType,
-  decodeHashId,
-  encodeHashId,
-  accountSelectors
-} from '@audius/common'
+import { decodeHashId, encodeHashId, accountSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 

--- a/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
+++ b/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
@@ -1,0 +1,47 @@
+import type { APIFavorite } from '@audius/common'
+import {
+  FavoriteType,
+  decodeHashId,
+  encodeHashId,
+  accountSelectors
+} from '@audius/common'
+import { useSelector } from 'react-redux'
+import { useAsync } from 'react-use'
+
+import { apiClient } from 'app/services/audius-api-client'
+
+const { getUserId } = accountSelectors
+
+export const useFetchAllFavoritedTrackIds = () => {
+  const currentUserId = useSelector(getUserId)
+  return useAsync(async () => {
+    let trackIds: number[] = []
+    let loadMore = true
+    let offset = 0
+    while (loadMore) {
+      const url = apiClient.makeUrl(
+        `/users/${encodeHashId(currentUserId)}/favorites`,
+        {
+          user_id: currentUserId,
+          limit: 500,
+          offset
+          // TODO: sort_method: added_date, sort_direction: descending
+        }
+      )
+      const { data: result } = await fetch(url).then((response) =>
+        response.json()
+      )
+
+      loadMore = result.length > 0
+      offset += result.length
+      trackIds = trackIds.concat(
+        result
+          .filter((trackSave) => trackSave.favorite_type === 'SaveType.track')
+          .map((trackSave: APIFavorite) =>
+            decodeHashId(trackSave.favorite_item_id)
+          )
+      )
+    }
+    return trackIds
+  }, [currentUserId])
+}

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -1,12 +1,7 @@
 import { useMemo } from 'react'
 
-import type { CommonState, Track } from '@audius/common'
-import {
-  useProxySelector,
-  savedPageSelectors,
-  lineupSelectors,
-  accountActions
-} from '@audius/common'
+import type { CommonState } from '@audius/common'
+import { accountActions } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
@@ -17,6 +12,7 @@ import IconPlaylists from 'app/assets/images/iconPlaylists.svg'
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { DownloadToggle } from 'app/components/offline-downloads'
 import { TopTabNavigator } from 'app/components/top-tab-bar'
+import { useFetchAllFavoritedTrackIds } from 'app/hooks/useFetchAllFavoritedTrackIds'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useLoadOfflineTracks } from 'app/hooks/useLoadOfflineTracks'
 import { usePopToTopOnDrawerOpen } from 'app/hooks/usePopToTopOnDrawerOpen'
@@ -26,12 +22,7 @@ import { AlbumsTab } from './AlbumsTab'
 import { PlaylistsTab } from './PlaylistsTab'
 import { TracksTab } from './TracksTab'
 import { getAccountCollections } from './selectors'
-const { makeGetTableMetadatas } = lineupSelectors
-
-const { getSavedTracksLineup } = savedPageSelectors
 const { fetchSavedPlaylists, fetchSavedAlbums } = accountActions
-
-const getTracks = makeGetTableMetadatas(getSavedTracksLineup)
 
 const messages = {
   header: 'Favorites'
@@ -60,7 +51,7 @@ export const FavoritesScreen = () => {
   const dispatch = useDispatch()
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
-  const savedTracks = useProxySelector(getTracks, [])
+  const { value: allFavoritedTrackIds } = useFetchAllFavoritedTrackIds()
 
   useEffectOnce(() => {
     dispatch(fetchSavedPlaylists())
@@ -73,15 +64,13 @@ export const FavoritesScreen = () => {
   )
 
   const allSavesTrackIds = useMemo(() => {
-    const allIds = (savedTracks?.entries ?? [])
-      .map((track: Track) => track.track_id)
-      .concat(
-        userCollections.flatMap((collection) =>
-          collection.playlist_contents.track_ids.map((trackId) => trackId.track)
-        )
+    const allIds = (allFavoritedTrackIds ?? []).concat(
+      userCollections.flatMap((collection) =>
+        collection.playlist_contents.track_ids.map((trackId) => trackId.track)
       )
+    )
     return allIds
-  }, [savedTracks, userCollections])
+  }, [allFavoritedTrackIds, userCollections])
 
   return (
     <Screen>

--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -67,12 +67,14 @@ export const listTracks = async (): Promise<string[]> => {
 export const getTrackJson = async (
   trackId: string
 ): Promise<UserTrackMetadata> => {
-  const trackJson = await readFile(getLocalTrackJsonPath(trackId))
   try {
+    const trackJson = await readFile(getLocalTrackJsonPath(trackId))
     return JSON.parse(trackJson)
   } catch (e) {
-    console.error(e)
-    return e
+    if (e instanceof SyntaxError) {
+      purgeDownloadedTrack(trackId)
+    }
+    return Promise.reject(e)
   }
 }
 


### PR DESCRIPTION
### Description

Fetch the small version of all the user's favorites so we don't have to paginate the lineup to know what to download.

Todo:
- [ ] Sort the API results by date favorited so the on-screen tracks go first (could hack it by using the saves lineup tracks)

### Dragons

Performance with large numbers of tracks

### How Has This Been Tested?

Simulator

Todo:
- [ ] Test on device

### Feature Flags ###

`OFFLINE_MODE_ENABLED`
