### PR TITLE
[C-1788][C-1784][C-1785] Fix offline queue loops and duplicates

### DIFF
--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -1,5 +1,6 @@
 import type { UserCollectionMetadata } from '@audius/common'
 import {
+  FavoriteSource,
   tracksSocialActions,
   collectionsSocialActions,
   accountSelectors
@@ -44,7 +45,12 @@ export function* downloadSavedCollection(
   const offlineCollections = yield* select(getOfflineCollections)
   const currentUserId = yield* select(getUserId)
 
-  if (!offlineCollections[DOWNLOAD_REASON_FAVORITES] || !currentUserId) return
+  if (
+    !offlineCollections[DOWNLOAD_REASON_FAVORITES] ||
+    action.source === FavoriteSource.OFFLINE_DOWNLOAD ||
+    !currentUserId
+  )
+    return
   const collection: UserCollectionMetadata = (yield* call(
     [apiClient, apiClient.getPlaylist],
     {


### PR DESCRIPTION
### Description

Prevent infinite favorite/download loop in saga
Prevent duplicate downloadReasons in saved json which caused extra jobs to be spawned on startup.