### PR TITLE
[C-1764] Fix offline app initialization for offline mode

### DIFF
--- a/packages/common/src/store/reachability/reducer.ts
+++ b/packages/common/src/store/reachability/reducer.ts
@@ -5,8 +5,8 @@ import { ReachabilityState } from './types'
 
 type ReachabilityActions = ActionType<typeof actions>
 
-const initialState = {
-  networkReachable: true
+const initialState: ReachabilityState = {
+  networkReachable: 'unknown'
 }
 
 const reducer = createReducer<ReachabilityState, ReachabilityActions>(

--- a/packages/common/src/store/reachability/reducer.ts
+++ b/packages/common/src/store/reachability/reducer.ts
@@ -6,7 +6,9 @@ import { ReachabilityState } from './types'
 type ReachabilityActions = ActionType<typeof actions>
 
 const initialState: ReachabilityState = {
-  networkReachable: 'unknown'
+  // Default to truthy 'unconfirmed' state to differentiate
+  // between optimistic reachability and confirmed reachability
+  networkReachable: 'unconfirmed'
 }
 
 const reducer = createReducer<ReachabilityState, ReachabilityActions>(

--- a/packages/common/src/store/reachability/types.ts
+++ b/packages/common/src/store/reachability/types.ts
@@ -1,3 +1,3 @@
 export type ReachabilityState = {
-  networkReachable: boolean | 'unknown'
+  networkReachable: boolean | 'unconfirmed'
 }

--- a/packages/common/src/store/reachability/types.ts
+++ b/packages/common/src/store/reachability/types.ts
@@ -1,3 +1,3 @@
 export type ReachabilityState = {
-  networkReachable: boolean
+  networkReachable: boolean | 'unknown'
 }

--- a/packages/mobile/src/store/store.ts
+++ b/packages/mobile/src/store/store.ts
@@ -81,7 +81,12 @@ const createRootReducer = () =>
     shareToStoryProgress
   })
 
-const sagaMiddleware = createSagaMiddleware({ context: storeContext })
+const sagaMiddleware = createSagaMiddleware({
+  context: storeContext,
+  onError: (e) => {
+    console.error('Caught Saga Error', e, e.stack)
+  }
+})
 
 const middlewares = [sagaMiddleware]
 

--- a/packages/web/src/common/store/backend/reducer.ts
+++ b/packages/web/src/common/store/backend/reducer.ts
@@ -30,7 +30,7 @@ const actionsMap = {
   [SETUP_BACKEND_FAILED](state: BackendState) {
     return {
       ...state,
-      isSetup: true,
+      isSetup: false,
       web3Error: false
     }
   }

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -56,7 +56,7 @@ export function* waitForReachability() {
 function* awaitReachability() {
   const isNativeMobile = yield* getContext('isNativeMobile')
   const isReachable = yield* select(getIsReachable)
-  if (isReachable || !isNativeMobile) return true
+  if (isReachable === true || !isNativeMobile) return true
   const { action } = yield* race({
     action: take(reachabilityActions.SET_REACHABLE),
     delay: delay(REACHABILITY_TIMEOUT_MS)
@@ -68,6 +68,11 @@ export function* setupBackend() {
   // Optimistically fetch account, then do it again later when we're sure we're connected
   // This ensures we always get the cached account when starting offline if available
   yield* put(accountActions.fetchLocalAccount())
+
+  // Init APICLient
+  const apiClient = yield* getContext('apiClient')
+  apiClient.init()
+
   const establishedReachability = yield* call(awaitReachability)
   // If we couldn't connect, show the error page
   // and just sit here waiting for reachability.
@@ -78,12 +83,9 @@ export function* setupBackend() {
     console.info('Reconnected')
   }
 
-  const apiClient = yield* getContext('apiClient')
   const fingerprintClient = yield* getContext('fingerprintClient')
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
 
-  // Init APICLient
-  apiClient.init()
   // Fire-and-forget init fp
   fingerprintClient.init()
   yield* put(accountActions.fetchAccount())

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -106,17 +106,25 @@ function* watchSetupBackend() {
   yield* takeEvery(backendActions.SETUP, setupBackend)
 }
 
-// Watch for changes to reachability and if not fully set up, re set-up the backend
-function* watchReachabilityChange() {
-  yield* call(waitForValue, (state) => !getIsReachable(state))
+// If not fully set up, re set-up the backend
+export function* setupBackendIfNotSetUp() {
+  console.log('SetupBackendSaga called')
+  yield* put(backendActions.setupBackend())
+
   const isSetup = yield* select(getIsSetup)
   if (!isSetup) {
-    yield* call(waitForValue, (state) => getIsReachable(state))
     // Try to set up again, which should block further actions until completed
+    console.log('SetupBackendSaga action dispatched')
     yield* put(backendActions.setupBackend())
+  } else {
+    console.log('SetupBackendSaga already set up')
   }
 }
 
+function* watchSetReachable() {
+  yield* takeEvery(reachabilityActions.SET_REACHABLE, setupBackendIfNotSetUp)
+}
+
 export default function sagas() {
-  return [watchSetupBackend, watchBackendErrors, watchReachabilityChange]
+  return [watchSetupBackend, watchBackendErrors, watchSetReachable]
 }

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -103,16 +103,12 @@ function* watchSetupBackend() {
 
 // If not fully set up, re set-up the backend
 export function* setupBackendIfNotSetUp() {
-  console.log('SetupBackendSaga called')
   yield* put(backendActions.setupBackend())
 
   const isSetup = yield* select(getIsSetup)
   if (!isSetup) {
     // Try to set up again, which should block further actions until completed
-    console.log('SetupBackendSaga action dispatched')
     yield* put(backendActions.setupBackend())
-  } else {
-    console.log('SetupBackendSaga already set up')
   }
 }
 

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -49,7 +49,7 @@ export function* waitForBackendSetup() {
 export function* awaitReachability() {
   const isNativeMobile = yield* getContext('isNativeMobile')
   const isReachable = yield* select(getIsReachable)
-  if (isReachable === true || !isNativeMobile) return true
+  if (isReachable || !isNativeMobile) return true
   const { action } = yield* race({
     action: take(reachabilityActions.SET_REACHABLE),
     delay: delay(REACHABILITY_LONG_TIMEOUT)

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -11,7 +11,8 @@ import {
   lineupActions as baseLineupActions,
   queueActions,
   playerSelectors,
-  queueSelectors
+  queueSelectors,
+  waitForAccount
 } from '@audius/common'
 import {
   all,
@@ -29,6 +30,8 @@ import {
 
 import { getToQueue } from 'common/store/queue/sagas'
 import { isMobileWeb } from 'common/utils/isMobileWeb'
+
+import { waitForBackendSetup } from '../backend/sagas'
 
 const { getSource, getUid, getPositions } = queueSelectors
 const { getUid: getCurrentPlayerTrackUid, getPlaying } = playerSelectors
@@ -117,6 +120,8 @@ function* fetchLineupMetadatasAsync(
   sourceSelector,
   action
 ) {
+  yield waitForBackendSetup()
+  yield waitForAccount()
   const initLineup = yield select(lineupSelector)
   const initSource = sourceSelector
     ? yield select((state) =>

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -20,7 +20,7 @@ import { all, call, put, take, takeEvery, select } from 'typed-redux-saga'
 
 import { make } from 'common/store/analytics/actions'
 import { SETUP_BACKEND_SUCCEEDED } from 'common/store/backend/actions'
-import { waitForWrite, waitForRead } from 'utils/sagaHelpers'
+import { waitForWrite } from 'utils/sagaHelpers'
 
 const ATA_SIZE = 165 // Size allocated for an associated token account
 
@@ -171,7 +171,7 @@ function* getWalletBalanceAndWallets() {
 }
 
 function* fetchBalanceAsync() {
-  yield* waitForRead()
+  yield* waitForWrite()
   const walletClient = yield* getContext('walletClient')
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
 

--- a/packages/web/src/common/store/wallet/sagas.ts
+++ b/packages/web/src/common/store/wallet/sagas.ts
@@ -64,6 +64,7 @@ function* getIsBalanceFrozen() {
 function* sendAsync({
   payload: { recipientWallet, amount: weiAudioAmount, chain }
 }: ReturnType<typeof send>) {
+  // WalletClient relies on audiusBackendInstance. Use waitForWrite to ensure it's initialized
   yield* waitForWrite()
   const walletClient = yield* getContext('walletClient')
 

--- a/packages/web/src/store/reachability/sagas.ts
+++ b/packages/web/src/store/reachability/sagas.ts
@@ -50,7 +50,7 @@ export function* waitForReachability() {
   yield* all([take(reachabilityActions.SET_REACHABLE)])
 }
 
-// Wait until reachability is either true. 'unconfirmed' is not good enough
+// Wait until reachability is true. 'unconfirmed' is not good enough
 export function* waitForConfirmedReachability() {
   const isReachable = yield* select(getIsReachable)
   if (isReachable === true) return

--- a/packages/web/src/store/reachability/sagas.ts
+++ b/packages/web/src/store/reachability/sagas.ts
@@ -1,5 +1,5 @@
 import { reachabilityActions, reachabilitySelectors } from '@audius/common'
-import { call, delay, put, race, select } from 'typed-redux-saga'
+import { delay, race, put, all, take, select, call } from 'typed-redux-saga'
 
 import { isMobileWeb } from 'common/utils/isMobileWeb'
 
@@ -10,9 +10,9 @@ const REACHABILITY_URL = process.env.REACT_APP_REACHABILITY_URL
 
 // Property values borrowed from
 // https://github.com/react-native-community/react-native-netinfo
-const REACHABILITY_LONG_TIMEOUT = 10 * 1000 // 10s
-const REACHABILITY_SHORT_TIMEOUT = 5 * 1000 // 5s
-const REACHABILITY_REQUEST_TIMEOUT = 15 * 1000 // 15s
+export const REACHABILITY_LONG_TIMEOUT = 10 * 1000 // 10s
+export const REACHABILITY_SHORT_TIMEOUT = 5 * 1000 // 5s
+export const REACHABILITY_REQUEST_TIMEOUT = 15 * 1000 // 15s
 
 // Check that a response from REACHABILITY_URL is valid
 const isResponseValid = (response: Response | undefined) =>
@@ -41,6 +41,20 @@ function* ping() {
     console.debug('Reachability call failed')
     return false
   }
+}
+
+// Wait until reachability is either true or 'unconfirmed'
+export function* waitForReachability() {
+  const isReachable = yield* select(getIsReachable)
+  if (isReachable !== false) return
+  yield* all([take(reachabilityActions.SET_REACHABLE)])
+}
+
+// Wait until reachability is either true. 'unconfirmed' is not good enough
+export function* waitForConfirmedReachability() {
+  const isReachable = yield* select(getIsReachable)
+  if (isReachable === true) return
+  yield* all([take(reachabilityActions.SET_REACHABLE)])
 }
 
 /** Updates the reachability setting in the store and log-warns of any change. */

--- a/packages/web/src/utils/sagaHelpers.ts
+++ b/packages/web/src/utils/sagaHelpers.ts
@@ -1,10 +1,11 @@
 import { waitForAccount } from '@audius/common'
 import { call } from 'typed-redux-saga'
 
+import { waitForBackendSetup } from 'common/store/backend/sagas'
 import {
-  waitForBackendSetup,
+  waitForConfirmedReachability,
   waitForReachability
-} from 'common/store/backend/sagas'
+} from 'store/reachability/sagas'
 
 /**
  * Required for all writes
@@ -12,6 +13,7 @@ import {
 export function* waitForWrite() {
   yield* call(waitForBackendSetup)
   yield* call(waitForAccount)
+  yield* call(waitForConfirmedReachability)
 }
 
 /**


### PR DESCRIPTION
### Description

An error thrown in the wallet saga `fetchBalanceAsync` were causing all sagas to stop. After which point, no new actions were being processed.

FetchBalanceAsync should have been waiting for audiusBackendInstance to be setup, but was not.

We've split the reachability check into more states, adding an 'unconfirmed' state which can be used to optimistically assume reachability unless it is explicitly false. We use this for read calls that can be made without the full backend and will simply fail to respond. For writes requiring audiusBackend setup, we will use the more strict check that will only pass if reachability has been tested and confirmed true.

Changes:
1. Added third 'unconfirmed' reachability state
2. Added error logging to saga onError handler
3. Optimistically ApiClient.init() and setup backend
4. Retry setupBackend on every change to reachability if it hasn't been successfully set up yet
5. WaitForWrite now waits for confirmed reachability

### Dragons

Changes to app startup are always scary.

WaitForRead and WaitForWrite are intuitive, but do not necessarily cover all the cases. We may want to take another pass at those soon.

### How Has This Been Tested?

iOS Simulator

TODO:
- [ ] make sure we didn't break web

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

This is part of offline mode work, but notably not covered by the feature flag.
