### PR TITLE
[C-1756][C-1767] Fix job cancellation for track download queue

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -116,3 +116,5 @@ export const cancelQueuedDownloads = async (
   })
   queue.start()
 }
+
+global.queue = queue

--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -116,5 +116,3 @@ export const cancelQueuedDownloads = async (
   })
   queue.start()
 }
-
-global.queue = queue

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -141,7 +141,7 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
     return new Error(message)
   }
 
-  const state = store.getState() as CommonState
+  const state = store.getState()
   const currentUserId = getUserId(state)
   const offlineTracks = getOfflineTracks(state)
   if (shouldAbortDownload(downloadReason)) {
@@ -251,6 +251,7 @@ const shouldAbortDownload = (downloadReason: DownloadReason) => {
     (downloadReason.is_from_favorites &&
       !offlineCollections[DOWNLOAD_REASON_FAVORITES]) ||
     (!downloadReason.is_from_favorites &&
+      downloadReason.collection_id &&
       !offlineCollections[downloadReason.collection_id])
   )
 }

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -144,8 +144,7 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
   const state = store.getState() as CommonState
   const currentUserId = getUserId(state)
   const offlineTracks = getOfflineTracks(state)
-  // Short-circuit download if the associated collection has been disabled
-  if (shouldAbortDownload(trackIdStr, downloadReason)) {
+  if (shouldAbortDownload(downloadReason)) {
     if (!offlineTracks[trackId]) {
       store.dispatch(removeDownload(trackIdStr))
     }
@@ -189,8 +188,8 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
         }
       }
 
-      if (shouldAbortDownload(trackIdStr, downloadReason)) {
-        // Don't dispatch removeDownlaod here, since it's already downloaded as part of another collection
+      if (shouldAbortDownload(downloadReason)) {
+        // Don't dispatch removeDownlaod in this case, since it's already downloaded as part of another collection
         return
       }
 
@@ -219,8 +218,7 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
       }
     }
 
-    // Short-circuit download if the associated collection has been disabled
-    if (shouldAbortDownload(trackIdStr, downloadReason)) {
+    if (shouldAbortDownload(downloadReason)) {
       store.dispatch(removeDownload(trackIdStr))
       return
     }
@@ -245,11 +243,8 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
   }
 }
 
-// Short-circuit download if the associated collection has been disabled
-const shouldAbortDownload = (
-  trackIdStr: string,
-  downloadReason: DownloadReason
-) => {
+// Util to check if we should short-circuit download in case the associated collection download has been cancelled
+const shouldAbortDownload = (downloadReason: DownloadReason) => {
   const state = store.getState()
   const offlineCollections = getOfflineCollections(state)
   return (


### PR DESCRIPTION
### Description

We have a mechanism to remove jobs from the queue when a collection download is toggled off. However, jobs that had already been picked up by a worker cannot be safely cancelled.

Added some bail-out points where the download worker will check if the download should be aborted.

### Dragons

We might litter a bit if we cancel after downloading assets.
We might complete a download on disk that isn't marked in state if cancelled after the last checkpoint.

### How Has This Been Tested?

iOS simulator

### Feature Flags ###

`OFFLINE_MODE_ENABLED`

