### PR TITLE
Change where we record user response so that the rate CTA drawer feels more responsive

### DIFF
--- a/packages/mobile/src/components/rate-cta-drawer/RateCtaDrawer.tsx
+++ b/packages/mobile/src/components/rate-cta-drawer/RateCtaDrawer.tsx
@@ -72,12 +72,13 @@ export const RateCtaDrawer = () => {
 
   const handleReviewConfirm = () => {
     const isAvailable = InAppReview.isAvailable()
+    track(make({ eventName: Name.RATE_CTA_RESPONSE_YES }))
+    setUserRateResponse('YES')
 
     if (isAvailable) {
       InAppReview.RequestInAppReview()
         .then((hasFlowFinishedSuccessfully) => {
-          setUserRateResponse('YES')
-          track(make({ eventName: Name.RATE_CTA_RESPONSE_YES }))
+          // Do things after the popup shows up
         })
         .catch((error) => {
           console.log(error)


### PR DESCRIPTION
### Description
Small update to track the user response before waiting for the review library to open the pop up so that the user doesn't think that the drawer is laggy/broken

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

