### PR TITLE
Fix other share drawers

### DIFF
--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -81,7 +81,7 @@ export const useShareToStory = ({
   }
 
   const trackImageUri =
-    (content.type === 'track' && trackImage && trackImage?.source[2].uri) ??
+    (content?.type === 'track' && trackImage && trackImage?.source[2].uri) ??
     DEFAULT_IMAGE_URL
   const captureStickerImage = useCallback(async () => {
     if (!isStickerImageLoadedRef.current) {

--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -79,8 +79,10 @@ export const useShareToStory = ({
     isStickerImageLoadedRef.current = true
     stickerLoadedEventEmitter.emit(STICKER_LOADED_EVENT)
   }
+
   const trackImageUri =
-    (trackImage && trackImage?.source[2].uri) ?? DEFAULT_IMAGE_URL
+    (content.type === 'track' && trackImage && trackImage?.source[2].uri) ??
+    DEFAULT_IMAGE_URL
   const captureStickerImage = useCallback(async () => {
     if (!isStickerImageLoadedRef.current) {
       // Wait for the sticker component and image inside it to load. If this hasn't happened in 5 seconds, assume that it failed.


### PR DESCRIPTION
### Description
Share drawers other than share track were erroring out due to:
` TypeError: undefined is not an object (evaluating 'trackImage.source[2].uri')
`

Turns out the `trackImage` not null check before didn't work because `useTrackImage` doesn't actually return null if its input is null...

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

