### PR TITLE
[C-1663] Update DownloadStatusIndicator to handle collectionIds

### DIFF
--- a/packages/mobile/src/components/card/Card.tsx
+++ b/packages/mobile/src/components/card/Card.tsx
@@ -6,7 +6,9 @@ import { Text, View } from 'react-native'
 
 import { Tile } from 'app/components/core'
 import UserBadges from 'app/components/user-badges/UserBadges'
-import { makeStyles } from 'app/styles'
+import { flexRowCentered, makeStyles } from 'app/styles'
+
+import { DownloadStatusIndicator } from '../offline-downloads'
 
 export type CardType = 'user' | 'collection'
 
@@ -40,11 +42,17 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   secondaryText: {
     ...typography.body2,
     color: palette.neutral,
+    marginHorizontal: spacing(1),
     textAlign: 'center'
+  },
+  secondaryTextContainer: {
+    ...flexRowCentered(),
+    justifyContent: 'center'
   }
 }))
 
 export type CardProps = {
+  id?: string
   onPress: () => void
   primaryText: string
   renderImage: () => ReactNode
@@ -56,6 +64,7 @@ export type CardProps = {
 
 export const Card = (props: CardProps) => {
   const {
+    id,
     onPress,
     primaryText,
     renderImage,
@@ -84,9 +93,14 @@ export const Card = (props: CardProps) => {
             <UserBadges user={user} badgeSize={12} hideName />
           ) : null}
         </Text>
-        <Text numberOfLines={1} style={styles.secondaryText}>
-          {secondaryText}
-        </Text>
+        <View style={styles.secondaryTextContainer}>
+          <Text numberOfLines={1} style={styles.secondaryText}>
+            {secondaryText}
+          </Text>
+          {type === 'collection' ? (
+            <DownloadStatusIndicator size={18} collectionId={id} />
+          ) : null}
+        </View>
       </View>
     </Tile>
   )

--- a/packages/mobile/src/components/collection-card/CollectionCard.tsx
+++ b/packages/mobile/src/components/collection-card/CollectionCard.tsx
@@ -35,6 +35,7 @@ export const CollectionCard = ({ collection, style }: CollectionCardProps) => {
       style={style}
       renderImage={renderImage}
       type='collection'
+      id={collection.playlist_id.toString()}
       primaryText={collection.playlist_name}
       secondaryText={formatPlaylistCardSecondaryText(
         collection.save_count,

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -56,6 +56,7 @@ export const LineupTile = ({
   } = item
   const { _artist_pick, name, user_id } = user
   const currentUserId = useSelector(getUserId)
+  const isCollection = 'playlist_id' in item
 
   const [artworkLoaded, setArtworkLoaded] = useState(false)
 
@@ -109,6 +110,7 @@ export const LineupTile = ({
           hidePlays={hidePlays}
           id={id}
           index={index}
+          isCollection={isCollection}
           isTrending={isTrending}
           isUnlisted={isUnlisted}
           playCount={playCount}

--- a/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
@@ -11,6 +11,7 @@ import { useDispatch } from 'react-redux'
 
 import IconHeart from 'app/assets/images/iconHeart.svg'
 import IconRepost from 'app/assets/images/iconRepost.svg'
+import { DownloadStatusIndicator } from 'app/components/offline-downloads'
 import Text from 'app/components/text'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles, flexRowCentered } from 'app/styles'
@@ -68,6 +69,7 @@ type Props = {
   hidePlays?: boolean
   id: ID
   index: number
+  isCollection?: boolean
   isTrending?: boolean
   isUnlisted?: boolean
   playCount?: number
@@ -82,6 +84,7 @@ export const LineupTileStats = ({
   hidePlays,
   id,
   index,
+  isCollection,
   isTrending,
   isUnlisted,
   playCount,
@@ -106,6 +109,11 @@ export const LineupTileStats = ({
     dispatch(setRepost(id, repostType))
     navigation.push('Reposts', { id, repostType })
   }, [dispatch, id, navigation, repostType])
+
+  const downloadIndicatorProps = {
+    size: 18,
+    [isCollection ? 'collectionId' : 'trackId']: id.toString()
+  }
 
   return (
     <View style={styles.stats}>
@@ -150,6 +158,9 @@ export const LineupTileStats = ({
               fill={neutralLight4}
             />
           </TouchableOpacity>
+          <View style={[trackTileStyles.statItem]}>
+            <DownloadStatusIndicator {...downloadIndicatorProps} />
+          </View>
         </View>
       )}
       {!hidePlays && (


### PR DESCRIPTION
### Description
* Update DownloadStatusIndicator to handle collections
*  Add download indicator to lineup tiles and collection cards
* Moved the call to fetch download track status to OfflineDownloader.tsx from the saved page so that download status could show up on the feed and trending screens, etc.

Didn't update the styles of the Card component bc that seemed like a large change across all cards that should be in its own PR

### Dragons

This relies on the collection being in state when the indicator tries to fetch the track for the collection and determine if it is in the process of being downloaded. Chatted with @amendelsohn and this is planned to be added as part of this project

### How Has This Been Tested?

Manually tested

![IMG_1342](https://user-images.githubusercontent.com/23732287/207374614-32611978-6f8d-4f3c-8efc-e91f8cac2738.PNG)
![IMG_1343](https://user-images.githubusercontent.com/23732287/207374631-e10eb3c9-235e-478d-88d8-bff599402614.PNG)
![IMG_1344](https://user-images.githubusercontent.com/23732287/207374723-8a0c2229-c5f3-432b-a917-4a6b29247742.PNG)

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

