### PR TITLE
Fix finish page upload title link

### DIFF
--- a/packages/web/src/pages/upload-page/components/FinishPage.js
+++ b/packages/web/src/pages/upload-page/components/FinishPage.js
@@ -131,7 +131,9 @@ class FinishPage extends Component {
       disableActions: true,
       uploading: true,
       showSkeleton: false,
-      onClickTitle: () => {inProgress ? undefined : onContinue()}
+      onClickTitle: () => {
+        return inProgress ? undefined : onContinue()
+      }
     }
 
     const erroredTrackSet = new Set(erroredTracks)

--- a/packages/web/src/pages/upload-page/components/FinishPage.js
+++ b/packages/web/src/pages/upload-page/components/FinishPage.js
@@ -130,7 +130,8 @@ class FinishPage extends Component {
       showArtworkIcon: false,
       disableActions: true,
       uploading: true,
-      showSkeleton: false
+      showSkeleton: false,
+      onClickTitle: () => {inProgress ? undefined : onContinue()}
     }
 
     const erroredTrackSet = new Set(erroredTracks)


### PR DESCRIPTION
### Description
Clicking on title when upload completes throws an error. This change just makes it in line with the view media button.

Link only routes when upload is complete.
### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*
Tested locally against stage for track, playlist, album.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

