### PR TITLE
[C-1821] Fix android manual sign up overflow

### DIFF
--- a/packages/mobile/src/components/core/Screen/SafeAreaScreen.tsx
+++ b/packages/mobile/src/components/core/Screen/SafeAreaScreen.tsx
@@ -1,4 +1,4 @@
-import { SafeAreaView } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import type { ScreenProps } from './Screen'
 import { Screen } from './Screen'

--- a/packages/mobile/src/screens/signon/ProfileAuto.tsx
+++ b/packages/mobile/src/screens/signon/ProfileAuto.tsx
@@ -10,7 +10,8 @@ import {
 } from 'common/store/pages/signon/selectors'
 import { EditingStatus } from 'common/store/pages/signon/types'
 import type { EditableField } from 'common/store/pages/signon/types'
-import { Animated, View, TouchableOpacity, SafeAreaView } from 'react-native'
+import { Animated, View, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconImage from 'app/assets/images/iconImage.svg'


### PR DESCRIPTION
### Description

Fixes issue with "I'd rather fill out my profile manually" on android when the nav bar buttons are enabled. We probably shouldn't be using `SafeAreaView` from `react-native` anywhere, there was also slightly broken layout on the Suggested followers screen

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

