### PR TITLE
[PAY-772] Update table styles to remove the space between the header text and sorters

### DIFF
--- a/packages/web/src/components/table/Table.module.css
+++ b/packages/web/src/components/table/Table.module.css
@@ -59,8 +59,8 @@
   line-height: 41px;
   user-select: none;
 }
-.tableHeader.hasSorter {
-  padding-right: 20px;
+.tableHeader.hasSorter .textCell {
+  padding-right: 6px;
 }
 .titleHeader + .titleHeader::before {
   content: '';


### PR DESCRIPTION
### Description
Small styling update. Should remove the space between the text and sorters so there is no gap in the clickable area

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

