### PR TITLE
Secret override for offline mode

### DIFF
--- a/packages/mobile/src/hooks/useIsOfflineModeEnabled.ts
+++ b/packages/mobile/src/hooks/useIsOfflineModeEnabled.ts
@@ -1,11 +1,37 @@
 import { FeatureFlags } from '@audius/common'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useAsync } from 'react-use'
 
 import { useFeatureFlag } from './useRemoteConfig'
 
+const OFFLINE_OVERRIDE_ASYNC_STORAGE_KEY = 'offline_mode_enabled_local_override'
+
 // DO NOT CHECK IN VALUE: true
 const hardCodeOverride = false
+let asyncOverride = false
+
+export const toggleLocalOfflineModeOverride = () => {
+  asyncOverride = !asyncOverride
+  AsyncStorage.setItem(
+    OFFLINE_OVERRIDE_ASYNC_STORAGE_KEY,
+    asyncOverride.toString()
+  )
+  alert(`Offline mode ${asyncOverride ? 'enabled' : 'disabled'}`)
+}
+
+export const useReadOfflineOverride = () =>
+  useAsync(async () => {
+    try {
+      asyncOverride = Boolean(
+        await AsyncStorage.getItem(OFFLINE_OVERRIDE_ASYNC_STORAGE_KEY)
+      )
+    } catch (e) {
+      console.log('error reading local offline mode override')
+    }
+  })
 
 // TODO: remove helpers when feature is shipped
 export const useIsOfflineModeEnabled = () =>
   useFeatureFlag(FeatureFlags.OFFLINE_MODE_ENABLED).isEnabled ||
+  asyncOverride ||
   hardCodeOverride

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -75,7 +75,7 @@ export function* watchPlay() {
   const isOfflineModeEnabled = yield* call(
     getFeatureEnabled,
     FeatureFlags.OFFLINE_MODE_ENABLED
-  ) ?? false
+  ) ?? true
 
   yield* takeLatest(play.type, function* (action: ReturnType<typeof play>) {
     const { uid, trackId, onEnd } = action.payload ?? {}


### PR DESCRIPTION
### Description

Add a secret dev switch to enable offline mode for testing. Required because we can't reach optimizely when we're offline

### Dragons

Is this an obscure enough trigger? We could put it somewhere less discoverable.

### How Has This Been Tested?

On iOS device

