### PR TITLE
Fix api-client types by fixing @audius/common absolute imports

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1,6 +1,6 @@
 import type { AudiusLibs } from '@audius/sdk/dist/native-libs'
 
-import { ID, TimeRange, StemTrackMetadata, Chain } from '../../models'
+import { ID, TimeRange, StemTrackMetadata } from '../../models'
 import { SearchKind } from '../../store/pages/search-results/types'
 import { decodeHashId, encodeHashId } from '../../utils/hashIds'
 import { Nullable, removeNullable } from '../../utils/typeUtils'
@@ -292,7 +292,7 @@ type GetRemixingArgs = {
 }
 
 type GetSearchArgs = {
-  currentUserId: ID
+  currentUserId: Nullable<ID>
   query: string
   kind?: SearchKind
   limit?: number
@@ -425,10 +425,7 @@ export type GetTipsArgs = {
 export type GetPremiumContentSignaturesArgs = {
   userId: ID
   trackMap: {
-    [id: ID]: {
-      chain: Chain
-      tokenIds?: string[]
-    }
+    [id: ID]: string[]
   }
 }
 

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1,20 +1,15 @@
 import type { AudiusLibs } from '@audius/sdk/dist/native-libs'
 
-import { ID, TimeRange, StemTrackMetadata, Chain } from 'models'
-import { AuthHeaders } from 'services/audius-backend'
-import {
-  IntKeys,
-  StringKeys,
-  RemoteConfigInstance
-} from 'services/remote-config'
-import { SearchKind } from 'store/pages/search-results/types'
-import { decodeHashId, encodeHashId } from 'utils/hashIds'
-import { Nullable, removeNullable } from 'utils/typeUtils'
-
+import { ID, TimeRange, StemTrackMetadata, Chain } from '../../models'
+import { SearchKind } from '../../store/pages/search-results/types'
+import { decodeHashId, encodeHashId } from '../../utils/hashIds'
+import { Nullable, removeNullable } from '../../utils/typeUtils'
+import { AuthHeaders } from '../audius-backend'
 import type { AudiusBackend } from '../audius-backend'
 import { getEagerDiscprov } from '../audius-backend/eagerLoadUtils'
 import { Env } from '../env'
 import { LocalStorage } from '../local-storage'
+import { IntKeys, StringKeys, RemoteConfigInstance } from '../remote-config'
 
 import * as adapter from './ResponseAdapter'
 import { processSearchResults } from './helper'

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -10,8 +10,8 @@ import {
   UserTrackMetadata,
   UserMetadata,
   StringWei
-} from 'models'
-import { removeNullable, decodeHashId } from 'utils'
+} from '../../models'
+import { removeNullable, decodeHashId } from '../../utils'
 
 import {
   APIActivity,

--- a/packages/common/src/services/local-storage/LocalStorage.ts
+++ b/packages/common/src/services/local-storage/LocalStorage.ts
@@ -1,7 +1,7 @@
 import { CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY } from '@audius/sdk/dist/core'
 
-import { User } from 'models/User'
-import { Nullable } from 'utils'
+import { User } from '../../models'
+import { Nullable } from '../../utils'
 
 // TODO: the following should come from @audius/libs/dist/core when
 // discoveryProvider/constants is migrated to typescript.

--- a/packages/common/src/utils/hashIds.ts
+++ b/packages/common/src/utils/hashIds.ts
@@ -1,6 +1,6 @@
 import Hashids from 'hashids'
 
-import { Nullable } from 'utils/typeUtils'
+import { Nullable } from './typeUtils'
 
 const HASH_SALT = 'azowernasdfoia'
 const MIN_LENGTH = 5

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -170,7 +170,7 @@ function* updateNewPremiumContentSignatures({
  * Halts if not all nfts have been fetched yet. Similarly, does not proceed if no tracks are in the cache yet.
  * Skips tracks whose signatures have already been previously obtained.
  */
-function* updateNFTGatedTrackAccess(
+async function* updateNFTGatedTrackAccess(
   action:
     | ReturnType<typeof ethNFTsFetched>
     | ReturnType<typeof solNFTsFetched>
@@ -239,6 +239,7 @@ function* updateNFTGatedTrackAccess(
   // request premium content signatures for the relevant nft-gated tracks
   // which the client believes the user should have access to
   const apiClient = yield* getContext('apiClient')
+
   const premiumContentSignatureMap = yield* call(
     [apiClient, apiClient.getPremiumContentSignatures],
     {

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -170,7 +170,7 @@ function* updateNewPremiumContentSignatures({
  * Halts if not all nfts have been fetched yet. Similarly, does not proceed if no tracks are in the cache yet.
  * Skips tracks whose signatures have already been previously obtained.
  */
-async function* updateNFTGatedTrackAccess(
+function* updateNFTGatedTrackAccess(
   action:
     | ReturnType<typeof ethNFTsFetched>
     | ReturnType<typeof solNFTsFetched>

--- a/packages/web/src/common/store/search-bar/sagas.ts
+++ b/packages/web/src/common/store/search-bar/sagas.ts
@@ -9,7 +9,7 @@ import { getSearch } from './selectors'
 
 const getUserId = accountSelectors.getUserId
 
-export async function* getSearchResults(searchText: string) {
+export function* getSearchResults(searchText: string) {
   yield* waitForRead()
 
   const apiClient = yield* getContext('apiClient')

--- a/packages/web/src/common/store/search-bar/sagas.ts
+++ b/packages/web/src/common/store/search-bar/sagas.ts
@@ -9,7 +9,7 @@ import { getSearch } from './selectors'
 
 const getUserId = accountSelectors.getUserId
 
-export function* getSearchResults(searchText: string) {
+export async function* getSearchResults(searchText: string) {
   yield* waitForRead()
 
   const apiClient = yield* getContext('apiClient')


### PR DESCRIPTION
### Description

Fixes issue where ApiClient consumers were not getting the correct input/return types, meaning things silently became type "any", yikes. When going to definition however, the types are correct, ie @audius/common is internally consistent, but its build is not. nice catch @piazzatron 

Issue ultimately due to absolute imports in @audius/common. This for whatever reason silently breaks the build with no warning, propagating "any" types to consumers.

- Fixed absolute imports
- Fixed emergent type bugs in @audius/web-client now that AudiusApi actually typed
