### PR TITLE
[PAY-747] Handle solana-nft-gated premium content

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -986,6 +986,196 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@metaplex-foundation/beet": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet/-/beet-0.7.1.tgz",
+      "integrity": "sha512-hNCEnS2WyCiYyko82rwuISsBY3KYpe828ubsd2ckeqZr7tl0WVLivGkoyA/qdiaaHEBGdGl71OpfWa2rqL3DiA==",
+      "requires": {
+        "ansicolors": "^0.3.2",
+        "bn.js": "^5.2.0",
+        "debug": "^4.3.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        }
+      }
+    },
+    "@metaplex-foundation/beet-solana": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/beet-solana/-/beet-solana-0.4.0.tgz",
+      "integrity": "sha512-B1L94N3ZGMo53b0uOSoznbuM5GBNJ8LwSeznxBxJ+OThvfHQ4B5oMUqb+0zdLRfkKGS7Q6tpHK9P+QK0j3w2cQ==",
+      "requires": {
+        "@metaplex-foundation/beet": ">=0.1.0",
+        "@solana/web3.js": "^1.56.2",
+        "bs58": "^5.0.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@solana/web3.js": {
+          "version": "1.70.1",
+          "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.70.1.tgz",
+          "integrity": "sha512-AnaqCF1cJ3w7d0yhvLGAKAcRI+n5o+ursQihhoTe4cUh8/9d4gbT73SoHYElS7e67OtAgLmSfbcC5hcOAgdvnQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@noble/ed25519": "^1.7.0",
+            "@noble/hashes": "^1.1.2",
+            "@noble/secp256k1": "^1.6.3",
+            "@solana/buffer-layout": "^4.0.0",
+            "bigint-buffer": "^1.1.5",
+            "bn.js": "^5.0.0",
+            "borsh": "^0.7.0",
+            "bs58": "^4.0.1",
+            "buffer": "6.0.1",
+            "fast-stable-stringify": "^1.0.0",
+            "jayson": "^3.4.4",
+            "node-fetch": "2",
+            "rpc-websockets": "^7.5.0",
+            "superstruct": "^0.14.2"
+          },
+          "dependencies": {
+            "bs58": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+              "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+              "requires": {
+                "base-x": "^3.0.2"
+              }
+            }
+          }
+        },
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        },
+        "borsh": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+          "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+          "requires": {
+            "bn.js": "^5.2.0",
+            "bs58": "^4.0.0",
+            "text-encoding-utf-8": "^1.0.2"
+          },
+          "dependencies": {
+            "bs58": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+              "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+              "requires": {
+                "base-x": "^3.0.2"
+              }
+            }
+          }
+        },
+        "bs58": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+          "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+          "requires": {
+            "base-x": "^4.0.0"
+          },
+          "dependencies": {
+            "base-x": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+              "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+            }
+          }
+        }
+      }
+    },
+    "@metaplex-foundation/cusper": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/cusper/-/cusper-0.0.2.tgz",
+      "integrity": "sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA=="
+    },
+    "@metaplex-foundation/mpl-token-metadata": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-2.5.2.tgz",
+      "integrity": "sha512-lAjQjj2gGtyLq8MOkp4tWZSC5DK9NWgPd3EoH0KQ9gMs3sKIJRik0CBaZg+JA0uLwzkiErY2Izus4vbWtRADJQ==",
+      "requires": {
+        "@metaplex-foundation/beet": "^0.7.1",
+        "@metaplex-foundation/beet-solana": "^0.4.0",
+        "@metaplex-foundation/cusper": "^0.0.2",
+        "@solana/spl-token": "^0.3.6",
+        "@solana/web3.js": "^1.66.2",
+        "bn.js": "^5.2.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@solana/spl-token": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.6.tgz",
+          "integrity": "sha512-P9pTXjDIRvVbjr3J0mCnSamYqLnICeds7IoH1/Ro2R9OBuOHdp5pqKZoscfZ3UYrgnCWUc1bc9M2m/YPHjw+1g==",
+          "requires": {
+            "@solana/buffer-layout": "^4.0.0",
+            "@solana/buffer-layout-utils": "^0.2.0",
+            "buffer": "^6.0.3"
+          }
+        },
+        "@solana/web3.js": {
+          "version": "1.70.1",
+          "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.70.1.tgz",
+          "integrity": "sha512-AnaqCF1cJ3w7d0yhvLGAKAcRI+n5o+ursQihhoTe4cUh8/9d4gbT73SoHYElS7e67OtAgLmSfbcC5hcOAgdvnQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@noble/ed25519": "^1.7.0",
+            "@noble/hashes": "^1.1.2",
+            "@noble/secp256k1": "^1.6.3",
+            "@solana/buffer-layout": "^4.0.0",
+            "bigint-buffer": "^1.1.5",
+            "bn.js": "^5.0.0",
+            "borsh": "^0.7.0",
+            "bs58": "^4.0.1",
+            "buffer": "6.0.1",
+            "fast-stable-stringify": "^1.0.0",
+            "jayson": "^3.4.4",
+            "node-fetch": "2",
+            "rpc-websockets": "^7.5.0",
+            "superstruct": "^0.14.2"
+          },
+          "dependencies": {
+            "buffer": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
+              "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+              }
+            }
+          }
+        },
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        },
+        "borsh": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+          "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+          "requires": {
+            "bn.js": "^5.2.0",
+            "bs58": "^4.0.0",
+            "text-encoding-utf-8": "^1.0.2"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
+      }
+    },
     "@multiformats/murmur3": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-1.1.3.tgz",
