### PR TITLE
Load offline collections properly with the dev override

### DIFF
--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -118,7 +118,7 @@ export const useLoadOfflineTracks = () => {
     dispatch(cacheActions.add(Kind.USERS, cacheUsers, false, true))
     dispatch(loadTracks(lineupTracks))
     dispatch(doneLoadingFromDisk())
-  })
+  }, [isOfflineModeEnabled])
 }
 
 /**


### PR DESCRIPTION
### Description

The dev override load is slightly delayed, so we need to rerun this when it's true.


