### PR TITLE
[C-1721] Fix case where cached track is incomplete

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -803,7 +803,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 60edbf7e11d91ae4c751d26c200dfd037099abe0
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   GCDWebServer: 2c156a56c8226e2d5c0c3f208a3621ccffbe3ce4
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
   google-cast-sdk-no-bluetooth: 5313156110d6e71fa336f6d742f1ee641e91fdca
   GoogleAppMeasurement: ae033c3aad67e68294369373056b4d74cc8ae0d6
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
@@ -814,7 +814,7 @@ SPEC CHECKSUMS:
   Permission-Notifications: 2662b6885535a98892b8e48da04b74fc898d70f8
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
-  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
+  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
   RCTRequired: 405e24508a0feed1771d48caebb85c581db53122
   RCTTypeSafety: 0654998ea6afd3dccecbf6bb379d7c10d1361a72
   React: cce3ac45191e66a78c79234582cbfe322e4dfd00
@@ -888,4 +888,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 86c7e909196d7920299e68babc12fcaf4882d3e8
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -58,7 +58,7 @@ export const TrackScreen = () => {
 
   const cachedTrack = useSelector((state) => getTrack(state, params))
 
-  const track = cachedTrack ?? searchTrack
+  const track = cachedTrack?.track_id ? cachedTrack : searchTrack
 
   const cachedUser = useSelector((state) =>
     getUser(state, { id: track?.owner_id })


### PR DESCRIPTION
### Description

Fixes interesting case where a track object exists, but doesn't have an id, or any real metadata. this happens due to a design choice to optimistically set a track's remix values before fetch has completed, resulting in a track object of `{_remixes: [..], _remixCount: 0}` for a few ticks before the full object comes in. This caused a bug on mobile side where we think we have a full track object and try to do `track?.track_id.toString()` The fix chosen in this pr is to continue using the "searchTrack" object before the fetchedTrack comes back with everything, using the existence of an id as that indicator.

@raymondjacobson i know you have context on this code, how do you feel about it? i think we might want to include the track_id in this cache change?
