### PR TITLE
[PAY-808] [PAY-810] Float new playlists to top of library

### DIFF
--- a/packages/common/src/store/pages/profile/reducer.ts
+++ b/packages/common/src/store/pages/profile/reducer.ts
@@ -38,7 +38,7 @@ const initialProfileState = {
   updateError: false,
   mostUsedTags: [],
 
-  collectionSortMode: CollectionSortMode.SAVE_COUNT,
+  collectionSortMode: CollectionSortMode.TIMESTAMP,
 
   profileMeterDismissed: false,
 

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -33,6 +33,7 @@ import { fetchUsers } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
+import { addPlaylistsNotInLibrary } from 'common/store/playlist-library/sagas'
 import { waitForWrite } from 'utils/sagaHelpers'
 
 import { reformat } from './utils'
@@ -233,6 +234,9 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
             }
           })
         )
+
+        // Write out the new playlist to the playlist library
+        yield call(addPlaylistsNotInLibrary)
 
         const event = make(Name.PLAYLIST_COMPLETE_CREATE, {
           source,

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -611,7 +611,7 @@ function* removeTrackFromPlaylistAsync(action) {
 }
 
 // Removes the invalid track ids from the playlist by calling `dangerouslySetPlaylistOrder`
-function* fixInvalidTracksInPlaylist(playlistId, userId, invalidTrackIds) {
+function* fixInvalidTracksInPlaylist(playlistId, invalidTrackIds) {
   yield waitForWrite()
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
   const apiClient = yield getContext('apiClient')
@@ -671,7 +671,6 @@ function* confirmRemoveTrackFromPlaylist(
             const updatedPlaylist = yield call(
               fixInvalidTracksInPlaylist,
               confirmedPlaylistId,
-              userId,
               invalidTrackIds
             )
             const isTrackRemoved =
@@ -801,7 +800,6 @@ function* confirmOrderPlaylist(userId, playlistId, trackIds, playlist) {
             yield call(
               fixInvalidTracksInPlaylist,
               confirmedPlaylistId,
-              userId,
               invalidTrackIds
             )
             const invalidIds = new Set(invalidTrackIds)

--- a/packages/web/src/common/store/playlist-library/sagas.ts
+++ b/packages/web/src/common/store/playlist-library/sagas.ts
@@ -165,7 +165,7 @@ export function* addPlaylistsNotInLibrary() {
           type: 'playlist'
         } as PlaylistIdentifier)
     )
-    const newContents = library.contents.concat(newEntries)
+    const newContents = [...newEntries, ...library.contents]
     yield put(
       update({ playlistLibrary: { ...library, contents: newContents } })
     )

--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -35,6 +35,7 @@ import { reformat } from 'common/store/cache/collections/utils'
 import { trackNewRemixEvent } from 'common/store/cache/tracks/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
+import { addPlaylistsNotInLibrary } from 'common/store/playlist-library/sagas'
 import { updateAndFlattenStems } from 'pages/upload-page/store/utils/stems'
 import { ERROR_PAGE } from 'utils/route'
 import { waitForWrite } from 'utils/sagaHelpers'
@@ -805,6 +806,9 @@ function* uploadCollection(tracks, userId, collectionMetadata, isAlbum) {
           })
         )
         yield put(cacheActions.setExpired(Kind.USERS, userId))
+
+        // Finally, add to the library
+        yield call(addPlaylistsNotInLibrary)
       },
       function* ({ timeout }) {
         // All other non-timeout errors have

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -376,6 +376,9 @@ const PlaylistLibrary = ({
         }
         acceptedKinds={['library-playlist', 'playlist-folder']}
       />
+      {Object.values(playlistsNotInLibrary).map((playlist) => {
+        return renderPlaylist(playlist.id)
+      })}
       {account && playlists && library ? (
         <LibraryContentsLevel
           contents={library.contents || []}
@@ -384,9 +387,6 @@ const PlaylistLibrary = ({
           renderFolder={renderFolder}
         />
       ) : null}
-      {Object.values(playlistsNotInLibrary).map((playlist) => {
-        return renderPlaylist(playlist.id)
-      })}
       {isEmpty(library?.contents) ? (
         <div className={cn(navColumnStyles.link, navColumnStyles.disabled)}>
           Create your first playlist!


### PR DESCRIPTION
### Description

- New playlists start on top of playlist library in navbar
- Changed default sort order to recency in profile page
- Fixed issues with playlist creation:
Prior to this PR, creating a playlist would write out a playlist to your account's collections, which would get flushed to local storage. The playlist library wouldn't get updated until *next session* as part of the sign on sagas, which check for playlist library state differing from account collection state. This PR writes out the playlist library as part of the confirmation flow.

### Dragons

Playlist creation flow is a bit scary. But this seems to work

### How Has This Been Tested?

Web. Testing mobile

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

