### PR TITLE
[C-1665] Fix deleteWallet bug

### DIFF
--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -87,6 +87,14 @@ export const mergeCustomizer = (
     return objValue
   }
 
+  if (key === 'associated_wallets') {
+    return srcValue
+  }
+
+  if (key === 'associated_sol_wallets') {
+    return srcValue
+  }
+
   // For playlist_contents, this is trickier.
   // We want to never merge because playlists can have
   // tracks be deleted since last time, but

--- a/packages/web/src/store/token-dashboard/sagas.ts
+++ b/packages/web/src/store/token-dashboard/sagas.ts
@@ -213,7 +213,7 @@ function* removeWallet(action: ConfirmRemoveWalletAction) {
             cacheActions.update(Kind.USERS, [
               {
                 id: accountUserId,
-                metadata: { metadata_multihash: updatedCID }
+                metadata: { ...updatedMetadata, metadata_multihash: updatedCID }
               }
             ])
           )


### PR DESCRIPTION
### Description

Fixes interesting edge-case where accountUser's associated_wallets were not updating correctly when deleting a wallet. This resulted in bad user experience where deleting an eth-wallet, then deleting a sol-wallet resulted in the eth-wallet being re-added to associated-wallets.

The crux of the issue had to do with two things:
1. Our deleteWallet success call did not tell redux to update accountUser's associatedWallets
2. Our update-cache merger did not respect deletions from associated-wallet object, meaning that the removed value would remain.


