### PR TITLE
[C-1789] Fix lottie colorize crash

### DIFF
--- a/packages/mobile/src/components/core/FlatList.tsx
+++ b/packages/mobile/src/components/core/FlatList.tsx
@@ -77,7 +77,7 @@ const AnimatedFlatList = forwardRef<RNFlatList, FlatListProps>(
 
     return (
       <View>
-        {handleRefresh ? (
+        {Platform.OS === 'ios' && handleRefresh ? (
           <PullToRefresh
             isRefreshing={isRefreshing}
             onRefresh={handleRefresh}

--- a/packages/mobile/src/components/core/PullToRefresh.tsx
+++ b/packages/mobile/src/components/core/PullToRefresh.tsx
@@ -198,10 +198,17 @@ export const PullToRefresh = ({
   const [shouldShowSpinner, setShouldShowSpinner] = useState(false)
   const animationRef = useRef<LottieView | null>()
 
-  const icon = shouldShowSpinner ? IconRefreshSpin : IconRefreshPull
-  const colorizedIcon = useMemo(
+  const colorizedIconRefreshSpin = useMemo(
     () =>
-      colorize(icon, {
+      colorize(IconRefreshSpin, {
+        'assets.0.layers.0.shapes.0.it.1.ck': color || neutralLight4
+      }),
+    [color, neutralLight4]
+  )
+
+  const colorizedIconRefreshPull = useMemo(
+    () =>
+      colorize(IconRefreshPull, {
         // arrow Outlines 4.Group 1.Stroke 1
         'assets.0.layers.0.shapes.0.it.1.c.k': color || neutralLight4,
         // arrow Outlines 2.Group 3.Stroke 1
@@ -211,8 +218,12 @@ export const PullToRefresh = ({
         // arrow Outlines.Group 2.Stroke 1
         'layers.2.shapes.1.it.1.c.k': color || neutralLight4
       }),
-    [icon, color, neutralLight4]
+    [color, neutralLight4]
   )
+
+  const colorizedIcon = shouldShowSpinner
+    ? colorizedIconRefreshSpin
+    : colorizedIconRefreshPull
 
   const handleAnimationFinish = useCallback(
     (isCancelled: boolean) => {

--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -54,7 +54,7 @@ const CollapsibleSectionList = (props: CollapsibleSectionListProps) => {
 
   return (
     <View>
-      {onRefresh ? (
+      {Platform.OS === 'ios' && onRefresh ? (
         <Portal hostName='PullToRefreshPortalHost'>
           <PullToRefresh
             isRefreshing={refreshing}
@@ -113,7 +113,7 @@ const AnimatedSectionList = forwardRef<RNSectionList, SectionListProps>(
 
     return (
       <View>
-        {handleRefresh ? (
+        {Platform.OS === 'ios' && handleRefresh ? (
           <PullToRefresh
             isRefreshing={isRefreshing}
             onRefresh={handleRefresh}


### PR DESCRIPTION
### Description

Updating to the latest lottie revealed a bug in our colorization of the PullToRefresh via a crash on android
* Fix lottie paths in PullToRefresh
* Only render PullToRefresh on ios (it's handled natively on android)

Will cherry pick onto release

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

