### PR TITLE
[PAY-757] Prevent use of premium tracks as remix parents

### DIFF
--- a/packages/web/src/common/store/remix-settings/sagas.ts
+++ b/packages/web/src/common/store/remix-settings/sagas.ts
@@ -68,6 +68,11 @@ function* watchFetchTrack() {
           })) as unknown as Track
         }
         if (track) {
+          // Premium tracks cannot be used as remix track parents
+          if (track.is_premium) {
+            yield* put(fetchTrackFailed())
+            return
+          }
           yield* put(fetchTrackSucceeded({ trackId: track.track_id }))
           return
         }


### PR DESCRIPTION
### Description

Sets premium track as invalid when trying to upload track as a remix of a premium track.

related to https://github.com/AudiusProject/audius-protocol/pull/4499

Also, when building premium content UI, we need to ensure that the "This is a remix switch" is non-existing when uploading a premium track, so premium track will not be a remix child.

### Dragons

part of track upload flow, but should be fine

### How Has This Been Tested?

Sets the track as invalid so user cannot proceed to use premium track as remix parent.

### How will this change be monitored?

n/a

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

