### PR TITLE
Fix playlist track removal

### DIFF
--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -651,10 +651,6 @@ function* confirmRemoveTrackFromPlaylist(
         // if it fails, check if the playlist is in a corrupted state and if so fix it before re-attempting to delete track from playlist
         let { blockHash, blockNumber, error } = yield call(
           audiusBackendInstance.deletePlaylistTrack,
-          playlistId,
-          trackId,
-          timestamp,
-          0,
           playlist
         )
         if (error) {

--- a/packages/web/src/components/table/components/OverflowMenuButton.tsx
+++ b/packages/web/src/components/table/components/OverflowMenuButton.tsx
@@ -48,7 +48,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
   const removeMenuItem = {
     text: removeText,
     onClick: () => {
-      if (trackId && index && uid) {
+      if (trackId && index !== undefined && uid) {
         onRemove?.(trackId, index, uid, date?.unix())
       }
     }


### PR DESCRIPTION
### Description
Fix bug with deleting last track of a playlist.

Fix bug with migrating to EntityManager only (no optimizely gating). EM only uses playlist obj doesn't need the other stuff.
https://github.com/AudiusProject/audius-client/commit/843d689fd7e9191a0d2ef481f1f75f9724fb6cf3
### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*
Tested locally successful track removals.
### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

