### PR TITLE
[PAY-845] Sort rewards tiles by completed/disbursed

### DIFF
--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -155,11 +155,14 @@ export const sortChallenges = (
 
     if (userChallenge1?.state === 'disbursed') {
       return 1
-    } else if (userChallenge1?.state === 'completed') {
+    }
+    if (userChallenge1?.state === 'completed') {
       return -1
-    } else if (userChallenge2?.state === 'disbursed') {
+    }
+    if (userChallenge2?.state === 'disbursed') {
       return -1
-    } else if (userChallenge2?.state === 'completed') {
+    }
+    if (userChallenge2?.state === 'completed') {
       return 1
     }
     return 0

--- a/packages/common/src/utils/challenges.ts
+++ b/packages/common/src/utils/challenges.ts
@@ -145,3 +145,23 @@ export const challengeRewardsConfig: Record<
     id: 'trending-underground'
   }
 }
+
+export const sortChallenges = (
+  userChallenges: Partial<Record<ChallengeRewardID, OptimisticUserChallenge>>
+): ((id1: ChallengeRewardID, id2: ChallengeRewardID) => number) => {
+  return (id1, id2) => {
+    const userChallenge1 = userChallenges[id1]
+    const userChallenge2 = userChallenges[id2]
+
+    if (userChallenge1?.state === 'disbursed') {
+      return 1
+    } else if (userChallenge1?.state === 'completed') {
+      return -1
+    } else if (userChallenge2?.state === 'disbursed') {
+      return -1
+    } else if (userChallenge2?.state === 'completed') {
+      return 1
+    }
+    return 0
+  }
+}

--- a/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
+++ b/packages/mobile/src/screens/audio-screen/ChallengeRewards.tsx
@@ -11,7 +11,8 @@ import {
   challengesSelectors,
   audioRewardsPageActions,
   audioRewardsPageSelectors,
-  modalsActions
+  modalsActions,
+  sortChallenges
 } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import { View } from 'react-native'
@@ -104,6 +105,7 @@ export const ChallengeRewards = () => {
     // Filter out challenges that DN didn't return
     .map((id) => userChallenges[id]?.challenge_id)
     .filter(removeNullable)
+    .sort(sortChallenges(optimisticUserChallenges))
     .map((id) => {
       const props = getChallengeConfig(id)
       return (

--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -4,6 +4,7 @@ import {
   ChallengeRewardID,
   OptimisticUserChallenge,
   removeNullable,
+  sortChallenges,
   StringKeys,
   fillString,
   formatNumberCommas,
@@ -168,6 +169,7 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
   const dispatch = useDispatch()
   const userChallengesLoading = useSelector(getUserChallengesLoading)
   const userChallenges = useSelector(getUserChallenges)
+  const optimisticUserChallenges = useSelector(getOptimisticUserChallenges)
   const [haveChallengesLoaded, setHaveChallengesLoaded] = useState(false)
 
   // The referred challenge only needs a tile if the user was referred
@@ -194,6 +196,7 @@ const RewardsTile = ({ className }: RewardsTileProps) => {
     // Filter out challenges that DN didn't return
     .map((id) => userChallenges[id]?.challenge_id)
     .filter(removeNullable)
+    .sort(sortChallenges(optimisticUserChallenges))
     .map((id) => {
       const props = getChallengeConfig(id)
       return <RewardPanel {...props} openModal={openModal} key={props.id} />


### PR DESCRIPTION
### Description
Completed rewards that are ready to claim float to the top of the rewards tiles. Rewards that are already disbursed sink to the bottom. Respects optimistic claiming. Both mobile and web.

### Dragons

### How Has This Been Tested?

Tested locally on web and ios sim. Also tested that aggregate rewards eg. invites function correctly.

### How will this change be monitored?

### Feature Flags ###


