### PR TITLE
[C-1646][C-1647] Handle more offline lineup states

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -141,6 +141,7 @@ export type OfflineTrackMetadata = {
   reasons_for_download: DownloadReason[]
   download_completed_time: EpochTimeStamp
   last_verified_time: EpochTimeStamp
+  favorite_created_at?: string
 }
 
 export type Stem = {

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -82,6 +82,7 @@ export type APIFavorite = {
   favorite_item_id: string
   favorite_type: FavoriteType
   user_id: string
+  created_at: string
 }
 
 export type APIRemix = {

--- a/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
@@ -23,6 +23,9 @@ import { DownloadStatusIndicator } from './DownloadStatusIndicator'
 export type TrackForDownload = {
   trackId: number
   downloadReason: DownloadReason
+  // Timestamp associated with when this track was favorited if the reason
+  // is favorites.
+  favoriteCreatedAt?: string
 }
 
 type DownloadToggleProps = {

--- a/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
+++ b/packages/mobile/src/hooks/useFetchAllFavoritedTrackIds.ts
@@ -1,4 +1,4 @@
-import type { APIFavorite } from '@audius/common'
+import type { APIFavorite, ID } from '@audius/common'
 import { decodeHashId, encodeHashId, accountSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
@@ -10,7 +10,8 @@ import { useIsOfflineModeEnabled } from './useIsOfflineModeEnabled'
 const { getUserId } = accountSelectors
 
 export const fetchAllFavoritedTrackIds = async (currentUserId: number) => {
-  let trackIds: number[] = []
+  let tracksAndTimestamps: Array<{ trackId: ID; favoriteCreatedAt: string }> =
+    []
   let loadMore = true
   let offset = 0
   // TODO: store results in state to avoid duplicate fetching
@@ -29,15 +30,16 @@ export const fetchAllFavoritedTrackIds = async (currentUserId: number) => {
 
     loadMore = result.length > 0
     offset += result.length
-    trackIds = trackIds.concat(
+    tracksAndTimestamps = tracksAndTimestamps.concat(
       result
         .filter((trackSave) => trackSave.favorite_type === 'SaveType.track')
-        .map((trackSave: APIFavorite) =>
-          decodeHashId(trackSave.favorite_item_id)
-        )
+        .map((trackSave: APIFavorite) => ({
+          trackId: decodeHashId(trackSave.favorite_item_id),
+          favoriteCreatedAt: trackSave.created_at
+        }))
     )
   }
-  return trackIds
+  return tracksAndTimestamps
 }
 
 export const useFetchAllFavoritedTrackIds = () => {

--- a/packages/mobile/src/hooks/useFetchAllFavoritedTracks.ts
+++ b/packages/mobile/src/hooks/useFetchAllFavoritedTracks.ts
@@ -9,9 +9,8 @@ import { useIsOfflineModeEnabled } from './useIsOfflineModeEnabled'
 
 const { getUserId } = accountSelectors
 
-export const fetchAllFavoritedTrackIds = async (currentUserId: number) => {
-  let tracksAndTimestamps: Array<{ trackId: ID; favoriteCreatedAt: string }> =
-    []
+export const fetchAllFavoritedTracks = async (currentUserId: number) => {
+  let tracksAndTimestamps: { trackId: ID; favoriteCreatedAt: string }[] = []
   let loadMore = true
   let offset = 0
   // TODO: store results in state to avoid duplicate fetching
@@ -42,11 +41,11 @@ export const fetchAllFavoritedTrackIds = async (currentUserId: number) => {
   return tracksAndTimestamps
 }
 
-export const useFetchAllFavoritedTrackIds = () => {
+export const useFetchAllFavoritedTracks = () => {
   const currentUserId = useSelector(getUserId)
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
   return useAsync(async () => {
     if (!isOfflineModeEnabled || !currentUserId) return
-    return fetchAllFavoritedTrackIds(currentUserId)
+    return fetchAllFavoritedTracks(currentUserId)
   }, [currentUserId])
 }

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+
 import type {
   CollectionMetadata,
   Track,
@@ -5,13 +7,13 @@ import type {
   UserTrackMetadata
 } from '@audius/common'
 import {
-  collectionPageLineupActions,
-  savedPageTracksLineupActions,
   Kind,
   makeUid,
   cacheActions,
   reachabilitySelectors
 } from '@audius/common'
+import { getCollection } from '@audius/common/dist/store/cache/collections/selectors'
+import type { LineupActions } from '@audius/common/dist/store/lineup/actions'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
@@ -76,36 +78,39 @@ export const useLoadOfflineTracks = () => {
     const trackIds = await listTracks()
     const cacheTracks: { uid: string; id: number; metadata: Track }[] = []
     const lineupTracks: (Track & UserTrackMetadata & { uid: string })[] = []
-    for (const trackId of trackIds) {
-      try {
-        const verified = await verifyTrack(trackId, true)
-        if (!verified) continue
-        getTrackJson(trackId)
-          .then((track: Track & UserTrackMetadata) => {
-            const lineupTrack = {
-              uid: makeUid(Kind.TRACKS, track.track_id),
-              kind: Kind.TRACKS,
-              ...track
-            }
-            cacheTracks.push({
-              id: track.track_id,
-              uid: lineupTrack.uid,
-              metadata: track
-            })
-            if (track.user) {
-              cacheUsers.push({
-                id: track.user.user_id,
-                uid: makeUid(Kind.USERS, track.user.user_id),
-                metadata: track.user
-              })
-            }
-            lineupTracks.push(lineupTrack)
+    await Promise.all(
+      trackIds.map(async (trackId) => {
+        try {
+          const verified = await verifyTrack(trackId, true)
+          if (!verified) return
+        } catch (e) {
+          console.warn('Error verifying track', trackId, e)
+        }
+        try {
+          const track: Track & UserTrackMetadata = await getTrackJson(trackId)
+          const lineupTrack = {
+            uid: makeUid(Kind.TRACKS, track.track_id),
+            kind: Kind.TRACKS,
+            ...track
+          }
+          cacheTracks.push({
+            id: track.track_id,
+            uid: lineupTrack.uid,
+            metadata: track
           })
-          .catch(() => console.warn('Failed to load track from disk', trackId))
-      } catch (e) {
-        console.warn('Error verifying track', trackId, e)
-      }
-    }
+          if (track.user) {
+            cacheUsers.push({
+              id: track.user.user_id,
+              uid: makeUid(Kind.USERS, track.user.user_id),
+              metadata: track.user
+            })
+          }
+          lineupTracks.push(lineupTrack)
+        } catch (e) {
+          console.warn('Failed to load track from disk', trackId, e)
+        }
+      })
+    )
 
     dispatch(cacheActions.add(Kind.TRACKS, cacheTracks, false, true))
     dispatch(cacheActions.add(Kind.USERS, cacheUsers, false, true))
@@ -114,40 +119,105 @@ export const useLoadOfflineTracks = () => {
   })
 }
 
-export const useOfflineCollectionLineup = (collectionId?: string) => {
+/**
+ * A helper hook that can substitute out the contents of a lineup for the
+ * equivalent "offline" version
+ * @param collectionId either the numeric collection id or DOWNLOAD_REASON_FAVORITES
+ * @param fetchOnlineContent a callback that can be used to refetch the online content
+ *  if reachability is established. This is normally what you would call inside
+ *  `useFocusEffect` on mount of the lineup
+ * @param lineupActions the actions instance for the lineup
+ */
+export const useOfflineCollectionLineup = (
+  collectionId: typeof DOWNLOAD_REASON_FAVORITES | number | null,
+  fetchOnlineContent: () => void,
+  lineupActions: LineupActions
+) => {
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
   const isReachable = useSelector(getIsReachable)
   const offlineTracks = useSelector(getOfflineTracks)
+  const collection = useSelector((state) => {
+    if (collectionId !== DOWNLOAD_REASON_FAVORITES) {
+      return getCollection(state, { id: collectionId as number })
+    }
+  })
+  const [hasGoneOffline, setHasGoneOffline] = useState(false)
 
   const dispatch = useDispatch()
 
-  useAsync(async () => {
-    if (!isOfflineModeEnabled || !collectionId) return
-
-    const lineupTracks = Object.values(offlineTracks).filter((track) =>
-      track.offline?.reasons_for_download.some(
-        (reason) => reason.collection_id === collectionId
-      )
-    )
-
+  // Record if we have gone offline so that when we come
+  // back online we can refetch fresh content
+  useEffect(() => {
     if (!isReachable) {
-      const populateLinupAction =
-        collectionId === DOWNLOAD_REASON_FAVORITES
-          ? savedPageTracksLineupActions.fetchLineupMetadatasSucceeded(
-              lineupTracks,
-              0,
-              lineupTracks.length,
-              false,
-              false
-            )
-          : collectionPageLineupActions.fetchLineupMetadatasSucceeded(
-              lineupTracks,
-              0,
-              lineupTracks.length,
-              false,
-              false
-            )
-      dispatch(populateLinupAction)
+      setHasGoneOffline(true)
     }
-  }, [isOfflineModeEnabled, isReachable, loadTracks, collectionId])
+  }, [isReachable, setHasGoneOffline])
+
+  // If we go offline, set lineup into a success state with
+  // offline data
+  useEffect(() => {
+    if (isOfflineModeEnabled && collectionId && !isReachable) {
+      const lineupTracks = Object.values(offlineTracks).filter((track) =>
+        track.offline?.reasons_for_download.some(
+          (reason) => reason.collection_id === collectionId.toString()
+        )
+      )
+
+      if (collectionId === DOWNLOAD_REASON_FAVORITES) {
+        // Reorder lineup tracks accorinding to favorite time
+        const sortedTracks = lineupTracks.sort((a, b) => {
+          const bTime = b.offline?.favorite_created_at
+          const aTime = a.offline?.favorite_created_at
+          if (aTime && bTime) {
+            if (aTime > bTime) {
+              return -1
+            }
+            return 1
+          }
+          return 0
+        })
+        dispatch(
+          lineupActions.fetchLineupMetadatasSucceeded(
+            sortedTracks,
+            0,
+            lineupTracks.length,
+            false,
+            false
+          )
+        )
+      } else {
+        // Reorder lineup tracks according to the collection
+        // TODO: This may have issues for playlists with duplicate tracks
+        const sortedTracks = collection?.playlist_contents.track_ids.map(
+          ({ track: trackId }) =>
+            lineupTracks.find((track) => trackId === track.track_id)
+        )
+        dispatch(
+          lineupActions.fetchLineupMetadatasSucceeded(
+            sortedTracks,
+            0,
+            lineupTracks.length,
+            false,
+            false
+          )
+        )
+      }
+    }
+  }, [
+    dispatch,
+    offlineTracks,
+    isOfflineModeEnabled,
+    lineupActions,
+    isReachable,
+    collectionId,
+    setHasGoneOffline,
+    collection?.playlist_contents.track_ids
+  ])
+
+  // If we go back online, trigger a refetch of the original content
+  useEffect(() => {
+    if (isReachable && hasGoneOffline) {
+      fetchOnlineContent()
+    }
+  }, [dispatch, isReachable, hasGoneOffline, fetchOnlineContent])
 }

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -4,7 +4,8 @@ import type {
   CollectionMetadata,
   Track,
   UserMetadata,
-  lineupActions
+  lineupActions,
+  UserTrackMetadata
 } from '@audius/common'
 import {
   Kind,
@@ -13,6 +14,7 @@ import {
   cacheCollectionsSelectors,
   reachabilitySelectors
 } from '@audius/common'
+import { orderBy } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
@@ -165,17 +167,11 @@ export const useOfflineCollectionLineup = (
 
       if (collectionId === DOWNLOAD_REASON_FAVORITES) {
         // Reorder lineup tracks accorinding to favorite time
-        const sortedTracks = lineupTracks.sort((a, b) => {
-          const bTime = b.offline?.favorite_created_at
-          const aTime = a.offline?.favorite_created_at
-          if (aTime && bTime) {
-            if (aTime > bTime) {
-              return -1
-            }
-            return 1
-          }
-          return 0
-        })
+        const sortedTracks = orderBy(
+          lineupTracks,
+          (track) => track.offline?.favorite_created_at,
+          ['desc']
+        )
         dispatch(
           lineupActions.fetchLineupMetadatasSucceeded(
             sortedTracks,
@@ -218,6 +214,7 @@ export const useOfflineCollectionLineup = (
   useEffect(() => {
     if (isReachable && hasGoneOffline) {
       fetchOnlineContent()
+      setHasGoneOffline(false)
     }
   }, [dispatch, isReachable, hasGoneOffline, fetchOnlineContent])
 }

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -4,16 +4,15 @@ import type {
   CollectionMetadata,
   Track,
   UserMetadata,
-  UserTrackMetadata
+  lineupActions
 } from '@audius/common'
 import {
   Kind,
   makeUid,
   cacheActions,
+  cacheCollectionsSelectors,
   reachabilitySelectors
 } from '@audius/common'
-import { getCollection } from '@audius/common/dist/store/cache/collections/selectors'
-import type { LineupActions } from '@audius/common/dist/store/lineup/actions'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
@@ -35,6 +34,7 @@ import {
 } from '../services/offline-downloader/offline-storage'
 
 import { useIsOfflineModeEnabled } from './useIsOfflineModeEnabled'
+const { getCollection } = cacheCollectionsSelectors
 const { getIsReachable } = reachabilitySelectors
 
 export const useLoadOfflineTracks = () => {
@@ -131,7 +131,7 @@ export const useLoadOfflineTracks = () => {
 export const useOfflineCollectionLineup = (
   collectionId: typeof DOWNLOAD_REASON_FAVORITES | number | null,
   fetchOnlineContent: () => void,
-  lineupActions: LineupActions
+  lineupActions: lineupActions.LineupActions
 ) => {
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
   const isReachable = useSelector(getIsReachable)

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -124,12 +124,7 @@ export const CollectionScreenDetailsTile = ({
   }, [dispatch, handleFetchLineup])
 
   useFocusEffect(handleFetchCollectionLineup)
-  useOfflineCollectionLineup(
-    collectionId,
-    handleFetchLineup,
-    tracksActions,
-    isReachable
-  )
+  useOfflineCollectionLineup(collectionId, handleFetchLineup, tracksActions)
 
   const duration = entries?.reduce(
     (duration, entry) => duration + entry.duration,

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -11,7 +11,8 @@ import {
   formatSecondsAsText,
   lineupSelectors,
   collectionPageLineupActions as tracksActions,
-  collectionPageSelectors
+  collectionPageSelectors,
+  reachabilitySelectors
 } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import { View } from 'react-native'
@@ -42,6 +43,7 @@ const {
 const { resetCollection } = collectionPageActions
 const { makeGetTableMetadatas } = lineupSelectors
 const { getPlaying, getUid, getCurrentTrack } = playerSelectors
+const { getIsReachable } = reachabilitySelectors
 
 const messages = {
   album: 'Album',
@@ -101,23 +103,33 @@ export const CollectionScreenDetailsTile = ({
   const dispatch = useDispatch()
 
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
+  const isReachable = useSelector(getIsReachable)
 
   const collection = useSelector(getCollection)
   const collectionUid = useSelector(getCollectionUid)
   const collectionId = useSelector(getCollectionId)
   const userUid = useSelector(getUserUid)
-  const { entries, status } = useProxySelector(getTracksLineup, [])
+  const { entries, status } = useProxySelector(getTracksLineup, [isReachable])
   const tracksLoading = status === Status.LOADING
   const numTracks = entries.length
 
-  const resetCollectionLineup = useCallback(() => {
-    dispatch(resetCollection(collectionUid, userUid))
+  const handleFetchLineup = useCallback(() => {
     dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch])
 
-  useFocusEffect(resetCollectionLineup)
-  useOfflineCollectionLineup(collectionId?.toString())
+  const handleFetchCollectionLineup = useCallback(() => {
+    dispatch(resetCollection(collectionUid, userUid))
+    handleFetchLineup()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, handleFetchLineup])
+
+  useFocusEffect(handleFetchCollectionLineup)
+  useOfflineCollectionLineup(
+    collectionId,
+    handleFetchLineup,
+    tracksActions,
+    isReachable
+  )
 
   const duration = entries?.reduce(
     (duration, entry) => duration + entry.duration,

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -14,7 +14,7 @@ import type { TrackForDownload } from 'app/components/offline-downloads'
 import { DownloadToggle } from 'app/components/offline-downloads'
 import { TopTabNavigator } from 'app/components/top-tab-bar'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
-import { useFetchAllFavoritedTrackIds } from 'app/hooks/useFetchAllFavoritedTrackIds'
+import { useFetchAllFavoritedTracks } from 'app/hooks/useFetchAllFavoritedTracks'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
 
@@ -51,7 +51,7 @@ export const FavoritesScreen = () => {
   const dispatch = useDispatch()
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
-  const { value: allFavoritedTrackIds } = useFetchAllFavoritedTrackIds()
+  const { value: allFavoritedTrackIds } = useFetchAllFavoritedTracks()
 
   useEffectOnce(() => {
     dispatch(fetchSavedPlaylists())

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -65,11 +65,12 @@ export const FavoritesScreen = () => {
   const tracksForDownload: TrackForDownload[] = useMemo(() => {
     const trackFavoritesToDownload: TrackForDownload[] = (
       allFavoritedTrackIds ?? []
-    ).map((trackId) => ({
+    ).map(({ trackId, favoriteCreatedAt }) => ({
       trackId,
       downloadReason: {
         is_from_favorites: true,
-        collection_id: DOWNLOAD_REASON_FAVORITES
+        collection_id: DOWNLOAD_REASON_FAVORITES,
+        favorite_created_at: favoriteCreatedAt
       }
     }))
     const collectionFavoritesToDownload: TrackForDownload[] =
@@ -80,6 +81,7 @@ export const FavoritesScreen = () => {
             is_from_favorites: true,
             collection_id: collection.playlist_id.toString()
           }
+          // TODO: include a favorite_created_at timestamp for sorting offline collections
         }))
       )
 

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -76,8 +76,7 @@ export const TracksTab = () => {
   useOfflineCollectionLineup(
     DOWNLOAD_REASON_FAVORITES,
     handleFetchSaves,
-    tracksActions,
-    isReachable
+    tracksActions
   )
 
   const [filterValue, setFilterValue] = useState('')

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import type { ID, UID } from '@audius/common'
 import {
@@ -27,7 +27,6 @@ import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useOfflineCollectionLineup } from 'app/hooks/useLoadOfflineTracks'
 import { make, track } from 'app/services/analytics'
 import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
-import { getOfflineTracks } from 'app/store/offline-downloads/selectors'
 import { makeStyles } from 'app/styles'
 
 import { FilterInput } from './FilterInput'
@@ -74,14 +73,18 @@ export const TracksTab = () => {
   }, [dispatch])
 
   useFocusEffect(handleFetchSaves)
-  useOfflineCollectionLineup(DOWNLOAD_REASON_FAVORITES)
+  useOfflineCollectionLineup(
+    DOWNLOAD_REASON_FAVORITES,
+    handleFetchSaves,
+    tracksActions,
+    isReachable
+  )
 
   const [filterValue, setFilterValue] = useState('')
   const isPlaying = useSelector(getPlaying)
   const playingUid = useSelector(getUid)
   const savedTracksStatus = useSelector(getSavedTracksStatus)
   const savedTracks = useProxySelector(getTracks, [])
-  const offlineTracks = useSelector(getOfflineTracks)
 
   const filterTrack = (track: TrackMetadata) => {
     const matchValue = filterValue?.toLowerCase()
@@ -129,17 +132,7 @@ export const TracksTab = () => {
   )
 
   const isLoading = savedTracksStatus !== Status.SUCCESS
-  const tracks = useMemo(
-    () =>
-      !isReachable && isOfflineModeEnabled
-        ? Object.values(offlineTracks).filter((track) =>
-            track.offline?.reasons_for_download.some(
-              (reason) => reason.collection_id === DOWNLOAD_REASON_FAVORITES
-            )
-          )
-        : savedTracks.entries,
-    [isOfflineModeEnabled, isReachable, offlineTracks, savedTracks.entries]
-  )
+  const tracks = savedTracks.entries
   const hasNoFavorites = tracks.length === 0
 
   return (

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -128,7 +128,7 @@ export const batchDownloadTrack = (tracksForDownload: TrackForDownload[]) => {
 }
 
 export const downloadTrack = async (trackForDownload: TrackForDownload) => {
-  const { trackId, downloadReason } = trackForDownload
+  const { trackId, downloadReason, favoriteCreatedAt } = trackForDownload
   const trackIdStr = trackId.toString()
 
   // Throw this
@@ -159,10 +159,6 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
   }
 
   track = await populateCoverArtSizes(track)
-  const lineupTrack = {
-    uid: makeUid(Kind.TRACKS, track.track_id),
-    ...track
-  }
 
   try {
     store.dispatch(startDownload(trackIdStr))
@@ -170,7 +166,7 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
       // Track is already downloaded, so rewrite the json
       // to include this collection in the reasons_for_download list
       const trackJson = await getTrackJson(trackIdStr)
-      const trackToWrite: UserTrackMetadata = {
+      const trackToWrite: Track & UserTrackMetadata = {
         ...trackJson,
         offline: {
           download_completed_time:
@@ -179,10 +175,15 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
             trackJson.offline?.last_verified_time ?? Date.now(),
           reasons_for_download: trackJson.offline?.reasons_for_download?.concat(
             downloadReason
-          ) ?? [downloadReason]
+          ) ?? [downloadReason],
+          favorite_created_at: trackJson.offline?.favorite_created_at
         }
       }
       await writeTrackJson(trackIdStr, trackToWrite)
+      const lineupTrack = {
+        uid: makeUid(Kind.TRACKS, track.track_id),
+        ...trackToWrite
+      }
       store.dispatch(loadTrack(lineupTrack))
       store.dispatch(completeDownload(trackIdStr))
       return
@@ -190,9 +191,25 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
 
     await downloadTrackCoverArt(track)
     await tryDownloadTrackFromEachCreatorNode(track)
-    await writeUserTrackJson(track, downloadReason)
+    const trackToWrite: Track & UserTrackMetadata = {
+      ...track,
+      offline: {
+        reasons_for_download: uniq([
+          downloadReason,
+          ...(track?.offline?.reasons_for_download ?? [])
+        ]),
+        download_completed_time: Date.now(),
+        last_verified_time: Date.now(),
+        favorite_created_at: favoriteCreatedAt
+      }
+    }
+    await writeTrackJson(trackIdStr, trackToWrite)
     const verified = await verifyTrack(trackIdStr, true)
     if (verified) {
+      const lineupTrack = {
+        uid: makeUid(Kind.TRACKS, track.track_id),
+        ...trackToWrite
+      }
       store.dispatch(loadTrack(lineupTrack))
       store.dispatch(completeDownload(trackIdStr))
       return
@@ -236,7 +253,8 @@ export const batchRemoveTrackDownload = async (
               diskTrack.offline?.download_completed_time ?? Date.now(),
             last_verified_time:
               diskTrack.offline?.last_verified_time ?? Date.now(),
-            reasons_for_download: remainingReasons
+            reasons_for_download: remainingReasons,
+            favorite_created_at: diskTrack.offline?.favorite_created_at
           }
         }
         await writeTrackJson(trackIdStr, trackToWrite)
@@ -247,30 +265,6 @@ export const batchRemoveTrackDownload = async (
       )
     }
   })
-}
-
-/** Unlike mp3 and album art, here we overwrite even if the file exists to ensure we have the latest */
-export const writeUserTrackJson = async (
-  track: UserTrackMetadata,
-  downloadReason: DownloadReason
-) => {
-  const trackToWrite: UserTrackMetadata = {
-    ...track,
-    offline: {
-      reasons_for_download: uniq([
-        downloadReason,
-        ...(track?.offline?.reasons_for_download ?? [])
-      ]),
-      download_completed_time: Date.now(),
-      last_verified_time: Date.now()
-    }
-  }
-
-  const pathToWrite = getLocalTrackJsonPath(track.track_id.toString())
-  if (await exists(pathToWrite)) {
-    await RNFS.unlink(pathToWrite)
-  }
-  await RNFS.write(pathToWrite, JSON.stringify(trackToWrite))
 }
 
 export const downloadTrackCoverArt = async (track: Track) => {

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import type {
   Collection,
   CommonState,
-  DownloadReason,
   Track,
   UserMetadata,
   UserTrackMetadata
@@ -43,7 +42,6 @@ import {
 import {
   getLocalAudioPath,
   getLocalTrackCoverArtDestination,
-  getLocalTrackJsonPath,
   purgeDownloadedTrack,
   getTrackJson,
   verifyTrack,

--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -2,6 +2,7 @@ import path from 'path'
 
 import type {
   Collection,
+  Track,
   User,
   UserMetadata,
   UserTrackMetadata
@@ -171,7 +172,7 @@ export const listTracks = async (): Promise<string[]> => {
 
 export const getTrackJson = async (
   trackId: string
-): Promise<UserTrackMetadata> => {
+): Promise<Track & UserTrackMetadata> => {
   try {
     const trackJson = await readFile(getLocalTrackJsonPath(trackId))
     return JSON.parse(trackJson)

--- a/packages/mobile/src/services/offline-downloader/offline-sync.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-sync.ts
@@ -10,11 +10,11 @@ import {
   accountSelectors,
   cacheTracksSelectors
 } from '@audius/common'
-import { fetchAllFavoritedTracks } from 'app/hooks/useFetchAllFavoritedTracks'
 import moment from 'moment'
 import queue from 'react-native-job-queue'
 
 import type { TrackForDownload } from 'app/components/offline-downloads'
+import { fetchAllFavoritedTracks } from 'app/hooks/useFetchAllFavoritedTracks'
 import { store } from 'app/store'
 import { getOfflineCollections } from 'app/store/offline-downloads/selectors'
 import { populateCoverArtSizes } from 'app/utils/populateCoverArtSizes'

--- a/packages/mobile/src/services/offline-downloader/offline-sync.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-sync.ts
@@ -10,11 +10,11 @@ import {
   accountSelectors,
   cacheTracksSelectors
 } from '@audius/common'
+import { fetchAllFavoritedTracks } from 'app/hooks/useFetchAllFavoritedTracks'
 import moment from 'moment'
 import queue from 'react-native-job-queue'
 
 import type { TrackForDownload } from 'app/components/offline-downloads'
-import { fetchAllFavoritedTrackIds } from 'app/hooks/useFetchAllFavoritedTrackIds'
 import { store } from 'app/store'
 import { getOfflineCollections } from 'app/store/offline-downloads/selectors'
 import { populateCoverArtSizes } from 'app/utils/populateCoverArtSizes'
@@ -80,7 +80,7 @@ const syncFavorites = async () => {
   const currentUserId = getUserId(state as unknown as CommonState)
   if (!currentUserId) return
 
-  const favoritedTrackIds = await fetchAllFavoritedTrackIds(currentUserId)
+  const favoritedTracks = await fetchAllFavoritedTracks(currentUserId)
   const cacheTracks = getTracks(state, {})
 
   const isTrackFavoriteReason = (downloadReason: DownloadReason) =>
@@ -99,15 +99,15 @@ const syncFavorites = async () => {
     .map(([id, track]) => track.track_id)
 
   const oldTrackIds = new Set([...queuedTracks, ...cachedFavoritedTrackIds])
-  const newTrackIds = new Set(favoritedTrackIds.map(({ trackId }) => trackId))
-  const addedTrackIds = [...favoritedTrackIds].filter(
+  const newTrackIds = new Set(favoritedTracks.map(({ trackId }) => trackId))
+  const addedTracks = [...favoritedTracks].filter(
     ({ trackId }) => !oldTrackIds.has(trackId)
   )
   const removedTrackIds = [...oldTrackIds].filter(
     (trackId) => !newTrackIds.has(trackId)
   )
 
-  const tracksForDownload: TrackForDownload[] = addedTrackIds.map(
+  const tracksForDownload: TrackForDownload[] = addedTracks.map(
     (addedTrack) => ({
       trackId: addedTrack.trackId,
       downloadReason: {


### PR DESCRIPTION
### Description

Resolves two issues (mostly):

[C-1646]: Add favorite created_at data to the `offlineDownloads` slice and forces the lineups to sort by either favorite or playlist added timestamp accordingly

[C-1647]: Make sure lineups (collection page & favorites page) allow you to deal with switching back & forth between reachability states. This involved a few things:
* Fix a couple bugs around promises where things were not being awaited properly (missing data in the `offlineDownloads` slice)
* Restructure the `useOfflineCollectionLineup` hook to accept a bit more lineup functionality so that the component itself can forget about conditionally rendering certain things. I think this is ok, but maybe not ideal. Hard to get better without significant code restructuring, but the mental modal here is that components should worry about what data should be loaded up front rather than worry about what it needs to render.
* A useEffect in the hook that will re-trigger fetching the original content when reachability is regained. This importantly will not fetch the data from the network because it presumably is already in the cache. (maybe not even a good thing anymore, but fyi)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

- This impacts lineups a little bit even with the feature flag turned off.
- This has a somewhat weird UX caveat where switching between online & offline lineups seem to yield different `uid`s which makes it seems like you're looking at a totally new list of tracks versus the one that you might have been playing. Audio still does work and you're able to play anything else, but it looks like you're listening to some other queue of tracks. This PR was getting a little crazy, so wanted to draw the line here, but I think a bit more love is needed.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Simulator extensively with a Button to switch reachability state, on device to cursorily test, but I do think substantial more testing is required.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

