### PR TITLE
[C-1810] Block more screens when offline

### DIFF
--- a/packages/mobile/src/components/core/Screen/ScreenContent.tsx
+++ b/packages/mobile/src/components/core/Screen/ScreenContent.tsx
@@ -10,9 +10,22 @@ const { getIsReachable } = reachabilitySelectors
 
 export type ScreenContentProps = OfflinePlaceholderProps & {
   children: ReactNode
+  isOfflineCapable?: boolean
 }
 
-export const ScreenContent = ({ children, ...other }: ScreenContentProps) => {
-  const isNotReachable = useSelector(getIsReachable) === false
-  return <>{isNotReachable ? <OfflinePlaceholder {...other} /> : children}</>
+export const ScreenContent = ({
+  children,
+  isOfflineCapable,
+  ...other
+}: ScreenContentProps) => {
+  const isReachable = useSelector(getIsReachable)
+  return (
+    <>
+      {isReachable || isOfflineCapable ? (
+        children
+      ) : (
+        <OfflinePlaceholder {...other} />
+      )}
+    </>
+  )
 }

--- a/packages/mobile/src/components/form-screen/FormScreen.tsx
+++ b/packages/mobile/src/components/form-screen/FormScreen.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native'
 import { isEmpty } from 'lodash'
 
 import type { ScreenProps } from '../core/Screen'
-import { Screen } from '../core/Screen'
+import { ScreenContent, Screen } from '../core/Screen'
 import { TextButton } from '../core/TextButton'
 
 const messages = {
@@ -19,7 +19,7 @@ type FormScreenProps = ScreenProps & {
   goBackOnSubmit?: boolean
 }
 
-export const FormScreen = (props: FormScreenProps) => {
+export const FormScreen = ({ children, ...props }: FormScreenProps) => {
   const { onSubmit, onReset, errors, goBackOnSubmit, ...other } = props
 
   const navigation = useNavigation()
@@ -53,12 +53,15 @@ export const FormScreen = (props: FormScreenProps) => {
     />
   )
 
+  // TODO: add <ScreenContent> to usages of SafeAreaScreen
   return (
     <Screen
       variant={'white'}
       topbarLeft={topbarLeft}
       topbarRight={topbarRight}
       {...other}
-    />
+    >
+      <ScreenContent>{children}</ScreenContent>
+    </Screen>
   )
 }

--- a/packages/mobile/src/components/skeletons/EntitySkeleton.tsx
+++ b/packages/mobile/src/components/skeletons/EntitySkeleton.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { times, random } from 'lodash'
 import { View } from 'react-native'
 
-import { Screen, Tile, Text, Divider } from 'app/components/core'
+import { Screen, Tile, Text, Divider, ScreenContent } from 'app/components/core'
 import Skeleton, { StaticSkeleton } from 'app/components/skeleton/Skeleton'
 import { makeStyles } from 'app/styles'
 
@@ -110,57 +110,59 @@ export const EntitySkeleton = (props: EntitySkeletonProps) => {
 
   return (
     <Screen>
-      <Tile styles={{ root: styles.root, content: styles.content }}>
-        <View style={styles.heading}>
-          <Text
-            fontSize='small'
-            weight='demiBold'
-            color='neutralLight4'
-            textTransform='uppercase'
-            style={styles.headingText}
-          >
-            {entityType ? messages[entityType] : ''}
-          </Text>
-          <Skeleton style={styles.trackArtwork} />
-          <StaticSkeleton style={styles.trackTitle} />
-          <StaticSkeleton style={styles.artistName} />
-          <StaticSkeleton style={styles.playButton} />
-          <View style={styles.socialActions}>
-            <StaticSkeleton style={styles.socialAction} />
-            <StaticSkeleton style={styles.socialAction} />
-            <StaticSkeleton style={styles.socialAction} />
-            <StaticSkeleton style={styles.socialAction} />
+      <ScreenContent>
+        <Tile styles={{ root: styles.root, content: styles.content }}>
+          <View style={styles.heading}>
+            <Text
+              fontSize='small'
+              weight='demiBold'
+              color='neutralLight4'
+              textTransform='uppercase'
+              style={styles.headingText}
+            >
+              {entityType ? messages[entityType] : ''}
+            </Text>
+            <Skeleton style={styles.trackArtwork} />
+            <StaticSkeleton style={styles.trackTitle} />
+            <StaticSkeleton style={styles.artistName} />
+            <StaticSkeleton style={styles.playButton} />
+            <View style={styles.socialActions}>
+              <StaticSkeleton style={styles.socialAction} />
+              <StaticSkeleton style={styles.socialAction} />
+              <StaticSkeleton style={styles.socialAction} />
+              <StaticSkeleton style={styles.socialAction} />
+            </View>
+            <Divider style={styles.divider} />
+            <View style={styles.metrics}>
+              <StaticSkeleton style={styles.metric} />
+              <StaticSkeleton style={styles.metric} />
+              <StaticSkeleton style={styles.metric} />
+            </View>
+            <View style={styles.description}>
+              {times(random(5, 15), () => random(20, 100)).map(
+                (elementWidth: number, i) => (
+                  <StaticSkeleton
+                    key={i}
+                    style={[styles.descriptionText, { width: elementWidth }]}
+                  />
+                )
+              )}
+            </View>
+            <Divider style={styles.divider} />
+            <View style={styles.metadataSection}>
+              <StaticSkeleton style={styles.metadata} />
+              <StaticSkeleton style={styles.metadata} />
+              <StaticSkeleton style={styles.metadata} />
+            </View>
+            {children ? (
+              <>
+                <Divider style={styles.divider} />
+                {children}
+              </>
+            ) : null}
           </View>
-          <Divider style={styles.divider} />
-          <View style={styles.metrics}>
-            <StaticSkeleton style={styles.metric} />
-            <StaticSkeleton style={styles.metric} />
-            <StaticSkeleton style={styles.metric} />
-          </View>
-          <View style={styles.description}>
-            {times(random(5, 15), () => random(20, 100)).map(
-              (elementWidth: number, i) => (
-                <StaticSkeleton
-                  key={i}
-                  style={[styles.descriptionText, { width: elementWidth }]}
-                />
-              )
-            )}
-          </View>
-          <Divider style={styles.divider} />
-          <View style={styles.metadataSection}>
-            <StaticSkeleton style={styles.metadata} />
-            <StaticSkeleton style={styles.metadata} />
-            <StaticSkeleton style={styles.metadata} />
-          </View>
-          {children ? (
-            <>
-              <Divider style={styles.divider} />
-              {children}
-            </>
-          ) : null}
-        </View>
-      </Tile>
+        </Tile>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
+++ b/packages/mobile/src/screens/audio-screen/AudioScreen.tsx
@@ -33,7 +33,8 @@ import {
   Button,
   GradientText,
   Text,
-  Tile
+  Tile,
+  ScreenContent
 } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
@@ -437,14 +438,16 @@ export const AudioScreen = () => {
       icon={IconCrown}
       title={messages.title}
     >
-      <ScrollView style={styles.tiles}>
-        {renderAudioTile()}
-        {renderWalletTile()}
-        {renderRewardsTile()}
-        {renderTrendingTile()}
-        {renderTierTile()}
-        {renderWhatTile()}
-      </ScrollView>
+      <ScreenContent>
+        <ScrollView style={styles.tiles}>
+          {renderAudioTile()}
+          {renderWalletTile()}
+          {renderRewardsTile()}
+          {renderTrendingTile()}
+          {renderTierTile()}
+          {renderWhatTile()}
+        </ScrollView>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/chats-screen/ChatsScreen.tsx
+++ b/packages/mobile/src/screens/chats-screen/ChatsScreen.tsx
@@ -4,7 +4,7 @@ import { chatActions, chatSelectors } from '@audius/common'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Screen, Text } from 'app/components/core'
+import { Screen, ScreenContent, Text } from 'app/components/core'
 
 const { getChats, getChatMessages } = chatSelectors
 
@@ -24,18 +24,20 @@ export const ChatsScreen = () => {
 
   return (
     <Screen>
-      <View>
-        <Text>You have {chats?.length} chats:</Text>
-        {messages.map((message) => {
-          return (
-            <View key={message.message_id}>
-              <Text>{message.sender_user_id} says:</Text>
-              <Text>{message.message}</Text>
-              <Text>{message.created_at}</Text>
-            </View>
-          )
-        })}
-      </View>
+      <ScreenContent>
+        <View>
+          <Text>You have {chats?.length} chats:</Text>
+          {messages.map((message) => {
+            return (
+              <View key={message.message_id}>
+                <Text>{message.sender_user_id} says:</Text>
+                <Text>{message.message}</Text>
+                <Text>{message.created_at}</Text>
+              </View>
+            )
+          })}
+        </View>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -31,6 +31,7 @@ import {
   VirtualizedScrollView
 } from 'app/components/core'
 import { CollectionImage } from 'app/components/image/CollectionImage'
+import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
 import { setVisibility } from 'app/store/drawers/slice'
@@ -136,6 +137,7 @@ const CollectionScreenComponent = (props: CollectionScreenComponentProps) => {
     save_count,
     updated_at
   } = collection
+  const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
   const url = useMemo(() => {
     return `/${encodeUrlName(user.handle)}/${
@@ -244,7 +246,7 @@ const CollectionScreenComponent = (props: CollectionScreenComponentProps) => {
 
   return (
     <Screen url={url}>
-      <ScreenContent>
+      <ScreenContent isOfflineCapable={isOfflineModeEnabled}>
         <VirtualizedScrollView
           listKey={`playlist-${collection.playlist_id}`}
           style={styles.root}

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -25,7 +25,11 @@ import { useFocusEffect } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import type { DynamicImageProps } from 'app/components/core'
-import { Screen, VirtualizedScrollView } from 'app/components/core'
+import {
+  ScreenContent,
+  Screen,
+  VirtualizedScrollView
+} from 'app/components/core'
 import { CollectionImage } from 'app/components/image/CollectionImage'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
@@ -240,31 +244,33 @@ const CollectionScreenComponent = (props: CollectionScreenComponentProps) => {
 
   return (
     <Screen url={url}>
-      <VirtualizedScrollView
-        listKey={`playlist-${collection.playlist_id}`}
-        style={styles.root}
-      >
-        <CollectionScreenDetailsTile
-          description={description ?? ''}
-          extraDetails={extraDetails}
-          hasReposted={has_current_user_reposted}
-          hasSaved={has_current_user_saved}
-          isAlbum={is_album}
-          isPrivate={is_private}
-          isPublishing={_is_publishing ?? false}
-          onPressFavorites={handlePressFavorites}
-          onPressOverflow={handlePressOverflow}
-          onPressRepost={handlePressRepost}
-          onPressReposts={handlePressReposts}
-          onPressSave={handlePressSave}
-          onPressShare={handlePressShare}
-          renderImage={renderImage}
-          repostCount={repost_count}
-          saveCount={save_count}
-          title={playlist_name}
-          user={user}
-        />
-      </VirtualizedScrollView>
+      <ScreenContent>
+        <VirtualizedScrollView
+          listKey={`playlist-${collection.playlist_id}`}
+          style={styles.root}
+        >
+          <CollectionScreenDetailsTile
+            description={description ?? ''}
+            extraDetails={extraDetails}
+            hasReposted={has_current_user_reposted}
+            hasSaved={has_current_user_saved}
+            isAlbum={is_album}
+            isPrivate={is_private}
+            isPublishing={_is_publishing ?? false}
+            onPressFavorites={handlePressFavorites}
+            onPressOverflow={handlePressOverflow}
+            onPressRepost={handlePressRepost}
+            onPressReposts={handlePressReposts}
+            onPressSave={handlePressSave}
+            onPressShare={handlePressShare}
+            renderImage={renderImage}
+            repostCount={repost_count}
+            saveCount={save_count}
+            title={playlist_name}
+            user={user}
+          />
+        </VirtualizedScrollView>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/edit-track-screen/components/FormScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/FormScreen.tsx
@@ -4,7 +4,7 @@ import { View } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import type { ScreenProps } from 'app/components/core'
-import { Button, Screen } from 'app/components/core'
+import { ScreenContent, Button, Screen } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { getIsKeyboardOpen } from 'app/store/keyboard/selectors'
 import { makeStyles } from 'app/styles'
@@ -48,12 +48,14 @@ export const FormScreen = (props: FormScreenProps) => {
 
   return (
     <Screen variant='secondary' style={[styles.root, styleProp]} {...other}>
-      {children}
-      {isKeyboardOpen ? null : (
-        <View style={styles.bottomSection}>
-          {bottomSection ?? defaultBottomSection}
-        </View>
-      )}
+      <ScreenContent>
+        {children}
+        {isKeyboardOpen ? null : (
+          <View style={styles.bottomSection}>
+            {bottomSection ?? defaultBottomSection}
+          </View>
+        )}
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/LetThemDJScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/LetThemDJScreen.tsx
@@ -10,7 +10,7 @@ import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { CollectionList } from 'app/components/collection-list'
-import { Screen, ScreenHeader } from 'app/components/core'
+import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { WithLoader } from 'app/components/with-loader/WithLoader'
 
 import { LET_THEM_DJ } from '../../collections'
@@ -35,11 +35,13 @@ export const LetThemDJScreen = () => {
   return (
     <Screen>
       <ScreenHeader text={LET_THEM_DJ.title} />
-      <View style={{ flex: 1 }}>
-        <WithLoader loading={status === Status.LOADING}>
-          <CollectionList collection={exploreData} />
-        </WithLoader>
-      </View>
+      <ScreenContent>
+        <View style={{ flex: 1 }}>
+          <WithLoader loading={status === Status.LOADING}>
+            <CollectionList collection={exploreData} />
+          </WithLoader>
+        </View>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/TopAlbumsScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/TopAlbumsScreen.tsx
@@ -9,7 +9,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 
 import { CollectionList } from 'app/components/collection-list'
-import { Screen, ScreenHeader } from 'app/components/core'
+import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { WithLoader } from 'app/components/with-loader/WithLoader'
 
 import { TOP_ALBUMS } from '../../collections'
@@ -34,9 +34,11 @@ export const TopAlbumsScreen = () => {
   return (
     <Screen>
       <ScreenHeader text={TOP_ALBUMS.title} />
-      <WithLoader loading={status === Status.LOADING}>
-        <CollectionList collection={exploreData} />
-      </WithLoader>
+      <ScreenContent>
+        <WithLoader loading={status === Status.LOADING}>
+          <CollectionList collection={exploreData} />
+        </WithLoader>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/TrendingPlaylistsScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/TrendingPlaylistsScreen.tsx
@@ -6,7 +6,7 @@ import {
 import { useSelector } from 'react-redux'
 
 import { RewardsBanner } from 'app/components/audio-rewards'
-import { Screen, ScreenHeader } from 'app/components/core'
+import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
 const { getLineup } = trendingPlaylistsPageLineupSelectors
 const { makeGetLineupMetadatas } = lineupSelectors
@@ -23,14 +23,16 @@ export const TrendingPlaylistsScreen = () => {
   return (
     <Screen>
       <ScreenHeader text={messages.header} />
-      <Lineup
-        lineup={lineup}
-        header={<RewardsBanner type='playlists' />}
-        actions={trendingPlaylistsPageLineupActions}
-        rankIconCount={5}
-        isTrending
-        selfLoad
-      />
+      <ScreenContent>
+        <Lineup
+          lineup={lineup}
+          header={<RewardsBanner type='playlists' />}
+          actions={trendingPlaylistsPageLineupActions}
+          rankIconCount={5}
+          isTrending
+          selfLoad
+        />
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/TrendingUndergroundScreen.tsx
+++ b/packages/mobile/src/screens/explore-screen/tabs/ForYouTab/TrendingUndergroundScreen.tsx
@@ -6,7 +6,7 @@ import {
 import { useSelector } from 'react-redux'
 
 import { RewardsBanner } from 'app/components/audio-rewards'
-import { ScreenHeader } from 'app/components/core'
+import { ScreenContent, ScreenHeader } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
 const { makeGetLineupMetadatas } = lineupSelectors
 const { getLineup } = trendingUndergroundPageLineupSelectors
@@ -23,14 +23,16 @@ export const TrendingUndergroundScreen = () => {
   return (
     <>
       <ScreenHeader text={messages.header} />
-      <Lineup
-        lineup={lineup}
-        header={<RewardsBanner type='underground' />}
-        actions={trendingUndergroundPageLineupActions}
-        rankIconCount={5}
-        isTrending
-        selfLoad
-      />
+      <ScreenContent>
+        <Lineup
+          lineup={lineup}
+          header={<RewardsBanner type='underground' />}
+          actions={trendingUndergroundPageLineupActions}
+          rankIconCount={5}
+          isTrending
+          selfLoad
+        />
+      </ScreenContent>
     </>
   )
 }

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -107,17 +107,9 @@ export const FavoritesScreen = () => {
           />
         )}
       </ScreenHeader>
-      {
-        // ScreenContent handles the offline indicator.
-        // Show favorites screen anyway when offline so users can see their downloads
-        isOfflineModeEnabled ? (
-          <TopTabNavigator screens={favoritesScreens} />
-        ) : (
-          <ScreenContent>
-            <TopTabNavigator screens={favoritesScreens} />
-          </ScreenContent>
-        )
-      }
+      <ScreenContent isOfflineCapable={isOfflineModeEnabled}>
+        {<TopTabNavigator screens={favoritesScreens} />}
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/mood-collection-screen/MoodCollectionScreen.tsx
+++ b/packages/mobile/src/screens/mood-collection-screen/MoodCollectionScreen.tsx
@@ -10,7 +10,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 
 import { CollectionList } from 'app/components/collection-list'
-import { Screen, ScreenHeader } from 'app/components/core'
+import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { WithLoader } from 'app/components/with-loader/WithLoader'
 import type { ExploreMoodCollection } from 'app/screens/explore-screen/collections'
 const { getCollections, getStatus } = explorePageCollectionsSelectors
@@ -43,9 +43,11 @@ export const MoodCollectionScreen = ({
   return (
     <Screen>
       <ScreenHeader text={`${collection.title} Playlists`} />
-      <WithLoader loading={status === Status.LOADING}>
-        <CollectionList collection={exploreData} />
-      </WithLoader>
+      <ScreenContent>
+        <WithLoader loading={status === Status.LOADING}>
+          <CollectionList collection={exploreData} />
+        </WithLoader>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -110,7 +110,7 @@ export const ProfileScreen = () => {
       topbarRight={topbarRight}
       url={handle && `/${encodeUrlName(handle)}`}
     >
-      <ScreenContent isOfflineCapable={true}>
+      <ScreenContent isOfflineCapable>
         {!profile ? (
           <ProfileScreenSkeleton />
         ) : (

--- a/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileScreen.tsx
@@ -14,7 +14,7 @@ import { Animated, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconShare from 'app/assets/images/iconShare.svg'
-import { IconButton, Screen } from 'app/components/core'
+import { IconButton, Screen, ScreenContent } from 'app/components/core'
 import { OfflinePlaceholder } from 'app/components/offline-placeholder'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
 import { useRoute } from 'app/hooks/useRoute'
@@ -110,30 +110,32 @@ export const ProfileScreen = () => {
       topbarRight={topbarRight}
       url={handle && `/${encodeUrlName(handle)}`}
     >
-      {!profile ? (
-        <ProfileScreenSkeleton />
-      ) : (
-        <>
-          <View style={styles.navigator}>
-            {isNotReachable ? (
-              <>
-                {renderHeader()}
-                <OfflinePlaceholder />
-              </>
-            ) : (
-              <>
-                <PortalHost name='PullToRefreshPortalHost' />
-                <ProfileTabNavigator
-                  renderHeader={renderHeader}
-                  animatedValue={scrollY}
-                  refreshing={isRefreshing}
-                  onRefresh={handleRefresh}
-                />
-              </>
-            )}
-          </View>
-        </>
-      )}
+      <ScreenContent isOfflineCapable={true}>
+        {!profile ? (
+          <ProfileScreenSkeleton />
+        ) : (
+          <>
+            <View style={styles.navigator}>
+              {isNotReachable ? (
+                <>
+                  {renderHeader()}
+                  <OfflinePlaceholder />
+                </>
+              ) : (
+                <>
+                  <PortalHost name='PullToRefreshPortalHost' />
+                  <ProfileTabNavigator
+                    renderHeader={renderHeader}
+                    animatedValue={scrollY}
+                    refreshing={isRefreshing}
+                    onRefresh={handleRefresh}
+                  />
+                </>
+              )}
+            </View>
+          </>
+        )}
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/search-results-screen/SearchResultsScreen.tsx
+++ b/packages/mobile/src/screens/search-results-screen/SearchResultsScreen.tsx
@@ -6,7 +6,7 @@ import IconAlbum from 'app/assets/images/iconAlbum.svg'
 import IconNote from 'app/assets/images/iconNote.svg'
 import IconPlaylists from 'app/assets/images/iconPlaylists.svg'
 import IconUser from 'app/assets/images/iconUser.svg'
-import { Screen, ScreenHeader } from 'app/components/core'
+import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import {
   TabNavigator,
   tabScreen
@@ -61,16 +61,18 @@ export const SearchResultsScreen = () => {
   return (
     <Screen topbarRight={null}>
       <ScreenHeader text={messages.header} />
-      <SearchFocusContext.Provider value={focusContext}>
-        <SearchQueryContext.Provider value={searchQueryContext}>
-          <TabNavigator initialScreenName='Profiles'>
-            {profilesScreen}
-            {tracksScreen}
-            {albumsScreen}
-            {playlistsScreen}
-          </TabNavigator>
-        </SearchQueryContext.Provider>
-      </SearchFocusContext.Provider>
+      <ScreenContent unboxed>
+        <SearchFocusContext.Provider value={focusContext}>
+          <SearchQueryContext.Provider value={searchQueryContext}>
+            <TabNavigator initialScreenName='Profiles'>
+              {profilesScreen}
+              {tracksScreen}
+              {albumsScreen}
+              {playlistsScreen}
+            </TabNavigator>
+          </SearchQueryContext.Provider>
+        </SearchFocusContext.Provider>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/search-results-screen/TagSearchScreen.tsx
+++ b/packages/mobile/src/screens/search-results-screen/TagSearchScreen.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from 'react-redux'
 
 import IconNote from 'app/assets/images/iconNote.svg'
 import IconUser from 'app/assets/images/iconUser.svg'
-import { Screen, Tag, ScreenHeader } from 'app/components/core'
+import { Screen, Tag, ScreenHeader, ScreenContent } from 'app/components/core'
 import { TabNavigator, tabScreen } from 'app/components/top-tab-bar'
 import { useRoute } from 'app/hooks/useRoute'
 import { makeStyles } from 'app/styles'
@@ -67,14 +67,16 @@ export const TagSearchScreen = () => {
       <ScreenHeader text={messages.header} styles={{ root: styles.headerRoot }}>
         <Tag style={styles.tag}>{query.replace(/^#/, '')}</Tag>
       </ScreenHeader>
-      <SearchFocusContext.Provider value={focusContext}>
-        <SearchQueryContext.Provider value={searchQueryContext}>
-          <TabNavigator initialScreenName='Tracks'>
-            {tracksScreen}
-            {profilesScreen}
-          </TabNavigator>
-        </SearchQueryContext.Provider>
-      </SearchFocusContext.Provider>
+      <ScreenContent unboxed>
+        <SearchFocusContext.Provider value={focusContext}>
+          <SearchQueryContext.Provider value={searchQueryContext}>
+            <TabNavigator initialScreenName='Tracks'>
+              {tracksScreen}
+              {profilesScreen}
+            </TabNavigator>
+          </SearchQueryContext.Provider>
+        </SearchFocusContext.Provider>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/AboutScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AboutScreen.tsx
@@ -10,7 +10,7 @@ import IconContact from 'app/assets/images/iconContact.svg'
 import IconDiscord from 'app/assets/images/iconDiscord.svg'
 import IconInstagram from 'app/assets/images/iconInstagram.svg'
 import IconTwitter from 'app/assets/images/iconTwitterBird.svg'
-import { Screen, Text } from 'app/components/core'
+import { Screen, ScreenContent, Text } from 'app/components/core'
 import { toggleLocalOfflineModeOverride } from 'app/hooks/useIsOfflineModeEnabled'
 import { makeStyles } from 'app/styles'
 
@@ -60,40 +60,42 @@ export const AboutScreen = () => {
 
   return (
     <Screen variant='secondary' title={messages.title} topbarRight={null}>
-      <View style={styles.header}>
-        <Image source={appIcon} style={styles.appIcon} />
-        <View>
-          <TouchableWithoutFeedback onPress={handleTitleClick}>
-            <Text variant='h2'>{messages.appName}</Text>
-          </TouchableWithoutFeedback>
-          <Text variant='body2'>
-            {messages.version} {VersionNumber.appVersion}
-          </Text>
-          <Text variant='body2'>{messages.copyright}</Text>
+      <ScreenContent isOfflineCapable>
+        <View style={styles.header}>
+          <Image source={appIcon} style={styles.appIcon} />
+          <View>
+            <TouchableWithoutFeedback onPress={handleTitleClick}>
+              <Text variant='h2'>{messages.appName}</Text>
+            </TouchableWithoutFeedback>
+            <Text variant='body2'>
+              {messages.version} {VersionNumber.appVersion}
+            </Text>
+            <Text variant='body2'>{messages.copyright}</Text>
+          </View>
         </View>
-      </View>
-      <SettingsRow url='https://discordapp.com/invite/yNUg2e2' firstItem>
-        <SettingsRowLabel label={messages.discord} icon={IconDiscord} />
-      </SettingsRow>
-      <SettingsRow url='https://twitter.com/AudiusProject'>
-        <SettingsRowLabel label={messages.twitter} icon={IconTwitter} />
-      </SettingsRow>
-      <SettingsRow url='https://www.instagram.com/audiusmusic/'>
-        <SettingsRowLabel label={messages.instagram} icon={IconInstagram} />
-      </SettingsRow>
-      <SettingsRow url='mailto:contact@audius.co'>
-        <SettingsRowLabel label={messages.contact} icon={IconContact} />
-      </SettingsRow>
-      <SettingsRow url='https://jobs.lever.co/audius'>
-        <SettingsRowLabel label={messages.careers} icon={IconCareers} />
-      </SettingsRow>
-      <Divider />
-      <SettingsRow url='https://help.audius.co/'>
-        <SettingsRowLabel label={messages.help} />
-      </SettingsRow>
-      <SettingsRow url='https://audius.co/legal/terms-of-use'>
-        <SettingsRowLabel label={messages.terms} />
-      </SettingsRow>
+        <SettingsRow url='https://discordapp.com/invite/yNUg2e2' firstItem>
+          <SettingsRowLabel label={messages.discord} icon={IconDiscord} />
+        </SettingsRow>
+        <SettingsRow url='https://twitter.com/AudiusProject'>
+          <SettingsRowLabel label={messages.twitter} icon={IconTwitter} />
+        </SettingsRow>
+        <SettingsRow url='https://www.instagram.com/audiusmusic/'>
+          <SettingsRowLabel label={messages.instagram} icon={IconInstagram} />
+        </SettingsRow>
+        <SettingsRow url='mailto:contact@audius.co'>
+          <SettingsRowLabel label={messages.contact} icon={IconContact} />
+        </SettingsRow>
+        <SettingsRow url='https://jobs.lever.co/audius'>
+          <SettingsRowLabel label={messages.careers} icon={IconCareers} />
+        </SettingsRow>
+        <Divider />
+        <SettingsRow url='https://help.audius.co/'>
+          <SettingsRowLabel label={messages.help} />
+        </SettingsRow>
+        <SettingsRow url='https://audius.co/legal/terms-of-use'>
+          <SettingsRowLabel label={messages.terms} />
+        </SettingsRow>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountSettingsScreen.tsx
@@ -19,7 +19,7 @@ import IconMail from 'app/assets/images/iconMail.svg'
 import IconRemove from 'app/assets/images/iconRemove.svg'
 import IconSignOut from 'app/assets/images/iconSignOut.svg'
 import IconVerified from 'app/assets/images/iconVerified.svg'
-import { ScrollView, Screen } from 'app/components/core'
+import { ScrollView, Screen, ScreenContent } from 'app/components/core'
 import { ToastContext } from 'app/components/toast/ToastContext'
 import { ProfilePicture } from 'app/components/user'
 import { useNavigation } from 'app/hooks/useNavigation'
@@ -120,53 +120,55 @@ export const AccountSettingsScreen = () => {
 
   return (
     <Screen title={messages.title} topbarRight={null} variant='secondary'>
-      <ScrollView>
-        <View style={styles.header}>
-          <ProfilePicture profile={accountUser} style={styles.profilePhoto} />
-          <Text style={styles.name}>{name}</Text>
-          <Text style={styles.handle}>@{handle}</Text>
-        </View>
-        <AccountSettingsItem
-          title={messages.recoveryTitle}
-          titleIconSource={Key}
-          description={messages.recoveryDescription}
-          buttonTitle={messages.recoveryButtonTitle}
-          buttonIcon={IconMail}
-          onPress={handlePressRecoveryEmail}
-        />
-        <AccountSettingsItem
-          title={messages.verifyTitle}
-          titleIconSource={Checkmark}
-          description={messages.verifyDescription}
-          buttonTitle={messages.verifyButtonTitle}
-          buttonIcon={IconVerified}
-          onPress={handlePressVerification}
-        />
-        <AccountSettingsItem
-          title={messages.passwordTitle}
-          titleIconSource={Lock}
-          description={messages.passwordDescription}
-          buttonTitle={messages.passwordButtonTitle}
-          buttonIcon={IconMail}
-          onPress={handlePressChangePassword}
-        />
-        <AccountSettingsItem
-          title={messages.deactivateAccountTitle}
-          titleIconSource={Door}
-          description={messages.deactivateAccountDescription}
-          buttonTitle={messages.deactivateAccountButtonTitle}
-          buttonIcon={IconRemove}
-          onPress={openDeactivateAccountDrawer}
-        />
-        <AccountSettingsItem
-          title={messages.signOutTitle}
-          titleIconSource={StopSign}
-          description={messages.signOutDescription}
-          buttonTitle={messages.signOutButtonTitle}
-          buttonIcon={IconSignOut}
-          onPress={openSignOutDrawer}
-        />
-      </ScrollView>
+      <ScreenContent>
+        <ScrollView>
+          <View style={styles.header}>
+            <ProfilePicture profile={accountUser} style={styles.profilePhoto} />
+            <Text style={styles.name}>{name}</Text>
+            <Text style={styles.handle}>@{handle}</Text>
+          </View>
+          <AccountSettingsItem
+            title={messages.recoveryTitle}
+            titleIconSource={Key}
+            description={messages.recoveryDescription}
+            buttonTitle={messages.recoveryButtonTitle}
+            buttonIcon={IconMail}
+            onPress={handlePressRecoveryEmail}
+          />
+          <AccountSettingsItem
+            title={messages.verifyTitle}
+            titleIconSource={Checkmark}
+            description={messages.verifyDescription}
+            buttonTitle={messages.verifyButtonTitle}
+            buttonIcon={IconVerified}
+            onPress={handlePressVerification}
+          />
+          <AccountSettingsItem
+            title={messages.passwordTitle}
+            titleIconSource={Lock}
+            description={messages.passwordDescription}
+            buttonTitle={messages.passwordButtonTitle}
+            buttonIcon={IconMail}
+            onPress={handlePressChangePassword}
+          />
+          <AccountSettingsItem
+            title={messages.deactivateAccountTitle}
+            titleIconSource={Door}
+            description={messages.deactivateAccountDescription}
+            buttonTitle={messages.deactivateAccountButtonTitle}
+            buttonIcon={IconRemove}
+            onPress={openDeactivateAccountDrawer}
+          />
+          <AccountSettingsItem
+            title={messages.signOutTitle}
+            titleIconSource={StopSign}
+            description={messages.signOutDescription}
+            buttonTitle={messages.signOutButtonTitle}
+            buttonIcon={IconSignOut}
+            onPress={openSignOutDrawer}
+          />
+        </ScrollView>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/AccountVerificationScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/AccountVerificationScreen.tsx
@@ -12,7 +12,7 @@ import PartyFace from 'app/assets/images/emojis/face-with-party-horn-and-party-h
 import IconInstagram from 'app/assets/images/iconInstagram.svg'
 import IconNote from 'app/assets/images/iconNote.svg'
 import IconTwitter from 'app/assets/images/iconTwitterBird.svg'
-import { Button, Screen, Text } from 'app/components/core'
+import { Button, Screen, ScreenContent, Text } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { SocialButton } from 'app/components/social-button'
 import { StatusMessage } from 'app/components/status-message'
@@ -376,7 +376,7 @@ export const AccountVerificationScreen = () => {
 
   return (
     <Screen title={messages.title} topbarRight={null} variant='secondary'>
-      {getPageContent()}
+      <ScreenContent>{getPageContent()}</ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/ChangePasswordScreen/ChangePasswordScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/ChangePasswordScreen/ChangePasswordScreen.tsx
@@ -9,7 +9,7 @@ import {
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Button, Screen, Text } from 'app/components/core'
+import { Button, Screen, ScreenContent, Text } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
@@ -159,7 +159,7 @@ export const ChangePasswordScreen = () => {
 
   return (
     <Screen topbarRight={null} variant='secondary'>
-      {renderContent()}
+      <ScreenContent>{renderContent()}</ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/ListeningHistoryScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/ListeningHistoryScreen.tsx
@@ -15,7 +15,12 @@ import { useFocusEffect } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconListeningHistory from 'app/assets/images/iconListeningHistory.svg'
-import { Screen, Tile, VirtualizedScrollView } from 'app/components/core'
+import {
+  Screen,
+  ScreenContent,
+  Tile,
+  VirtualizedScrollView
+} from 'app/components/core'
 import { EmptyTileCTA } from 'app/components/empty-tile-cta'
 import { TrackList } from 'app/components/track-list'
 import type { TracksMetadata } from 'app/components/track-list/types'
@@ -92,27 +97,29 @@ export const ListeningHistoryScreen = () => {
       topbarRight={null}
       variant='secondary'
     >
-      <WithLoader loading={status === Status.LOADING}>
-        {status === Status.SUCCESS && entries.length === 0 ? (
-          <EmptyTileCTA message={messages.noHistoryMessage} />
-        ) : (
-          <VirtualizedScrollView listKey='listening-history-screen'>
-            <Tile
-              styles={{
-                root: styles.container,
-                tile: styles.trackListContainer
-              }}
-            >
-              <TrackList
-                tracks={entries as TracksMetadata}
-                showDivider
-                togglePlay={togglePlay}
-                trackItemAction='overflow'
-              />
-            </Tile>
-          </VirtualizedScrollView>
-        )}
-      </WithLoader>
+      <ScreenContent>
+        <WithLoader loading={status === Status.LOADING}>
+          {status === Status.SUCCESS && entries.length === 0 ? (
+            <EmptyTileCTA message={messages.noHistoryMessage} />
+          ) : (
+            <VirtualizedScrollView listKey='listening-history-screen'>
+              <Tile
+                styles={{
+                  root: styles.container,
+                  tile: styles.trackListContainer
+                }}
+              >
+                <TrackList
+                  tracks={entries as TracksMetadata}
+                  showDivider
+                  togglePlay={togglePlay}
+                  trackItemAction='overflow'
+                />
+              </Tile>
+            </VirtualizedScrollView>
+          )}
+        </WithLoader>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/NotificationSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/NotificationSettingsScreen.tsx
@@ -2,7 +2,7 @@ import { PushNotificationSetting, settingsPageActions } from '@audius/common'
 import { useDispatch } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
-import { Screen } from 'app/components/core'
+import { Screen, ScreenContent } from 'app/components/core'
 import { remindUserToTurnOnNotifications } from 'app/components/notification-reminder/NotificationReminder'
 
 import { Divider } from './Divider'
@@ -33,32 +33,34 @@ export const NotificationSettingsScreen = () => {
 
   return (
     <Screen title={messages.title} variant='secondary' topbarRight={null}>
-      <NotificationRow
-        label={messages.enablePn}
-        type={PushNotificationSetting.MobilePush}
-      />
-      <NotificationRow
-        label={messages.milestones}
-        type={PushNotificationSetting.MilestonesAndAchievements}
-      />
-      <NotificationRow
-        label={messages.followers}
-        type={PushNotificationSetting.Followers}
-      />
-      <NotificationRow
-        label={messages.reposts}
-        type={PushNotificationSetting.Reposts}
-      />
-      <NotificationRow
-        label={messages.favorites}
-        type={PushNotificationSetting.Favorites}
-      />
-      <NotificationRow
-        label={messages.remixes}
-        type={PushNotificationSetting.Remixes}
-      />
-      <Divider />
-      <EmailFrequencyControlRow />
+      <ScreenContent>
+        <NotificationRow
+          label={messages.enablePn}
+          type={PushNotificationSetting.MobilePush}
+        />
+        <NotificationRow
+          label={messages.milestones}
+          type={PushNotificationSetting.MilestonesAndAchievements}
+        />
+        <NotificationRow
+          label={messages.followers}
+          type={PushNotificationSetting.Followers}
+        />
+        <NotificationRow
+          label={messages.reposts}
+          type={PushNotificationSetting.Reposts}
+        />
+        <NotificationRow
+          label={messages.favorites}
+          type={PushNotificationSetting.Favorites}
+        />
+        <NotificationRow
+          label={messages.remixes}
+          type={PushNotificationSetting.Remixes}
+        />
+        <Divider />
+        <EmailFrequencyControlRow />
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/SettingsScreen.tsx
@@ -8,7 +8,7 @@ import Headphone from 'app/assets/images/emojis/headphone.png'
 import SpeechBalloon from 'app/assets/images/emojis/speech-balloon.png'
 import Trophy from 'app/assets/images/emojis/trophy.png'
 import IconSettings from 'app/assets/images/iconSettings.svg'
-import { Screen, ScrollView } from 'app/components/core'
+import { Screen, ScreenContent, ScrollView } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
 import { Theme } from 'app/utils/theme'
@@ -74,29 +74,40 @@ export const SettingsScreen = () => {
       url='/settings'
       topbarRight={null}
     >
-      <ScrollView>
-        <Image source={audiusLogoHorizontal} style={styles.logo} />
-        <AccountSettingsRow />
-        <SettingsRow onPress={handlePressRewards}>
-          <SettingsRowLabel label={messages.audioRewards} iconSource={Trophy} />
-        </SettingsRow>
-        <SettingsRow onPress={handlePressHistory}>
-          <SettingsRowLabel
-            label={messages.listeningHistory}
-            iconSource={Headphone}
-          />
-        </SettingsRow>
-        <Divider />
-        <SettingsRow onPress={handlePressNotifications}>
-          <SettingsRowLabel label={messages.notifications} iconSource={Bell} />
-        </SettingsRow>
-        <AppearanceSettingsRow />
-        {IS_IOS ? <CastSettingsRow /> : null}
-        <Divider />
-        <SettingsRow onPress={handlePressAbout}>
-          <SettingsRowLabel label={messages.about} iconSource={SpeechBalloon} />
-        </SettingsRow>
-      </ScrollView>
+      <ScreenContent isOfflineCapable>
+        <ScrollView>
+          <Image source={audiusLogoHorizontal} style={styles.logo} />
+          <AccountSettingsRow />
+          <SettingsRow onPress={handlePressRewards}>
+            <SettingsRowLabel
+              label={messages.audioRewards}
+              iconSource={Trophy}
+            />
+          </SettingsRow>
+          <SettingsRow onPress={handlePressHistory}>
+            <SettingsRowLabel
+              label={messages.listeningHistory}
+              iconSource={Headphone}
+            />
+          </SettingsRow>
+          <Divider />
+          <SettingsRow onPress={handlePressNotifications}>
+            <SettingsRowLabel
+              label={messages.notifications}
+              iconSource={Bell}
+            />
+          </SettingsRow>
+          <AppearanceSettingsRow />
+          {IS_IOS ? <CastSettingsRow /> : null}
+          <Divider />
+          <SettingsRow onPress={handlePressAbout}>
+            <SettingsRowLabel
+              label={messages.about}
+              iconSource={SpeechBalloon}
+            />
+          </SettingsRow>
+        </ScrollView>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/signon/FirstFollows.tsx
+++ b/packages/mobile/src/screens/signon/FirstFollows.tsx
@@ -11,7 +11,7 @@ import type {
 } from 'common/store/pages/signon/types'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { SafeAreaScreen } from 'app/components/core'
+import { SafeAreaScreen, ScreenContent } from 'app/components/core'
 import { SuggestedFollows } from 'app/components/suggested-follows'
 import { track, make } from 'app/services/analytics'
 import { EventNames } from 'app/types/analytics'
@@ -54,11 +54,13 @@ const FirstFollows = (props: FirstFollowsProps) => {
 
   return (
     <SafeAreaScreen>
-      <SuggestedFollows
-        title={messages.title}
-        onArtistsSelected={handleArtistsSelected}
-        screen='sign-on'
-      />
+      <ScreenContent>
+        <SuggestedFollows
+          title={messages.title}
+          onArtistsSelected={handleArtistsSelected}
+          screen='sign-on'
+        />
+      </ScreenContent>
     </SafeAreaScreen>
   )
 }

--- a/packages/mobile/src/screens/tip-artist-screen/TipScreen.tsx
+++ b/packages/mobile/src/screens/tip-artist-screen/TipScreen.tsx
@@ -1,14 +1,16 @@
 import type { ScreenProps } from 'app/components/core'
-import { Screen } from 'app/components/core'
+import { ScreenContent, Screen } from 'app/components/core'
 
 type TipScreenProps = ScreenProps
 
-export const TipScreen = (props: TipScreenProps) => {
+export const TipScreen = ({ children, ...props }: TipScreenProps) => {
   return (
     <Screen
       variant='white'
       style={{ paddingVertical: 60, paddingHorizontal: 16 }}
       {...props}
-    />
+    >
+      <ScreenContent>{children}</ScreenContent>
+    </Screen>
   )
 }

--- a/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackRemixesScreen.tsx
@@ -10,7 +10,7 @@ import {
 import { Text, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Screen, ScreenHeader } from 'app/components/core'
+import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
 import UserBadges from 'app/components/user-badges'
 import { useNavigation } from 'app/hooks/useNavigation'
@@ -107,30 +107,32 @@ export const TrackRemixesScreen = () => {
   return (
     <Screen>
       <ScreenHeader text={messages.header} />
-      <Lineup
-        lineup={lineup}
-        loadMore={loadMore}
-        header={
-          track && user ? (
-            <View style={styles.header}>
-              <Text style={styles.text}>{remixesCountText}</Text>
-              <Text style={styles.text}>
-                <Text style={styles.link} onPress={handlePressTrack}>
-                  {track.title}
-                </Text>{' '}
-                <Text>{messages.by}</Text>{' '}
-                <Text onPress={handlePressArtistName}>
-                  <Text style={styles.link}>{user.name}</Text>
-                  {user ? (
-                    <UserBadges user={user} badgeSize={10} hideName />
-                  ) : null}
+      <ScreenContent>
+        <Lineup
+          lineup={lineup}
+          loadMore={loadMore}
+          header={
+            track && user ? (
+              <View style={styles.header}>
+                <Text style={styles.text}>{remixesCountText}</Text>
+                <Text style={styles.text}>
+                  <Text style={styles.link} onPress={handlePressTrack}>
+                    {track.title}
+                  </Text>{' '}
+                  <Text>{messages.by}</Text>{' '}
+                  <Text onPress={handlePressArtistName}>
+                    <Text style={styles.link}>{user.name}</Text>
+                    {user ? (
+                      <UserBadges user={user} badgeSize={10} hideName />
+                    ) : null}
+                  </Text>
                 </Text>
-              </Text>
-            </View>
-          ) : null
-        }
-        actions={tracksActions}
-      />
+              </View>
+            ) : null
+          }
+          actions={tracksActions}
+        />
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -11,7 +11,7 @@ import { Text, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconArrow from 'app/assets/images/iconArrow.svg'
-import { Button, Screen } from 'app/components/core'
+import { Button, Screen, ScreenContent } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
@@ -120,43 +120,45 @@ export const TrackScreen = () => {
 
   return (
     <Screen url={track?.permalink}>
-      <Lineup
-        actions={tracksActions}
-        count={6}
-        header={
-          <TrackScreenMainContent
-            lineup={lineup}
-            remixParentTrack={remixParentTrack}
-            track={track}
-            user={user}
-            lineupHeader={
-              hasValidRemixParent ? originalTrackTitle : moreByArtistTitle
-            }
-          />
-        }
-        leadingElementId={remixParentTrack?.track_id}
-        leadingElementDelineator={
-          <>
-            <View style={styles.buttonContainer}>
-              <Button
-                title={messages.viewOtherRemixes}
-                icon={IconArrow}
-                variant='primary'
-                size='small'
-                onPress={handlePressGoToRemixes}
-                fullWidth
-                styles={{
-                  root: styles.button
-                }}
-              />
-            </View>
-            {moreByArtistTitle}
-          </>
-        }
-        lineup={lineup}
-        start={1}
-        includeLineupStatus
-      />
+      <ScreenContent isOfflineCapable>
+        <Lineup
+          actions={tracksActions}
+          count={6}
+          header={
+            <TrackScreenMainContent
+              lineup={lineup}
+              remixParentTrack={remixParentTrack}
+              track={track}
+              user={user}
+              lineupHeader={
+                hasValidRemixParent ? originalTrackTitle : moreByArtistTitle
+              }
+            />
+          }
+          leadingElementId={remixParentTrack?.track_id}
+          leadingElementDelineator={
+            <>
+              <View style={styles.buttonContainer}>
+                <Button
+                  title={messages.viewOtherRemixes}
+                  icon={IconArrow}
+                  variant='primary'
+                  size='small'
+                  onPress={handlePressGoToRemixes}
+                  fullWidth
+                  styles={{
+                    root: styles.button
+                  }}
+                />
+              </View>
+              {moreByArtistTitle}
+            </>
+          }
+          lineup={lineup}
+          start={1}
+          includeLineupStatus
+        />
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -13,6 +13,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import IconArrow from 'app/assets/images/iconArrow.svg'
 import { Button, Screen, ScreenContent } from 'app/components/core'
 import { Lineup } from 'app/components/lineup'
+import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
 import { makeStyles } from 'app/styles'
@@ -52,6 +53,7 @@ export const TrackScreen = () => {
   const navigation = useNavigation()
   const { params } = useRoute<'Track'>()
   const dispatch = useDispatch()
+  const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
   const { searchTrack, id, canBeUnlisted = true, handle, slug } = params ?? {}
 
@@ -120,7 +122,7 @@ export const TrackScreen = () => {
 
   return (
     <Screen url={track?.permalink}>
-      <ScreenContent isOfflineCapable>
+      <ScreenContent isOfflineCapable={isOfflineModeEnabled}>
         <Lineup
           actions={tracksActions}
           count={6}

--- a/packages/mobile/src/screens/upload-screen/screens/SelectTrackScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/SelectTrackScreen.tsx
@@ -7,7 +7,14 @@ import { useAsyncFn } from 'react-use'
 
 import IconRemove from 'app/assets/images/iconRemove.svg'
 import IconUpload from 'app/assets/images/iconUpload.svg'
-import { Button, ErrorText, Screen, Text, Tile } from 'app/components/core'
+import {
+  Button,
+  ErrorText,
+  Screen,
+  ScreenContent,
+  Text,
+  Tile
+} from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { make, track as trackAnalytcs } from 'app/services/analytics'
@@ -101,31 +108,33 @@ export const SelectTrackScreen = () => {
       }
       url='/select-track'
     >
-      <Tile styles={{ root: styles.tile, content: styles.tileContent }}>
-        <IconUpload
-          fill={neutralLight4}
-          height={spacing(20)}
-          width={spacing(20)}
-        />
-        <Text fontSize='xxl' weight='bold' style={styles.title}>
-          {messages.title}
-        </Text>
-        <Text variant='h4' style={styles.description}>
-          {messages.description}
-        </Text>
-        <Button
-          title={messages.browse}
-          fullWidth
-          variant='primary'
-          size='large'
-          icon={isLoading ? LoadingSpinner : undefined}
-          disabled={Boolean(isLoading)}
-          onPress={handleSelectTrack}
-        />
-        {error && !loading ? (
-          <ErrorText style={styles.errorText}>{error.message}</ErrorText>
-        ) : null}
-      </Tile>
+      <ScreenContent>
+        <Tile styles={{ root: styles.tile, content: styles.tileContent }}>
+          <IconUpload
+            fill={neutralLight4}
+            height={spacing(20)}
+            width={spacing(20)}
+          />
+          <Text fontSize='xxl' weight='bold' style={styles.title}>
+            {messages.title}
+          </Text>
+          <Text variant='h4' style={styles.description}>
+            {messages.description}
+          </Text>
+          <Button
+            title={messages.browse}
+            fullWidth
+            variant='primary'
+            size='large'
+            icon={isLoading ? LoadingSpinner : undefined}
+            disabled={Boolean(isLoading)}
+            onPress={handleSelectTrack}
+          />
+          {error && !loading ? (
+            <ErrorText style={styles.errorText}>{error.message}</ErrorText>
+          ) : null}
+        </Tile>
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
+++ b/packages/mobile/src/screens/upload-screen/screens/UploadingTracksScreen.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
 import IconUpload from 'app/assets/images/iconUpload.svg'
-import { Screen, Text, Tile } from 'app/components/core'
+import { Screen, ScreenContent, Text, Tile } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
@@ -92,29 +92,31 @@ export const UploadingTracksScreen = () => {
       topbarLeft={null}
       url='/uploading-track'
     >
-      <Tile styles={{ root: styles.tile, content: styles.tileContent }}>
-        <View style={styles.title}>
-          <IconUpload
-            fill={neutralLight4}
-            width={24}
-            height={24}
-            style={styles.tileIcon}
-          />
-          <Text fontSize='xxl' weight='bold' color='neutralLight4'>
-            {messages.uploadTitle}
+      <ScreenContent>
+        <Tile styles={{ root: styles.tile, content: styles.tileContent }}>
+          <View style={styles.title}>
+            <IconUpload
+              fill={neutralLight4}
+              width={24}
+              height={24}
+              style={styles.tileIcon}
+            />
+            <Text fontSize='xxl' weight='bold' color='neutralLight4'>
+              {messages.uploadTitle}
+            </Text>
+          </View>
+          <Text variant='body' style={styles.description}>
+            {messages.uploadDescription}
           </Text>
-        </View>
-        <Text variant='body' style={styles.description}>
-          {messages.uploadDescription}
-        </Text>
-      </Tile>
-      {tracks.map((track) => (
-        <UploadingTrackTile
-          key={track.metadata.title}
-          track={track}
-          uploadProgress={trackUploadProgress}
-        />
-      ))}
+        </Tile>
+        {tracks.map((track) => (
+          <UploadingTrackTile
+            key={track.metadata.title}
+            track={track}
+            uploadProgress={trackUploadProgress}
+          />
+        ))}
+      </ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/user-list-screen/UserListScreen.tsx
+++ b/packages/mobile/src/screens/user-list-screen/UserListScreen.tsx
@@ -2,7 +2,7 @@ import type { ComponentType, ReactElement, ReactNode } from 'react'
 
 import type { SvgProps } from 'react-native-svg'
 
-import { Screen } from 'app/components/core'
+import { Screen, ScreenContent } from 'app/components/core'
 
 type UserListScreenProps = {
   title: ReactNode
@@ -15,7 +15,7 @@ export const UserListScreen = (props: UserListScreenProps) => {
 
   return (
     <Screen variant='white' title={title} icon={titleIcon}>
-      {children}
+      <ScreenContent>{children}</ScreenContent>
     </Screen>
   )
 }

--- a/packages/mobile/src/screens/wallet-connect/WalletConnectScreen.tsx
+++ b/packages/mobile/src/screens/wallet-connect/WalletConnectScreen.tsx
@@ -2,7 +2,7 @@ import { View } from 'react-native'
 
 import IconLink from 'app/assets/images/iconLink.svg'
 import IconRemove from 'app/assets/images/iconRemove.svg'
-import { Text, Screen } from 'app/components/core'
+import { Text, Screen, ScreenContent } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles } from 'app/styles'
 
@@ -58,16 +58,18 @@ export const WalletConnectScreen = () => {
       }
       url='/wallet-connect'
     >
-      <View style={styles.root}>
-        <Text weight='bold' style={styles.subtitle}>
-          {messages.subtitle}
-        </Text>
-        <Text weight='medium' fontSize='medium' style={styles.text}>
-          {messages.text}
-        </Text>
-        <ConnectNewWalletButton />
-        <LinkedWallets />
-      </View>
+      <ScreenContent>
+        <View style={styles.root}>
+          <Text weight='bold' style={styles.subtitle}>
+            {messages.subtitle}
+          </Text>
+          <Text weight='medium' fontSize='medium' style={styles.text}>
+            {messages.text}
+          </Text>
+          <ConnectNewWalletButton />
+          <LinkedWallets />
+        </View>
+      </ScreenContent>
     </Screen>
   )
 }


### PR DESCRIPTION
### Description

Shows the offline indicator instead of failing to show content that requires connectivity.

Recommend review with hide whitespace changes.

### Dragons

Might be better off with a blanket solution for all screens. We could pass in an `offline={true}` prop for those that don't require it.

