### PR TITLE
Move offline mode feature backdoor to about page

### DIFF
--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import type { CommonState } from '@audius/common'
 import { accountActions } from '@audius/common'
-import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
@@ -17,7 +16,6 @@ import { TopTabNavigator } from 'app/components/top-tab-bar'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
 import { useFetchAllFavoritedTracks } from 'app/hooks/useFetchAllFavoritedTracks'
 import {
-  toggleLocalOfflineModeOverride,
   useIsOfflineModeEnabled,
   useReadOfflineOverride
 } from 'app/hooks/useIsOfflineModeEnabled'
@@ -54,20 +52,11 @@ const favoritesScreens = [
 export const FavoritesScreen = () => {
   useAppTabScreen()
   const dispatch = useDispatch()
-  const [clickCount, setClickCount] = useState(0)
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
   const { value: allFavoritedTrackIds } = useFetchAllFavoritedTracks()
 
   useReadOfflineOverride()
-  const handleHeaderClick = useCallback(() => {
-    if (clickCount >= 10) {
-      toggleLocalOfflineModeOverride()
-      setClickCount(0)
-    } else {
-      setClickCount(clickCount + 1)
-    }
-  }, [clickCount])
 
   useEffectOnce(() => {
     dispatch(fetchSavedPlaylists())
@@ -106,20 +95,18 @@ export const FavoritesScreen = () => {
 
   return (
     <Screen>
-      <TouchableWithoutFeedback onPress={handleHeaderClick}>
-        <ScreenHeader
-          text={messages.header}
-          icon={IconFavorite}
-          styles={{ icon: { marginLeft: 3 } }}
-        >
-          {isOfflineModeEnabled && (
-            <DownloadToggle
-              tracksForDownload={tracksForDownload}
-              isFavoritesDownload
-            />
-          )}
-        </ScreenHeader>
-      </TouchableWithoutFeedback>
+      <ScreenHeader
+        text={messages.header}
+        icon={IconFavorite}
+        styles={{ icon: { marginLeft: 3 } }}
+      >
+        {isOfflineModeEnabled && (
+          <DownloadToggle
+            tracksForDownload={tracksForDownload}
+            isFavoritesDownload
+          />
+        )}
+      </ScreenHeader>
       {
         // ScreenContent handles the offline indicator.
         // Show favorites screen anyway when offline so users can see their downloads

--- a/packages/mobile/src/screens/settings-screen/AboutScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AboutScreen.tsx
@@ -1,5 +1,7 @@
+import { useCallback, useState } from 'react'
+
 import { COPYRIGHT_TEXT } from 'audius-client/src/utils/copyright'
-import { View, Image } from 'react-native'
+import { View, Image, TouchableWithoutFeedback } from 'react-native'
 import VersionNumber from 'react-native-version-number'
 
 import appIcon from 'app/assets/images/appIcon.png'
@@ -9,6 +11,7 @@ import IconDiscord from 'app/assets/images/iconDiscord.svg'
 import IconInstagram from 'app/assets/images/iconInstagram.svg'
 import IconTwitter from 'app/assets/images/iconTwitterBird.svg'
 import { Screen, Text } from 'app/components/core'
+import { toggleLocalOfflineModeOverride } from 'app/hooks/useIsOfflineModeEnabled'
 import { makeStyles } from 'app/styles'
 
 import { Divider } from './Divider'
@@ -45,13 +48,24 @@ const useStyles = makeStyles(({ spacing }) => ({
 
 export const AboutScreen = () => {
   const styles = useStyles()
+  const [clickCount, setClickCount] = useState(0)
+  const handleTitleClick = useCallback(() => {
+    if (clickCount >= 9) {
+      toggleLocalOfflineModeOverride()
+      setClickCount(0)
+    } else {
+      setClickCount(clickCount + 1)
+    }
+  }, [clickCount])
 
   return (
     <Screen variant='secondary' title={messages.title} topbarRight={null}>
       <View style={styles.header}>
         <Image source={appIcon} style={styles.appIcon} />
         <View>
-          <Text variant='h2'>{messages.appName}</Text>
+          <TouchableWithoutFeedback onPress={handleTitleClick}>
+            <Text variant='h2'>{messages.appName}</Text>
+          </TouchableWithoutFeedback>
           <Text variant='body2'>
             {messages.version} {VersionNumber.appVersion}
           </Text>


### PR DESCRIPTION
### Description

Move the dev backdoor to a place where it doesn't conflict with the offline download toggle.
This unblocks Android where the download toggle's touch target was being occluded by the backdoor's onclick.

![image](https://user-images.githubusercontent.com/2358254/210439903-f316c3b3-8afd-43d6-a78e-9b360e7a7946.png)