@@ -994,6 +1184,21 @@
         "multiformats": "^9.5.4",
         "murmurhash3js-revisited": "^3.0.0"
       }
+    },
+    "@noble/ed25519": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
+      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw=="
+    },
+    "@noble/hashes": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.4.tgz",
+      "integrity": "sha512-+PYsVPrTSqtVjatKt2A/Proukn2Yrz61OBThOCKErc5w2/r1Fh37vbDv0Eah7pyNltrmacjwTvdw3JoR+WE4TA=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
+      "integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
     },
     "@optimizely/js-sdk-datafile-manager": {
       "version": "0.5.0",
@@ -1277,6 +1482,17 @@
             "ieee754": "^1.2.1"
           }
         }
+      }
+    },
+    "@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "requires": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
       }
     },
     "@solana/spl-token": {
@@ -1927,6 +2143,11 @@
         "color-convert": "^2.0.1"
       }
     },
+    "ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2091,6 +2312,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "requires": {
+        "bindings": "^1.3.0"
+      }
     },
     "bignumber.js": {
       "version": "9.1.1",
@@ -3719,6 +3948,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@audius/sdk": "1.0.27",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",
+    "@metaplex-foundation/mpl-token-metadata": "2.5.2",
     "@optimizely/optimizely-sdk": "4.0.0",
     "@reduxjs/toolkit": "1.3.4",
     "bn.js": "4.11.6",

--- a/packages/common/src/models/Collectible.ts
+++ b/packages/common/src/models/Collectible.ts
@@ -1,6 +1,7 @@
 import { Nullable } from '../utils/typeUtils'
 
 import { Chain } from './Chain'
+import { Metadata } from "@metaplex-foundation/mpl-token-metadata"
 
 export type CollectiblesMetadata = {
   [key: string]: object
@@ -40,5 +41,5 @@ export type Collectible = {
   assetContractAddress: Nullable<string>
 
   // solana nfts
-  chainMetadata: Nullable<string>
+  chainMetadata: Nullable<Metadata>
 }

--- a/packages/common/src/models/Collectible.ts
+++ b/packages/common/src/models/Collectible.ts
@@ -42,5 +42,5 @@ export type Collectible = {
   assetContractAddress: Nullable<string>
 
   // solana nfts
-  chainMetadata: Nullable<Metadata>
+  solanaChainMetadata: Nullable<Metadata>
 }

--- a/packages/common/src/models/Collectible.ts
+++ b/packages/common/src/models/Collectible.ts
@@ -32,8 +32,13 @@ export type Collectible = {
   dateLastTransferred: Nullable<string>
   externalLink: Nullable<string>
   permaLink: Nullable<string>
-  assetContractAddress: Nullable<string>
   chain: Chain
   wallet: string
   duration?: number
+
+  // ethereum nfts
+  assetContractAddress: Nullable<string>
+
+  // solana nfts
+  chainMetadata: Nullable<string>
 }

--- a/packages/common/src/models/Collectible.ts
+++ b/packages/common/src/models/Collectible.ts
@@ -1,7 +1,8 @@
+import { Metadata } from '@metaplex-foundation/mpl-token-metadata'
+
 import { Nullable } from '../utils/typeUtils'
 
 import { Chain } from './Chain'
-import { Metadata } from "@metaplex-foundation/mpl-token-metadata"
 
 export type CollectiblesMetadata = {
   [key: string]: object

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -63,7 +63,7 @@ type PremiumConditionsEthNFTCollection = {
 
 type PremiumConditionsSolNFTCollection = {
   chain: Chain.Sol
-  name: string
+  address: string
 }
 
 export type PremiumConditions = {

--- a/packages/common/src/services/opensea-client/ethCollectibleHelpers.ts
+++ b/packages/common/src/services/opensea-client/ethCollectibleHelpers.ts
@@ -314,7 +314,8 @@ export const assetToCollectible = async (
     permaLink: asset.permalink,
     assetContractAddress: asset.asset_contract?.address ?? null,
     chain: Chain.Eth,
-    wallet: asset.wallet
+    wallet: asset.wallet,
+    chainMetadata: null
   }
 }
 

--- a/packages/common/src/services/opensea-client/ethCollectibleHelpers.ts
+++ b/packages/common/src/services/opensea-client/ethCollectibleHelpers.ts
@@ -315,7 +315,7 @@ export const assetToCollectible = async (
     assetContractAddress: asset.asset_contract?.address ?? null,
     chain: Chain.Eth,
     wallet: asset.wallet,
-    chainMetadata: null
+    solanaChainMetadata: null
   }
 }
 

--- a/packages/common/src/services/solana-client/SolanaClient.ts
+++ b/packages/common/src/services/solana-client/SolanaClient.ts
@@ -164,8 +164,12 @@ export class SolanaClient {
           this.metadataProgramIdPublicKey
         )
       )[0]
-      const { collection, collectionDetails } = await Metadata.fromAccountAddress(this.connection, programAddress)
-      return !collection && !!collectionDetails
+      const { collectionDetails } = await Metadata.fromAccountAddress(this.connection, programAddress)
+
+      // "If the CollectionDetails field is set, it means the NFT is a Collection NFT
+      // and additional attributes can be found inside this field."
+      // https://docs.metaplex.com/programs/token-metadata/certified-collections#differentiating-regular-nfts-from-collection-nfts
+      return !!collectionDetails
     } catch (e) {
       return null
     }

--- a/packages/common/src/services/solana-client/SolanaClient.ts
+++ b/packages/common/src/services/solana-client/SolanaClient.ts
@@ -1,3 +1,4 @@
+import { Metadata } from '@metaplex-foundation/mpl-token-metadata'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { Connection, PublicKey } from '@solana/web3.js'
 
@@ -5,7 +6,6 @@ import { Collectible, CollectibleState } from '../../models'
 
 import { solanaNFTToCollectible } from './solCollectibleHelpers'
 import { SolanaNFTType } from './types'
-import { Metadata } from "@metaplex-foundation/mpl-token-metadata"
 
 type SolanaClientArgs = {
   solanaClusterEndpoint: string | undefined
@@ -89,7 +89,7 @@ export class SolanaClient {
           )
 
           const chainMetadatas = await Promise.all(
-            programAddresses.map(async address => {
+            programAddresses.map(async (address) => {
               try {
                 return await Metadata.fromAccountAddress(connection, address)
               } catch (e) {
@@ -97,7 +97,7 @@ export class SolanaClient {
               }
             })
           )
-          const metadataUris = chainMetadatas.map(m => m?.data.uri)
+          const metadataUris = chainMetadatas.map((m) => m?.data.uri)
 
           const results = await Promise.all(
             metadataUris.map(async (url) => {
@@ -119,9 +119,11 @@ export class SolanaClient {
             .map((nftMetadata, i) => ({
               metadata: nftMetadata,
               chainMetadata: chainMetadatas[i],
-              type: chainMetadatas[i]?.data.uri.includes('staratlas') ? SolanaNFTType.STAR_ATLAS : SolanaNFTType.METAPLEX
+              type: chainMetadatas[i]?.data.uri.includes('staratlas')
+                ? SolanaNFTType.STAR_ATLAS
+                : SolanaNFTType.METAPLEX
             }))
-            .filter(r => !!r.metadata && !!r.chainMetadata && !!r.type)
+            .filter((r) => !!r.metadata && !!r.chainMetadata && !!r.type)
         })
       )
 
@@ -130,7 +132,12 @@ export class SolanaClient {
           const collectibles = await Promise.all(
             nftsForAddress.map(
               async (nft) =>
-                await solanaNFTToCollectible(nft.metadata, wallets[i], nft.type, nft.chainMetadata)
+                await solanaNFTToCollectible(
+                  nft.metadata,
+                  wallets[i],
+                  nft.type,
+                  nft.chainMetadata
+                )
             )
           )
           return collectibles.filter(Boolean) as Collectible[]
@@ -164,7 +171,10 @@ export class SolanaClient {
           this.metadataProgramIdPublicKey
         )
       )[0]
-      const { collectionDetails } = await Metadata.fromAccountAddress(this.connection, programAddress)
+      const { collectionDetails } = await Metadata.fromAccountAddress(
+        this.connection,
+        programAddress
+      )
 
       // "If the CollectionDetails field is set, it means the NFT is a Collection NFT
       // and additional attributes can be found inside this field."

--- a/packages/common/src/services/solana-client/SolanaClient.ts
+++ b/packages/common/src/services/solana-client/SolanaClient.ts
@@ -5,6 +5,7 @@ import { Collectible, CollectibleState } from '../../models'
 
 import { solanaNFTToCollectible } from './solCollectibleHelpers'
 import { SolanaNFTType } from './types'
+import { Metadata } from "@metaplex-foundation/mpl-token-metadata"
 
 type SolanaClientArgs = {
   solanaClusterEndpoint: string | undefined
@@ -87,19 +88,22 @@ export class SolanaClient {
             )
           )
 
-          const accountInfos = await connection.getMultipleAccountsInfo(
-            programAddresses
+          const chainMetadatas = await Promise.all(
+            programAddresses.map(async address => {
+              try {
+                return await Metadata.fromAccountAddress(connection, address)
+              } catch (e) {
+                return null
+              }
+            })
           )
-          const nonNullInfos = accountInfos?.filter(Boolean) ?? []
-
-          const metadataUrls = nonNullInfos
-            .map((x) => this._utf8ArrayToNFTType(x!.data))
-            .filter(Boolean) as { type: SolanaNFTType; url: string }[]
+          const metadataUris = chainMetadatas.map(m => m?.data.uri)
 
           const results = await Promise.all(
-            metadataUrls.map(async (item) => {
+            metadataUris.map(async (url) => {
+              if (!url) return Promise.resolve(null)
               // Remove control characters from url
-              const sanitizedURL = item.url.replace(
+              const sanitizedURL = url.replace(
                 // eslint-disable-next-line
                 /[\u0000-\u001F\u007F-\u009F]/g,
                 ''
@@ -111,12 +115,13 @@ export class SolanaClient {
             })
           )
 
-          const metadatas = results.filter(Boolean).map((metadata, i) => ({
-            metadata,
-            type: metadataUrls[i].type
-          }))
-
-          return metadatas.filter((r) => !!r.metadata)
+          return results
+            .map((nftMetadata, i) => ({
+              metadata: nftMetadata,
+              chainMetadata: chainMetadatas[i],
+              type: chainMetadatas[i]?.data.uri.includes('staratlas') ? SolanaNFTType.STAR_ATLAS : SolanaNFTType.METAPLEX
+            }))
+            .filter(r => !!r.metadata && !!r.chainMetadata && !!r.type)
         })
       )
 
@@ -125,7 +130,7 @@ export class SolanaClient {
           const collectibles = await Promise.all(
             nftsForAddress.map(
               async (nft) =>
-                await solanaNFTToCollectible(nft.metadata, wallets[i], nft.type)
+                await solanaNFTToCollectible(nft.metadata, wallets[i], nft.type, nft.chainMetadata)
             )
           )
           return collectibles.filter(Boolean) as Collectible[]
@@ -145,123 +150,24 @@ export class SolanaClient {
     }
   }
 
-  /**
-   * Decode bytes to get url for nft metadata
-   * Check urls based on nft standard e.g. metaplex, or nft collection e.g. solamander, or known domains e.g. ipfs
-   * This is because there may be multiple different collections of nfts on e.g. metaplex (arweave), also
-   * a given nft collection can have nfts living in different domains e.g. solamander on cloudfront or arweave or etc., also
-   * nfts may live in ipfs or other places
-   */
-  _utf8ArrayToNFTType = (
-    array: Uint8Array
-  ): { type: SolanaNFTType; url: string } | null => {
-    const text = new TextDecoder().decode(array)
+  isCollectionNFT = async (mintAddress: string) => {
+    if (this.connection === null) return
 
-    // for the sake of simplicty/readability/understandability, we check the decoded url
-    // one by one against metaplex, star atlas, and others
-    return (
-      this._metaplex(text) ||
-      this._starAtlas(text) ||
-      this._jsonExtension(text) ||
-      this._ipfs(text)
-    )
-  }
-
-  _metaplex = (text: string): { type: SolanaNFTType; url: string } | null => {
-    const query = 'https://'
-    const startIndex = text.indexOf(query)
-    if (startIndex === -1) return null
-
-    // metaplex standard nfts live in arweave, see link below
-    // https://github.com/metaplex-foundation/metaplex/blob/81023eb3e52c31b605e1dcf2eb1e7425153600cd/js/packages/web/src/contexts/meta/processMetaData.ts#L29
-    const isMetaplex = text.includes('arweave')
-    const foundNFTUrl = startIndex > -1 && isMetaplex
-    if (!foundNFTUrl) return null
-
-    const suffix = '/'
-    const suffixIndex = text.indexOf(suffix, startIndex + query.length)
-    if (suffixIndex === -1) return null
-
-    const hashLength = 43
-    const endIndex = suffixIndex + suffix.length + hashLength
-    const url = text.substring(startIndex, endIndex)
-    return {
-      type: SolanaNFTType.METAPLEX,
-      url
-    }
-  }
-
-  _starAtlas = (text: string): { type: SolanaNFTType; url: string } | null => {
-    const query = 'https://'
-    const startIndex = text.indexOf(query)
-    if (startIndex === -1) return null
-
-    // star atlas nfts live in https://galaxy.staratlas.com/nfts/...
-    const isStarAtlas = text.includes('staratlas')
-    const foundNFTUrl = startIndex > -1 && isStarAtlas
-    if (!foundNFTUrl) return null
-
-    const suffix = '/nfts/'
-    const suffixIndex = text.indexOf(suffix, startIndex + query.length)
-    if (suffixIndex === -1) return null
-
-    const hashLength = 44
-    const endIndex = suffixIndex + suffix.length + hashLength
-    const url = text.substring(startIndex, endIndex)
-    return {
-      type: SolanaNFTType.STAR_ATLAS,
-      url
-    }
-  }
-
-  _jsonExtension = (
-    text: string
-  ): { type: SolanaNFTType; url: string } | null => {
-    // Look for 'https://<...>.json' and that will be the metadata location
-    // examples:
-    // https://d1b6hed00dtfsr.cloudfront.net/9086.json
-    // https://cdn.piggygang.com/meta/3ad355d46a9cb2ee57049db4df57088f.json
-
-    const query = 'https://'
-    const startIndex = text.indexOf(query)
-    if (startIndex === -1) return null
-
-    const extension = '.json'
-    const extensionIndex = text.indexOf(extension)
-    const foundNFTUrl = startIndex > -1 && extensionIndex > -1
-    if (!foundNFTUrl) return null
-
-    const endIndex = extensionIndex + extension.length
-    const url = text.substring(startIndex, endIndex)
-    return {
-      type: SolanaNFTType.METAPLEX,
-      url
-    }
-  }
-
-  _ipfs = (text: string): { type: SolanaNFTType; url: string } | null => {
-    // Look for 'https://ipfs.io/ipfs/<...alphanumeric...>' and that will be the metadata location
-    // e.g. https://ipfs.io/ipfs/QmWJC47JYuvxYw63cRq81bBNGFXPjhQH8nXg71W5JeRMrC
-
-    const query = 'https://'
-    const startIndex = text.indexOf(query)
-    if (startIndex === -1) return null
-
-    const isIpfs = text.includes('ipfs')
-    const foundNFTUrl = startIndex > -1 && isIpfs
-    if (!foundNFTUrl) return null
-
-    const suffix = '/ipfs/'
-    const suffixIndex = text.indexOf(suffix, startIndex + query.length)
-    if (suffixIndex === -1) return null
-
-    let endIndex = suffixIndex + suffix.length
-    while (/[a-zA-Z0-9]/.test(text.charAt(endIndex++))) {}
-
-    const url = text.substring(startIndex, endIndex)
-    return {
-      type: SolanaNFTType.METAPLEX,
-      url
+    try {
+      const programAddress = (
+        await PublicKey.findProgramAddress(
+          [
+            Buffer.from('metadata'),
+            this.metadataProgramIdPublicKey.toBytes(),
+            new PublicKey(mintAddress).toBytes()
+          ],
+          this.metadataProgramIdPublicKey
+        )
+      )[0]
+      const { collection, collectionDetails } = await Metadata.fromAccountAddress(this.connection, programAddress)
+      return !collection && !!collectionDetails
+    } catch (e) {
+      return null
     }
   }
 }

--- a/packages/common/src/services/solana-client/solCollectibleHelpers.ts
+++ b/packages/common/src/services/solana-client/solCollectibleHelpers.ts
@@ -261,7 +261,7 @@ const nftComputedMedia = async (
 
 const metaplexNFTToCollectible = async (
   nft: MetaplexNFT,
-  chainMetadata: Nullable<Metadata>,
+  solanaChainMetadata: Nullable<Metadata>,
   address: string
 ): Promise<Collectible> => {
   const identifier = [nft.symbol, nft.name, nft.image]
@@ -276,7 +276,7 @@ const metaplexNFTToCollectible = async (
     externalLink: nft.external_url,
     isOwned: true,
     chain: Chain.Sol,
-    chainMetadata
+    solanaChainMetadata
   } as Collectible
 
   if (
@@ -309,7 +309,7 @@ const metaplexNFTToCollectible = async (
 
 const starAtlasNFTToCollectible = async (
   nft: StarAtlasNFT,
-  chainMetadata: Nullable<Metadata>
+  solanaChainMetadata: Nullable<Metadata>
 ): Promise<Collectible> => {
   const identifier = [nft._id, nft.symbol, nft.name, nft.image]
     .filter(Boolean)
@@ -322,7 +322,7 @@ const starAtlasNFTToCollectible = async (
     description: nft.description,
     isOwned: true,
     chain: Chain.Sol,
-    chainMetadata
+    solanaChainMetadata
   } as Collectible
 
   // todo: check if there are gif or video nfts for star atlas
@@ -364,17 +364,17 @@ export const solanaNFTToCollectible = async (
   nft: SolanaNFT,
   address: string,
   type: SolanaNFTType,
-  chainMetadata: Nullable<Metadata>
+  solanaChainMetadata: Nullable<Metadata>
 ): Promise<Nullable<Collectible>> => {
   switch (type) {
     case SolanaNFTType.METAPLEX:
       return metaplexNFTToCollectible(
         nft as MetaplexNFT,
-        chainMetadata,
+        solanaChainMetadata,
         address
       )
     case SolanaNFTType.STAR_ATLAS:
-      return starAtlasNFTToCollectible(nft as StarAtlasNFT, chainMetadata)
+      return starAtlasNFTToCollectible(nft as StarAtlasNFT, solanaChainMetadata)
     default:
       return null
   }

--- a/packages/common/src/services/solana-client/solCollectibleHelpers.ts
+++ b/packages/common/src/services/solana-client/solCollectibleHelpers.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from '@metaplex-foundation/mpl-token-metadata'
+
 import { Chain, Collectible, CollectibleMediaType } from '../../models'
 import { Nullable } from '../../utils/typeUtils'
 
@@ -367,7 +368,11 @@ export const solanaNFTToCollectible = async (
 ): Promise<Nullable<Collectible>> => {
   switch (type) {
     case SolanaNFTType.METAPLEX:
-      return metaplexNFTToCollectible(nft as MetaplexNFT, chainMetadata, address)
+      return metaplexNFTToCollectible(
+        nft as MetaplexNFT,
+        chainMetadata,
+        address
+      )
     case SolanaNFTType.STAR_ATLAS:
       return starAtlasNFTToCollectible(nft as StarAtlasNFT, chainMetadata)
     default:

--- a/packages/common/src/services/solana-client/solCollectibleHelpers.ts
+++ b/packages/common/src/services/solana-client/solCollectibleHelpers.ts
@@ -277,7 +277,7 @@ const metaplexNFTToCollectible = async (
     isOwned: true,
     chain: Chain.Sol,
     chainMetadata
-  } as unknown as Collectible
+  } as Collectible
 
   if (
     (nft.properties?.creators ?? []).some(
@@ -323,7 +323,7 @@ const starAtlasNFTToCollectible = async (
     isOwned: true,
     chain: Chain.Sol,
     chainMetadata
-  } as unknown as Collectible
+  } as Collectible
 
   // todo: check if there are gif or video nfts for star atlas
   const is3DObj = [nft.image, nft.media?.thumbnailUrl]

--- a/packages/common/src/services/solana-client/solCollectibleHelpers.ts
+++ b/packages/common/src/services/solana-client/solCollectibleHelpers.ts
@@ -1,3 +1,4 @@
+import type { Metadata } from '@metaplex-foundation/mpl-token-metadata'
 import { Chain, Collectible, CollectibleMediaType } from '../../models'
 import { Nullable } from '../../utils/typeUtils'
 
@@ -259,6 +260,7 @@ const nftComputedMedia = async (
 
 const metaplexNFTToCollectible = async (
   nft: MetaplexNFT,
+  chainMetadata: Nullable<Metadata>,
   address: string
 ): Promise<Collectible> => {
   const identifier = [nft.symbol, nft.name, nft.image]
@@ -272,8 +274,9 @@ const metaplexNFTToCollectible = async (
     description: nft.description,
     externalLink: nft.external_url,
     isOwned: true,
-    chain: Chain.Sol
-  } as Collectible
+    chain: Chain.Sol,
+    chainMetadata
+  } as unknown as Collectible
 
   if (
     (nft.properties?.creators ?? []).some(
@@ -304,7 +307,8 @@ const metaplexNFTToCollectible = async (
 }
 
 const starAtlasNFTToCollectible = async (
-  nft: StarAtlasNFT
+  nft: StarAtlasNFT,
+  chainMetadata: Nullable<Metadata>
 ): Promise<Collectible> => {
   const identifier = [nft._id, nft.symbol, nft.name, nft.image]
     .filter(Boolean)
@@ -316,8 +320,9 @@ const starAtlasNFTToCollectible = async (
     name: nft.name,
     description: nft.description,
     isOwned: true,
-    chain: Chain.Sol
-  } as Collectible
+    chain: Chain.Sol,
+    chainMetadata
+  } as unknown as Collectible
 
   // todo: check if there are gif or video nfts for star atlas
   const is3DObj = [nft.image, nft.media?.thumbnailUrl]
@@ -357,13 +362,14 @@ const starAtlasNFTToCollectible = async (
 export const solanaNFTToCollectible = async (
   nft: SolanaNFT,
   address: string,
-  type: SolanaNFTType
+  type: SolanaNFTType,
+  chainMetadata: Nullable<Metadata>
 ): Promise<Nullable<Collectible>> => {
   switch (type) {
     case SolanaNFTType.METAPLEX:
-      return metaplexNFTToCollectible(nft as MetaplexNFT, address)
+      return metaplexNFTToCollectible(nft as MetaplexNFT, chainMetadata, address)
     case SolanaNFTType.STAR_ATLAS:
-      return starAtlasNFTToCollectible(nft as StarAtlasNFT)
+      return starAtlasNFTToCollectible(nft as StarAtlasNFT, chainMetadata)
     default:
       return null
   }

--- a/packages/common/src/services/solana-client/types.ts
+++ b/packages/common/src/services/solana-client/types.ts
@@ -1,5 +1,6 @@
+import type { Metadata } from '@metaplex-foundation/mpl-token-metadata'
+
 import { Nullable } from '../../utils/typeUtils'
-import type { Metadata } from "@metaplex-foundation/mpl-token-metadata"
 
 export enum SolanaNFTType {
   METAPLEX = 'METAPLEX',

--- a/packages/common/src/services/solana-client/types.ts
+++ b/packages/common/src/services/solana-client/types.ts
@@ -38,7 +38,7 @@ export type MetaplexNFT = {
   animation_url: Nullable<string>
   external_url: Nullable<string>
   properties: Nullable<MetaplexNFTProperties>
-  chainMetadata: Metadata
+  solanaChainMetadata: Metadata
 }
 
 // example: https://galaxy.staratlas.com/nfts/2iMhgB4pbdKvwJHVyitpvX5z1NBNypFonUgaSAt9dtDt
@@ -53,7 +53,7 @@ export type StarAtlasNFT = {
   }
   deactivated: boolean
   createdAt: string
-  chainMetadata: Metadata
+  solanaChainMetadata: Metadata
 }
 
 export type SolanaNFT = MetaplexNFT | StarAtlasNFT

--- a/packages/common/src/services/solana-client/types.ts
+++ b/packages/common/src/services/solana-client/types.ts
@@ -1,4 +1,5 @@
 import { Nullable } from '../../utils/typeUtils'
+import type { Metadata } from "@metaplex-foundation/mpl-token-metadata"
 
 export enum SolanaNFTType {
   METAPLEX = 'METAPLEX',
@@ -36,6 +37,7 @@ export type MetaplexNFT = {
   animation_url: Nullable<string>
   external_url: Nullable<string>
   properties: Nullable<MetaplexNFTProperties>
+  chainMetadata: Metadata
 }
 
 // example: https://galaxy.staratlas.com/nfts/2iMhgB4pbdKvwJHVyitpvX5z1NBNypFonUgaSAt9dtDt
@@ -50,6 +52,7 @@ export type StarAtlasNFT = {
   }
   deactivated: boolean
   createdAt: string
+  chainMetadata: Metadata
 }
 
 export type SolanaNFT = MetaplexNFT | StarAtlasNFT

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -120,9 +120,10 @@ function* getTokenIdMap({
 
         // add trackId <> tokenIds entry if track is gated on ERC1155 nft collection,
         // otherwsise, set tokenIds for trackId to empty array
-        trackMap[trackId] = nftCollection.standard === 'ERC1155'
-          ? ethContractMap[nftCollection.address]
-          : []
+        trackMap[trackId] =
+          nftCollection.standard === 'ERC1155'
+            ? ethContractMap[nftCollection.address]
+            : []
       } else if (nftCollection.chain === Chain.Sol) {
         if (solCollectionMintSet.has(nftCollection.address)) {
           // add trackId to trackMap, no need for tokenIds here

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -57,8 +57,6 @@ function* getTokenIdMap({
 }) {
   const trackMap: { [id: number]: string[] } = {}
 
-  // Handle tracks gated by ethereum nft collections
-
   // Build map of eth nft contract address -> list of token ids
   // ERC1155 requires token ids to get the balance of a wallet for a given collection
   // We can ignore token ids for ERC721 nfts
@@ -73,7 +71,18 @@ function* getTokenIdMap({
     }
   })
 
-  // todo: Handle tracks gated by solana nft collections
+  // Build a set of sol nft collection mint addresses
+  const solCollectionMintSet: Set<string> = new Set()
+  solCollectibles.forEach((c: Collectible) => {
+    if (!c.chainMetadata) return
+
+    // "If the Collection field is set, it means the NFT is part of the collection specified within that field."
+    // https://docs.metaplex.com/programs/token-metadata/certified-collections#linking-regular-nfts-to-collection-nfts
+    const { collection } = c.chainMetadata
+    if (collection?.verified) {
+      solCollectionMintSet.add(collection.key.toBase58())
+    }
+  })
 
   Object.keys(tracks)
     .map(Number)
@@ -105,22 +114,20 @@ function* getTokenIdMap({
       }
 
       if (nftCollection.chain === Chain.Eth) {
-        const tokenIds =
-          'address' in nftCollection
-            ? ethContractMap[nftCollection.address]
-            : undefined
-        if (!tokenIds) return
+        // skip this track entry if user does not own an nft from its nft collection gate
+        const tokenIds = ethContractMap[nftCollection.address]
+        if (!tokenIds || !tokenIds.length) return
 
-        if (
-          'standard' in nftCollection &&
-          nftCollection.standard === 'ERC1155'
-        ) {
-          trackMap[trackId] = ethContractMap[nftCollection.address]
-        } else {
+        // add trackId <> tokenIds entry if track is gated on ERC1155 nft collection,
+        // otherwsise, set tokenIds for trackId to empty array
+        trackMap[trackId] = nftCollection.standard === 'ERC1155'
+          ? ethContractMap[nftCollection.address]
+          : []
+      } else if (nftCollection.chain === Chain.Sol) {
+        if (solCollectionMintSet.has(nftCollection.address)) {
+          // add trackId to trackMap, no need for tokenIds here
           trackMap[trackId] = []
         }
-      } else if (nftCollection.chain === Chain.Sol) {
-        // todo
       }
     })
 
@@ -182,7 +189,7 @@ function* updateNFTGatedTrackAccess(
     Object.keys(premiumTrackSignatureMap).map(Number)
   )
 
-  // update premium content signatures from tracks' metadata with the  signature
+  // update premium content signatures from tracks' metadata with the signature
   const areTracksAdded =
     'kind' in action && action.kind === Kind.TRACKS && !!action.entries.length
   if (areTracksAdded) {

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -74,11 +74,11 @@ function* getTokenIdMap({
   // Build a set of sol nft collection mint addresses
   const solCollectionMintSet: Set<string> = new Set()
   solCollectibles.forEach((c: Collectible) => {
-    if (!c.chainMetadata) return
+    if (!c.solanaChainMetadata) return
 
     // "If the Collection field is set, it means the NFT is part of the collection specified within that field."
     // https://docs.metaplex.com/programs/token-metadata/certified-collections#linking-regular-nfts-to-collection-nfts
-    const { collection } = c.chainMetadata
+    const { collection } = c.solanaChainMetadata
     if (collection?.verified) {
       solCollectionMintSet.add(collection.key.toBase58())
     }


### PR DESCRIPTION
### Description

- Add logic to pass in track ids for solana-nft-gated tracks to get their premium content signatures.
- Add function `isCollectionNFT` to `SolanaClient` to check whether a mint address represents an NFT that denotes a collection. This will later be used by the premium content UI to ensure solana nfts which gate track access are valid.
- Update Collectible and sol nft collection types.
- Simplify logic to get sol nft chain metadata.

### Dragons

none

### How Has This Been Tested?

Tested by hardcoding solana collectibles from another profile and premium tracks gated on some solana nft collection and seeing that the client would build and make the correct request to DN to fetch the nft-gated track signatures.

### How will this change be monitored?

n/a

### Feature Flags ###

existing `premium_content_enabled` feature flag

