### PR TITLE
Make default Table isEmptyRow

### DIFF
--- a/packages/web/src/components/table/Table.tsx
+++ b/packages/web/src/components/table/Table.tsx
@@ -85,7 +85,7 @@ type TableProps = {
   onReorder?: (source: number, destination: number) => void
   onShowMoreToggle?: (setting: boolean) => void
   onSort?: (...props: any[]) => void
-  isEmptyRow: (row: any) => boolean
+  isEmptyRow?: (row: any) => boolean
   pageSize?: number
   scrollRef?: React.MutableRefObject<HTMLDivElement | undefined>
   showMoreLimit?: number
@@ -441,7 +441,8 @@ export const Table = ({
       renderSkeletonRow,
       isReorderable,
       renderDraggableRow,
-      renderTableRow
+      renderTableRow,
+      isEmptyRow
     ]
   )
 
@@ -477,7 +478,7 @@ export const Table = ({
 
   const isRowLoaded = useCallback(
     ({ index }) => !isEmptyRow(rows[index]),
-    [rows]
+    [rows, isEmptyRow]
   )
 
   // Pagination Functions

--- a/packages/web/src/components/table/Table.tsx
+++ b/packages/web/src/components/table/Table.tsx
@@ -61,7 +61,8 @@ export const dateSorter = (accessor: string) => (rowA: any, rowB: any) => {
   return 0
 }
 
-const isEmptyRow = (row: any) => {
+// Used in TracksTable, CollectiblesPlaylistTable
+const isEmptyRowDefault = (row: any) => {
   return Boolean(!row?.original?.uid || row?.original?.kind === Kind.EMPTY)
 }
 
@@ -84,6 +85,7 @@ type TableProps = {
   onReorder?: (source: number, destination: number) => void
   onShowMoreToggle?: (setting: boolean) => void
   onSort?: (...props: any[]) => void
+  isEmptyRow: (row: any) => boolean
   pageSize?: number
   scrollRef?: React.MutableRefObject<HTMLDivElement | undefined>
   showMoreLimit?: number
@@ -112,6 +114,7 @@ export const Table = ({
   onReorder,
   onShowMoreToggle,
   onSort,
+  isEmptyRow = isEmptyRowDefault,
   pageSize = 50,
   scrollRef,
   showMoreLimit,


### PR DESCRIPTION
### Description
We need to use a different `isEmptyRow` fn in `AudioTransactionsTable`. Parametrize it and use the current one as a default.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested on local.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

