### PR TITLE
[C-1726] useLocalImage

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -141,6 +141,7 @@ export const Audio = () => {
   )
   const currentUserId = useSelector(getUserId)
   const isReachable = useSelector(getIsReachable)
+  const isNotReachable = isReachable === false
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
   // Queue things
@@ -457,7 +458,7 @@ export const Audio = () => {
 
     currentUriRef.current = newUri
 
-    const localImageSource = !isReachable
+    const localImageSource = isNotReachable
       ? await getLocalTrackImageSource(
           track ? String(track.track_id) : undefined
         )
@@ -470,7 +471,7 @@ export const Audio = () => {
         localSource: localImageSource
       })?.[2]?.uri ?? DEFAULT_IMAGE_URL
 
-    const nextLocalImageSource = !isReachable
+    const nextLocalImageSource = isNotReachable
       ? await getLocalTrackImageSource(
           nextTrack ? String(nextTrack.track_id) : undefined
         )

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -33,6 +33,7 @@ import { useEffectOnce } from 'react-use'
 import { DEFAULT_IMAGE_URL } from 'app/components/image/TrackImage'
 import { getImageSourceOptimistic } from 'app/hooks/useContentNodeImage'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
+import { getLocalTrackImageSource } from 'app/hooks/useLocalImage'
 import { useOfflineTrackUri } from 'app/hooks/useOfflineTrackUri'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { apiClient } from 'app/services/audius-api-client'
@@ -455,20 +456,29 @@ export const Audio = () => {
     }
 
     currentUriRef.current = newUri
+
+    const localImageSource = await getLocalTrackImageSource(
+      track ? String(track.track_id) : undefined
+    )
+
     const imageUrl =
       getImageSourceOptimistic({
         cid: track ? track.cover_art_sizes || track.cover_art : null,
-        user: trackOwner
-        // localSource
+        user: trackOwner,
+        localSource: localImageSource
       })?.[2]?.uri ?? DEFAULT_IMAGE_URL
