### PR TITLE
Fix notification userInteraction

### DIFF
--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -423,11 +423,10 @@ export type TipReceivePushNotification = {
   slot: number
   initiator: ID
   metadata: {
-    // TODO: Need to verify camelCase vs snake_case
-    entityId: ID
-    entityType: Entity.User
+    entity_id: ID
+    entity_type: Entity.User
     amount: StringWei
-    tipTxSignature: string
+    tx_signature: string
   }
 }
 

--- a/packages/mobile/src/notifications.ts
+++ b/packages/mobile/src/notifications.ts
@@ -64,11 +64,7 @@ class PushNotifications {
 
   onNotification = (notification: any) => {
     console.info(`Received notification ${JSON.stringify(notification)}`)
-    if (
-      Platform.OS === 'android' ||
-      notification.userInteration ||
-      !notification.foreground
-    ) {
+    if (notification.userInteraction) {
       track(
         make({
           eventName: EventNames.NOTIFICATIONS_OPEN_PUSH_NOTIFICATION,
@@ -80,8 +76,7 @@ class PushNotifications {
             : {})
         })
       )
-
-      this.navigation?.navigate(notification.data.data)
+      this.navigation?.navigate(notification.data.data ?? notification.data)
     }
   }
 


### PR DESCRIPTION
### Description

Updates onNotification function to only navigate when the user explicitly presses on a notification in the notification panel, ie `userInteraction = true`

Also handles case where notification data is sometimes (always?) `notification.data`, not `notification.data.data`