### PR TITLE
[QA-282] Fix app crash on edit playlist screen when missing collection image source

### DIFF
--- a/packages/mobile/src/screens/edit-playlist-screen/EditPlaylistScreen.tsx
+++ b/packages/mobile/src/screens/edit-playlist-screen/EditPlaylistScreen.tsx
@@ -141,7 +141,7 @@ export const EditPlaylistScreen = () => {
   const initialValues = {
     playlist_name,
     description,
-    artwork: { url: collectionImageSource?.source[0].uri ?? '' },
+    artwork: { url: collectionImageSource?.source[0]?.uri ?? '' },
     removedTracks: [],
     tracks,
     track_ids: playlist.playlist_contents.track_ids


### PR DESCRIPTION
### Description
Small issue where missing collection image source would crash the app

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

