### PR TITLE
update playlist_page route to accept permalink optionally

### DIFF
--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -274,19 +274,35 @@ export const fullAlbumPage = (handle: string, title: string, id: ID) => {
   return `${BASE_URL}${albumPage(handle, title, id)}`
 }
 
-
-export const playlistPage = (handle: string, playlistName?: string | null, playlistId?: ID | null, permalink?: string | null) => {
+export const playlistPage = (
+  handle: string,
+  playlistName?: string | null,
+  playlistId?: ID | null,
+  permalink?: string | null
+) => {
   // Prioritize permalink if available. If not, default to legacy routing
   if (permalink) {
     return permalink
   } else if (playlistName && playlistId) {
-    return `/${encodeUrlName(handle)}/playlist/${encodeUrlName(playlistName)}-${playlistId}`
+    return `/${encodeUrlName(handle)}/playlist/${encodeUrlName(
+      playlistName
+    )}-${playlistId}`
   } else {
     throw Error('Missing required arguments to get PlaylistPage route.')
   }
 }
-export const fullPlaylistPage = (handle: string, playlistName?: string | null, playlistId?: ID | null, permalink?: string | null) => {
-  return `${BASE_URL}${playlistPage(handle, playlistName, playlistId, permalink)}`
+export const fullPlaylistPage = (
+  handle: string,
+  playlistName?: string | null,
+  playlistId?: ID | null,
+  permalink?: string | null
+) => {
+  return `${BASE_URL}${playlistPage(
+    handle,
+    playlistName,
+    playlistId,
+    permalink
+  )}`
 }
 
 export const audioNftPlaylistPage = (handle: string) => {

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -274,15 +274,19 @@ export const fullAlbumPage = (handle: string, title: string, id: ID) => {
   return `${BASE_URL}${albumPage(handle, title, id)}`
 }
 
-export const playlistPage = (
-  handle: string,
-  title: string,
-  id: ID | string
-) => {
-  return `/${encodeUrlName(handle)}/playlist/${encodeUrlName(title)}-${id}`
+
+export const playlistPage = (handle: string, playlistName?: string | null, playlistId?: ID | null, permalink?: string | null) => {
+  // Prioritize permalink if available. If not, default to legacy routing
+  if (permalink) {
+    return permalink
+  } else if (playlistName && playlistId) {
+    return `/${encodeUrlName(handle)}/playlist/${encodeUrlName(playlistName)}-${playlistId}`
+  } else {
+    throw Error('Missing required arguments to get PlaylistPage route.')
+  }
 }
-export const fullPlaylistPage = (handle: string, title: string, id: ID) => {
-  return `${BASE_URL}${playlistPage(handle, title, id)}`
+export const fullPlaylistPage = (handle: string, playlistName?: string | null, playlistId?: ID | null, permalink?: string | null) => {
+  return `${BASE_URL}${playlistPage(handle, playlistName, playlistId, permalink)}`
 }
 
 export const audioNftPlaylistPage = (handle: string) => {


### PR DESCRIPTION
### Description
This adds an optional permalink argument to the PLAYLIST_PAGE route generation and branches off of whether a permalink is available or the playlist id and playlist name are available for legacy routing. 

I know we discussed passing in a playlist object, but that approach didn't work because not all calls to this had a playlist object to pass in. I tried another approach where it accepted an object of PlaylistPageArgs, but that required a lot of changes to all calls to this function and looked bulkier. This approach seemed the least invasive and easy to build off of but let me know what you think! 

### Testing
Tested locally pointed to stage data. Loading playlists worked fine. Creating one didn't work but I think that's because stage is messed up right now? 