### PR TITLE
[C-1738] Fix mobile crash

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -2073,6 +2073,12 @@
         "@walletconnect/window-getters": "^1.0.0"
       }
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -2475,6 +2481,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -2690,6 +2705,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "cids": {
       "version": "0.7.5",
@@ -3968,6 +3989,15 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -4016,6 +4046,15 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^4.0.2"
       }
     },
     "fix-hmr": {
@@ -4508,6 +4547,15 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -4515,6 +4563,12 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -4549,6 +4603,12 @@
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA=="
     },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -4570,6 +4630,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -4798,6 +4867,15 @@
       "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
       "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4910,6 +4988,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -5129,6 +5217,12 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "no-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -5222,6 +5316,16 @@
         "wrappy": "1"
       }
     },
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -5235,6 +5339,12 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -5311,6 +5421,163 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "patch-package": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "path-exists": {
       "version": "4.0.0",
@@ -6035,6 +6302,12 @@
         }
       }
     },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6411,6 +6684,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "toidentifier": {
       "version": "1.0.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,7 @@
     "build": "rollup -c",
     "lint": "eslint --cache src",
     "lint:fix": "npm run lint -- --fix",
-    "postinstall": "rm -rf node_modules/react",
+    "postinstall": "rm -rf node_modules/react && patch-package",
     "start": "rollup -c -w",
     "typecheck": "tsc --noEmit"
   },
@@ -55,6 +55,7 @@
     "@types/redux-saga": "0.10.5",
     "eslint": "8.19.0",
     "eslint-config-audius": "1.5.2",
+    "patch-package": "6.4.7",
     "react": "17.0.2",
     "rollup": "2.76.0",
     "rollup-plugin-dts": "4.2.2",

