### PR TITLE
Set snapchat key based on environment

### DIFF
--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
 
         <meta-data android:name="com.dieam.reactnativepushnotification.notification_channel_name" android:value="Activity"/>
         <meta-data android:name="com.dieam.reactnativepushnotification.notification_channel_description" android:value="Your activity on Audius"/>
-        <meta-data android:name="com.snapchat.kit.sdk.clientId" android:value="87c93c66-5a79-4ee0-be45-44f27e823474" />
+        <meta-data android:name="com.snapchat.kit.sdk.clientId" android:value="e4716145-55b7-4a90-9d90-e977733713ed" />
         <!-- Change the resource name to your App's accent color - or any other color you want -->
         <meta-data android:name="com.dieam.reactnativepushnotification.notification_color" android:resource="@android:color/white"/>
 

--- a/packages/mobile/ios/AudiusReactNative.xcodeproj/project.pbxproj
+++ b/packages/mobile/ios/AudiusReactNative.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.audius.audiusmusic;
 				PRODUCT_NAME = "Audius Music";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development co.audius.audiusmusic";
+				SCSDK_CLIENT_ID = e4716145-55b7-4a90-9d90-e977733713ed;
 				SWIFT_OBJC_BRIDGING_HEADER = "AudiusReactNative-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -504,6 +505,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.audius.audiusmusic;
 				PRODUCT_NAME = "Audius Music";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development co.audius.audiusmusic";
+
+				SCSDK_CLIENT_ID = e4716145-55b7-4a90-9d90-e977733713ed;
 				SWIFT_OBJC_BRIDGING_HEADER = "AudiusReactNative-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -697,6 +700,7 @@
 				PRODUCT_NAME = "Audius Music Release Candidate";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore co.audius.audiusmusic.releasecandidate";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore co.audius.audiusmusic.releasecandidate";
+				SCSDK_CLIENT_ID = e4716145-55b7-4a90-9d90-e977733713ed;
 				SWIFT_OBJC_BRIDGING_HEADER = "AudiusReactNative-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -784,6 +788,7 @@
 				PRODUCT_NAME = "Audius Music Release Candidate Staging";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore co.audius.audiusmusic.staging.releasecandidate";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore co.audius.audiusmusic.staging.releasecandidate";
+				SCSDK_CLIENT_ID = 6f90a744-e5d0-4115-ad14-fb1a356085cd;
 				SWIFT_OBJC_BRIDGING_HEADER = "AudiusReactNative-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -875,6 +880,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.audius.audiusmusic.staging;
 				PRODUCT_NAME = "Audius Music Staging";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development co.audius.audiusmusic.staging";
+				SCSDK_CLIENT_ID = 6f90a744-e5d0-4115-ad14-fb1a356085cd;
 				SWIFT_OBJC_BRIDGING_HEADER = "AudiusReactNative-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -960,6 +966,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = co.audius.audiusmusic.staging;
 				PRODUCT_NAME = "Audius Music Staging";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development co.audius.audiusmusic.staging";
+				SCSDK_CLIENT_ID = 6f90a744-e5d0-4115-ad14-fb1a356085cd;
 				SWIFT_OBJC_BRIDGING_HEADER = "AudiusReactNative-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/packages/mobile/ios/AudiusReactNative/Info.plist
+++ b/packages/mobile/ios/AudiusReactNative/Info.plist
@@ -45,7 +45,7 @@
       <string>snapchat</string>
 		</array>
     <key>SCSDKClientId</key>
-    <string>87c93c66-5a79-4ee0-be45-44f27e823474</string>
+    <string>$(SCSDK_CLIENT_ID)</string>
     <key>SCSDKRedirectUrl</key>
 	  <string>audius://snap-kit/oauth2</string>
     


### PR DESCRIPTION
### Description

Set snapchat key based on env on iOS, this should get iOS share to snapchat in a testable state.
Will need to do similar for android, but need to get android building first

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

