### PR TITLE
Add getImageSourceOptimistic

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -30,10 +30,7 @@ import TrackPlayer, {
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
-import {
-  DEFAULT_IMAGE_URL,
-  useTrackImage
-} from 'app/components/image/TrackImage'
+import { DEFAULT_IMAGE_URL } from 'app/components/image/TrackImage'
 import { getImageSourceOptimistic } from 'app/hooks/useContentNodeImage'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useOfflineTrackUri } from 'app/hooks/useOfflineTrackUri'

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_IMAGE_URL,
   useTrackImage
 } from 'app/components/image/TrackImage'
+import { getImageSourceOptimistic } from 'app/hooks/useContentNodeImage'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useOfflineTrackUri } from 'app/hooks/useOfflineTrackUri'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
@@ -140,7 +141,6 @@ export const Audio = () => {
   const trackOwner = useSelector((state) =>
     getUser(state, { id: track?.owner_id })
   )
-  const trackImageSource = useTrackImage(track, trackOwner ?? undefined)
   const currentUserId = useSelector(getUserId)
   const isReachable = useSelector(getIsReachable)
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
@@ -161,10 +161,6 @@ export const Audio = () => {
   )
   const nextTrackOwner = useSelector((state) =>
     getUser(state, { id: nextTrack?.owner_id })
-  )
-  const nextTrackImageSource = useTrackImage(
-    nextTrack,
-    nextTrackOwner ?? undefined
   )
 
   const { isCasting } = useChromecast()
@@ -447,9 +443,21 @@ export const Audio = () => {
     }
 
     currentUriRef.current = newUri
-    const imageUrl = trackImageSource?.source?.[2]?.uri ?? DEFAULT_IMAGE_URL
+    const imageUrl =
+      getImageSourceOptimistic({
+        cid: track ? track.cover_art_sizes || track.cover_art : null,
+        user: trackOwner
+        // localSource
+      })?.[2]?.uri ?? DEFAULT_IMAGE_URL
+
     const nextImageUrl =
-      nextTrackImageSource?.source?.[2]?.uri ?? DEFAULT_IMAGE_URL
+      getImageSourceOptimistic({
+        cid: nextTrack
+          ? nextTrack.cover_art_sizes || nextTrack.cover_art
+          : null,
+        user: nextTrackOwner
+        // localSource
+      })?.[2]?.uri ?? DEFAULT_IMAGE_URL
 
     // NOTE: Adding two tracks into the queue to make sure that android has a next button on the lock screen and notification controls
     // This should be removed when the track player queue is used properly
@@ -495,13 +503,11 @@ export const Audio = () => {
     loadingOfflineTrack,
     nextSource,
     nextTrack,
-    nextTrackImageSource?.source,
-    nextTrackOwner?.name,
+    nextTrackOwner,
     playing,
     source,
     track,
-    trackImageSource?.source,
-    trackOwner?.name
+    trackOwner
   ])
 
   const handleTogglePlay = useCallback(


### PR DESCRIPTION
### Description

* Adds `getImageSourceOptimistic` that will return the first image source for a given user and cid. This can be used to get the image source for an array of tracks for example for the react-native-track-player

### Dragons

`useLocalImage` is still a hook so we can't support local images in the track-player yet, but can add that next

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

