### PR TITLE
Skip offline content sync when offline

### DIFF
--- a/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
+++ b/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { accountSelectors } from '@audius/common'
+import { accountSelectors, reachabilitySelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
@@ -12,6 +12,7 @@ import {
 import { getIsDoneLoadingFromDisk } from 'app/store/offline-downloads/selectors'
 
 const { getUserId } = accountSelectors
+const { getIsReachable } = reachabilitySelectors
 
 export const OfflineDownloader = () => {
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
@@ -27,13 +28,15 @@ export const OfflineDownloader = () => {
 
   const [syncStarted, setSyncStarted] = useState(false)
   const currentUserId = useSelector(getUserId)
+  const isReachable = useSelector(getIsReachable)
   const isDoneLoadingFromDisk = useSelector(getIsDoneLoadingFromDisk)
+
   useEffect(() => {
-    if (!syncStarted && currentUserId && isDoneLoadingFromDisk) {
+    if (!syncStarted && currentUserId && isDoneLoadingFromDisk && isReachable) {
       setSyncStarted(true)
       startSyncWorker()
     }
-  }, [syncStarted, currentUserId, isDoneLoadingFromDisk])
+  }, [syncStarted, currentUserId, isDoneLoadingFromDisk, isReachable])
 
   return null
 }

--- a/packages/mobile/src/services/offline-downloader/offline-sync.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-sync.ts
@@ -18,6 +18,7 @@ import { fetchAllFavoritedTrackIds } from 'app/hooks/useFetchAllFavoritedTrackId
 import { store } from 'app/store'
 import { getOfflineCollections } from 'app/store/offline-downloads/selectors'
 import { populateCoverArtSizes } from 'app/utils/populateCoverArtSizes'
+import { pingTest } from 'app/utils/reachability'
 import { isAvailableForPlay } from 'app/utils/trackUtils'
 
 import { apiClient } from '../audius-api-client'
@@ -47,8 +48,10 @@ const STALE_DURATION_TRACKS = moment.duration(7, 'days')
  *  Check for new and removed collections
  */
 export const startSyncWorker = async () => {
-  const state = store.getState()
+  const reachable = await pingTest()
+  if (!reachable) return
 
+  const state = store.getState()
   const collections = getCollections(state)
   const offlineCollectionsState = getOfflineCollections(state)
   if (offlineCollectionsState[DOWNLOAD_REASON_FAVORITES]) {

--- a/packages/mobile/src/utils/reachability.ts
+++ b/packages/mobile/src/utils/reachability.ts
@@ -23,7 +23,7 @@ export const checkNetInfoReachability = (netInfo: NetInfoState | null) => {
 const isResponseValid = (response: Response | undefined) =>
   response && response.ok
 
-const pingTest = async () => {
+export const pingTest = async () => {
   // If there's no reachability url available, consider ourselves reachable
   if (!REACHABILITY_URL) {
     console.warn('No reachability url provided')


### PR DESCRIPTION
### Description

Since we default reachability to true, we need to ping test before running the sync process. This avoids making tons of failed requests to discovery.

