### PR TITLE
[QA-269] Update counter effect logic to only reset track position when the track index is the same

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -326,11 +326,26 @@ export const Audio = () => {
     }
   }, [seek, setSeekPosition])
 
+  // Keep track of the track index the last time counter was updated
+  const counterTrackIndex = useRef<number | null>(null)
+
+  const resetPositionForSameTrack = useCallback(() => {
+    // NOTE: Make sure that we only set seek position to 0 when we are restarting a track
+    const trackIndex = queueShuffle ? queueShuffleIndex : queueIndex
+    if (trackIndex === counterTrackIndex.current) setSeekPosition(0)
+    counterTrackIndex.current = trackIndex
+  }, [queueIndex, queueShuffle, queueShuffleIndex, setSeekPosition])
+
+  const counterRef = useRef<number | null>(null)
+
   // Restart (counter) handler
   useEffect(() => {
-    setSeekPosition(0)
+    if (counter !== counterRef.current) {
+      counterRef.current = counter
+      resetPositionForSameTrack()
+    }
     setListenLoggedForTrack(false)
-  }, [counter, setSeekPosition])
+  }, [counter, resetPositionForSameTrack])
 
   const { loading: loadingOfflineTrack, value: offlineTrackUri } =
     useOfflineTrackUri(track?.track_id.toString())


### PR DESCRIPTION
### Description
Update logic for the counter effect to only reset the playback position when the track index has not changed. This will reset it when we restart the track, but not when playing a new track.

There was some wonkiness with the effect being called too many times due to the function updating when the queue index updated so there is some hacky counterRef logic to help with that.

### Dragons

N/A

### How Has This Been Tested?

Manually tested on iOS

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

