### PR TITLE
[C-1649] Reset libs on app start

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -473,7 +473,7 @@ type GetUserSupporterArgs = {
 
 type AudiusAPIClientConfig = {
   audiusBackendInstance: AudiusBackend
-  getAudiusLibs: () => AudiusLibs
+  getAudiusLibs: () => Nullable<AudiusLibs>
   overrideEndpoint?: string
   remoteConfigInstance: RemoteConfigInstance
   localStorage: LocalStorage
@@ -486,7 +486,7 @@ export class AudiusAPIClient {
   }
 
   audiusBackendInstance: AudiusBackend
-  getAudiusLibs: () => AudiusLibs
+  getAudiusLibs: () => Nullable<AudiusLibs>
   overrideEndpoint?: string
   remoteConfigInstance: RemoteConfigInstance
   localStorage: LocalStorage

--- a/packages/mobile/src/App.tsx
+++ b/packages/mobile/src/App.tsx
@@ -33,6 +33,7 @@ import { NotificationReminder } from './components/notification-reminder/Notific
 import { OfflineDownloader } from './components/offline-downloads/OfflineDownloader'
 import { useEnterForeground } from './hooks/useAppState'
 import { WalletConnectProvider } from './screens/wallet-connect'
+import { setLibs } from './services/libs'
 
 Sentry.init({
   dsn: Config.SENTRY_DSN
@@ -58,6 +59,11 @@ const Modals = () => {
 }
 
 const App = () => {
+  // Reset libs so that we get a clean app start
+  useEffectOnce(() => {
+    setLibs(null)
+  })
+
   const [isReadyToSetupBackend, setIsReadyToSetupBackend] = useState(false)
 
   useAsync(async () => {

--- a/packages/mobile/src/services/libs.ts
+++ b/packages/mobile/src/services/libs.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events'
 
+import type { Nullable } from '@audius/common'
 import type { AudiusLibs } from '@audius/sdk/dist/native-libs'
 
 // TODO: declare this at the root and use actual audiusLibs type
@@ -11,11 +12,11 @@ declare global {
 
 export const libsInitEventEmitter = new EventEmitter()
 
-export let audiusLibs: AudiusLibs
+export let audiusLibs: Nullable<AudiusLibs>
 
 export const LIBS_INITTED_EVENT = 'LIBS_INITTED_EVENT'
 
-export const setLibs = (libs: AudiusLibs) => (audiusLibs = libs)
+export const setLibs = (libs: Nullable<AudiusLibs>) => (audiusLibs = libs)
 
 /**
  * Wait for the `LIBS_INITTED_EVENT` or pass through if there

--- a/packages/mobile/src/services/libs.ts
+++ b/packages/mobile/src/services/libs.ts
@@ -12,7 +12,7 @@ declare global {
 
 export const libsInitEventEmitter = new EventEmitter()
 
-export let audiusLibs: Nullable<AudiusLibs>
+export let audiusLibs: Nullable<AudiusLibs> = null
 
 export const LIBS_INITTED_EVENT = 'LIBS_INITTED_EVENT'
 


### PR DESCRIPTION
### Description

There is some preserved state between separate runs of the app (especially on android). Sometimes top level code like configuring the store or declaring the `audiusLibs` variable is not run. This causes an issue where consumers of libs think it is already initted but it is in a broken state

Working case:
![image](https://user-images.githubusercontent.com/19916043/206810686-93952c6c-8ea8-44c4-b079-c5a2644869e0.png)

Broken case:
![image](https://user-images.githubusercontent.com/19916043/206810701-b905715f-c89d-4a4f-9ebf-fe3b5c8d9c82.png)

Manually clearing libs in an effect in App fixes the problem because this effect is run before the store configuration or any sagas. It also runs every time the app is opened

Will make another PR to address similar issue with store

### Dragons

Could be dangerous if this effect were to run after the libs initialization. But that seems to be impossible

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

