### PR TITLE
[C-1836] Add null check to the useUpdateRequired hook

### DIFF
--- a/packages/mobile/src/hooks/useUpdateRequired.ts
+++ b/packages/mobile/src/hooks/useUpdateRequired.ts
@@ -10,5 +10,7 @@ const { version } = packageInfo
 export const useUpdateRequired = () => {
   const minAppVersion = useRemoteVar(StringKeys.MIN_APP_VERSION)
 
-  return { updateRequired: semver.lt(version, minAppVersion) }
+  return {
+    updateRequired: minAppVersion ? semver.lt(version, minAppVersion) : false
+  }
 }


### PR DESCRIPTION
### Description
Add a null check to avoid error when checking for version before remote config has been loaded

### Dragons

N/A

### How Has This Been Tested?

N/A

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