+
+    const nextLocalImageSource = await getLocalTrackImageSource(
+      nextTrack ? String(nextTrack.track_id) : undefined
+    )
 
     const nextImageUrl =
       getImageSourceOptimistic({
         cid: nextTrack
           ? nextTrack.cover_art_sizes || nextTrack.cover_art
           : null,
-        user: nextTrackOwner
-        // localSource
+        user: nextTrackOwner,
+        localSource: nextLocalImageSource
       })?.[2]?.uri ?? DEFAULT_IMAGE_URL
 
     // NOTE: Adding two tracks into the queue to make sure that android has a next button on the lock screen and notification controls

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -457,9 +457,11 @@ export const Audio = () => {
 
     currentUriRef.current = newUri
 
-    const localImageSource = await getLocalTrackImageSource(
-      track ? String(track.track_id) : undefined
-    )
+    const localImageSource = !isReachable
+      ? await getLocalTrackImageSource(
+          track ? String(track.track_id) : undefined
+        )
+      : undefined
 
     const imageUrl =
       getImageSourceOptimistic({
@@ -468,9 +470,11 @@ export const Audio = () => {
         localSource: localImageSource
       })?.[2]?.uri ?? DEFAULT_IMAGE_URL
 
-    const nextLocalImageSource = await getLocalTrackImageSource(
-      nextTrack ? String(nextTrack.track_id) : undefined
-    )
+    const nextLocalImageSource = !isReachable
+      ? await getLocalTrackImageSource(
+          nextTrack ? String(nextTrack.track_id) : undefined
+        )
+      : undefined
 
     const nextImageUrl =
       getImageSourceOptimistic({

--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -1,8 +1,3 @@
-/**
- * TODO: with usLocalCollectionImage, useTrackImage becomes an async-like hook where contentNodeSource is null until
- * localSource returns. This ended up degrading background track-player tasks where new tracks would not
- * display their artwork.
- **/
 import type { Collection, Nullable, User } from '@audius/common'
 import { cacheUsersSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
@@ -11,7 +6,7 @@ import imageEmpty from 'app/assets/images/imageBlank2x.png'
 import type { DynamicImageProps } from 'app/components/core'
 import { DynamicImage } from 'app/components/core'
 import { useContentNodeImage } from 'app/hooks/useContentNodeImage'
-// import { useLocalCollectionImage } from 'app/hooks/useLocalImage'
+import { useLocalCollectionImage } from 'app/hooks/useLocalImage'
 
 const { getUser } = cacheUsersSelectors
 
@@ -32,19 +27,18 @@ export const useCollectionImage = (
     getUser(state, { id: collection?.playlist_owner_id })
   )
 
-  // const { value: localSource, loading } = useLocalCollectionImage(
-  //   collection?.playlist_id.toString()
-  // )
+  const { value: localSource, loading } = useLocalCollectionImage(
+    collection?.playlist_id.toString()
+  )
 
   const contentNodeSource = useContentNodeImage({
     cid,
     user: selectedUser ?? user ?? null,
-    fallbackImageSource: imageEmpty
-    // localSource
+    fallbackImageSource: imageEmpty,
+    localSource
   })
 
-  return contentNodeSource
-  // return loading ? null : contentNodeSource
+  return loading ? null : contentNodeSource
 }
 
 type CollectionImageProps = {

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -1,8 +1,3 @@
-/**
- * TODO: with useLocalTrackImage, useTrackImage becomes an async-like hook where contentNodeSource is null until
- * localSource returns. This ended up degrading background track-player tasks where new tracks would not
- * display their artwork.
- **/
 import type { User, Track, Nullable } from '@audius/common'
 import { cacheUsersSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
@@ -11,7 +6,7 @@ import imageEmpty from 'app/assets/images/imageBlank2x.png'
 import type { DynamicImageProps } from 'app/components/core'
 import { DynamicImage } from 'app/components/core'
 import { useContentNodeImage } from 'app/hooks/useContentNodeImage'
-// import { useLocalTrackImage } from 'app/hooks/useLocalImage'
+import { useLocalTrackImage } from 'app/hooks/useLocalImage'
 
 const { getUser } = cacheUsersSelectors
 
@@ -29,19 +24,18 @@ export const useTrackImage = (
   const selectedUser = useSelector((state) =>
     getUser(state, { id: track?.owner_id })
   )
-  // const { value: localSource, loading } = useLocalTrackImage(
-  //   track?.track_id.toString(),
-  // )
+  const { value: localSource, loading } = useLocalTrackImage(
+    track?.track_id.toString()
+  )
 
   const contentNodeSource = useContentNodeImage({
     cid,
     user: user ?? selectedUser,
-    fallbackImageSource: imageEmpty
-    // localSource: localSource
+    fallbackImageSource: imageEmpty,
+    localSource
   })
 
-  // return loading ? null : contentNodeSource
-  return contentNodeSource
+  return loading ? null : contentNodeSource
 }
 
 type TrackImageProps = {

--- a/packages/mobile/src/hooks/useLocalImage.ts
+++ b/packages/mobile/src/hooks/useLocalImage.ts
@@ -53,11 +53,11 @@ export const getLocalImageSource = async (
 export const useLocalImage = (
   getLocalPath: (size: string) => string | undefined
 ): AsyncState<ImageURISource[]> => {
-  const isReachable = useSelector(getIsReachable)
+  const isNotReachable = useSelector(getIsReachable) === false
 
   return useAsync(async () => {
     // Only check for local images if not reachable
-    if (!isReachable) {
+    if (isNotReachable) {
       return []
     }
 

--- a/packages/mobile/src/hooks/useLocalImage.ts
+++ b/packages/mobile/src/hooks/useLocalImage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 
 import { SquareSizes } from '@audius/common'
 import type { ImageURISource } from 'react-native'
@@ -11,49 +11,63 @@ import {
   getLocalTrackCoverArtPath
 } from 'app/services/offline-downloader'
 
-export const useLocalCollectionImage = (trackId?: string) => {
-  const getLocalPath = useCallback(
-    (size: string) =>
-      trackId ? getLocalCollectionCoverArtPath(trackId, size) : undefined,
-    [trackId]
-  )
-  return useLocalImage(getLocalPath)
+const getLocalTrackImagePath = (trackId?: string) => (size: string) =>
+  trackId ? getLocalTrackCoverArtPath(trackId, size) : undefined
+
+const getLocalCollectionImagePath = (collectionId?: string) => (size: string) =>
+  collectionId ? getLocalCollectionCoverArtPath(collectionId, size) : undefined
+
+export const getLocalTrackImageSource = (trackId?: string) => {
+  return getLocalImageSource(getLocalTrackImagePath(trackId))
 }
 
-export const useLocalTrackImage = (trackId?: string) => {
-  const getLocalPath = useCallback(
-    (size: string) =>
-      trackId ? getLocalTrackCoverArtPath(trackId, size) : undefined,
-    [trackId]
-  )
-  return useLocalImage(getLocalPath)
+export const getLocalCollectionImageSource = (collectionId?: string) => {
+  return getLocalImageSource(getLocalCollectionImagePath(collectionId))
+}
+
+export const getLocalImageSource = async (
+  getLocalPath: (size: string) => string | undefined
+) => {
+  const imageSources = Object.values(SquareSizes)
+    .reverse()
+    .map(
+      (size): ImageURISource => ({
+        uri: `file://${getLocalPath(size.toString())}`,
+        width: parseInt(size.split('x')[0]),
+        height: parseInt(size.split('x')[1])
+      })
+    )
+    .filter((source) => !!source.uri)
+
+  const verifiedSources: ImageURISource[] = []
+  for (const source of imageSources) {
+    if (source?.uri && (await exists(source.uri))) {
+      verifiedSources.push(source)
+    }
+  }
+  return verifiedSources
 }
 
 export const useLocalImage = (
   getLocalPath: (size: string) => string | undefined
 ): AsyncState<ImageURISource[]> => {
-  const imageSources = useMemo(
-    () =>
-      Object.values(SquareSizes)
-        .reverse()
-        .map(
-          (size): ImageURISource => ({
-            uri: `file://${getLocalPath(size.toString())}`,
-            width: parseInt(size.split('x')[0]),
-            height: parseInt(size.split('x')[1])
-          })
-        )
-        .filter((source) => !!source.uri),
-    [getLocalPath]
-  )
-
   return useAsync(async () => {
-    const verifiedSources: ImageURISource[] = []
-    for (const source of imageSources) {
-      if (source?.uri && (await exists(source.uri))) {
-        verifiedSources.push(source)
-      }
-    }
-    return verifiedSources
-  }, [getLocalPath, imageSources])
+    return await getLocalImageSource(getLocalPath)
+  }, [getLocalPath])
+}
+
+export const useLocalTrackImage = (trackId?: string) => {
+  const getLocalPath = useCallback(
+    (size: string) => getLocalTrackImagePath(trackId)(size),
+    [trackId]
+  )
+  return useLocalImage(getLocalPath)
+}
+
+export const useLocalCollectionImage = (collectionId?: string) => {
+  const getLocalPath = useCallback(
+    (size: string) => getLocalCollectionImagePath(collectionId)(size),
+    [collectionId]
+  )
+  return useLocalImage(getLocalPath)
 }


### PR DESCRIPTION
### Description

* Re-enables useLocalImage. `Audio` is now using `getImageSourceOptimistic` so the initial problem with image hooks returning null is resolved
* Adds `getLocalImageSource`. This is used In `Audio` to get the local source

Wanted to get your thoughts on the performance of `useLocalImage` in general. We are now doing 3 filesystem reads for every image load before starting to fetch the image remotely. Maybe we do only want to enable local images when reachability is false? Also this is another good argument for making image sizing explicit, because we would only need a single filesystem read

### Dragons

Touches all images

### How Has This Been Tested?

Tested that images, lock screen images, work online/offline. Felt like the perf is maybe slightly worse

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

