### PR TITLE
Add is playlist upload to meta on upload

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -116,6 +116,7 @@ export type TrackMetadata = {
   permalink: string
 
   // Optional Fields
+  is_playlist_upload?: boolean
   is_invalid?: boolean
   stem_of?: {
     parent_track_id: ID

--- a/packages/common/src/schemas/index.ts
+++ b/packages/common/src/schemas/index.ts
@@ -41,7 +41,8 @@ const trackMetadataSchema = {
   license: null,
   isrc: null,
   iswc: null,
-  download: null
+  download: null,
+  is_playlist_upload: false
 }
 
 export const newTrackMetadata = (fields, validate = false) => {

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -422,7 +422,8 @@ export const makeStemTrack = (stem: APIStem): StemTrackMetadata | undefined => {
     is_available: true,
     is_premium: false,
     premium_conditions: null,
-    premium_content_signature: null
+    premium_content_signature: null,
+    is_playlist_upload: false
   }
 }
 

--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -405,7 +405,10 @@ export function* handleUploads({
     const request = {
       id,
       track: value.track,
-      metadata: value.metadata,
+      metadata: {
+        is_playlist_upload: isCollection,
+        ...value.metadata
+      },
       index: value.index,
       artwork: isCollection ? null : value.artwork,
       isCollection,


### PR DESCRIPTION
### Description
Client change to add extra field in metadata for is playlist upload
NOTE: libs changes it depends on https://github.com/AudiusProject/audius-protocol/pull/4469/files

Fixes PLAT-526

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

