### PR TITLE
Fix AudiusSDK to not select prod discovery nodes on state environment

### DIFF
--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -13,7 +13,7 @@ import { call, takeLatest, put } from 'typed-redux-saga'
 import { fetchUsers } from 'common/store/cache/users/sagas'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
-import { audiusSdk } from 'services/audius-sdk/audiusSdk'
+import { audiusSdk } from 'services/audius-sdk'
 
 const {
   fetchAudioTransactions,
@@ -23,8 +23,6 @@ const {
   setAudioTransactionsCount
 } = audioTransactionsPageActions
 const { fetchTransactionDetailsSucceeded } = transactionDetailsActions
-
-const { transactions } = audiusSdk.full
 
 const transactionTypeMap: Record<string, TransactionType> = {
   purchase_stripe: TransactionType.PURCHASE,
@@ -109,8 +107,9 @@ function* fetchAudioTransactionsAsync() {
         audiusBackendInstance,
         audiusBackendInstance.signDiscoveryNodeRequest
       ])
+      const sdk = yield* call(audiusSdk)
       const response = yield* call(
-        [transactions, transactions.getAudioTransactionHistory],
+        [sdk, sdk.full.transactions.getAudioTransactionHistory],
         {
           encodedDataMessage: data,
           encodedDataSignature: signature,
@@ -176,8 +175,9 @@ function* fetchTransactionsCount() {
       audiusBackendInstance,
       audiusBackendInstance.signDiscoveryNodeRequest
     ])
+    const sdk = yield* call(audiusSdk)
     const response = yield* call(
-      [transactions, transactions.getAudioTransactionHistoryCount],
+      [sdk, sdk.full.transactions.getAudioTransactionHistoryCount],
       {
         encodedDataMessage: data,
         encodedDataSignature: signature

--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -109,7 +109,10 @@ function* fetchAudioTransactionsAsync() {
       ])
       const sdk = yield* call(audiusSdk)
       const response = yield* call(
-        [sdk, sdk.full.transactions.getAudioTransactionHistory],
+        [
+          sdk.full.transactions,
+          sdk.full.transactions.getAudioTransactionHistory
+        ],
         {
           encodedDataMessage: data,
           encodedDataSignature: signature,
@@ -177,7 +180,10 @@ function* fetchTransactionsCount() {
     ])
     const sdk = yield* call(audiusSdk)
     const response = yield* call(
-      [sdk, sdk.full.transactions.getAudioTransactionHistoryCount],
+      [
+        sdk.full.transactions,
+        sdk.full.transactions.getAudioTransactionHistoryCount
+      ],
       {
         encodedDataMessage: data,
         encodedDataSignature: signature

--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -1,6 +1,112 @@
+import { StringKeys, IntKeys } from '@audius/common'
 import { sdk } from '@audius/sdk'
+import { keccak_256 } from '@noble/hashes/sha3'
+import * as secp from '@noble/secp256k1'
 
-export const audiusSdk = sdk({
-  appName: 'audius-client',
-  ethWeb3Config: {}
-} as any)
+import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
+import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
+
+declare global {
+  interface Window {
+    audiusLibs: any
+    audiusSdk: ReturnType<typeof sdk>
+  }
+}
+
+const { getRemoteVar, waitForRemoteConfig } = remoteConfigInstance
+const getBlockList = (remoteVarKey: StringKeys) => {
+  const list = getRemoteVar(remoteVarKey)
+  if (list) {
+    try {
+      return new Set<string>(list.split(','))
+    } catch (e) {
+      console.error(e)
+      return null
+    }
+  }
+  return null
+}
+const discoveryNodeBlockList = getBlockList(
+  StringKeys.DISCOVERY_NODE_BLOCK_LIST
+)
+let inProgress = false
+const SDK_LOADED_EVENT_NAME = 'AUDIUS_SDK_LOADED'
+
+const initSdk = async () => {
+  inProgress = true
+  await waitForRemoteConfig()
+  const audiusSdk = sdk({
+    appName: 'audius-client',
+    discoveryProviderConfig: {
+      blacklist: discoveryNodeBlockList ?? undefined,
+      reselectTimeout:
+        getRemoteVar(IntKeys.DISCOVERY_PROVIDER_SELECTION_TIMEOUT_MS) ??
+        undefined,
+      selectionRequestTimeout:
+        getRemoteVar(IntKeys.DISCOVERY_NODE_SELECTION_REQUEST_TIMEOUT) ??
+        undefined,
+      selectionRequestRetries:
+        getRemoteVar(IntKeys.DISCOVERY_NODE_SELECTION_REQUEST_RETRIES) ??
+        undefined,
+      unhealthySlotDiffPlays:
+        getRemoteVar(IntKeys.DISCOVERY_NODE_MAX_SLOT_DIFF_PLAYS) ?? undefined,
+      unhealthyBlockDiff:
+        getRemoteVar(IntKeys.DISCOVERY_NODE_MAX_BLOCK_DIFF) ?? undefined
+    },
+    ethContractsConfig: {
+      tokenContractAddress: process.env.REACT_APP_ETH_TOKEN_ADDRESS ?? '',
+      registryAddress: process.env.REACT_APP_ETH_REGISTRY_ADDRESS ?? '',
+      claimDistributionContractAddress:
+        process.env.REACT_APP_CLAIM_DISTRIBUTION_CONTRACT_ADDRESS ?? '',
+      wormholeContractAddress: process.env.REACT_APP_WORMHOLE_ADDRESS ?? ''
+    },
+    ethWeb3Config: {
+      tokenAddress: process.env.REACT_APP_ETH_TOKEN_ADDRESS ?? '',
+      registryAddress: process.env.REACT_APP_ETH_REGISTRY_ADDRESS ?? '',
+      providers: (process.env.REACT_APP_ETH_PROVIDER_URL || '').split(','),
+      ownerWallet: process.env.REACT_APP_ETH_OWNER_WALLET,
+      claimDistributionContractAddress:
+        process.env.REACT_APP_CLAIM_DISTRIBUTION_CONTRACT_ADDRESS ?? '',
+      wormholeContractAddress: process.env.REACT_APP_WORMHOLE_ADDRESS ?? ''
+    },
+    identityServiceConfig: {
+      identityServiceEndpoint: process.env.REACT_APP_IDENTITY_SERVICE!
+    },
+    walletApi: {
+      sign: async (data: string) => {
+        await waitForLibsInit()
+        return await secp.sign(
+          keccak_256(data),
+          window.audiusLibs.hedgehog.getWallet().privateKey,
+          {
+            recovered: true,
+            der: false
+          }
+        )
+      },
+      getSharedSecret: async (publicKey: string | Uint8Array) => {
+        await waitForLibsInit()
+        return secp.getSharedSecret(
+          window.audiusLibs.hedgehog.getWallet().privateKey,
+          publicKey,
+          true
+        )
+      }
+    }
+  })
+  window.audiusSdk = audiusSdk
+  inProgress = false
+  window.dispatchEvent(new CustomEvent(SDK_LOADED_EVENT_NAME))
+  return audiusSdk
+}
+
+export const audiusSdk = async () => {
+  if (inProgress) {
+    await new Promise((resolve) => {
+      window.addEventListener(SDK_LOADED_EVENT_NAME, resolve)
+    })
+  } else if (!window.audiusSdk) {
+    return await initSdk()
+  }
+  return window.audiusSdk
+}

--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -1,9 +1,6 @@
 import { StringKeys, IntKeys } from '@audius/common'
 import { sdk } from '@audius/sdk'
-import { keccak_256 } from '@noble/hashes/sha3'
-import * as secp from '@noble/secp256k1'
 
-import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 
 declare global {
@@ -71,27 +68,6 @@ const initSdk = async () => {
     },
     identityServiceConfig: {
       identityServiceEndpoint: process.env.REACT_APP_IDENTITY_SERVICE!
-    },
-    walletApi: {
-      sign: async (data: string) => {
-        await waitForLibsInit()
-        return await secp.sign(
-          keccak_256(data),
-          window.audiusLibs.hedgehog.getWallet().privateKey,
-          {
-            recovered: true,
-            der: false
-          }
-        )
-      },
-      getSharedSecret: async (publicKey: string | Uint8Array) => {
-        await waitForLibsInit()
-        return secp.getSharedSecret(
-          window.audiusLibs.hedgehog.getWallet().privateKey,
-          publicKey,
-          true
-        )
-      }
     }
   })
   window.audiusSdk = audiusSdk


### PR DESCRIPTION
### Description

Fixes the discovery node selection for SDK on stage to not use prod - worth considering though how to not have both libs and SDK do selection, possibly by reusing components or something.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested to make sure transactions history still works

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