--- a/packages/common/patches/@noble+ed25519+1.7.1.patch
+++ b/packages/common/patches/@noble+ed25519+1.7.1.patch
@@ -1,0 +1,909 @@
+diff --git a/node_modules/@noble/ed25519/lib/react-native.js b/node_modules/@noble/ed25519/lib/react-native.js
+new file mode 100644
+index 0000000..285a95b
+--- /dev/null
++++ b/node_modules/@noble/ed25519/lib/react-native.js
+@@ -0,0 +1,891 @@
++// This patch is required for compatibility with BigInteger.js in react-native
++// It can be removed when react-native is upgraded to 0.70
++
++"use strict";
++/*! noble-ed25519 - MIT License (c) 2019 Paul Miller (paulmillr.com) */
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.utils = exports.curve25519 = exports.getSharedSecret = exports.sync = exports.verify = exports.sign = exports.getPublicKey = exports.Signature = exports.Point = exports.RistrettoPoint = exports.ExtendedPoint = exports.CURVE = void 0;
++const nodeCrypto = require("crypto");
++const _0n = BigInt(0);
++const _1n = BigInt(1);
++const _2n = BigInt(2);
++const CU_O = BigInt('7237005577332262213973186563042994240857116359379907606001950938285454250989');
++const CURVE = Object.freeze({
++    a: BigInt(-1),
++    d: BigInt('37095705934669439343138083508754565189542113879843219016388785533085940283555'),
++    P: BigInt('57896044618658097711785492504343953926634992332820282019728792003956564819949'),
++    l: CU_O,
++    n: CU_O,
++    h: BigInt(8),
++    Gx: BigInt('15112221349535400772501151409588531511454012693041857206046113283949847762202'),
++    Gy: BigInt('46316835694926478169428394003475163141307993866256225615783033603165251855960'),
++});
++exports.CURVE = CURVE;
++const POW_2_256 = BigInt('10000000000000000000000000000000000000000000000000000000000000000', 16);
++const SQRT_M1 = BigInt('19681161376707505956807079304988542015446066515923890162744021073123829784752');
++const SQRT_D = BigInt('6853475219497561581579357271197624642482790079785650197046958215289687604742');
++const SQRT_AD_MINUS_ONE = BigInt('25063068953384623474111414158702152701244531502492656460079210482610430750235');
++const INVSQRT_A_MINUS_D = BigInt('54469307008909316920995813868745141605393597292927456921205312896311721017578');
++const ONE_MINUS_D_SQ = BigInt('1159843021668779879193775521855586647937357759715417654439879720876111806838');
++const D_MINUS_ONE_SQ = BigInt('40440834346308536858101042469323190826248399146238708352240133220865137265952');
++class ExtendedPoint {
++    constructor(x, y, z, t) {
++        this.x = x;
++        this.y = y;
++        this.z = z;
++        this.t = t;
++    }
++    static fromAffine(p) {
++        if (!(p instanceof Point)) {
++            throw new TypeError('ExtendedPoint#fromAffine: expected Point');
++        }
++        if (p.equals(Point.ZERO))
++            return ExtendedPoint.ZERO;
++        return new ExtendedPoint(p.x, p.y, _1n, mod(p.x * p.y));
++    }
++    static toAffineBatch(points) {
++        const toInv = invertBatch(points.map((p) => p.z));
++        return points.map((p, i) => p.toAffine(toInv[i]));
++    }
++    static normalizeZ(points) {
++        return this.toAffineBatch(points).map(this.fromAffine);
++    }
++    equals(other) {
++        assertExtPoint(other);
++        const { x: X1, y: Y1, z: Z1 } = this;
++        const { x: X2, y: Y2, z: Z2 } = other;
++        const X1Z2 = mod(X1 * Z2);
++        const X2Z1 = mod(X2 * Z1);
++        const Y1Z2 = mod(Y1 * Z2);
++        const Y2Z1 = mod(Y2 * Z1);
++        return X1Z2 === X2Z1 && Y1Z2 === Y2Z1;
++    }
++    negate() {
++        return new ExtendedPoint(mod(-this.x), this.y, this.z, mod(-this.t));
++    }
++    double() {
++        const { x: X1, y: Y1, z: Z1 } = this;
++        const { a } = CURVE;
++        const A = mod(X1 * X1);
++        const B = mod(Y1 * Y1);
++        const C = mod(_2n * mod(Z1 * Z1));
++        const D = mod(a * A);
++        const x1y1 = X1 + Y1;
++        const E = mod(mod(x1y1 * x1y1) - A - B);
++        const G = D + B;
++        const F = G - C;
++        const H = D - B;
++        const X3 = mod(E * F);
++        const Y3 = mod(G * H);
++        const T3 = mod(E * H);
++        const Z3 = mod(F * G);
++        return new ExtendedPoint(X3, Y3, Z3, T3);
++    }
++    add(other) {
++        assertExtPoint(other);
++        const { x: X1, y: Y1, z: Z1, t: T1 } = this;
++        const { x: X2, y: Y2, z: Z2, t: T2 } = other;
++        const A = mod((Y1 - X1) * (Y2 + X2));
++        const B = mod((Y1 + X1) * (Y2 - X2));
++        const F = mod(B - A);
++        if (F === _0n)
++            return this.double();
++        const C = mod(Z1 * _2n * T2);
++        const D = mod(T1 * _2n * Z2);
++        const E = D + C;
++        const G = B + A;
++        const H = D - C;
++        const X3 = mod(E * F);
++        const Y3 = mod(G * H);
++        const T3 = mod(E * H);
++        const Z3 = mod(F * G);
++        return new ExtendedPoint(X3, Y3, Z3, T3);
++    }
++    subtract(other) {
++        return this.add(other.negate());
++    }
++    precomputeWindow(W) {
++        const windows = 1 + 256 / W;
++        const points = [];
++        let p = this;
++        let base = p;
++        for (let window = 0; window < windows; window++) {
++            base = p;
++            points.push(base);
++            for (let i = 1; i < 2 ** (W - 1); i++) {
++                base = base.add(p);
++                points.push(base);
++            }
++            p = base.double();
++        }
++        return points;
++    }
++    wNAF(n, affinePoint) {
++        if (!affinePoint && this.equals(ExtendedPoint.BASE))
++            affinePoint = Point.BASE;
++        const W = (affinePoint && affinePoint._WINDOW_SIZE) || 1;
++        if (256 % W) {
++            throw new Error('Point#wNAF: Invalid precomputation window, must be power of 2');
++        }
++        let precomputes = affinePoint && pointPrecomputes.get(affinePoint);
++        if (!precomputes) {
++            precomputes = this.precomputeWindow(W);
++            if (affinePoint && W !== 1) {
++                precomputes = ExtendedPoint.normalizeZ(precomputes);
++                pointPrecomputes.set(affinePoint, precomputes);
++            }
++        }
++        let p = ExtendedPoint.ZERO;
++        let f = ExtendedPoint.ZERO;
++        const windows = 1 + 256 / W;
++        const windowSize = 2 ** (W - 1);
++        const mask = BigInt(2 ** W - 1);
++        const maxNumber = 2 ** W;
++        const shiftBy = BigInt(W);
++        for (let window = 0; window < windows; window++) {
++            const offset = window * windowSize;
++            let wbits = Number(n & mask);
++            n >>= shiftBy;
++            if (wbits > windowSize) {
++                wbits -= maxNumber;
++                n += _1n;
++            }
++            if (wbits === 0) {
++                let pr = precomputes[offset];
++                if (window % 2)
++                    pr = pr.negate();
++                f = f.add(pr);
++            }
++            else {
++                let cached = precomputes[offset + Math.abs(wbits) - 1];
++                if (wbits < 0)
++                    cached = cached.negate();
++                p = p.add(cached);
++            }
++        }
++        return ExtendedPoint.normalizeZ([p, f])[0];
++    }
++    multiply(scalar, affinePoint) {
++        return this.wNAF(normalizeScalar(scalar, CURVE.l), affinePoint);
++    }
++    multiplyUnsafe(scalar) {
++        let n = normalizeScalar(scalar, CURVE.l, false);
++        const G = ExtendedPoint.BASE;
++        const P0 = ExtendedPoint.ZERO;
++        if (n === _0n)
++            return P0;
++        if (this.equals(P0) || n === _1n)
++            return this;
++        if (this.equals(G))
++            return this.wNAF(n);
++        let p = P0;
++        let d = this;
++        while (n > _0n) {
++            if (n & _1n)
++                p = p.add(d);
++            d = d.double();
++            n >>= _1n;
++        }
++        return p;
++    }
++    isSmallOrder() {
++        return this.multiplyUnsafe(CURVE.h).equals(ExtendedPoint.ZERO);
++    }
++    isTorsionFree() {
++        return this.multiplyUnsafe(CURVE.l).equals(ExtendedPoint.ZERO);
++    }
++    toAffine(invZ = invert(this.z)) {
++        const { x, y, z } = this;
++        const ax = mod(x * invZ);
++        const ay = mod(y * invZ);
++        const zz = mod(z * invZ);
++        if (zz !== _1n)
++            throw new Error('invZ was invalid');
++        return new Point(ax, ay);
++    }
++    fromRistrettoBytes() {
++        legacyRist();
++    }
++    toRistrettoBytes() {
++        legacyRist();
++    }
++    fromRistrettoHash() {
++        legacyRist();
++    }
++}
++exports.ExtendedPoint = ExtendedPoint;
++ExtendedPoint.BASE = new ExtendedPoint(CURVE.Gx, CURVE.Gy, _1n, mod(CURVE.Gx * CURVE.Gy));
++ExtendedPoint.ZERO = new ExtendedPoint(_0n, _1n, _1n, _0n);
++function assertExtPoint(other) {
++    if (!(other instanceof ExtendedPoint))
++        throw new TypeError('ExtendedPoint expected');
++}
++function assertRstPoint(other) {
++    if (!(other instanceof RistrettoPoint))
++        throw new TypeError('RistrettoPoint expected');
++}
++function legacyRist() {
++    throw new Error('Legacy method: switch to RistrettoPoint');
++}
++class RistrettoPoint {
++    constructor(ep) {
++        this.ep = ep;
++    }
++    static calcElligatorRistrettoMap(r0) {
++        const { d } = CURVE;
++        const r = mod(SQRT_M1 * r0 * r0);
++        const Ns = mod((r + _1n) * ONE_MINUS_D_SQ);
++        let c = BigInt(-1);
++        const D = mod((c - d * r) * mod(r + d));
++        let { isValid: Ns_D_is_sq, value: s } = uvRatio(Ns, D);
++        let s_ = mod(s * r0);
++        if (!edIsNegative(s_))
++            s_ = mod(-s_);
++        if (!Ns_D_is_sq)
++            s = s_;
++        if (!Ns_D_is_sq)
++            c = r;
++        const Nt = mod(c * (r - _1n) * D_MINUS_ONE_SQ - D);
++        const s2 = s * s;
++        const W0 = mod((s + s) * D);
++        const W1 = mod(Nt * SQRT_AD_MINUS_ONE);
++        const W2 = mod(_1n - s2);
++        const W3 = mod(_1n + s2);
++        return new ExtendedPoint(mod(W0 * W3), mod(W2 * W1), mod(W1 * W3), mod(W0 * W2));
++    }
++    static hashToCurve(hex) {
++        hex = ensureBytes(hex, 64);
++        const r1 = bytes255ToNumberLE(hex.slice(0, 32));
++        const R1 = this.calcElligatorRistrettoMap(r1);
++        const r2 = bytes255ToNumberLE(hex.slice(32, 64));
++        const R2 = this.calcElligatorRistrettoMap(r2);
++        return new RistrettoPoint(R1.add(R2));
++    }
++    static fromHex(hex) {
++        hex = ensureBytes(hex, 32);
++        const { a, d } = CURVE;
++        const emsg = 'RistrettoPoint.fromHex: the hex is not valid encoding of RistrettoPoint';
++        const s = bytes255ToNumberLE(hex);
++        if (!equalBytes(numberTo32BytesLE(s), hex) || edIsNegative(s))
++            throw new Error(emsg);
++        const s2 = mod(s * s);
++        const u1 = mod(_1n + a * s2);
++        const u2 = mod(_1n - a * s2);
++        const u1_2 = mod(u1 * u1);
++        const u2_2 = mod(u2 * u2);
++        const v = mod(a * d * u1_2 - u2_2);
++        const { isValid, value: I } = invertSqrt(mod(v * u2_2));
++        const Dx = mod(I * u2);
++        const Dy = mod(I * Dx * v);
++        let x = mod((s + s) * Dx);
++        if (edIsNegative(x))
++            x = mod(-x);
++        const y = mod(u1 * Dy);
++        const t = mod(x * y);
++        if (!isValid || edIsNegative(t) || y === _0n)
++            throw new Error(emsg);
++        return new RistrettoPoint(new ExtendedPoint(x, y, _1n, t));
++    }
++    toRawBytes() {
++        let { x, y, z, t } = this.ep;
++        const u1 = mod(mod(z + y) * mod(z - y));
++        const u2 = mod(x * y);
++        const u2sq = mod(u2 * u2);
++        const { value: invsqrt } = invertSqrt(mod(u1 * u2sq));
++        const D1 = mod(invsqrt * u1);
++        const D2 = mod(invsqrt * u2);
++        const zInv = mod(D1 * D2 * t);
++        let D;
++        if (edIsNegative(t * zInv)) {
++            let _x = mod(y * SQRT_M1);
++            let _y = mod(x * SQRT_M1);
++            x = _x;
++            y = _y;
++            D = mod(D1 * INVSQRT_A_MINUS_D);
++        }
++        else {
++            D = D2;
++        }
++        if (edIsNegative(x * zInv))
++            y = mod(-y);
++        let s = mod((z - y) * D);
++        if (edIsNegative(s))
++            s = mod(-s);
++        return numberTo32BytesLE(s);
++    }
++    toHex() {
++        return bytesToHex(this.toRawBytes());
++    }
++    toString() {
++        return this.toHex();
++    }
++    equals(other) {
++        assertRstPoint(other);
++        const a = this.ep;
++        const b = other.ep;
++        const one = mod(a.x * b.y) === mod(a.y * b.x);
++        const two = mod(a.y * b.y) === mod(a.x * b.x);
++        return one || two;
++    }
++    add(other) {
++        assertRstPoint(other);
++        return new RistrettoPoint(this.ep.add(other.ep));
++    }
++    subtract(other) {
++        assertRstPoint(other);
++        return new RistrettoPoint(this.ep.subtract(other.ep));
++    }
++    multiply(scalar) {
++        return new RistrettoPoint(this.ep.multiply(scalar));
++    }
++    multiplyUnsafe(scalar) {
++        return new RistrettoPoint(this.ep.multiplyUnsafe(scalar));
++    }
++}
++exports.RistrettoPoint = RistrettoPoint;
++RistrettoPoint.BASE = new RistrettoPoint(ExtendedPoint.BASE);
++RistrettoPoint.ZERO = new RistrettoPoint(ExtendedPoint.ZERO);
++const pointPrecomputes = new WeakMap();
++class Point {
++    constructor(x, y) {
++        this.x = x;
++        this.y = y;
++    }
++    _setWindowSize(windowSize) {
++        this._WINDOW_SIZE = windowSize;
++        pointPrecomputes.delete(this);
++    }
++    static fromHex(hex, strict = true) {
++        const { d, P } = CURVE;
++        hex = ensureBytes(hex, 32);
++        const normed = hex.slice();
++        normed[31] = hex[31] & ~0x80;
++        const y = bytesToNumberLE(normed);
++        if (strict && y >= P)
++            throw new Error('Expected 0 < hex < P');
++        if (!strict && y >= POW_2_256)
++            throw new Error('Expected 0 < hex < 2**256');
++        const y2 = mod(y * y);
++        const u = mod(y2 - _1n);
++        const v = mod(d * y2 + _1n);
++        let { isValid, value: x } = uvRatio(u, v);
++        if (!isValid)
++            throw new Error('Point.fromHex: invalid y coordinate');
++        const isXOdd = (x & _1n) === _1n;
++        const isLastByteOdd = (hex[31] & 0x80) !== 0;
++        if (isLastByteOdd !== isXOdd) {
++            x = mod(-x);
++        }
++        return new Point(x, y);
++    }
++    static async fromPrivateKey(privateKey) {
++        return (await getExtendedPublicKey(privateKey)).point;
++    }
++    toRawBytes() {
++        const bytes = numberTo32BytesLE(this.y);
++        bytes[31] |= this.x & _1n ? 0x80 : 0;
++        return bytes;
++    }
++    toHex() {
++        return bytesToHex(this.toRawBytes());
++    }
++    toX25519() {
++        const { y } = this;
++        const u = mod((_1n + y) * invert(_1n - y));
++        return numberTo32BytesLE(u);
++    }
++    isTorsionFree() {
++        return ExtendedPoint.fromAffine(this).isTorsionFree();
++    }
++    equals(other) {
++        return this.x === other.x && this.y === other.y;
++    }
++    negate() {
++        return new Point(mod(-this.x), this.y);
++    }
++    add(other) {
++        return ExtendedPoint.fromAffine(this).add(ExtendedPoint.fromAffine(other)).toAffine();
++    }
++    subtract(other) {
++        return this.add(other.negate());
++    }
++    multiply(scalar) {
++        return ExtendedPoint.fromAffine(this).multiply(scalar, this).toAffine();
++    }
++}
++exports.Point = Point;
++Point.BASE = new Point(CURVE.Gx, CURVE.Gy);
++Point.ZERO = new Point(_0n, _1n);
++class Signature {
++    constructor(r, s) {
++        this.r = r;
++        this.s = s;
++        this.assertValidity();
++    }
++    static fromHex(hex) {
++        const bytes = ensureBytes(hex, 64);
++        const r = Point.fromHex(bytes.slice(0, 32), false);
++        const s = bytesToNumberLE(bytes.slice(32, 64));
++        return new Signature(r, s);
++    }
++    assertValidity() {
++        const { r, s } = this;
++        if (!(r instanceof Point))
++            throw new Error('Expected Point instance');
++        normalizeScalar(s, CURVE.l, false);
++        return this;
++    }
++    toRawBytes() {
++        const u8 = new Uint8Array(64);
++        u8.set(this.r.toRawBytes());
++        u8.set(numberTo32BytesLE(this.s), 32);
++        return u8;
++    }
++    toHex() {
++        return bytesToHex(this.toRawBytes());
++    }
++}
++exports.Signature = Signature;
++function concatBytes(...arrays) {
++    if (!arrays.every((a) => a instanceof Uint8Array))
++        throw new Error('Expected Uint8Array list');
++    if (arrays.length === 1)
++        return arrays[0];
++    const length = arrays.reduce((a, arr) => a + arr.length, 0);
++    const result = new Uint8Array(length);
++    for (let i = 0, pad = 0; i < arrays.length; i++) {
++        const arr = arrays[i];
++        result.set(arr, pad);
++        pad += arr.length;
++    }
++    return result;
++}
++const hexes = Array.from({ length: 256 }, (v, i) => i.toString(16).padStart(2, '0'));
++function bytesToHex(uint8a) {
++    if (!(uint8a instanceof Uint8Array))
++        throw new Error('Uint8Array expected');
++    let hex = '';
++    for (let i = 0; i < uint8a.length; i++) {
++        hex += hexes[uint8a[i]];
++    }
++    return hex;
++}
++function hexToBytes(hex) {
++    if (typeof hex !== 'string') {
++        throw new TypeError('hexToBytes: expected string, got ' + typeof hex);
++    }
++    if (hex.length % 2)
++        throw new Error('hexToBytes: received invalid unpadded hex');
++    const array = new Uint8Array(hex.length / 2);
++    for (let i = 0; i < array.length; i++) {
++        const j = i * 2;
++        const hexByte = hex.slice(j, j + 2);
++        const byte = Number.parseInt(hexByte, 16);
++        if (Number.isNaN(byte) || byte < 0)
++            throw new Error('Invalid byte sequence');
++        array[i] = byte;
++    }
++    return array;
++}
++function numberTo32BytesBE(num) {
++    const length = 32;
++    const hex = num.toString(16).padStart(length * 2, '0');
++    return hexToBytes(hex);
++}
++function numberTo32BytesLE(num) {
++    return numberTo32BytesBE(num).reverse();
++}
++function edIsNegative(num) {
++    return (mod(num) & _1n) === _1n;
++}
++function bytesToNumberLE(uint8a) {
++    if (!(uint8a instanceof Uint8Array))
++        throw new Error('Expected Uint8Array');
++    return BigInt(bytesToHex(Uint8Array.from(uint8a).reverse()), 16);
++}
++const MAX_255B = BigInt('7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 16);
++function bytes255ToNumberLE(bytes) {
++    return mod(bytesToNumberLE(bytes) & MAX_255B);
++}
++function mod(a, b = CURVE.P) {
++    const res = a % b;
++    return res >= _0n ? res : b + res;
++}
++function invert(number, modulo = CURVE.P) {
++    if (number === _0n || modulo <= _0n) {
++        throw new Error(`invert: expected positive integers, got n=${number} mod=${modulo}`);
++    }
++    let a = mod(number, modulo);
++    let b = modulo;
++    let x = _0n, y = _1n, u = _1n, v = _0n;
++    while (a !== _0n) {
++        const q = b / a;
++        const r = b % a;
++        const m = x - u * q;
++        const n = y - v * q;
++        b = a, a = r, x = u, y = v, u = m, v = n;
++    }
++    const gcd = b;
++    if (gcd !== _1n)
++        throw new Error('invert: does not exist');
++    return mod(x, modulo);
++}
++function invertBatch(nums, p = CURVE.P) {
++    const tmp = new Array(nums.length);
++    const lastMultiplied = nums.reduce((acc, num, i) => {
++        if (num === _0n)
++            return acc;
++        tmp[i] = acc;
++        return mod(acc * num, p);
++    }, _1n);
++    const inverted = invert(lastMultiplied, p);
++    nums.reduceRight((acc, num, i) => {
++        if (num === _0n)
++            return acc;
++        tmp[i] = mod(acc * tmp[i], p);
++        return mod(acc * num, p);
++    }, inverted);
++    return tmp;
++}
++function pow2(x, power) {
++    const { P } = CURVE;
++    let res = x;
++    while (power-- > _0n) {
++        res *= res;
++        res %= P;
++    }
++    return res;
++}
++function pow_2_252_3(x) {
++    const { P } = CURVE;
++    const _5n = BigInt(5);
++    const _10n = BigInt(10);
++    const _20n = BigInt(20);
++    const _40n = BigInt(40);
++    const _80n = BigInt(80);
++    const x2 = (x * x) % P;
++    const b2 = (x2 * x) % P;
++    const b4 = (pow2(b2, _2n) * b2) % P;
++    const b5 = (pow2(b4, _1n) * x) % P;
++    const b10 = (pow2(b5, _5n) * b5) % P;
++    const b20 = (pow2(b10, _10n) * b10) % P;
++    const b40 = (pow2(b20, _20n) * b20) % P;
++    const b80 = (pow2(b40, _40n) * b40) % P;
++    const b160 = (pow2(b80, _80n) * b80) % P;
++    const b240 = (pow2(b160, _80n) * b80) % P;
++    const b250 = (pow2(b240, _10n) * b10) % P;
++    const pow_p_5_8 = (pow2(b250, _2n) * x) % P;
++    return { pow_p_5_8, b2 };
++}
++function uvRatio(u, v) {
++    const v3 = mod(v * v * v);
++    const v7 = mod(v3 * v3 * v);
++    const pow = pow_2_252_3(u * v7).pow_p_5_8;
++    let x = mod(u * v3 * pow);
++    const vx2 = mod(v * x * x);
++    const root1 = x;
++    const root2 = mod(x * SQRT_M1);
++    const useRoot1 = vx2 === u;
++    const useRoot2 = vx2 === mod(-u);
++    const noRoot = vx2 === mod(-u * SQRT_M1);
++    if (useRoot1)
++        x = root1;
++    if (useRoot2 || noRoot)
++        x = root2;
++    if (edIsNegative(x))
++        x = mod(-x);
++    return { isValid: useRoot1 || useRoot2, value: x };
++}
++function invertSqrt(number) {
++    return uvRatio(_1n, number);
++}
++function modlLE(hash) {
++    return mod(bytesToNumberLE(hash), CURVE.l);
++}
++function equalBytes(b1, b2) {
++    if (b1.length !== b2.length) {
++        return false;
++    }
++    for (let i = 0; i < b1.length; i++) {
++        if (b1[i] !== b2[i]) {
++            return false;
++        }
++    }
++    return true;
++}
++function ensureBytes(hex, expectedLength) {
++    const bytes = hex instanceof Uint8Array ? Uint8Array.from(hex) : hexToBytes(hex);
++    if (typeof expectedLength === 'number' && bytes.length !== expectedLength)
++        throw new Error(`Expected ${expectedLength} bytes`);
++    return bytes;
++}
++function normalizeScalar(num, max, strict = true) {
++    if (!max)
++        throw new TypeError('Specify max value');
++    if (typeof num === 'number' && Number.isSafeInteger(num))
++        num = BigInt(num);
++    if (typeof num === 'bigint' && num < max) {
++        if (strict) {
++            if (_0n < num)
++                return num;
++        }
++        else {
++            if (_0n <= num)
++                return num;
++        }
++    }
++    throw new TypeError('Expected valid scalar: 0 < scalar < max');
++}
++function adjustBytes25519(bytes) {
++    bytes[0] &= 248;
++    bytes[31] &= 127;
++    bytes[31] |= 64;
++    return bytes;
++}
++function decodeScalar25519(n) {
++    return bytesToNumberLE(adjustBytes25519(ensureBytes(n, 32)));
++}
++function checkPrivateKey(key) {
++    key =
++        typeof key === 'bigint' || typeof key === 'number'
++            ? numberTo32BytesBE(normalizeScalar(key, POW_2_256))
++            : ensureBytes(key);
++    if (key.length !== 32)
++        throw new Error(`Expected 32 bytes`);
++    return key;
++}
++function getKeyFromHash(hashed) {
++    const head = adjustBytes25519(hashed.slice(0, 32));
++    const prefix = hashed.slice(32, 64);
++    const scalar = modlLE(head);
++    const point = Point.BASE.multiply(scalar);
++    const pointBytes = point.toRawBytes();
++    return { head, prefix, scalar, point, pointBytes };
++}
++let _sha512Sync;
++function sha512s(...m) {
++    if (typeof _sha512Sync !== 'function')
++        throw new Error('utils.sha512Sync must be set to use sync methods');
++    return _sha512Sync(...m);
++}
++async function getExtendedPublicKey(key) {
++    return getKeyFromHash(await exports.utils.sha512(checkPrivateKey(key)));
++}
++function getExtendedPublicKeySync(key) {
++    return getKeyFromHash(sha512s(checkPrivateKey(key)));
++}
++async function getPublicKey(privateKey) {
++    return (await getExtendedPublicKey(privateKey)).pointBytes;
++}
++exports.getPublicKey = getPublicKey;
++function getPublicKeySync(privateKey) {
++    return getExtendedPublicKeySync(privateKey).pointBytes;
++}
++async function sign(message, privateKey) {
++    message = ensureBytes(message);
++    const { prefix, scalar, pointBytes } = await getExtendedPublicKey(privateKey);
++    const r = modlLE(await exports.utils.sha512(prefix, message));
++    const R = Point.BASE.multiply(r);
++    const k = modlLE(await exports.utils.sha512(R.toRawBytes(), pointBytes, message));
++    const s = mod(r + k * scalar, CURVE.l);
++    return new Signature(R, s).toRawBytes();
++}
++exports.sign = sign;
++function signSync(message, privateKey) {
++    message = ensureBytes(message);
++    const { prefix, scalar, pointBytes } = getExtendedPublicKeySync(privateKey);
++    const r = modlLE(sha512s(prefix, message));
++    const R = Point.BASE.multiply(r);
++    const k = modlLE(sha512s(R.toRawBytes(), pointBytes, message));
++    const s = mod(r + k * scalar, CURVE.l);
++    return new Signature(R, s).toRawBytes();
++}
++function prepareVerification(sig, message, publicKey) {
++    message = ensureBytes(message);
++    if (!(publicKey instanceof Point))
++        publicKey = Point.fromHex(publicKey, false);
++    const { r, s } = sig instanceof Signature ? sig.assertValidity() : Signature.fromHex(sig);
++    const SB = ExtendedPoint.BASE.multiplyUnsafe(s);
++    return { r, s, SB, pub: publicKey, msg: message };
++}
++function finishVerification(publicKey, r, SB, hashed) {
++    const k = modlLE(hashed);
++    const kA = ExtendedPoint.fromAffine(publicKey).multiplyUnsafe(k);
++    const RkA = ExtendedPoint.fromAffine(r).add(kA);
++    return RkA.subtract(SB).multiplyUnsafe(CURVE.h).equals(ExtendedPoint.ZERO);
++}
++async function verify(sig, message, publicKey) {
++    const { r, SB, msg, pub } = prepareVerification(sig, message, publicKey);
++    const hashed = await exports.utils.sha512(r.toRawBytes(), pub.toRawBytes(), msg);
++    return finishVerification(pub, r, SB, hashed);
++}
++exports.verify = verify;
++function verifySync(sig, message, publicKey) {
++    const { r, SB, msg, pub } = prepareVerification(sig, message, publicKey);
++    const hashed = sha512s(r.toRawBytes(), pub.toRawBytes(), msg);
++    return finishVerification(pub, r, SB, hashed);
++}
++exports.sync = {
++    getExtendedPublicKey: getExtendedPublicKeySync,
++    getPublicKey: getPublicKeySync,
++    sign: signSync,
++    verify: verifySync,
++};
++async function getSharedSecret(privateKey, publicKey) {
++    const { head } = await getExtendedPublicKey(privateKey);
++    const u = Point.fromHex(publicKey).toX25519();
++    return exports.curve25519.scalarMult(head, u);
++}
++exports.getSharedSecret = getSharedSecret;
++Point.BASE._setWindowSize(8);
++function cswap(swap, x_2, x_3) {
++    const dummy = mod(swap * (x_2 - x_3));
++    x_2 = mod(x_2 - dummy);
++    x_3 = mod(x_3 + dummy);
++    return [x_2, x_3];
++}
++function montgomeryLadder(pointU, scalar) {
++    const { P } = CURVE;
++    const u = normalizeScalar(pointU, P);
++    const k = normalizeScalar(scalar, P);
++    const a24 = BigInt(121665);
++    const x_1 = u;
++    let x_2 = _1n;
++    let z_2 = _0n;
++    let x_3 = u;
++    let z_3 = _1n;
++    let swap = _0n;
++    let sw;
++    for (let t = BigInt(255 - 1); t >= _0n; t--) {
++        const k_t = (k >> t) & _1n;
++        swap ^= k_t;
++        sw = cswap(swap, x_2, x_3);
++        x_2 = sw[0];
++        x_3 = sw[1];
++        sw = cswap(swap, z_2, z_3);
++        z_2 = sw[0];
++        z_3 = sw[1];
++        swap = k_t;
++        const A = x_2 + z_2;
++        const AA = mod(A * A);
++        const B = x_2 - z_2;
++        const BB = mod(B * B);
++        const E = AA - BB;
++        const C = x_3 + z_3;
++        const D = x_3 - z_3;
++        const DA = mod(D * A);
++        const CB = mod(C * B);
++        const dacb = DA + CB;
++        const da_cb = DA - CB;
++        x_3 = mod(dacb * dacb);
++        z_3 = mod(x_1 * mod(da_cb * da_cb));
++        x_2 = mod(AA * BB);
++        z_2 = mod(E * (AA + mod(a24 * E)));
++    }
++    sw = cswap(swap, x_2, x_3);
++    x_2 = sw[0];
++    x_3 = sw[1];
++    sw = cswap(swap, z_2, z_3);
++    z_2 = sw[0];
++    z_3 = sw[1];
++    const { pow_p_5_8, b2 } = pow_2_252_3(z_2);
++    const xp2 = mod(pow2(pow_p_5_8, BigInt(3)) * b2);
++    return mod(x_2 * xp2);
++}
++function encodeUCoordinate(u) {
++    return numberTo32BytesLE(mod(u, CURVE.P));
++}
++function decodeUCoordinate(uEnc) {
++    const u = ensureBytes(uEnc, 32);
++    u[31] &= 127;
++    return bytesToNumberLE(u);
++}
++exports.curve25519 = {
++    BASE_POINT_U: '0900000000000000000000000000000000000000000000000000000000000000',
++    scalarMult(privateKey, publicKey) {
++        const u = decodeUCoordinate(publicKey);
++        const p = decodeScalar25519(privateKey);
++        const pu = montgomeryLadder(u, p);
++        if (pu === _0n)
++            throw new Error('Invalid private or public key received');
++        return encodeUCoordinate(pu);
++    },
++    scalarMultBase(privateKey) {
++        return exports.curve25519.scalarMult(privateKey, exports.curve25519.BASE_POINT_U);
++    },
++};
++const crypto = {
++    node: nodeCrypto,
++    web: typeof self === 'object' && 'crypto' in self ? self.crypto : undefined,
++};
++exports.utils = {
++    bytesToHex,
++    hexToBytes,
++    concatBytes,
++    getExtendedPublicKey,
++    mod,
++    invert,
++    TORSION_SUBGROUP: [
++        '0100000000000000000000000000000000000000000000000000000000000000',
++        'c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a',
++        '0000000000000000000000000000000000000000000000000000000000000080',
++        '26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc05',
++        'ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f',
++        '26e8958fc2b227b045c3f489f2ef98f0d5dfac05d3c63339b13802886d53fc85',
++        '0000000000000000000000000000000000000000000000000000000000000000',
++        'c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac03fa',
++    ],
++    hashToPrivateScalar: (hash) => {
++        hash = ensureBytes(hash);
++        if (hash.length < 40 || hash.length > 1024)
++            throw new Error('Expected 40-1024 bytes of private key as per FIPS 186');
++        return mod(bytesToNumberLE(hash), CURVE.l - _1n) + _1n;
++    },
++    randomBytes: (bytesLength = 32) => {
++        if (crypto.web) {
++            return crypto.web.getRandomValues(new Uint8Array(bytesLength));
++        }
++        else if (crypto.node) {
++            const { randomBytes } = crypto.node;
++            return new Uint8Array(randomBytes(bytesLength).buffer);
++        }
++        else {
++            throw new Error("The environment doesn't have randomBytes function");
++        }
++    },
++    randomPrivateKey: () => {
++        return exports.utils.randomBytes(32);
++    },
++    sha512: async (...messages) => {
++        const message = concatBytes(...messages);
++        if (crypto.web) {
++            const buffer = await crypto.web.subtle.digest('SHA-512', message.buffer);
++            return new Uint8Array(buffer);
++        }
++        else if (crypto.node) {
++            return Uint8Array.from(crypto.node.createHash('sha512').update(message).digest());
++        }
++        else {
++            throw new Error("The environment doesn't have sha512 function");
++        }
++    },
++    precompute(windowSize = 8, point = Point.BASE) {
++        const cached = point.equals(Point.BASE) ? point : new Point(point.x, point.y);
++        cached._setWindowSize(windowSize);
++        cached.multiply(_2n);
++        return cached;
++    },
++    sha512Sync: undefined,
++};
++Object.defineProperties(exports.utils, {
++    sha512Sync: {
++        configurable: false,
++        get() {
++            return _sha512Sync;
++        },
++        set(val) {
++            if (!_sha512Sync)
++                _sha512Sync = val;
++        },
++    },
++});
+diff --git a/node_modules/@noble/ed25519/package.json b/node_modules/@noble/ed25519/package.json
+index dc95e3d..688e0b5 100644
+--- a/node_modules/@noble/ed25519/package.json
++++ b/node_modules/@noble/ed25519/package.json
+@@ -96,6 +96,7 @@
+   "license": "MIT",
+   "main": "lib/index.js",
+   "module": "lib/esm/index.js",
++  "react-native": "lib/react-native.js",
+   "name": "@noble/ed25519",
+   "prettier": {
+     "printWidth": 100,

--- a/packages/common/patches/@noble+secp256k1+1.7.0.patch
+++ b/packages/common/patches/@noble+secp256k1+1.7.0.patch
@@ -1,0 +1,1209 @@
+diff --git a/node_modules/@noble/secp256k1/lib/react-native.js b/node_modules/@noble/secp256k1/lib/react-native.js
+new file mode 100644
+index 0000000..f3039fb
+--- /dev/null
++++ b/node_modules/@noble/secp256k1/lib/react-native.js
+@@ -0,0 +1,1191 @@
++// This patch is required for compatibility with BigInteger.js in react-native
++// It can be removed when react-native is upgraded to 0.70
++
++"use strict";
++/*! noble-secp256k1 - MIT License (c) 2019 Paul Miller (paulmillr.com) */
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.utils = exports.schnorr = exports.verify = exports.signSync = exports.sign = exports.getSharedSecret = exports.recoverPublicKey = exports.getPublicKey = exports.Signature = exports.Point = exports.CURVE = void 0;
++const nodeCrypto = require("crypto");
++const _0n = BigInt(0);
++const _1n = BigInt(1);
++const _2n = BigInt(2);
++const _3n = BigInt(3);
++const _8n = BigInt(8);
++const CURVE = Object.freeze({
++    a: _0n,
++    b: BigInt(7),
++    P: BigInt('fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f', 16),
++    n: BigInt('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141', 16),
++    h: _1n,
++    Gx: BigInt('55066263022277343669578718895168534326250603453777594175500187360389116729240'),
++    Gy: BigInt('32670510020758816978083085130507043184471273380659243275938904335757337482424'),
++    beta: BigInt('7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee', 16),
++});
++exports.CURVE = CURVE;
++function weistrass(x) {
++    const { a, b } = CURVE;
++    const x2 = mod(x * x);
++    const x3 = mod(x2 * x);
++    return mod(x3 + a * x + b);
++}
++const USE_ENDOMORPHISM = CURVE.a === _0n;
++class ShaError extends Error {
++    constructor(message) {
++        super(message);
++    }
++}
++class JacobianPoint {
++    constructor(x, y, z) {
++        this.x = x;
++        this.y = y;
++        this.z = z;
++    }
++    static fromAffine(p) {
++        if (!(p instanceof Point)) {
++            throw new TypeError('JacobianPoint#fromAffine: expected Point');
++        }
++        return new JacobianPoint(p.x, p.y, _1n);
++    }
++    static toAffineBatch(points) {
++        const toInv = invertBatch(points.map((p) => p.z));
++        return points.map((p, i) => p.toAffine(toInv[i]));
++    }
++    static normalizeZ(points) {
++        return JacobianPoint.toAffineBatch(points).map(JacobianPoint.fromAffine);
++    }
++    equals(other) {
++        if (!(other instanceof JacobianPoint))
++            throw new TypeError('JacobianPoint expected');
++        const { x: X1, y: Y1, z: Z1 } = this;
++        const { x: X2, y: Y2, z: Z2 } = other;
++        const Z1Z1 = mod(Z1 * Z1);
++        const Z2Z2 = mod(Z2 * Z2);
++        const U1 = mod(X1 * Z2Z2);
++        const U2 = mod(X2 * Z1Z1);
++        const S1 = mod(mod(Y1 * Z2) * Z2Z2);
++        const S2 = mod(mod(Y2 * Z1) * Z1Z1);
++        return U1 === U2 && S1 === S2;
++    }
++    negate() {
++        return new JacobianPoint(this.x, mod(-this.y), this.z);
++    }
++    double() {
++        const { x: X1, y: Y1, z: Z1 } = this;
++        const A = mod(X1 * X1);
++        const B = mod(Y1 * Y1);
++        const C = mod(B * B);
++        const x1b = X1 + B;
++        const D = mod(_2n * (mod(x1b * x1b) - A - C));
++        const E = mod(_3n * A);
++        const F = mod(E * E);
++        const X3 = mod(F - _2n * D);
++        const Y3 = mod(E * (D - X3) - _8n * C);
++        const Z3 = mod(_2n * Y1 * Z1);
++        return new JacobianPoint(X3, Y3, Z3);
++    }
++    add(other) {
++        if (!(other instanceof JacobianPoint))
++            throw new TypeError('JacobianPoint expected');
++        const { x: X1, y: Y1, z: Z1 } = this;
++        const { x: X2, y: Y2, z: Z2 } = other;
++        if (X2 === _0n || Y2 === _0n)
++            return this;
++        if (X1 === _0n || Y1 === _0n)
++            return other;
++        const Z1Z1 = mod(Z1 * Z1);
++        const Z2Z2 = mod(Z2 * Z2);
++        const U1 = mod(X1 * Z2Z2);
++        const U2 = mod(X2 * Z1Z1);
++        const S1 = mod(mod(Y1 * Z2) * Z2Z2);
++        const S2 = mod(mod(Y2 * Z1) * Z1Z1);
++        const H = mod(U2 - U1);
++        const r = mod(S2 - S1);
++        if (H === _0n) {
++            if (r === _0n) {
++                return this.double();
++            }
++            else {
++                return JacobianPoint.ZERO;
++            }
++        }
++        const HH = mod(H * H);
++        const HHH = mod(H * HH);
++        const V = mod(U1 * HH);
++        const X3 = mod(r * r - HHH - _2n * V);
++        const Y3 = mod(r * (V - X3) - S1 * HHH);
++        const Z3 = mod(Z1 * Z2 * H);
++        return new JacobianPoint(X3, Y3, Z3);
++    }
++    subtract(other) {
++        return this.add(other.negate());
++    }
++    multiplyUnsafe(scalar) {
++        const P0 = JacobianPoint.ZERO;
++        if (typeof scalar === 'bigint' && scalar === _0n)
++            return P0;
++        let n = normalizeScalar(scalar);
++        if (n === _1n)
++            return this;
++        if (!USE_ENDOMORPHISM) {
++            let p = P0;
++            let d = this;
++            while (n > _0n) {
++                if (n & _1n)
++                    p = p.add(d);
++                d = d.double();
++                n >>= _1n;
++            }
++            return p;
++        }
++        let { k1neg, k1, k2neg, k2 } = splitScalarEndo(n);
++        let k1p = P0;
++        let k2p = P0;
++        let d = this;
++        while (k1 > _0n || k2 > _0n) {
++            if (k1 & _1n)
++                k1p = k1p.add(d);
++            if (k2 & _1n)
++                k2p = k2p.add(d);
++            d = d.double();
++            k1 >>= _1n;
++            k2 >>= _1n;
++        }
++        if (k1neg)
++            k1p = k1p.negate();
++        if (k2neg)
++            k2p = k2p.negate();
++        k2p = new JacobianPoint(mod(k2p.x * CURVE.beta), k2p.y, k2p.z);
++        return k1p.add(k2p);
++    }
++    precomputeWindow(W) {
++        const windows = USE_ENDOMORPHISM ? 128 / W + 1 : 256 / W + 1;
++        const points = [];
++        let p = this;
++        let base = p;
++        for (let window = 0; window < windows; window++) {
++            base = p;
++            points.push(base);
++            for (let i = 1; i < 2 ** (W - 1); i++) {
++                base = base.add(p);
++                points.push(base);
++            }
++            p = base.double();
++        }
++        return points;
++    }
++    wNAF(n, affinePoint) {
++        if (!affinePoint && this.equals(JacobianPoint.BASE))
++            affinePoint = Point.BASE;
++        const W = (affinePoint && affinePoint._WINDOW_SIZE) || 1;
++        if (256 % W) {
++            throw new Error('Point#wNAF: Invalid precomputation window, must be power of 2');
++        }
++        let precomputes = affinePoint && pointPrecomputes.get(affinePoint);
++        if (!precomputes) {
++            precomputes = this.precomputeWindow(W);
++            if (affinePoint && W !== 1) {
++                precomputes = JacobianPoint.normalizeZ(precomputes);
++                pointPrecomputes.set(affinePoint, precomputes);
++            }
++        }
++        let p = JacobianPoint.ZERO;
++        let f = JacobianPoint.ZERO;
++        const windows = 1 + (USE_ENDOMORPHISM ? 128 / W : 256 / W);
++        const windowSize = 2 ** (W - 1);
++        const mask = BigInt(2 ** W - 1);
++        const maxNumber = 2 ** W;
++        const shiftBy = BigInt(W);
++        for (let window = 0; window < windows; window++) {
++            const offset = window * windowSize;
++            let wbits = Number(n & mask);
++            n >>= shiftBy;
++            if (wbits > windowSize) {
++                wbits -= maxNumber;
++                n += _1n;
++            }
++            if (wbits === 0) {
++                let pr = precomputes[offset];
++                if (window % 2)
++                    pr = pr.negate();
++                f = f.add(pr);
++            }
++            else {
++                let cached = precomputes[offset + Math.abs(wbits) - 1];
++                if (wbits < 0)
++                    cached = cached.negate();
++                p = p.add(cached);
++            }
++        }
++        return { p, f };
++    }
++    multiply(scalar, affinePoint) {
++        let n = normalizeScalar(scalar);
++        let point;
++        let fake;
++        if (USE_ENDOMORPHISM) {
++            const { k1neg, k1, k2neg, k2 } = splitScalarEndo(n);
++            let { p: k1p, f: f1p } = this.wNAF(k1, affinePoint);
++            let { p: k2p, f: f2p } = this.wNAF(k2, affinePoint);
++            if (k1neg)
++                k1p = k1p.negate();
++            if (k2neg)
++                k2p = k2p.negate();
++            k2p = new JacobianPoint(mod(k2p.x * CURVE.beta), k2p.y, k2p.z);
++            point = k1p.add(k2p);
++            fake = f1p.add(f2p);
++        }
++        else {
++            const { p, f } = this.wNAF(n, affinePoint);
++            point = p;
++            fake = f;
++        }
++        return JacobianPoint.normalizeZ([point, fake])[0];
++    }
++    toAffine(invZ = invert(this.z)) {
++        const { x, y, z } = this;
++        const iz1 = invZ;
++        const iz2 = mod(iz1 * iz1);
++        const iz3 = mod(iz2 * iz1);
++        const ax = mod(x * iz2);
++        const ay = mod(y * iz3);
++        const zz = mod(z * iz1);
++        if (zz !== _1n)
++            throw new Error('invZ was invalid');
++        return new Point(ax, ay);
++    }
++}
++JacobianPoint.BASE = new JacobianPoint(CURVE.Gx, CURVE.Gy, _1n);
++JacobianPoint.ZERO = new JacobianPoint(_0n, _1n, _0n);
++const pointPrecomputes = new WeakMap();
++class Point {
++    constructor(x, y) {
++        this.x = x;
++        this.y = y;
++    }
++    _setWindowSize(windowSize) {
++        this._WINDOW_SIZE = windowSize;
++        pointPrecomputes.delete(this);
++    }
++    hasEvenY() {
++        return this.y % _2n === _0n;
++    }
++    static fromCompressedHex(bytes) {
++        const isShort = bytes.length === 32;
++        const x = bytesToNumber(isShort ? bytes : bytes.subarray(1));
++        if (!isValidFieldElement(x))
++            throw new Error('Point is not on curve');
++        const y2 = weistrass(x);
++        let y = sqrtMod(y2);
++        const isYOdd = (y & _1n) === _1n;
++        if (isShort) {
++            if (isYOdd)
++                y = mod(-y);
++        }
++        else {
++            const isFirstByteOdd = (bytes[0] & 1) === 1;
++            if (isFirstByteOdd !== isYOdd)
++                y = mod(-y);
++        }
++        const point = new Point(x, y);
++        point.assertValidity();
++        return point;
++    }
++    static fromUncompressedHex(bytes) {
++        const x = bytesToNumber(bytes.subarray(1, 33));
++        const y = bytesToNumber(bytes.subarray(33, 65));
++        const point = new Point(x, y);
++        point.assertValidity();
++        return point;
++    }
++    static fromHex(hex) {
++        const bytes = ensureBytes(hex);
++        const len = bytes.length;
++        const header = bytes[0];
++        if (len === 32 || (len === 33 && (header === 0x02 || header === 0x03))) {
++            return this.fromCompressedHex(bytes);
++        }
++        if (len === 65 && header === 0x04)
++            return this.fromUncompressedHex(bytes);
++        throw new Error(`Point.fromHex: received invalid point. Expected 32-33 compressed bytes or 65 uncompressed bytes, not ${len}`);
++    }
++    static fromPrivateKey(privateKey) {
++        return Point.BASE.multiply(normalizePrivateKey(privateKey));
++    }
++    static fromSignature(msgHash, signature, recovery) {
++        msgHash = ensureBytes(msgHash);
++        const h = truncateHash(msgHash);
++        const { r, s } = normalizeSignature(signature);
++        if (recovery !== 0 && recovery !== 1) {
++            throw new Error('Cannot recover signature: invalid recovery bit');
++        }
++        const prefix = recovery & 1 ? '03' : '02';
++        const R = Point.fromHex(prefix + numTo32bStr(r));
++        const { n } = CURVE;
++        const rinv = invert(r, n);
++        const u1 = mod(-h * rinv, n);
++        const u2 = mod(s * rinv, n);
++        const Q = Point.BASE.multiplyAndAddUnsafe(R, u1, u2);
++        if (!Q)
++            throw new Error('Cannot recover signature: point at infinify');
++        Q.assertValidity();
++        return Q;
++    }
++    toRawBytes(isCompressed = false) {
++        return hexToBytes(this.toHex(isCompressed));
++    }
++    toHex(isCompressed = false) {
++        const x = numTo32bStr(this.x);
++        if (isCompressed) {
++            const prefix = this.hasEvenY() ? '02' : '03';
++            return `${prefix}${x}`;
++        }
++        else {
++            return `04${x}${numTo32bStr(this.y)}`;
++        }
++    }
++    toHexX() {
++        return this.toHex(true).slice(2);
++    }
++    toRawX() {
++        return this.toRawBytes(true).slice(1);
++    }
++    assertValidity() {
++        const msg = 'Point is not on elliptic curve';
++        const { x, y } = this;
++        if (!isValidFieldElement(x) || !isValidFieldElement(y))
++            throw new Error(msg);
++        const left = mod(y * y);
++        const right = weistrass(x);
++        if (mod(left - right) !== _0n)
++            throw new Error(msg);
++    }
++    equals(other) {
++        return this.x === other.x && this.y === other.y;
++    }
++    negate() {
++        return new Point(this.x, mod(-this.y));
++    }
++    double() {
++        return JacobianPoint.fromAffine(this).double().toAffine();
++    }
++    add(other) {
++        return JacobianPoint.fromAffine(this).add(JacobianPoint.fromAffine(other)).toAffine();
++    }
++    subtract(other) {
++        return this.add(other.negate());
++    }
++    multiply(scalar) {
++        return JacobianPoint.fromAffine(this).multiply(scalar, this).toAffine();
++    }
++    multiplyAndAddUnsafe(Q, a, b) {
++        const P = JacobianPoint.fromAffine(this);
++        const aP = a === _0n || a === _1n || this !== Point.BASE ? P.multiplyUnsafe(a) : P.multiply(a);
++        const bQ = JacobianPoint.fromAffine(Q).multiplyUnsafe(b);
++        const sum = aP.add(bQ);
++        return sum.equals(JacobianPoint.ZERO) ? undefined : sum.toAffine();
++    }
++}
++exports.Point = Point;
++Point.BASE = new Point(CURVE.Gx, CURVE.Gy);
++Point.ZERO = new Point(_0n, _0n);
++function sliceDER(s) {
++    return Number.parseInt(s[0], 16) >= 8 ? '00' + s : s;
++}
++function parseDERInt(data) {
++    if (data.length < 2 || data[0] !== 0x02) {
++        throw new Error(`Invalid signature integer tag: ${bytesToHex(data)}`);
++    }
++    const len = data[1];
++    const res = data.subarray(2, len + 2);
++    if (!len || res.length !== len) {
++        throw new Error(`Invalid signature integer: wrong length`);
++    }
++    if (res[0] === 0x00 && res[1] <= 0x7f) {
++        throw new Error('Invalid signature integer: trailing length');
++    }
++    return { data: bytesToNumber(res), left: data.subarray(len + 2) };
++}
++function parseDERSignature(data) {
++    if (data.length < 2 || data[0] != 0x30) {
++        throw new Error(`Invalid signature tag: ${bytesToHex(data)}`);
++    }
++    if (data[1] !== data.length - 2) {
++        throw new Error('Invalid signature: incorrect length');
++    }
++    const { data: r, left: sBytes } = parseDERInt(data.subarray(2));
++    const { data: s, left: rBytesLeft } = parseDERInt(sBytes);
++    if (rBytesLeft.length) {
++        throw new Error(`Invalid signature: left bytes after parsing: ${bytesToHex(rBytesLeft)}`);
++    }
++    return { r, s };
++}
++class Signature {
++    constructor(r, s) {
++        this.r = r;
++        this.s = s;
++        this.assertValidity();
++    }
++    static fromCompact(hex) {
++        const arr = hex instanceof Uint8Array;
++        const name = 'Signature.fromCompact';
++        if (typeof hex !== 'string' && !arr)
++            throw new TypeError(`${name}: Expected string or Uint8Array`);
++        const str = arr ? bytesToHex(hex) : hex;
++        if (str.length !== 128)
++            throw new Error(`${name}: Expected 64-byte hex`);
++        return new Signature(hexToNumber(str.slice(0, 64)), hexToNumber(str.slice(64, 128)));
++    }
++    static fromDER(hex) {
++        const arr = hex instanceof Uint8Array;
++        if (typeof hex !== 'string' && !arr)
++            throw new TypeError(`Signature.fromDER: Expected string or Uint8Array`);
++        const { r, s } = parseDERSignature(arr ? hex : hexToBytes(hex));
++        return new Signature(r, s);
++    }
++    static fromHex(hex) {
++        return this.fromDER(hex);
++    }
++    assertValidity() {
++        const { r, s } = this;
++        if (!isWithinCurveOrder(r))
++            throw new Error('Invalid Signature: r must be 0 < r < n');
++        if (!isWithinCurveOrder(s))
++            throw new Error('Invalid Signature: s must be 0 < s < n');
++    }
++    hasHighS() {
++        const HALF = CURVE.n >> _1n;
++        return this.s > HALF;
++    }
++    normalizeS() {
++        return this.hasHighS() ? new Signature(this.r, CURVE.n - this.s) : this;
++    }
++    toDERRawBytes(isCompressed = false) {
++        return hexToBytes(this.toDERHex(isCompressed));
++    }
++    toDERHex(isCompressed = false) {
++        const sHex = sliceDER(numberToHexUnpadded(this.s));
++        if (isCompressed)
++            return sHex;
++        const rHex = sliceDER(numberToHexUnpadded(this.r));
++        const rLen = numberToHexUnpadded(rHex.length / 2);
++        const sLen = numberToHexUnpadded(sHex.length / 2);
++        const length = numberToHexUnpadded(rHex.length / 2 + sHex.length / 2 + 4);
++        return `30${length}02${rLen}${rHex}02${sLen}${sHex}`;
++    }
++    toRawBytes() {
++        return this.toDERRawBytes();
++    }
++    toHex() {
++        return this.toDERHex();
++    }
++    toCompactRawBytes() {
++        return hexToBytes(this.toCompactHex());
++    }
++    toCompactHex() {
++        return numTo32bStr(this.r) + numTo32bStr(this.s);
++    }
++}
++exports.Signature = Signature;
++function concatBytes(...arrays) {
++    if (!arrays.every((b) => b instanceof Uint8Array))
++        throw new Error('Uint8Array list expected');
++    if (arrays.length === 1)
++        return arrays[0];
++    const length = arrays.reduce((a, arr) => a + arr.length, 0);
++    const result = new Uint8Array(length);
++    for (let i = 0, pad = 0; i < arrays.length; i++) {
++        const arr = arrays[i];
++        result.set(arr, pad);
++        pad += arr.length;
++    }
++    return result;
++}
++const hexes = Array.from({ length: 256 }, (v, i) => i.toString(16).padStart(2, '0'));
++function bytesToHex(uint8a) {
++    if (!(uint8a instanceof Uint8Array))
++        throw new Error('Expected Uint8Array');
++    let hex = '';
++    for (let i = 0; i < uint8a.length; i++) {
++        hex += hexes[uint8a[i]];
++    }
++    return hex;
++}
++const POW_2_256 = BigInt('10000000000000000000000000000000000000000000000000000000000000000', 16);
++function numTo32bStr(num) {
++    if (typeof num !== 'bigint')
++        throw new Error('Expected bigint');
++    if (!(_0n <= num && num < POW_2_256))
++        throw new Error('Expected number < 2^256');
++    return num.toString(16).padStart(64, '0');
++}
++function numTo32b(num) {
++    const b = hexToBytes(numTo32bStr(num));
++    if (b.length !== 32)
++        throw new Error('Error: expected 32 bytes');
++    return b;
++}
++function numberToHexUnpadded(num) {
++    const hex = num.toString(16);
++    return hex.length & 1 ? `0${hex}` : hex;
++}
++function hexToNumber(hex) {
++    if (typeof hex !== 'string') {
++        throw new TypeError('hexToNumber: expected string, got ' + typeof hex);
++    }
++    return BigInt(hex, 16);
++}
++function hexToBytes(hex) {
++    if (typeof hex !== 'string') {
++        throw new TypeError('hexToBytes: expected string, got ' + typeof hex);
++    }
++    if (hex.length % 2)
++        throw new Error('hexToBytes: received invalid unpadded hex' + hex.length);
++    const array = new Uint8Array(hex.length / 2);
++    for (let i = 0; i < array.length; i++) {
++        const j = i * 2;
++        const hexByte = hex.slice(j, j + 2);
++        const byte = Number.parseInt(hexByte, 16);
++        if (Number.isNaN(byte) || byte < 0)
++            throw new Error('Invalid byte sequence');
++        array[i] = byte;
++    }
++    return array;
++}
++function bytesToNumber(bytes) {
++    return hexToNumber(bytesToHex(bytes));
++}
++function ensureBytes(hex) {
++    return hex instanceof Uint8Array ? Uint8Array.from(hex) : hexToBytes(hex);
++}
++function normalizeScalar(num) {
++    if (typeof num === 'number' && Number.isSafeInteger(num) && num > 0)
++        return BigInt(num);
++    if (typeof num === 'bigint' && isWithinCurveOrder(num))
++        return num;
++    throw new TypeError('Expected valid private scalar: 0 < scalar < curve.n');
++}
++function mod(a, b = CURVE.P) {
++    const result = a % b;
++    return result >= _0n ? result : b + result;
++}
++function pow2(x, power) {
++    const { P } = CURVE;
++    let res = x;
++    while (power-- > _0n) {
++        res *= res;
++        res %= P;
++    }
++    return res;
++}
++function sqrtMod(x) {
++    const { P } = CURVE;
++    const _6n = BigInt(6);
++    const _11n = BigInt(11);
++    const _22n = BigInt(22);
++    const _23n = BigInt(23);
++    const _44n = BigInt(44);
++    const _88n = BigInt(88);
++    const b2 = (x * x * x) % P;
++    const b3 = (b2 * b2 * x) % P;
++    const b6 = (pow2(b3, _3n) * b3) % P;
++    const b9 = (pow2(b6, _3n) * b3) % P;
++    const b11 = (pow2(b9, _2n) * b2) % P;
++    const b22 = (pow2(b11, _11n) * b11) % P;
++    const b44 = (pow2(b22, _22n) * b22) % P;
++    const b88 = (pow2(b44, _44n) * b44) % P;
++    const b176 = (pow2(b88, _88n) * b88) % P;
++    const b220 = (pow2(b176, _44n) * b44) % P;
++    const b223 = (pow2(b220, _3n) * b3) % P;
++    const t1 = (pow2(b223, _23n) * b22) % P;
++    const t2 = (pow2(t1, _6n) * b2) % P;
++    return pow2(t2, _2n);
++}
++function invert(number, modulo = CURVE.P) {
++    if (number === _0n || modulo <= _0n) {
++        throw new Error(`invert: expected positive integers, got n=${number} mod=${modulo}`);
++    }
++    let a = mod(number, modulo);
++    let b = modulo;
++    let x = _0n, y = _1n, u = _1n, v = _0n;
++    while (a !== _0n) {
++        const q = b / a;
++        const r = b % a;
++        const m = x - u * q;
++        const n = y - v * q;
++        b = a, a = r, x = u, y = v, u = m, v = n;
++    }
++    const gcd = b;
++    if (gcd !== _1n)
++        throw new Error('invert: does not exist');
++    return mod(x, modulo);
++}
++function invertBatch(nums, p = CURVE.P) {
++    const scratch = new Array(nums.length);
++    const lastMultiplied = nums.reduce((acc, num, i) => {
++        if (num === _0n)
++            return acc;
++        scratch[i] = acc;
++        return mod(acc * num, p);
++    }, _1n);
++    const inverted = invert(lastMultiplied, p);
++    nums.reduceRight((acc, num, i) => {
++        if (num === _0n)
++            return acc;
++        scratch[i] = mod(acc * scratch[i], p);
++        return mod(acc * num, p);
++    }, inverted);
++    return scratch;
++}
++const divNearest = (a, b) => (a + b / _2n) / b;
++const ENDO = {
++    a1: BigInt('3086d221a7d46bcde86c90e49284eb15', 16),
++    b1: -_1n * BigInt('e4437ed6010e88286f547fa90abfe4c3', 16),
++    a2: BigInt('114ca50f7a8e2f3f657c1108d9d44cfd8', 16),
++    b2: BigInt('3086d221a7d46bcde86c90e49284eb15', 16),
++    POW_2_128: BigInt('100000000000000000000000000000000', 16),
++};
++function splitScalarEndo(k) {
++    const { n } = CURVE;
++    const { a1, b1, a2, b2, POW_2_128 } = ENDO;
++    const c1 = divNearest(b2 * k, n);
++    const c2 = divNearest(-b1 * k, n);
++    let k1 = mod(k - c1 * a1 - c2 * a2, n);
++    let k2 = mod(-c1 * b1 - c2 * b2, n);
++    const k1neg = k1 > POW_2_128;
++    const k2neg = k2 > POW_2_128;
++    if (k1neg)
++        k1 = n - k1;
++    if (k2neg)
++        k2 = n - k2;
++    if (k1 > POW_2_128 || k2 > POW_2_128) {
++        throw new Error('splitScalarEndo: Endomorphism failed, k=' + k);
++    }
++    return { k1neg, k1, k2neg, k2 };
++}
++function truncateHash(hash) {
++    const { n } = CURVE;
++    const byteLength = hash.length;
++    const delta = byteLength * 8 - 256;
++    let h = bytesToNumber(hash);
++    if (delta > 0)
++        h = h >> BigInt(delta);
++    if (h >= n)
++        h -= n;
++    return h;
++}
++let _sha256Sync;
++let _hmacSha256Sync;
++class HmacDrbg {
++    constructor() {
++        this.v = new Uint8Array(32).fill(1);
++        this.k = new Uint8Array(32).fill(0);
++        this.counter = 0;
++    }
++    hmac(...values) {
++        return exports.utils.hmacSha256(this.k, ...values);
++    }
++    hmacSync(...values) {
++        return _hmacSha256Sync(this.k, ...values);
++    }
++    checkSync() {
++        if (typeof _hmacSha256Sync !== 'function')
++            throw new ShaError('hmacSha256Sync needs to be set');
++    }
++    incr() {
++        if (this.counter >= 1000)
++            throw new Error('Tried 1,000 k values for sign(), all were invalid');
++        this.counter += 1;
++    }
++    async reseed(seed = new Uint8Array()) {
++        this.k = await this.hmac(this.v, Uint8Array.from([0x00]), seed);
++        this.v = await this.hmac(this.v);
++        if (seed.length === 0)
++            return;
++        this.k = await this.hmac(this.v, Uint8Array.from([0x01]), seed);
++        this.v = await this.hmac(this.v);
++    }
++    reseedSync(seed = new Uint8Array()) {
++        this.checkSync();
++        this.k = this.hmacSync(this.v, Uint8Array.from([0x00]), seed);
++        this.v = this.hmacSync(this.v);
++        if (seed.length === 0)
++            return;
++        this.k = this.hmacSync(this.v, Uint8Array.from([0x01]), seed);
++        this.v = this.hmacSync(this.v);
++    }
++    async generate() {
++        this.incr();
++        this.v = await this.hmac(this.v);
++        return this.v;
++    }
++    generateSync() {
++        this.checkSync();
++        this.incr();
++        this.v = this.hmacSync(this.v);
++        return this.v;
++    }
++}
++function isWithinCurveOrder(num) {
++    return _0n < num && num < CURVE.n;
++}
++function isValidFieldElement(num) {
++    return _0n < num && num < CURVE.P;
++}
++function kmdToSig(kBytes, m, d) {
++    const k = bytesToNumber(kBytes);
++    if (!isWithinCurveOrder(k))
++        return;
++    const { n } = CURVE;
++    const q = Point.BASE.multiply(k);
++    const r = mod(q.x, n);
++    if (r === _0n)
++        return;
++    const s = mod(invert(k, n) * mod(m + d * r, n), n);
++    if (s === _0n)
++        return;
++    const sig = new Signature(r, s);
++    const recovery = (q.x === sig.r ? 0 : 2) | Number(q.y & _1n);
++    return { sig, recovery };
++}
++function normalizePrivateKey(key) {
++    let num;
++    if (typeof key === 'bigint') {
++        num = key;
++    }
++    else if (typeof key === 'number' && Number.isSafeInteger(key) && key > 0) {
++        num = BigInt(key);
++    }
++    else if (typeof key === 'string') {
++        if (key.length !== 64)
++            throw new Error('Expected 32 bytes of private key');
++        num = hexToNumber(key);
++    }
++    else if (key instanceof Uint8Array) {
++        if (key.length !== 32)
++            throw new Error('Expected 32 bytes of private key');
++        num = bytesToNumber(key);
++    }
++    else {
++        throw new TypeError('Expected valid private key');
++    }
++    if (!isWithinCurveOrder(num))
++        throw new Error('Expected private key: 0 < key < n');
++    return num;
++}
++function normalizePublicKey(publicKey) {
++    if (publicKey instanceof Point) {
++        publicKey.assertValidity();
++        return publicKey;
++    }
++    else {
++        return Point.fromHex(publicKey);
++    }
++}
++function normalizeSignature(signature) {
++    if (signature instanceof Signature) {
++        signature.assertValidity();
++        return signature;
++    }
++    try {
++        return Signature.fromDER(signature);
++    }
++    catch (error) {
++        return Signature.fromCompact(signature);
++    }
++}
++function getPublicKey(privateKey, isCompressed = false) {
++    return Point.fromPrivateKey(privateKey).toRawBytes(isCompressed);
++}
++exports.getPublicKey = getPublicKey;
++function recoverPublicKey(msgHash, signature, recovery, isCompressed = false) {
++    return Point.fromSignature(msgHash, signature, recovery).toRawBytes(isCompressed);
++}
++exports.recoverPublicKey = recoverPublicKey;
++function isProbPub(item) {
++    const arr = item instanceof Uint8Array;
++    const str = typeof item === 'string';
++    const len = (arr || str) && item.length;
++    if (arr)
++        return len === 33 || len === 65;
++    if (str)
++        return len === 66 || len === 130;
++    if (item instanceof Point)
++        return true;
++    return false;
++}
++function getSharedSecret(privateA, publicB, isCompressed = false) {
++    if (isProbPub(privateA))
++        throw new TypeError('getSharedSecret: first arg must be private key');
++    if (!isProbPub(publicB))
++        throw new TypeError('getSharedSecret: second arg must be public key');
++    const b = normalizePublicKey(publicB);
++    b.assertValidity();
++    return b.multiply(normalizePrivateKey(privateA)).toRawBytes(isCompressed);
++}
++exports.getSharedSecret = getSharedSecret;
++function bits2int(bytes) {
++    const slice = bytes.length > 32 ? bytes.slice(0, 32) : bytes;
++    return bytesToNumber(slice);
++}
++function bits2octets(bytes) {
++    const z1 = bits2int(bytes);
++    const z2 = mod(z1, CURVE.n);
++    return int2octets(z2 < _0n ? z1 : z2);
++}
++function int2octets(num) {
++    return numTo32b(num);
++}
++function initSigArgs(msgHash, privateKey, extraEntropy) {
++    if (msgHash == null)
++        throw new Error(`sign: expected valid message hash, not "${msgHash}"`);
++    const h1 = ensureBytes(msgHash);
++    const d = normalizePrivateKey(privateKey);
++    const seedArgs = [int2octets(d), bits2octets(h1)];
++    if (extraEntropy != null) {
++        if (extraEntropy === true)
++            extraEntropy = exports.utils.randomBytes(32);
++        const e = ensureBytes(extraEntropy);
++        if (e.length !== 32)
++            throw new Error('sign: Expected 32 bytes of extra data');
++        seedArgs.push(e);
++    }
++    const seed = concatBytes(...seedArgs);
++    const m = bits2int(h1);
++    return { seed, m, d };
++}
++function finalizeSig(recSig, opts) {
++    let { sig, recovery } = recSig;
++    const { canonical, der, recovered } = Object.assign({ canonical: true, der: true }, opts);
++    if (canonical && sig.hasHighS()) {
++        sig = sig.normalizeS();
++        recovery ^= 1;
++    }
++    const hashed = der ? sig.toDERRawBytes() : sig.toCompactRawBytes();
++    return recovered ? [hashed, recovery] : hashed;
++}
++async function sign(msgHash, privKey, opts = {}) {
++    const { seed, m, d } = initSigArgs(msgHash, privKey, opts.extraEntropy);
++    let sig;
++    const drbg = new HmacDrbg();
++    await drbg.reseed(seed);
++    while (!(sig = kmdToSig(await drbg.generate(), m, d)))
++        await drbg.reseed();
++    return finalizeSig(sig, opts);
++}
++exports.sign = sign;
++function signSync(msgHash, privKey, opts = {}) {
++    const { seed, m, d } = initSigArgs(msgHash, privKey, opts.extraEntropy);
++    let sig;
++    const drbg = new HmacDrbg();
++    drbg.reseedSync(seed);
++    while (!(sig = kmdToSig(drbg.generateSync(), m, d)))
++        drbg.reseedSync();
++    return finalizeSig(sig, opts);
++}
++exports.signSync = signSync;
++const vopts = { strict: true };
++function verify(signature, msgHash, publicKey, opts = vopts) {
++    let sig;
++    try {
++        sig = normalizeSignature(signature);
++        msgHash = ensureBytes(msgHash);
++    }
++    catch (error) {
++        return false;
++    }
++    const { r, s } = sig;
++    if (opts.strict && sig.hasHighS())
++        return false;
++    const h = truncateHash(msgHash);
++    let P;
++    try {
++        P = normalizePublicKey(publicKey);
++    }
++    catch (error) {
++        return false;
++    }
++    const { n } = CURVE;
++    const sinv = invert(s, n);
++    const u1 = mod(h * sinv, n);
++    const u2 = mod(r * sinv, n);
++    const R = Point.BASE.multiplyAndAddUnsafe(P, u1, u2);
++    if (!R)
++        return false;
++    const v = mod(R.x, n);
++    return v === r;
++}
++exports.verify = verify;
++function schnorrChallengeFinalize(ch) {
++    return mod(bytesToNumber(ch), CURVE.n);
++}
++class SchnorrSignature {
++    constructor(r, s) {
++        this.r = r;
++        this.s = s;
++        this.assertValidity();
++    }
++    static fromHex(hex) {
++        const bytes = ensureBytes(hex);
++        if (bytes.length !== 64)
++            throw new TypeError(`SchnorrSignature.fromHex: expected 64 bytes, not ${bytes.length}`);
++        const r = bytesToNumber(bytes.subarray(0, 32));
++        const s = bytesToNumber(bytes.subarray(32, 64));
++        return new SchnorrSignature(r, s);
++    }
++    assertValidity() {
++        const { r, s } = this;
++        if (!isValidFieldElement(r) || !isWithinCurveOrder(s))
++            throw new Error('Invalid signature');
++    }
++    toHex() {
++        return numTo32bStr(this.r) + numTo32bStr(this.s);
++    }
++    toRawBytes() {
++        return hexToBytes(this.toHex());
++    }
++}
++function schnorrGetPublicKey(privateKey) {
++    return Point.fromPrivateKey(privateKey).toRawX();
++}
++class InternalSchnorrSignature {
++    constructor(message, privateKey, auxRand = exports.utils.randomBytes()) {
++        if (message == null)
++            throw new TypeError(`sign: Expected valid message, not "${message}"`);
++        this.m = ensureBytes(message);
++        const { x, scalar } = this.getScalar(normalizePrivateKey(privateKey));
++        this.px = x;
++        this.d = scalar;
++        this.rand = ensureBytes(auxRand);
++        if (this.rand.length !== 32)
++            throw new TypeError('sign: Expected 32 bytes of aux randomness');
++    }
++    getScalar(priv) {
++        const point = Point.fromPrivateKey(priv);
++        const scalar = point.hasEvenY() ? priv : CURVE.n - priv;
++        return { point, scalar, x: point.toRawX() };
++    }
++    initNonce(d, t0h) {
++        return numTo32b(d ^ bytesToNumber(t0h));
++    }
++    finalizeNonce(k0h) {
++        const k0 = mod(bytesToNumber(k0h), CURVE.n);
++        if (k0 === _0n)
++            throw new Error('sign: Creation of signature failed. k is zero');
++        const { point: R, x: rx, scalar: k } = this.getScalar(k0);
++        return { R, rx, k };
++    }
++    finalizeSig(R, k, e, d) {
++        return new SchnorrSignature(R.x, mod(k + e * d, CURVE.n)).toRawBytes();
++    }
++    error() {
++        throw new Error('sign: Invalid signature produced');
++    }
++    async calc() {
++        const { m, d, px, rand } = this;
++        const tag = exports.utils.taggedHash;
++        const t = this.initNonce(d, await tag(TAGS.aux, rand));
++        const { R, rx, k } = this.finalizeNonce(await tag(TAGS.nonce, t, px, m));
++        const e = schnorrChallengeFinalize(await tag(TAGS.challenge, rx, px, m));
++        const sig = this.finalizeSig(R, k, e, d);
++        if (!(await schnorrVerify(sig, m, px)))
++            this.error();
++        return sig;
++    }
++    calcSync() {
++        const { m, d, px, rand } = this;
++        const tag = exports.utils.taggedHashSync;
++        const t = this.initNonce(d, tag(TAGS.aux, rand));
++        const { R, rx, k } = this.finalizeNonce(tag(TAGS.nonce, t, px, m));
++        const e = schnorrChallengeFinalize(tag(TAGS.challenge, rx, px, m));
++        const sig = this.finalizeSig(R, k, e, d);
++        if (!schnorrVerifySync(sig, m, px))
++            this.error();
++        return sig;
++    }
++}
++async function schnorrSign(msg, privKey, auxRand) {
++    return new InternalSchnorrSignature(msg, privKey, auxRand).calc();
++}
++function schnorrSignSync(msg, privKey, auxRand) {
++    return new InternalSchnorrSignature(msg, privKey, auxRand).calcSync();
++}
++function initSchnorrVerify(signature, message, publicKey) {
++    const raw = signature instanceof SchnorrSignature;
++    const sig = raw ? signature : SchnorrSignature.fromHex(signature);
++    if (raw)
++        sig.assertValidity();
++    return {
++        ...sig,
++        m: ensureBytes(message),
++        P: normalizePublicKey(publicKey),
++    };
++}
++function finalizeSchnorrVerify(r, P, s, e) {
++    const R = Point.BASE.multiplyAndAddUnsafe(P, normalizePrivateKey(s), mod(-e, CURVE.n));
++    if (!R || !R.hasEvenY() || R.x !== r)
++        return false;
++    return true;
++}
++async function schnorrVerify(signature, message, publicKey) {
++    try {
++        const { r, s, m, P } = initSchnorrVerify(signature, message, publicKey);
++        const e = schnorrChallengeFinalize(await exports.utils.taggedHash(TAGS.challenge, numTo32b(r), P.toRawX(), m));
++        return finalizeSchnorrVerify(r, P, s, e);
++    }
++    catch (error) {
++        return false;
++    }
++}
++function schnorrVerifySync(signature, message, publicKey) {
++    try {
++        const { r, s, m, P } = initSchnorrVerify(signature, message, publicKey);
++        const e = schnorrChallengeFinalize(exports.utils.taggedHashSync(TAGS.challenge, numTo32b(r), P.toRawX(), m));
++        return finalizeSchnorrVerify(r, P, s, e);
++    }
++    catch (error) {
++        if (error instanceof ShaError)
++            throw error;
++        return false;
++    }
++}
++exports.schnorr = {
++    Signature: SchnorrSignature,
++    getPublicKey: schnorrGetPublicKey,
++    sign: schnorrSign,
++    verify: schnorrVerify,
++    signSync: schnorrSignSync,
++    verifySync: schnorrVerifySync,
++};
++Point.BASE._setWindowSize(8);
++const crypto = {
++    node: nodeCrypto,
++    web: typeof self === 'object' && 'crypto' in self ? self.crypto : undefined,
++};
++const TAGS = {
++    challenge: 'BIP0340/challenge',
++    aux: 'BIP0340/aux',
++    nonce: 'BIP0340/nonce',
++};
++const TAGGED_HASH_PREFIXES = {};
++exports.utils = {
++    bytesToHex,
++    hexToBytes,
++    concatBytes,
++    mod,
++    invert,
++    isValidPrivateKey(privateKey) {
++        try {
++            normalizePrivateKey(privateKey);
++            return true;
++        }
++        catch (error) {
++            return false;
++        }
++    },
++    _bigintTo32Bytes: numTo32b,
++    _normalizePrivateKey: normalizePrivateKey,
++    hashToPrivateKey: (hash) => {
++        hash = ensureBytes(hash);
++        if (hash.length < 40 || hash.length > 1024)
++            throw new Error('Expected 40-1024 bytes of private key as per FIPS 186');
++        const num = mod(bytesToNumber(hash), CURVE.n - _1n) + _1n;
++        return numTo32b(num);
++    },
++    randomBytes: (bytesLength = 32) => {
++        if (crypto.web) {
++            return crypto.web.getRandomValues(new Uint8Array(bytesLength));
++        }
++        else if (crypto.node) {
++            const { randomBytes } = crypto.node;
++            return Uint8Array.from(randomBytes(bytesLength));
++        }
++        else {
++            throw new Error("The environment doesn't have randomBytes function");
++        }
++    },
++    randomPrivateKey: () => {
++        return exports.utils.hashToPrivateKey(exports.utils.randomBytes(40));
++    },
++    sha256: async (...messages) => {
++        if (crypto.web) {
++            const buffer = await crypto.web.subtle.digest('SHA-256', concatBytes(...messages));
++            return new Uint8Array(buffer);
++        }
++        else if (crypto.node) {
++            const { createHash } = crypto.node;
++            const hash = createHash('sha256');
++            messages.forEach((m) => hash.update(m));
++            return Uint8Array.from(hash.digest());
++        }
++        else {
++            throw new Error("The environment doesn't have sha256 function");
++        }
++    },
++    hmacSha256: async (key, ...messages) => {
++        if (crypto.web) {
++            const ckey = await crypto.web.subtle.importKey('raw', key, { name: 'HMAC', hash: { name: 'SHA-256' } }, false, ['sign']);
++            const message = concatBytes(...messages);
++            const buffer = await crypto.web.subtle.sign('HMAC', ckey, message);
++            return new Uint8Array(buffer);
++        }
++        else if (crypto.node) {
++            const { createHmac } = crypto.node;
++            const hash = createHmac('sha256', key);
++            messages.forEach((m) => hash.update(m));
++            return Uint8Array.from(hash.digest());
++        }
++        else {
++            throw new Error("The environment doesn't have hmac-sha256 function");
++        }
++    },
++    sha256Sync: undefined,
++    hmacSha256Sync: undefined,
++    taggedHash: async (tag, ...messages) => {
++        let tagP = TAGGED_HASH_PREFIXES[tag];
++        if (tagP === undefined) {
++            const tagH = await exports.utils.sha256(Uint8Array.from(tag, (c) => c.charCodeAt(0)));
++            tagP = concatBytes(tagH, tagH);
++            TAGGED_HASH_PREFIXES[tag] = tagP;
++        }
++        return exports.utils.sha256(tagP, ...messages);
++    },
++    taggedHashSync: (tag, ...messages) => {
++        if (typeof _sha256Sync !== 'function')
++            throw new ShaError('sha256Sync is undefined, you need to set it');
++        let tagP = TAGGED_HASH_PREFIXES[tag];
++        if (tagP === undefined) {
++            const tagH = _sha256Sync(Uint8Array.from(tag, (c) => c.charCodeAt(0)));
++            tagP = concatBytes(tagH, tagH);
++            TAGGED_HASH_PREFIXES[tag] = tagP;
++        }
++        return _sha256Sync(tagP, ...messages);
++    },
++    precompute(windowSize = 8, point = Point.BASE) {
++        const cached = point === Point.BASE ? point : new Point(point.x, point.y);
++        cached._setWindowSize(windowSize);
++        cached.multiply(_3n);
++        return cached;
++    },
++};
++Object.defineProperties(exports.utils, {
++    sha256Sync: {
++        configurable: false,
++        get() {
++            return _sha256Sync;
++        },
++        set(val) {
++            if (!_sha256Sync)
++                _sha256Sync = val;
++        },
++    },
++    hmacSha256Sync: {
++        configurable: false,
++        get() {
++            return _hmacSha256Sync;
++        },
++        set(val) {
++            if (!_hmacSha256Sync)
++                _hmacSha256Sync = val;
++        },
++    },
++});
+diff --git a/node_modules/@noble/secp256k1/package.json b/node_modules/@noble/secp256k1/package.json
+index 40aa828..5adef10 100644
+--- a/node_modules/@noble/secp256k1/package.json
++++ b/node_modules/@noble/secp256k1/package.json
+@@ -96,6 +96,7 @@
+   "main": "lib/index.js",
+   "module": "lib/esm/index.js",
+   "name": "@noble/secp256k1",
++  "react-native": "lib/react-native.js",
+   "repository": {
+     "type": "git",
+     "url": "git+https://github.com/paulmillr/noble-secp256k1.git"

--- a/packages/mobile/index.js
+++ b/packages/mobile/index.js
@@ -14,7 +14,8 @@ require('react-native-url-polyfill/auto')
 
 // Polyfill BigInt
 if (typeof BigInt === 'undefined') {
-  global.BigInt = require('big-integer')
+  // eslint-disable-next-line
+  BigInt = require('big-integer')
 }
 
 const App = require('./src/App').default


### PR DESCRIPTION
### Description
The addition of `@metaplex-foundation/mpl-token-metadata` in https://github.com/AudiusProject/audius-client/pull/2398 caused a crash on mobile when loading a profile with solana collectibles (It was not possible to repro locally on ios and only able to repro locally on android without the debugger attached)

This was the error being thrown: https://sentry.io/organizations/audius/issues/3832938092/?query=bigint&referrer=issue-stream&statsPeriod=14d

This PR:
* Polyfills BigInt with `big-integer` 
* Patches @noble packages for compatibility `big-integer`. `big-integer` does not support `0x` prefixes, instead uses a radix argument

Solana docs specify a min version of react-native of 0.70 which would fix this problem also. We should prioritize upgrading so that we don't need this hacky fix for long https://github.com/solana-labs/solana-web3.js/blob/34b107635cd21d9e61c705ded316064df06950a0/README.md#compatibility

### Dragons

The only thing that could potentially break here is the solana nft premium content stuff, but this fix should keep that working too!

### How Has This Been Tested?

Android locally, will test on ios once on stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

