### PR TITLE
Fix tooltip on completed upload page C-1516 

### DIFF
--- a/packages/web/src/pages/upload-page/components/ShareBanner.module.css
+++ b/packages/web/src/pages/upload-page/components/ShareBanner.module.css
@@ -127,15 +127,6 @@
   text-align: center;
 }
 
-.toast {
-  top: 16px !important;
-  left: 240px !important;
-  right: 0px !important;
-  display: flex;
-  justify-content: center;
-  padding: 0px;
-}
-
 .buttonContainer {
   display: flex;
   flex-wrap: wrap;

--- a/packages/web/src/pages/upload-page/components/ShareBanner.tsx
+++ b/packages/web/src/pages/upload-page/components/ShareBanner.tsx
@@ -233,10 +233,8 @@ const ShareBanner = ({ isHidden, type, upload, user }: ShareBannerProps) => {
       </div>
       <div className={styles.copyLinkWrapper} onClick={onCopy}>
         <Toast
-          useCaret={false}
-          mount={MountPlacement.BODY}
+          mount={MountPlacement.PARENT}
           placement={ComponentPlacement.TOP}
-          overlayClassName={styles.toast}
           delay={TOAST_DELAY}
           text={messages.copiedToClipboard}
         >


### PR DESCRIPTION
### Description

Now:
<img width="1166" alt="Screen Shot 2022-12-27 at 7 52 58 PM" src="https://user-images.githubusercontent.com/36916764/209754698-67fbceb7-e850-4780-9e1d-c6461b43282b.png">

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

