### PR TITLE
[C-1397] Add appVersion to optimizely audience attributes

### DIFF
--- a/packages/common/src/services/remote-config/remote-config.ts
+++ b/packages/common/src/services/remote-config/remote-config.ts
@@ -43,6 +43,7 @@ export type RemoteConfigOptions<Client> = {
   setFeatureFlagSessionId: (id: number) => Promise<void>
   setLogLevel: () => void
   environment: Environment
+  appVersion: string
 }
 
 export const remoteConfig = <
@@ -60,7 +61,8 @@ export const remoteConfig = <
   getFeatureFlagSessionId,
   setFeatureFlagSessionId,
   setLogLevel,
-  environment
+  environment,
+  appVersion
 }: RemoteConfigOptions<Client>) => {
   const state: State = {
     didInitialize: false,
@@ -219,8 +221,10 @@ export const remoteConfig = <
 
     try {
       const enabled = state.didInitialize
-        ? client.isFeatureEnabled(flag, id.toString(), { userId: id }) ??
-          defaultVal
+        ? client.isFeatureEnabled(flag, id.toString(), {
+            userId: id,
+            appVersion
+          }) ?? defaultVal
         : defaultVal
       return enabled
     } catch (err) {

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -997,7 +997,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: 9f6df8cb028c2acd537ce24c1993aba142eceaf0
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   google-cast-sdk-dynamic-xcframework-no-bluetooth: 1fa9e267df3fd6f8a1c6e3345142ca5286297968
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -5162,69 +5162,51 @@
       }
     },
     "@optimizely/js-sdk-datafile-manager": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.5.0.tgz",
-      "integrity": "sha512-ZDov8jphA+Ez+fA0anioA8ooJrraCFbeGm7GejzPTCZPMisNGtchrpdHr9TMd+hld+TOMBZ5NbqfMvvYhbB34A==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.9.5.tgz",
+      "integrity": "sha512-O4ujr1nBBAQBtx8YoKNpzzaEZgsE+aU4dxubT17ePqv/YVUWE+JOY21tSRrqZy/BlbbyzL+ElT8hrGB5ZzVoIQ==",
       "requires": {
-        "@optimizely/js-sdk-logging": "^0.1.0",
-        "@optimizely/js-sdk-utils": "^0.2.0",
+        "@optimizely/js-sdk-logging": "^0.3.1",
+        "@optimizely/js-sdk-utils": "^0.4.0",
         "decompress-response": "^4.2.1"
       }
     },
     "@optimizely/js-sdk-event-processor": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-event-processor/-/js-sdk-event-processor-0.4.0.tgz",
-      "integrity": "sha512-5fqBG9N66O+9KWktUTH/OmMiQ4SKi42gP7qqWNKe0Ciu5PlBMTREKmo8+EixcDvDW8yQBvIPBj6GWzKz0RVAxg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-event-processor/-/js-sdk-event-processor-0.9.5.tgz",
+      "integrity": "sha512-g5zqAjJuexxgbNvn7dacFkQXQxH3+OtjELfmSswvhxP9EHkyNR0ZdQF/kBxFxr335F2/RRPvAJ9tQBPkwaBg8g==",
       "requires": {
-        "@optimizely/js-sdk-logging": "^0.1.0",
-        "@optimizely/js-sdk-utils": "^0.2.0"
+        "@optimizely/js-sdk-logging": "^0.3.1",
+        "@optimizely/js-sdk-utils": "^0.4.0"
       }
     },
     "@optimizely/js-sdk-logging": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.1.0.tgz",
-      "integrity": "sha512-Bs2zHvsdNIk2QSg05P6mKIlROHoBIRNStbrVwlePm603CucojKRPlFJG4rt7sFZQOo8xS8I7z1BmE4QI3/ZE9A==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.1.tgz",
+      "integrity": "sha512-K71Jf283FP0E4oXehcXTTM3gvgHZHr7FUrIsw//0mdJlotHJT4Nss4hE0CWPbBxO7LJAtwNnO+VIA/YOcO4vHg==",
       "requires": {
-        "@optimizely/js-sdk-utils": "^0.1.0"
-      },
-      "dependencies": {
-        "@optimizely/js-sdk-utils": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.1.0.tgz",
-          "integrity": "sha512-p7499GgVaX94YmkrwOiEtLgxgjXTPbUQsvETaAil5J7zg1TOA4Wl8ClalLSvCh+AKWkxGdkL4/uM/zfbxPSNNw==",
-          "requires": {
-            "uuid": "^3.3.2"
-          }
-        }
+        "@optimizely/js-sdk-utils": "^0.4.0"
       }
     },
     "@optimizely/js-sdk-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.2.0.tgz",
