### PR TITLE
Fix the base58 error on solana nft collection key

### DIFF
--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -82,7 +82,10 @@ function* getTokenIdMap({
     if (collection?.verified) {
       // Weirdly enough, sometimes the key is a string, and other times it's a PublicKey
       // even though the @metaplex-foundation collection type defines it as a web3.PublicKey
-      const mintKey = typeof collection.key === 'string' ? collection.key : collection.key.toBase58()
+      const mintKey =
+        typeof collection.key === 'string'
+          ? collection.key
+          : collection.key.toBase58()
       solCollectionMintSet.add(mintKey)
     }
   })

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -80,7 +80,10 @@ function* getTokenIdMap({
     // https://docs.metaplex.com/programs/token-metadata/certified-collections#linking-regular-nfts-to-collection-nfts
     const { collection } = c.solanaChainMetadata
     if (collection?.verified) {
-      solCollectionMintSet.add(collection.key.toBase58())
+      // Weirdly enough, sometimes the key is a string, and other times it's a PublicKey
+      // even though the @metaplex-foundation collection type defines it as a web3.PublicKey
+      const mintKey = typeof collection.key === 'string' ? collection.key : collection.key.toBase58()
+      solCollectionMintSet.add(mintKey)
     }
   })
 


### PR DESCRIPTION
### Description

Fix the base58 error on solana nft collection key.
As written in the comment above the fix, the types returned are sometimes strings, other types PublicKey even though the library type says that it should be PublicKey.

`toBase58` function does not exist on strings, and this is what caused the bug.

See screenshot below for types returned by the library.

![Screen Shot 2023-01-04 at 4 40 38 PM](https://user-images.githubusercontent.com/9600175/210656169-e242eecf-e3c8-463e-9f74-b0c0bfe6550d.png)

### Dragons

None

### How Has This Been Tested?

No longer fails with account that currently fails on staging.

### How will this change be monitored?

N/A

### Feature Flags ###

None

