### PR TITLE
Entity manager notification writes

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2164,9 +2164,10 @@ export const audiusBackend = ({
     await waitForLibsInit()
     const account = audiusLibs.Account.getCurrentUser()
     if (!account) return
+    let notificationsReadResponse
     try {
       const { data, signature } = await signData()
-      return await fetch(`${identityServiceUrl}/notifications/all`, {
+      const response = await fetch(`${identityServiceUrl}/notifications/all`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -2174,10 +2175,23 @@ export const audiusBackend = ({
           [AuthHeaders.Signature]: signature
         },
         body: JSON.stringify({ isViewed: true, clearBadges: !!nativeMobile })
-      }).then((res) => res.json())
+      })
+      notificationsReadResponse = await response.json()
     } catch (e) {
       console.error(e)
     }
+    try {
+      if (
+        await getFeatureEnabled(
+          FeatureFlags.ENTITY_MANAGER_VIEW_NOTIFICATIONS_ENABLED
+        )
+      ) {
+        await audiusLibs.Notifications.viewNotification({})
+      }
+    } catch (err) {
+      console.error(e)
+    }
+    return notificationsReadResponse
   }
 
   async function clearNotificationBadges() {
@@ -2696,9 +2710,10 @@ export const audiusBackend = ({
     const account = audiusLibs.Account.getCurrentUser()
     if (!account) return
 
+    let updatedPlaylistResponse = false
     try {
       const { data, signature } = await signData()
-      return await fetch(
+      const response = await fetch(
         `${identityServiceUrl}/user_playlist_updates?walletAddress=${account.wallet}&playlistId=${playlistId}`,
         {
           method: 'POST',
@@ -2709,10 +2724,22 @@ export const audiusBackend = ({
           }
         }
       )
+      updatedPlaylistResponse = await response.json()
     } catch (err) {
       console.log(getErrorMessage(err))
-      return false
     }
+    try {
+      if (
+        await getFeatureEnabled(
+          FeatureFlags.ENTITY_MANAGER_VIEW_PLAYLIST_ENABLED
+        )
+      ) {
+        await audiusLibs.Notifications.viewPlaylist({ playlistId })
+      }
+    } catch (err) {
+      console.log(getErrorMessage(err))
+    }
+    return updatedPlaylistResponse
   }
 
   async function updateHCaptchaScore(token: string) {

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2189,7 +2189,7 @@ export const audiusBackend = ({
         await audiusLibs.Notifications.viewNotification({})
       }
     } catch (err) {
-      console.error(e)
+      console.error(err)
     }
     return notificationsReadResponse
   }

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -36,7 +36,9 @@ export enum FeatureFlags {
   SHARE_TO_SNAPCHAT = 'share_to_snapchat',
   CHAT_ENABLED = 'chat_enabled',
   FAST_CACHE = 'fast_cache',
-  SAFE_FAST_CACHE = 'safe_fast_cache'
+  SAFE_FAST_CACHE = 'safe_fast_cache',
+  ENTITY_MANAGER_VIEW_PLAYLIST_ENABLED = 'entity_manager_view_playlist_enabled',
+  ENTITY_MANAGER_VIEW_NOTIFICATIONS_ENABLED = 'entity_manager_view_notifications_enabled'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -88,5 +90,7 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.SHARE_TO_SNAPCHAT]: false,
   [FeatureFlags.CHAT_ENABLED]: false,
   [FeatureFlags.FAST_CACHE]: false,
-  [FeatureFlags.SAFE_FAST_CACHE]: false
+  [FeatureFlags.SAFE_FAST_CACHE]: false,
+  [FeatureFlags.ENTITY_MANAGER_VIEW_PLAYLIST_ENABLED]: false,
+  [FeatureFlags.ENTITY_MANAGER_VIEW_NOTIFICATIONS_ENABLED]: false
 }

--- a/packages/web/src/components/nav/desktop/NavColumn.tsx
+++ b/packages/web/src/components/nav/desktop/NavColumn.tsx
@@ -228,7 +228,7 @@ const NavColumn = ({
   ])
 
   const onClickNavLinkWithAccount = useCallback(
-    (e?: MouseEvent<HTMLAnchorElement>, id?: number) => {
+    (e?: MouseEvent, id?: number) => {
       if (!account) {
         e?.preventDefault()
         goToSignUp('restricted page')

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -56,7 +56,7 @@ const {
 } = accountSelectors
 
 type PlaylistLibraryProps = {
-  onClickNavLinkWithAccount: () => void
+  onClickNavLinkWithAccount: (e?: MouseEvent, playlistId?: number) => void
 }
 
 type LibraryContentsLevelProps = {
@@ -271,8 +271,10 @@ const PlaylistLibrary = ({
   }
 
   const onClickPlaylist = useCallback(
-    (playlistId: ID, hasUpdate: boolean) => {
-      onClickNavLinkWithAccount()
+    (e: MouseEvent, playlistId: ID, hasUpdate: boolean) => {
+      if (hasUpdate) {
+        onClickNavLinkWithAccount(e, playlistId)
+      }
       record(
         make(Name.PLAYLIST_LIBRARY_CLICKED, {
           playlistId,

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo, MouseEvent } from 'react'
 
 import {
   ID,

--- a/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistNavItem.tsx
@@ -97,7 +97,7 @@ type PlaylistNavItemProps = {
   hasUpdate?: boolean
   dragging: boolean
   draggingKind: string
-  onClickPlaylist: (id: ID, hasUpdate: boolean) => void
+  onClickPlaylist: (e: MouseEvent, id: ID, hasUpdate: boolean) => void
   onClickEdit?: (id: ID) => void
   isInsideFolder?: boolean
 }
@@ -149,7 +149,7 @@ export const PlaylistNavItem = ({
               draggingKind !== 'library-playlist') ||
               !isOwner)
         })}
-        onClick={() => onClickPlaylist(id, hasUpdate)}
+        onClick={(e) => onClickPlaylist(e, id, hasUpdate)}
         onMouseEnter={() => {
           setIsHovering(true)
         }}


### PR DESCRIPTION
### Description
Adds two feature flags (also created in optimizely)
`ENTITY_MANAGER_VIEW_PLAYLIST_ENABLED`: For enabling client to send playlist view entity manager actions
`ENTITY_MANAGER_VIEW_NOTIFICATIONS_ENABLED`: For enabling client to send view notifications action to entity manager

Note: this also fixes a method for sending the action from the web navbar

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
e2e locally 

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

