### PR TITLE
[C-1692] Prevent infinite failed requests while offline

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -491,6 +491,7 @@ export class AudiusAPIClient {
   remoteConfigInstance: RemoteConfigInstance
   localStorage: LocalStorage
   env: Env
+  isReachable?: boolean = true
 
   constructor({
     audiusBackendInstance,
@@ -506,6 +507,10 @@ export class AudiusAPIClient {
     this.remoteConfigInstance = remoteConfigInstance
     this.localStorage = localStorage
     this.env = env
+  }
+
+  setIsReachable(isReachable: boolean) {
+    this.isReachable = isReachable
   }
 
   async getTrending({
@@ -1665,7 +1670,13 @@ export class AudiusAPIClient {
     splitArrayParams = false
   ): Promise<Nullable<T>> {
     if (this.initializationState.state !== 'initialized')
-      throw new Error('_constructURL called uninitialized')
+      throw new Error('_getResponse called uninitialized')
+
+    // If not reachable, abort
+    if (!this.isReachable) {
+      console.debug(`APIClient: Not reachable, aborting request`)
+      return null
+    }
 
     // If a param has a null value, remove it
     const sanitizedParams = Object.keys(params).reduce((acc, cur) => {

--- a/packages/mobile/src/utils/reachability.ts
+++ b/packages/mobile/src/utils/reachability.ts
@@ -6,6 +6,7 @@ import { AppState } from 'react-native'
 
 import { env } from 'app/services/env'
 import { dispatch } from 'app/store'
+import { storeContext } from 'app/store/storeContext'
 
 const REACHABILITY_URL = env.REACHABILITY_URL
 
@@ -64,6 +65,7 @@ const updateReachability = async (netInfoState: NetInfoState) => {
     // Supercede the setUnreachable debounce if necessary
     setUnreachable(false)
     dispatch(reachabilityActions.setReachable())
+    storeContext.apiClient.setIsReachable(true)
   }
 }
 
@@ -72,6 +74,7 @@ const setUnreachable = debounce(
   (isUnreachable: boolean) => {
     if (isUnreachable) {
       dispatch(reachabilityActions.setUnreachable())
+      storeContext.apiClient.setIsReachable(false)
     }
   },
   2500,


### PR DESCRIPTION
### Description

* Check reachability in AudiusApiClient so retries stop once we enter an unreachable state. This means there are still some requests that fail before we get into the unreachable state, but they stop fairly quickly. Would be ideal to have the unreachable state happen faster, but bc we do a ping check it takes a bit
* Check reachability in `getNotifications`. This function gets run on an interval, so we can prevent failed requests by returning early

The reachability handlers not being in sagas made this kind of interesting. I'm definitely still in favor of moving away from sagas but the border between saga <> non-saga can be annoying

### Dragons

I noticed that coming back online doesn't seem to be working. Once my wifi is reconnected and I press reload in the app, nothing happens. Not sure if you are aware of this @amendelsohn but I could dig in if you want me to

### How Has This Been Tested?

iOS simulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

