### PR TITLE
[C-1699] Add analytics for Rate CTA drawer

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -283,7 +283,12 @@ export enum Name {
   // Buy Audio Recovery
   BUY_AUDIO_RECOVERY_OPENED = 'Buy Audio Recovery: Opened',
   BUY_AUDIO_RECOVERY_SUCCESS = 'Buy Audio Recovery: Success',
-  BUY_AUDIO_RECOVERY_FAILURE = 'Buy Audio Recovery: Failure'
+  BUY_AUDIO_RECOVERY_FAILURE = 'Buy Audio Recovery: Failure',
+
+  // Rate & Review CTA
+  RATE_CTA_DISPLAYED = 'Rate CTA: Displayed',
+  RATE_CTA_RESPONSE_YES = 'Rate CTA: User Responded Yes',
+  RATE_CTA_RESPONSE_NO = 'Rate CTA: User Responded No'
 }
 
 type PageView = {
@@ -1342,6 +1347,18 @@ type BuyAudioRecoveryFailure = {
   error: string
 }
 
+type RateCtaDisplayed = {
+  eventName: Name.RATE_CTA_DISPLAYED
+}
+
+type RateCtaResponseNo = {
+  eventName: Name.RATE_CTA_RESPONSE_NO
+}
+
+type RateCtaResponseYes = {
+  eventName: Name.RATE_CTA_RESPONSE_YES
+}
+
 type RewardsClaimStartCognitoFlow = {
   eventName: Name.REWARDS_CLAIM_START_COGNITO_FLOW
   handle: string | null
@@ -1532,5 +1549,8 @@ export type AllTrackingEvents =
   | BuyAudioRecoveryOpened
   | BuyAudioRecoverySuccess
   | BuyAudioRecoveryFailure
+  | RateCtaDisplayed
+  | RateCtaResponseNo
+  | RateCtaResponseYes
   | RewardsClaimStartCognitoFlow
   | RewardsClaimFinishCognitoFlow

--- a/packages/mobile/src/components/rate-cta-drawer/RateCtaDrawer.tsx
+++ b/packages/mobile/src/components/rate-cta-drawer/RateCtaDrawer.tsx
@@ -1,3 +1,4 @@
+import { Name } from '@audius/common'
 import { View } from 'react-native'
 import InAppReview from 'react-native-in-app-review'
 
@@ -7,6 +8,7 @@ import IconThumbsUp from 'app/assets/images/iconThumbsUp.svg'
 import { Button, Text } from 'app/components/core'
 import { NativeDrawer } from 'app/components/drawer'
 import { useAsyncStorage } from 'app/hooks/useAsyncStorage'
+import { make, track } from 'app/services/analytics'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -76,6 +78,7 @@ export const RateCtaDrawer = () => {
       InAppReview.RequestInAppReview()
         .then((hasFlowFinishedSuccessfully) => {
           setUserRateResponse('YES')
+          track(make({ eventName: Name.RATE_CTA_RESPONSE_YES }))
         })
         .catch((error) => {
           console.log(error)
@@ -84,6 +87,7 @@ export const RateCtaDrawer = () => {
   }
 
   const handleReviewDeny = () => {
+    track(make({ eventName: Name.RATE_CTA_RESPONSE_NO }))
     setUserRateResponse('NO')
   }
 

--- a/packages/mobile/src/store/rate-cta/sagas.ts
+++ b/packages/mobile/src/store/rate-cta/sagas.ts
@@ -1,4 +1,6 @@
+import { Name } from '@audius/common'
 import { waitForWrite } from 'audius-client/src/utils/sagaHelpers'
+import { make } from 'common/store/analytics/actions'
 import { call, put, takeEvery } from 'typed-redux-saga'
 
 import { setVisibility } from '../drawers/slice'
@@ -8,6 +10,7 @@ import { requestReview } from './slice'
 function* displayRequestReviewDrawer() {
   yield* call(waitForWrite)
   yield put(setVisibility({ drawer: 'RateCallToAction', visible: true }))
+  yield* put(make(Name.RATE_CTA_DISPLAYED, {}))
 }
 
 function* watchRequestReview() {


### PR DESCRIPTION
### Description
Adding analytics for the Rate CTA drawer on display, no response, and yes response

### Dragons

N/A

### How Has This Been Tested?

Testing now, assuming it works though

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

