### PR TITLE
[C-1768] Fix android build w/ snapchat

### DIFF
--- a/packages/mobile/android/build.gradle
+++ b/packages/mobile/android/build.gradle
@@ -9,6 +9,10 @@ buildscript {
         castFrameworkVersion = "21.0.0"
         ndkVersion = "23.1.7779620"
         ffmpegKitPackage = "https-gpl-lts"
+
+        // The correct property is `kotlin_version` but 
+        // snap-kit-react-native` depends on `kotlinVersion`
+        kotlinVersion = "1.6.0"
     }
     repositories {
         google()

--- a/packages/mobile/android/build.gradle
+++ b/packages/mobile/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         ffmpegKitPackage = "https-gpl-lts"
 
         // The correct property is `kotlin_version` but 
-        // snap-kit-react-native` depends on `kotlinVersion`
+        // snap-kit-react-native depends on `kotlinVersion`
         kotlinVersion = "1.6.0"
     }
     repositories {


### PR DESCRIPTION
### Description

Android build was failing because of incompatible kotlin versions, but looking at the snapchat package source code I found that it incorrectly references `kotlinVersion` instead of `kotlin_version`. Setting `kotlinVersion` in our project fixes the issue

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

