### PR TITLE
[PAY-819] Fix track update cid bug

### DIFF
--- a/packages/common/src/schemas/index.ts
+++ b/packages/common/src/schemas/index.ts
@@ -47,7 +47,7 @@ const trackMetadataSchema = {
 
 export const newTrackMetadata = (fields, validate = false) => {
   const validFields = validate
-    ? pick(fields, Object.keys(trackMetadataSchema).concat(['track_id']))
+    ? pick(fields, Object.keys(trackMetadataSchema).concat(['track_id', 'track_cid']))
     : fields
   const remixParentTrackId = fields?.remix_of?.tracks?.[0]?.parent_track_id
   return {

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -269,7 +269,6 @@ export const makeTrack = (
     downloadable: undefined,
     favorite_count: undefined,
     is_streamable: undefined,
-    track_cid: undefined
   }
 
   delete marshalled.id
@@ -279,7 +278,6 @@ export const makeTrack = (
   delete marshalled.downloadable
   delete marshalled.favorite_count
   delete marshalled.is_streamable
-  delete marshalled.track_cid
 
   return marshalled
 }


### PR DESCRIPTION
### Description

Track updates/edits currently do not send over the track cid as part of the metadata, therefore causing DNs to set the track_cid value to null for the updated track. This fixes it.

### Dragons

None

### How Has This Been Tested?

Local dapp vs prod. Updated track and cid remained intact.

### How will this change be monitored?

N/A

### Feature Flags ###

None

