### PR TITLE
[C-1772] Fix share-drawer for tracks with missing images

### DIFF
--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -84,7 +84,7 @@ export const useShareToStory = ({
   }
 
   const trackImageUri =
-    (content?.type === 'track' && trackImage && trackImage?.source[2].uri) ??
+    (content?.type === 'track' && trackImage?.source?.[2]?.uri) ??
     DEFAULT_IMAGE_URL
   const captureStickerImage = useCallback(async () => {
     if (!isStickerImageLoadedRef.current) {


### PR DESCRIPTION
### Description

Fixes subtle bug where sharing a track with no image causes a bug with useShareStory hook. Im starting to think it might make sense to try and delay the rendering of these hooks until a user clicks on the "share" buttons, but also that would not fix this bug. just some thoughts to prevent too much code running in the simple rendering of the share drawer.

also i wonder if there is a way for us to have better typecheck here, since this passed even though source can be ` number` or `ImageSource[]`