-      "integrity": "sha512-aHEccRVc5YjWAdIVtniKfUE3tuzHriIWZTS4sLEq/lXkNTITSL1jrBEJD91CVY5BahWu/aG/aOafrA7XGH3sDQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.4.0.tgz",
+      "integrity": "sha512-QG2oytnITW+VKTJK+l0RxjaS5VrA6W+AZMzpeg4LCB4Rn4BEKtF+EcW/5S1fBDLAviGq/0TLpkjM3DlFkJ9/Gw==",
       "requires": {
         "uuid": "^3.3.2"
       }
     },
     "@optimizely/optimizely-sdk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-4.0.0.tgz",
-      "integrity": "sha512-ufwndTjg6wPXnJmbW/3SK2F3Dt7E1S1VQZ5oCoYrsLZ2oFrhES/urbWWTzC1t83gAokbqzSEZDuc/OBdZ6c9SA==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-4.9.2.tgz",
+      "integrity": "sha512-aPUU2KGDgo0VmbYNXeUCttXQgbBr59leUhyNPidy1J3YixEhzo0Q9UXCzhf4SgCTCtHCwahE7g0Lf36U0IVPgQ==",
       "requires": {
-        "@optimizely/js-sdk-datafile-manager": "^0.5.0",
-        "@optimizely/js-sdk-event-processor": "^0.4.0",
-        "@optimizely/js-sdk-logging": "^0.1.0",
-        "@optimizely/js-sdk-utils": "^0.2.0",
-        "json-schema": "^0.2.3",
+        "@optimizely/js-sdk-datafile-manager": "^0.9.5",
+        "@optimizely/js-sdk-event-processor": "^0.9.2",
+        "@optimizely/js-sdk-logging": "^0.3.1",
+        "json-schema": "^0.4.0",
         "murmurhash": "0.0.2",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "json-schema": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.5.tgz",
-          "integrity": "sha512-gWJOWYFrhQ8j7pVm0EM8Slr+EPVq1Phf6lvzvD/WCeqkrx/f2xBI0xOsRRS9xCn3I4vKtP519dvs3TP09r24wQ=="
-        }
       }
     },
     "@project-serum/anchor": {
@@ -10523,7 +10505,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -11030,7 +11012,7 @@
     "dedent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
-      "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s="
+      "integrity": "sha512-cSfRWjXJtZQeRuZGVvDrJroCR5V2UvBNUMHsPCdNYzuAG8b9V8aAy3KUcdQrGQPXs17Y+ojbPh1aOCplg9YR9g=="
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -11119,7 +11101,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "denodeify": {
       "version": "1.2.1",
@@ -11333,7 +11315,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
       "version": "1.4.26",
@@ -11380,7 +11362,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -11515,7 +11497,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -12031,7 +12013,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eth-ens-namehash": {
       "version": "2.0.8",
@@ -13671,7 +13653,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -13735,7 +13717,7 @@
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -13750,12 +13732,12 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14247,7 +14229,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -14502,7 +14484,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "immer": {
       "version": "9.0.7",
@@ -16363,7 +16345,7 @@
     "keymirror": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/keymirror/-/keymirror-0.1.1.tgz",
-      "integrity": "sha1-kYiJ6hP40KQufFVyUO7nE63JXDU="
+      "integrity": "sha512-vIkZAFWoDijgQT/Nvl2AHCMmnegN2ehgTPYuyy2hWQkQSntI0S7ESYqdLkoSe1HyEBFHHkCgSIvVdSEiWwKvCg=="
     },
     "keyv": {
       "version": "3.1.0",
@@ -16466,7 +16448,7 @@
     "lie": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -24237,7 +24219,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unquote": {
       "version": "1.1.1",
@@ -24441,7 +24423,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.4.0",
@@ -24476,7 +24458,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -44,7 +44,7 @@
     "@hcaptcha/react-native-hcaptcha": "1.3.4",
     "@noble/hashes": "1.1.5",
     "@noble/secp256k1": "1.7.0",
-    "@optimizely/optimizely-sdk": "4.0.0",
+    "@optimizely/optimizely-sdk": "4.9.2",
     "@react-native-async-storage/async-storage": "1.17.10",
     "@react-native-clipboard/clipboard": "1.9.0",
     "@react-native-community/cli-platform-ios": "9.0.0",

--- a/packages/mobile/src/services/remote-config/remote-config-instance.ts
+++ b/packages/mobile/src/services/remote-config/remote-config-instance.ts
@@ -6,12 +6,17 @@ import Config from 'react-native-config'
 
 import { reportToSentry } from 'app/utils/reportToSentry'
 
+import packageInfo from '../../../package.json'
+
 export const FEATURE_FLAG_ASYNC_STORAGE_SESSION_KEY = 'featureFlagSessionId-2'
+
+const { version: appVersion } = packageInfo
 
 const OPTIMIZELY_KEY = Config.OPTIMIZELY_KEY
 const DATA_FILE_URL = 'https://experiments.audius.co/datafiles/%s.json'
 
 export const remoteConfigInstance = remoteConfig({
+  appVersion,
   createOptimizelyClient: async () => {
     return optimizely.createInstance({
       sdkKey: OPTIMIZELY_KEY,

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -5448,12 +5448,12 @@
       "integrity": "sha512-aPfcBeLErM/PPiAuAbNFLN5sNbZLc3KZlar27uohllN8Zs6jJbHyJU1y7cMA6W/zuq+thkaG8mujiS+3iD/FWQ=="
     },
     "@optimizely/js-sdk-datafile-manager": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.5.0.tgz",
-      "integrity": "sha512-ZDov8jphA+Ez+fA0anioA8ooJrraCFbeGm7GejzPTCZPMisNGtchrpdHr9TMd+hld+TOMBZ5NbqfMvvYhbB34A==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-datafile-manager/-/js-sdk-datafile-manager-0.9.5.tgz",
+      "integrity": "sha512-O4ujr1nBBAQBtx8YoKNpzzaEZgsE+aU4dxubT17ePqv/YVUWE+JOY21tSRrqZy/BlbbyzL+ElT8hrGB5ZzVoIQ==",
       "requires": {
-        "@optimizely/js-sdk-logging": "^0.1.0",
-        "@optimizely/js-sdk-utils": "^0.2.0",
+        "@optimizely/js-sdk-logging": "^0.3.1",
+        "@optimizely/js-sdk-utils": "^0.4.0",
         "decompress-response": "^4.2.1"
       },
       "dependencies": {
@@ -5473,52 +5473,48 @@
       }
     },
     "@optimizely/js-sdk-event-processor": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-event-processor/-/js-sdk-event-processor-0.4.0.tgz",
-      "integrity": "sha512-5fqBG9N66O+9KWktUTH/OmMiQ4SKi42gP7qqWNKe0Ciu5PlBMTREKmo8+EixcDvDW8yQBvIPBj6GWzKz0RVAxg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-event-processor/-/js-sdk-event-processor-0.9.5.tgz",
+      "integrity": "sha512-g5zqAjJuexxgbNvn7dacFkQXQxH3+OtjELfmSswvhxP9EHkyNR0ZdQF/kBxFxr335F2/RRPvAJ9tQBPkwaBg8g==",
       "requires": {
-        "@optimizely/js-sdk-logging": "^0.1.0",
-        "@optimizely/js-sdk-utils": "^0.2.0"
+        "@optimizely/js-sdk-logging": "^0.3.1",
+        "@optimizely/js-sdk-utils": "^0.4.0"
       }
     },
     "@optimizely/js-sdk-logging": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.1.0.tgz",
-      "integrity": "sha512-Bs2zHvsdNIk2QSg05P6mKIlROHoBIRNStbrVwlePm603CucojKRPlFJG4rt7sFZQOo8xS8I7z1BmE4QI3/ZE9A==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-logging/-/js-sdk-logging-0.3.1.tgz",
+      "integrity": "sha512-K71Jf283FP0E4oXehcXTTM3gvgHZHr7FUrIsw//0mdJlotHJT4Nss4hE0CWPbBxO7LJAtwNnO+VIA/YOcO4vHg==",
       "requires": {
-        "@optimizely/js-sdk-utils": "^0.1.0"
-      },
-      "dependencies": {
-        "@optimizely/js-sdk-utils": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.1.0.tgz",
-          "integrity": "sha512-p7499GgVaX94YmkrwOiEtLgxgjXTPbUQsvETaAil5J7zg1TOA4Wl8ClalLSvCh+AKWkxGdkL4/uM/zfbxPSNNw==",
-          "requires": {
-            "uuid": "^3.3.2"
-          }
-        }
+        "@optimizely/js-sdk-utils": "^0.4.0"
       }
     },
     "@optimizely/js-sdk-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.2.0.tgz",
-      "integrity": "sha512-aHEccRVc5YjWAdIVtniKfUE3tuzHriIWZTS4sLEq/lXkNTITSL1jrBEJD91CVY5BahWu/aG/aOafrA7XGH3sDQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@optimizely/js-sdk-utils/-/js-sdk-utils-0.4.0.tgz",
+      "integrity": "sha512-QG2oytnITW+VKTJK+l0RxjaS5VrA6W+AZMzpeg4LCB4Rn4BEKtF+EcW/5S1fBDLAviGq/0TLpkjM3DlFkJ9/Gw==",
       "requires": {
         "uuid": "^3.3.2"
       }
     },
     "@optimizely/optimizely-sdk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-4.0.0.tgz",
-      "integrity": "sha512-ufwndTjg6wPXnJmbW/3SK2F3Dt7E1S1VQZ5oCoYrsLZ2oFrhES/urbWWTzC1t83gAokbqzSEZDuc/OBdZ6c9SA==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@optimizely/optimizely-sdk/-/optimizely-sdk-4.9.2.tgz",
+      "integrity": "sha512-aPUU2KGDgo0VmbYNXeUCttXQgbBr59leUhyNPidy1J3YixEhzo0Q9UXCzhf4SgCTCtHCwahE7g0Lf36U0IVPgQ==",
       "requires": {
-        "@optimizely/js-sdk-datafile-manager": "^0.5.0",
-        "@optimizely/js-sdk-event-processor": "^0.4.0",
-        "@optimizely/js-sdk-logging": "^0.1.0",
-        "@optimizely/js-sdk-utils": "^0.2.0",
-        "json-schema": "^0.2.3",
+        "@optimizely/js-sdk-datafile-manager": "^0.9.5",
+        "@optimizely/js-sdk-event-processor": "^0.9.2",
+        "@optimizely/js-sdk-logging": "^0.3.1",
+        "json-schema": "^0.4.0",
         "murmurhash": "0.0.2",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "json-schema": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+          "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+        }
       }
     },
     "@pinata/sdk": {
@@ -24096,7 +24092,7 @@
     "murmurhash": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/murmurhash/-/murmurhash-0.0.2.tgz",
-      "integrity": "sha1-bwe9ihEF5wnCb8iUIMtZMMJFhf4="
+      "integrity": "sha512-LKlwdZKWzvCQpMszb2HO5leJ7P9T4m5XuDKku8bM0uElrzqK9cn0+iozwQS8jO4SNjrp4w7olalgd8WgsIjhWA=="
     },
     "murmurhash3js-revisited": {
       "version": "3.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -72,7 +72,7 @@
     "@opentelemetry/resources": "1.6.0",
     "@opentelemetry/sdk-trace-web": "1.6.0",
     "@opentelemetry/semantic-conventions": "1.6.0",
-    "@optimizely/optimizely-sdk": "4.0.0",
+    "@optimizely/optimizely-sdk": "4.9.2",
     "@project-serum/sol-wallet-adapter": "0.2.5",
     "@reduxjs/toolkit": "1.3.4",
     "@sentry/browser": "6.16.1",

--- a/packages/web/src/services/remote-config/remote-config-instance.ts
+++ b/packages/web/src/services/remote-config/remote-config-instance.ts
@@ -4,6 +4,10 @@ import { isEmpty } from 'lodash'
 
 import { reportToSentry } from 'store/errors/reportToSentry'
 
+import packageInfo from '../../../package.json'
+
+const { version: appVersion } = packageInfo
+
 declare global {
   interface Window {
     optimizelyDatafile: Config['datafile']
@@ -13,6 +17,7 @@ declare global {
 export const FEATURE_FLAG_LOCAL_STORAGE_SESSION_KEY = 'featureFlagSessionId-2'
 
 export const remoteConfigInstance = remoteConfig({
+  appVersion,
   createOptimizelyClient: async () => {
     // Wait for optimizely to load if necessary (as it can be an async or defer tag)
     if (!window.optimizelyDatafile) {


### PR DESCRIPTION
### Description

This allows us to apply feature flags to specific versions of the app, removing the need to rename feature flags before releasing a long running feature!

We can create audiences in Optimizely like so:
![image](https://user-images.githubusercontent.com/19916043/211681327-257598c9-9fb6-4ff6-a780-ba822ec16e71.png)
and then only roll out a feature to that audience.

The `version` attribute type required optimizely-sdk > 4.3.0. We have an outstanding snyk pr to upgrade to latest anyway so I upgraded to 4.9.2

### Dragons

Feature flag changes are dangerous

### How Has This Been Tested?

Tested on staging with different app versions

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

