### PR TITLE
use allSettled util instead of Promise.allSettled

### DIFF
--- a/packages/common/src/utils/allSettled.ts
+++ b/packages/common/src/utils/allSettled.ts
@@ -1,4 +1,5 @@
 export const allSettled =
+  // eslint-disable-next-line no-restricted-properties
   Promise.allSettled ||
   ((promises: any[]) =>
     Promise.all(

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './allSettled'
 export * from './browserNotifications'
 export * from './error'
 export * from './fillString'

--- a/packages/mobile/.eslintrc.js
+++ b/packages/mobile/.eslintrc.js
@@ -37,6 +37,15 @@ module.exports = {
       {
         disallowTypeAnnotations: false
       }
+    ],
+    'no-restricted-properties': [
+      'error',
+      {
+        object: 'Promise',
+        property: 'allSettled',
+        message:
+          'Do NOT use `Promise.allSettled` as it will be undefined. Use `allSettled` from `@audius/common` instead.'
+      }
     ]
   }
 }

--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -7,7 +7,7 @@ import type {
   UserMetadata,
   UserTrackMetadata
 } from '@audius/common'
-import { SquareSizes } from '@audius/common'
+import { allSettled, SquareSizes } from '@audius/common'
 import RNFS, { exists, readDir, readFile } from 'react-native-fs'
 
 import { store } from 'app/store'
@@ -205,7 +205,7 @@ export const verifyTrack = async (
     exists(path.join(getLocalTrackDir(trackId), `${size}.jpg`))
   )
 
-  const results = await Promise.allSettled([audioFile, jsonFile, ...artFiles])
+  const results = await allSettled([audioFile, jsonFile, ...artFiles])
   const booleanResults = results.map(
     (result) => result.status === 'fulfilled' && !!result.value
   )

--- a/packages/mobile/src/utils/populateCoverArtSizes.ts
+++ b/packages/mobile/src/utils/populateCoverArtSizes.ts
@@ -4,7 +4,7 @@ import type {
   Track,
   UserMetadata
 } from '@audius/common'
-import { DefaultSizes, SquareSizes } from '@audius/common'
+import { DefaultSizes, SquareSizes, allSettled } from '@audius/common'
 
 import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 
@@ -26,7 +26,7 @@ export const populateCoverArtSizes = async <T extends EntityWithArt>(
   )
   const multihash = entity.cover_art_sizes || entity.cover_art
   if (!multihash) return newEntity
-  await Promise.allSettled(
+  await allSettled(
     Object.values(SquareSizes).map(async (size) => {
       const coverArtSize = multihash === entity.cover_art_sizes ? size : null
       const url = await audiusBackendInstance.getImageUrl(


### PR DESCRIPTION
### Description

https://stackoverflow.com/q/66575667

`Promise.allSettled` is undefined in the js runner in prod but not the one used in dev. The dev runner has extra features for debugging and has the function populated.

### Dragons

Do we want the eslint warning for web and stems also?

### How Has This Been Tested?

Simulator with staging target:  `npx react-native run-ios --simulator "iPhone 14 Pro" --configuration Staging`

### How will this change be monitored?

eslint rule to prevent future failure

### Feature Flags ###

all failures were behind `OFFLINE_MODE_ENABLED`
