### PR TITLE
Don't stop loading if one collection fails

### DIFF
--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -28,6 +28,7 @@ import {
   getOfflineCollections,
   getTrackJson,
   listTracks,
+  purgeDownloadedCollection,
   verifyTrack
 } from '../services/offline-downloader/offline-storage'
 
@@ -67,6 +68,7 @@ export const useLoadOfflineTracks = () => {
         }
       } catch (e) {
         console.warn('Failed to load offline collection', collectionId)
+        purgeDownloadedCollection(collectionId)
       }
     }
     dispatch(cacheActions.add(Kind.COLLECTIONS, cacheCollections, false, true))

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -49,20 +49,24 @@ export const useLoadOfflineTracks = () => {
       metadata: CollectionMetadata
     }[] = []
     for (const collectionId of offlineCollections) {
-      dispatch(addCollection(collectionId))
-      if (collectionId === DOWNLOAD_REASON_FAVORITES) continue
-      const collection = await getCollectionJson(collectionId)
-      cacheCollections.push({
-        id: collectionId,
-        uid: makeUid(Kind.COLLECTIONS, collectionId),
-        metadata: collection
-      })
-      if (collection.user) {
-        cacheUsers.push({
-          id: collection.user.user_id,
-          uid: makeUid(Kind.USERS, collection.user.user_id),
-          metadata: collection.user
+      try {
+        if (collectionId === DOWNLOAD_REASON_FAVORITES) continue
+        const collection = await getCollectionJson(collectionId)
+        dispatch(addCollection(collectionId))
+        cacheCollections.push({
+          id: collectionId,
+          uid: makeUid(Kind.COLLECTIONS, collectionId),
+          metadata: collection
         })
+        if (collection.user) {
+          cacheUsers.push({
+            id: collection.user.user_id,
+            uid: makeUid(Kind.USERS, collection.user.user_id),
+            metadata: collection.user
+          })
+        }
+      } catch (e) {
+        console.warn('Failed to load offline collection', collectionId)
       }
     }
     dispatch(cacheActions.add(Kind.COLLECTIONS, cacheCollections, false, true))


### PR DESCRIPTION
### Description

`useLoadOfflineTracks` was choking if any collection failed to load from disk. Likely due to a corrupted file that was half written before last time. Wrapping it in a try catch lets us move on and still load the rest.
