### PR TITLE
[C-1083, C-1080] Add offline play count recording

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -275,10 +275,10 @@ export const Audio = () => {
 
     if (position > RECORD_LISTEN_SECONDS && !listenLoggedForTrack) {
       setListenLoggedForTrack(true)
-      if (isOfflineModeEnabled && !isReachable) {
-        queue.addJob<PlayCountWorkerPayload>(PLAY_COUNTER_WORKER, { trackId })
-      } else if (isReachable) {
+      if (isReachable) {
         dispatch(recordListen(trackId))
+      } else if (isOfflineModeEnabled && !isReachable) {
+        queue.addJob<PlayCountWorkerPayload>(PLAY_COUNTER_WORKER, { trackId })
       }
     }
 

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -273,11 +273,7 @@ export const Audio = () => {
     const duration = await TrackPlayer.getDuration()
     const position = await TrackPlayer.getPosition()
 
-    if (
-      position > RECORD_LISTEN_SECONDS &&
-      !listenLoggedForTrack &&
-      isReachable
-    ) {
+    if (position > RECORD_LISTEN_SECONDS && !listenLoggedForTrack) {
       setListenLoggedForTrack(true)
       if (isOfflineModeEnabled && !isReachable) {
         queue.addJob<PlayCountWorkerPayload>(PLAY_COUNTER_WORKER, { trackId })

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -16,6 +16,7 @@ import {
   Genre,
   tracksSocialActions
 } from '@audius/common'
+import queue from 'react-native-job-queue'
 import TrackPlayer, {
   AppKilledPlaybackBehavior,
   Capability,
@@ -33,10 +34,13 @@ import {
   DEFAULT_IMAGE_URL,
   useTrackImage
 } from 'app/components/image/TrackImage'
+import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useOfflineTrackUri } from 'app/hooks/useOfflineTrackUri'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { apiClient } from 'app/services/audius-api-client'
 import { audiusBackendInstance } from 'app/services/audius-backend-instance'
+import type { PlayCountWorkerPayload } from 'app/services/offline-downloader/workers/playCounterWorker'
+import { PLAY_COUNTER_WORKER } from 'app/services/offline-downloader/workers/playCounterWorker'
 
 import { useChromecast } from './GoogleCast'
 
@@ -139,6 +143,7 @@ export const Audio = () => {
   const trackImageSource = useTrackImage(track, trackOwner ?? undefined)
   const currentUserId = useSelector(getUserId)
   const isReachable = useSelector(getIsReachable)
+  const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
   // Queue things
   const queueIndex = useSelector(getIndex)
@@ -274,7 +279,11 @@ export const Audio = () => {
       isReachable
     ) {
       setListenLoggedForTrack(true)
-      dispatch(recordListen(trackId))
+      if (isOfflineModeEnabled && !isReachable) {
+        queue.addJob<PlayCountWorkerPayload>(PLAY_COUNTER_WORKER, { trackId })
+      } else if (isReachable) {
+        dispatch(recordListen(trackId))
+      }
     }
 
     if (!isCasting) {
@@ -291,7 +300,8 @@ export const Audio = () => {
     isReachable,
     listenLoggedForTrack,
     trackId,
-    dispatch
+    dispatch,
+    isOfflineModeEnabled
   ])
 
   useEffect(() => {

--- a/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
@@ -186,7 +186,11 @@ export const DownloadToggle = ({
         <Switch
           value={isCollectionMarkedForDownload}
           onValueChange={handleToggleDownload}
+<<<<<<< HEAD
           disabled={disabled}
+=======
+          disabled={(!collectionId && !isFavoritesDownload) || disabled}
+>>>>>>> e36e24f8c ([C-1083] Add offline play count recording)
         />
       </View>
     </View>

--- a/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
@@ -186,7 +186,7 @@ export const DownloadToggle = ({
         <Switch
           value={isCollectionMarkedForDownload}
           onValueChange={handleToggleDownload}
-          disabled={(!collectionId && !isFavoritesDownload) || disabled}
+          disabled={disabled}
         />
       </View>
     </View>

--- a/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
@@ -186,11 +186,7 @@ export const DownloadToggle = ({
         <Switch
           value={isCollectionMarkedForDownload}
           onValueChange={handleToggleDownload}
-<<<<<<< HEAD
-          disabled={disabled}
-=======
           disabled={(!collectionId && !isFavoritesDownload) || disabled}
->>>>>>> e36e24f8c ([C-1083] Add offline play count recording)
         />
       </View>
     </View>

--- a/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
+++ b/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { accountSelectors, reachabilitySelectors } from '@audius/common'
+import queue from 'react-native-job-queue'
 import { useSelector } from 'react-redux'
 
 import {
@@ -21,6 +22,7 @@ export const OfflineDownloader = () => {
   useReadOfflineOverride()
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
   const [initialized, setInitialized] = useState(false)
+
   useEffect(() => {
     if (!initialized && isOfflineModeEnabled) {
       setInitialized(true)
@@ -41,6 +43,17 @@ export const OfflineDownloader = () => {
       startSyncWorker()
     }
   }, [syncStarted, currentUserId, isDoneLoadingFromDisk, isReachable])
+
+  useEffect(() => {
+    if (!initialized) return
+    const isQueueRunning = queue.isRunning
+
+    if (isReachable && !isQueueRunning) {
+      queue.start()
+    } else if (!isReachable && isQueueRunning) {
+      queue.stop()
+    }
+  }, [initialized, isReachable])
 
   return null
 }

--- a/packages/mobile/src/services/offline-downloader/offline-sync.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-sync.ts
@@ -23,8 +23,6 @@ import { isAvailableForPlay } from 'app/utils/trackUtils'
 
 import { apiClient } from '../audius-api-client'
 
-import type { TrackDownloadWorkerPayload } from './offline-download-queue'
-import { TRACK_DOWNLOAD_WORKER } from './offline-download-queue'
 import {
   batchDownloadTrack,
   batchRemoveTrackDownload,
@@ -35,6 +33,8 @@ import {
   removeCollectionDownload
 } from './offline-downloader'
 import { purgeDownloadedTrack, writeTrackJson } from './offline-storage'
+import type { TrackDownloadWorkerPayload } from './workers/trackDownloadWorker'
+import { TRACK_DOWNLOAD_WORKER } from './workers/trackDownloadWorker'
 
 const { getCollections } = cacheCollectionsSelectors
 const { getTracks } = cacheTracksSelectors

--- a/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
@@ -1,0 +1,17 @@
+import { tracksSocialActions } from '@audius/common'
+import { Worker } from 'react-native-job-queue'
+
+import { store } from 'app/store'
+
+const { recordListen } = tracksSocialActions
+
+export const PLAY_COUNTER_WORKER = 'play_counter_worker'
+
+export type PlayCountWorkerPayload = { trackId: number }
+
+const countPlay = async (payload: PlayCountWorkerPayload) => {
+  const { trackId } = payload
+  store.dispatch(recordListen(trackId))
+}
+
+export const playCounterWorker = new Worker(PLAY_COUNTER_WORKER, countPlay)

--- a/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
@@ -1,0 +1,34 @@
+import type { CancellablePromise } from 'react-native-job-queue'
+import { Worker } from 'react-native-job-queue'
+
+import type { TrackForDownload } from 'app/components/offline-downloads'
+import { store } from 'app/store'
+import {
+  errorDownload,
+  removeDownload
+} from 'app/store/offline-downloads/slice'
+
+import { batchRemoveTrackDownload, downloadTrack } from '../offline-downloader'
+
+export const TRACK_DOWNLOAD_WORKER = 'track_download_worker'
+export type TrackDownloadWorkerPayload = TrackForDownload
+
+const onFailure = ({ payload }: { payload: TrackForDownload }) => {
+  store.dispatch(errorDownload(payload.trackId.toString()))
+}
+
+const executor = (payload: TrackDownloadWorkerPayload) => {
+  const promise: CancellablePromise<void> = downloadTrack(payload)
+  promise.rn_job_queue_cancel = () => {
+    promise.finally(() => {
+      store.dispatch(removeDownload(payload.trackId.toString()))
+      batchRemoveTrackDownload([payload])
+    })
+  }
+  return promise
+}
+
+export const trackDownloadWorker = new Worker(TRACK_DOWNLOAD_WORKER, executor, {
+  onFailure,
+  concurrency: 10
+})


### PR DESCRIPTION
### Description

Adds offline play count recording using react-native-queue
Additional changes: 
- Divides out worker types into separate files
- Adds helper for reseting workers
- starts/stops the queue based on reachability status

