### PR TITLE
Fix setup states

### DIFF
--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -9,7 +9,8 @@ import {
 } from '@audius/common'
 import addToPlaylistSagas from 'common/store/add-to-playlist/sagas'
 import analyticsSagas from 'common/store/analytics/sagas'
-import backendSagas, { setupBackend } from 'common/store/backend/sagas'
+import { setupBackend } from 'common/store/backend/actions'
+import backendSagas from 'common/store/backend/sagas'
 import collectionsSagas from 'common/store/cache/collections/sagas'
 import coreCacheSagas from 'common/store/cache/sagas'
 import tracksSagas from 'common/store/cache/tracks/sagas'
@@ -54,7 +55,7 @@ import repostPageSagas from 'common/store/user-list/reposts/sagas'
 import supportingPageSagas from 'common/store/user-list/supporting/sagas'
 import topSupportersPageSagas from 'common/store/user-list/top-supporters/sagas'
 import walletSagas from 'common/store/wallet/sagas'
-import { all, fork } from 'typed-redux-saga'
+import { all, put, fork } from 'typed-redux-saga'
 
 import accountSagas from './account/sagas'
 import initKeyboardEvents from './keyboard/sagas'
@@ -69,8 +70,10 @@ import themeSagas from './theme/sagas'
 import walletsSagas from './wallet-connect/sagas'
 
 export default function* rootSaga() {
-  yield* fork(setupBackend)
   const sagas = [
+    function* () {
+      yield put(setupBackend())
+    },
     // Config
     ...backendSagas(),
     ...analyticsSagas(),

--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -9,7 +9,6 @@ import {
 } from '@audius/common'
 import addToPlaylistSagas from 'common/store/add-to-playlist/sagas'
 import analyticsSagas from 'common/store/analytics/sagas'
-import { setupBackend } from 'common/store/backend/actions'
 import backendSagas from 'common/store/backend/sagas'
 import collectionsSagas from 'common/store/cache/collections/sagas'
 import coreCacheSagas from 'common/store/cache/sagas'
@@ -55,7 +54,7 @@ import repostPageSagas from 'common/store/user-list/reposts/sagas'
 import supportingPageSagas from 'common/store/user-list/supporting/sagas'
 import topSupportersPageSagas from 'common/store/user-list/top-supporters/sagas'
 import walletSagas from 'common/store/wallet/sagas'
-import { all, put, fork } from 'typed-redux-saga'
+import { all, fork } from 'typed-redux-saga'
 
 import accountSagas from './account/sagas'
 import initKeyboardEvents from './keyboard/sagas'
@@ -71,9 +70,6 @@ import walletsSagas from './wallet-connect/sagas'
 
 export default function* rootSaga() {
   const sagas = [
-    function* () {
-      yield put(setupBackend())
-    },
     // Config
     ...backendSagas(),
     ...analyticsSagas(),

--- a/packages/mobile/src/store/sign-out/sagas.ts
+++ b/packages/mobile/src/store/sign-out/sagas.ts
@@ -8,12 +8,9 @@ import {
   waitForValue
 } from '@audius/common'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
-import {
-  getIsSettingUp,
-  getIsSetup
-} from 'audius-client/src/common/store/backend/selectors'
+import { getIsSettingUp } from 'audius-client/src/common/store/backend/selectors'
 import { make } from 'common/store/analytics/actions'
-import { takeLatest, put, call, select, take } from 'typed-redux-saga'
+import { takeLatest, put, call } from 'typed-redux-saga'
 
 import { ENTROPY_KEY, THEME_STORAGE_KEY } from 'app/constants/storage-keys'
 import { audiusBackendInstance } from 'app/services/audius-backend-instance'

--- a/packages/mobile/src/store/sign-out/sagas.ts
+++ b/packages/mobile/src/store/sign-out/sagas.ts
@@ -4,10 +4,14 @@ import {
   accountActions,
   feedPageLineupActions,
   themeActions,
-  Theme
+  Theme,
+  waitForValue
 } from '@audius/common'
 import { setupBackend } from 'audius-client/src/common/store/backend/actions'
-import { getIsSetup } from 'audius-client/src/common/store/backend/selectors'
+import {
+  getIsSettingUp,
+  getIsSetup
+} from 'audius-client/src/common/store/backend/selectors'
 import { make } from 'common/store/analytics/actions'
 import { takeLatest, put, call, select, take } from 'typed-redux-saga'
 
@@ -28,14 +32,9 @@ const storageKeysToRemove = [THEME_STORAGE_KEY, ENTROPY_KEY]
 
 function* signOut() {
   yield* put(make(Name.SETTINGS_LOG_OUT, {}))
-  // UX obstruction, but if the user somehow makes it
-  // all the way to the sign out flow before the
-  // backend has initted (e.g. there's still an account fetch)
-  // in-flight, we need to wait here.
-  const isBackendSetup = yield* select(getIsSetup)
-  if (!isBackendSetup) {
-    yield* take(accountActions.fetchAccountSucceeded.type)
-  }
+
+  // Wait for in-flight set up to resolve
+  yield* call(waitForValue, getIsSettingUp, {}, (isSettingUp) => !isSettingUp)
 
   yield* put(resetAccount())
   yield* put(feedPageLineupActions.reset())

--- a/packages/web/src/common/store/backend/reducer.ts
+++ b/packages/web/src/common/store/backend/reducer.ts
@@ -1,11 +1,13 @@
 import { SETUP, SETUP_BACKEND_SUCCEEDED, SETUP_BACKEND_FAILED } from './actions'
 
 type BackendState = {
+  isSettingUp: boolean
   isSetup: boolean
   web3Error: boolean
 }
 
 const initialState: BackendState = {
+  isSettingUp: false,
   isSetup: false,
   web3Error: false
 }
@@ -14,6 +16,7 @@ const actionsMap = {
   [SETUP](state: BackendState) {
     return {
       ...state,
+      isSettingUp: true,
       isSetup: false
     }
   },
@@ -23,6 +26,7 @@ const actionsMap = {
   ) {
     return {
       ...state,
+      isSettingUp: false,
       isSetup: true,
       web3Error: action.web3Error
     }
@@ -30,6 +34,7 @@ const actionsMap = {
   [SETUP_BACKEND_FAILED](state: BackendState) {
     return {
       ...state,
+      isSettingUp: false,
       isSetup: false,
       web3Error: false
     }

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -115,6 +115,10 @@ function* watchSetReachable() {
   yield* takeEvery(reachabilityActions.SET_REACHABLE, setupBackendIfNotSetUp)
 }
 
+function* init() {
+  yield* put(backendActions.setupBackend())
+}
+
 export default function sagas() {
-  return [watchSetupBackend, watchBackendErrors, watchSetReachable]
+  return [init, watchSetupBackend, watchBackendErrors, watchSetReachable]
 }

--- a/packages/web/src/common/store/backend/sagas.ts
+++ b/packages/web/src/common/store/backend/sagas.ts
@@ -19,7 +19,7 @@ import { REACHABILITY_LONG_TIMEOUT } from 'store/reachability/sagas'
 
 import * as backendActions from './actions'
 import { watchBackendErrors } from './errorSagas'
-import { getIsSetup } from './selectors'
+import { getIsSettingUp, getIsSetup } from './selectors'
 const { getIsReachable } = reachabilitySelectors
 
 /**
@@ -103,10 +103,9 @@ function* watchSetupBackend() {
 
 // If not fully set up, re set-up the backend
 export function* setupBackendIfNotSetUp() {
-  yield* put(backendActions.setupBackend())
-
   const isSetup = yield* select(getIsSetup)
-  if (!isSetup) {
+  const isSettingUp = yield* select(getIsSettingUp)
+  if (!isSetup && !isSettingUp) {
     // Try to set up again, which should block further actions until completed
     yield* put(backendActions.setupBackend())
   }

--- a/packages/web/src/common/store/backend/selectors.ts
+++ b/packages/web/src/common/store/backend/selectors.ts
@@ -2,4 +2,5 @@
 import { AppState } from 'store/types'
 
 export const getWeb3Error = (state: AppState) => state.backend.web3Error
+export const getIsSettingUp = (state: AppState) => state.backend.isSettingUp
 export const getIsSetup = (state: AppState) => state.backend.isSetup

--- a/packages/web/src/common/store/backend/types.ts
+++ b/packages/web/src/common/store/backend/types.ts
@@ -1,4 +1,5 @@
 export interface BackendState {
   isSetup: boolean
+  isSettingUp: boolean
   web3Error: boolean
 }

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -120,8 +120,6 @@ function* fetchLineupMetadatasAsync(
   sourceSelector,
   action
 ) {
-  yield waitForBackendSetup()
-  yield waitForAccount()
   const initLineup = yield select(lineupSelector)
   const initSource = sourceSelector
     ? yield select((state) =>

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -11,8 +11,7 @@ import {
   lineupActions as baseLineupActions,
   queueActions,
   playerSelectors,
-  queueSelectors,
-  waitForAccount
+  queueSelectors
 } from '@audius/common'
 import {
   all,
@@ -30,8 +29,6 @@ import {
 
 import { getToQueue } from 'common/store/queue/sagas'
 import { isMobileWeb } from 'common/utils/isMobileWeb'
-
-import { waitForBackendSetup } from '../backend/sagas'
 
 const { getSource, getUid, getPositions } = queueSelectors
 const { getUid: getCurrentPlayerTrackUid, getPlaying } = playerSelectors

--- a/packages/web/src/components/reachability-bar/components/ReachabilityBarContainer.tsx
+++ b/packages/web/src/components/reachability-bar/components/ReachabilityBarContainer.tsx
@@ -11,7 +11,7 @@ const ReachabilityBar = () => {
 }
 
 type ReachabilityBarProps = {
-  isReachable: boolean | null
+  isReachable: boolean | 'unconfirmed'
 }
 
 const upPosition = {

--- a/packages/web/src/store/sagas.ts
+++ b/packages/web/src/store/sagas.ts
@@ -87,7 +87,7 @@ import notificationSagasWeb from './notifications/sagas'
 export default function* rootSaga() {
   const sagas = ([] as (() => Generator<any, void, any>)[]).concat(
     function* () {
-      yield put(setupBackend())
+      yield* put(setupBackend())
     },
     // Config
     analyticsSagas(),

--- a/packages/web/src/store/sagas.ts
+++ b/packages/web/src/store/sagas.ts
@@ -8,12 +8,13 @@ import {
   toastSagas,
   vipDiscordModalSagas
 } from '@audius/common'
-import { all, fork } from 'redux-saga/effects'
+import { all, fork, put } from 'redux-saga/effects'
 
 import accountSagas from 'common/store/account/sagas'
 import addToPlaylistSagas from 'common/store/add-to-playlist/sagas'
 import analyticsSagas from 'common/store/analytics/sagas'
-import backendSagas, { setupBackend } from 'common/store/backend/sagas'
+import { setupBackend } from 'common/store/backend/actions'
+import backendSagas from 'common/store/backend/sagas'
 import collectionsSagas from 'common/store/cache/collections/sagas'
 import coreCacheSagas from 'common/store/cache/sagas'
 import tracksSagas from 'common/store/cache/tracks/sagas'
@@ -84,8 +85,10 @@ import tokenDashboardSagas from 'store/token-dashboard/sagas'
 import notificationSagasWeb from './notifications/sagas'
 
 export default function* rootSaga() {
-  yield fork(setupBackend)
   const sagas = ([] as (() => Generator<any, void, any>)[]).concat(
+    function* () {
+      yield put(setupBackend())
+    },
     // Config
     analyticsSagas(),
     webAnalyticsSagas(),

--- a/packages/web/src/store/sagas.ts
+++ b/packages/web/src/store/sagas.ts
@@ -8,12 +8,11 @@ import {
   toastSagas,
   vipDiscordModalSagas
 } from '@audius/common'
-import { all, fork, put } from 'redux-saga/effects'
+import { all, fork } from 'redux-saga/effects'
 
 import accountSagas from 'common/store/account/sagas'
 import addToPlaylistSagas from 'common/store/add-to-playlist/sagas'
 import analyticsSagas from 'common/store/analytics/sagas'
-import { setupBackend } from 'common/store/backend/actions'
 import backendSagas from 'common/store/backend/sagas'
 import collectionsSagas from 'common/store/cache/collections/sagas'
 import coreCacheSagas from 'common/store/cache/sagas'
@@ -86,9 +85,6 @@ import notificationSagasWeb from './notifications/sagas'
 
 export default function* rootSaga() {
   const sagas = ([] as (() => Generator<any, void, any>)[]).concat(
-    function* () {
-      yield* put(setupBackend())
-    },
     // Config
     analyticsSagas(),
     webAnalyticsSagas(),


### PR DESCRIPTION
### Description

Changes:
* Move setupBackend first call to action so that every call follows the same flow and sets isSettingUp = true. This informs us to not double-fire setupBackend in the ifNotAlreadySetup check
* Remove extraneous setupBackend call in ifNotAlreadySetup
* Fix corresponding sign out method to use isSettingUp state

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

ONLY tested on web:
- Lineup load
- Sign in/sign out

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

