### PR TITLE
[C-1862] Add back button to manual profile creation screen

### DIFF
--- a/packages/mobile/src/screens/signon/CreatePassword.tsx
+++ b/packages/mobile/src/screens/signon/CreatePassword.tsx
@@ -427,7 +427,7 @@ const CreatePassword = ({ navigation, route }: CreatePasswordProps) => {
               emailAddress: emailField.value
             })
           )
-          navigation.replace('ProfileAuto')
+          navigation.push('ProfileAuto')
         }}
         disabled={isDisabled}
         containerStyle={styles.mainButtonContainer}

--- a/packages/mobile/src/screens/signon/FirstFollows.tsx
+++ b/packages/mobile/src/screens/signon/FirstFollows.tsx
@@ -49,7 +49,7 @@ const FirstFollows = (props: FirstFollowsProps) => {
       })
     )
 
-    navigation.replace('SignupLoadingPage')
+    navigation.push('SignupLoadingPage')
   }
 
   return (

--- a/packages/mobile/src/screens/signon/ProfileAuto.tsx
+++ b/packages/mobile/src/screens/signon/ProfileAuto.tsx
@@ -171,13 +171,6 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
   const [hasNavigatedAway, setHasNavigatedAway] = useState(false)
   const [didValidateHandle, setDidValidateHandle] = useState(false)
 
-  const goTo = useCallback(
-    (page: 'ProfileManual' | 'FirstFollows') => {
-      navigation.replace(page)
-    },
-    [navigation]
-  )
-
   const validateHandle = useCallback(
     (handle: string, verified: boolean) => {
       dispatch(signOnActions.validateHandle(handle, verified))
@@ -291,7 +284,7 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
       ) {
         trackOAuthComplete(completeEvent, handle, verified)
         setOAuthInfo()
-        goTo('ProfileManual')
+        navigation.push('ProfileManual')
         setHasNavigatedAway(true)
         setIsLoading(false)
       } else if (handleField.status === EditingStatus.SUCCESS) {
@@ -305,7 +298,7 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
             handle
           })
         )
-        goTo('FirstFollows')
+        navigation.push('FirstFollows')
         setHasNavigatedAway(true)
         setIsLoading(false)
       }
@@ -317,7 +310,7 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
       validateHandle,
       setOAuthInfo,
       signUp,
-      goTo,
+      navigation,
       trackOAuthComplete
     ]
   )
@@ -397,6 +390,10 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
       })
     )
   }
+
+  const handlePressManual = useCallback(() => {
+    navigation.push('ProfileManual')
+  }, [navigation])
 
   useEffect(() => {
     if (abandoned) {
@@ -479,7 +476,7 @@ const ProfileAuto = ({ navigation }: ProfileAutoProps) => {
 
             <TouchableOpacity
               activeOpacity={0.6}
-              onPress={() => goTo('ProfileManual')}
+              onPress={handlePressManual}
               style={styles.manualButton}
             >
               <Text

--- a/packages/mobile/src/screens/signon/ProfileManual.tsx
+++ b/packages/mobile/src/screens/signon/ProfileManual.tsx
@@ -361,8 +361,12 @@ const ProfileManual = ({ navigation }: ProfileManualProps) => {
         emailAddress: emailField.value
       })
     )
-    navigation.replace('FirstFollows')
+    navigation.push('FirstFollows')
   }
+
+  const handlePressBackButton = useCallback(() => {
+    navigation.replace('ProfileAuto')
+  }, [navigation])
 
   return (
     <SafeAreaView style={{ backgroundColor: 'white' }}>
@@ -375,7 +379,7 @@ const ProfileManual = ({ navigation }: ProfileManualProps) => {
           keyboardShouldPersistTaps='always'
         >
           <View>
-            <SignupHeader />
+            <SignupHeader showBackButton onPressBack={handlePressBackButton} />
             <TouchableWithoutFeedback
               onPress={Keyboard.dismiss}
               accessible={false}

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -646,7 +646,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
                     email,
                     () => {
                       // On available email, move to create password
-                      navigation.replace('CreatePassword')
+                      navigation.push('CreatePassword')
                       setIsWorking(false)
                     },
                     () => {

--- a/packages/mobile/src/screens/signon/SignOnScreen.tsx
+++ b/packages/mobile/src/screens/signon/SignOnScreen.tsx
@@ -88,7 +88,7 @@ export const SignOnScreen = () => {
   return (
     <Stack.Navigator
       initialRouteName='SignOn'
-      screenOptions={{ animationTypeForReplace: 'push' }}
+      screenOptions={{ animationTypeForReplace: 'pop' }}
     >
       {signOnScreens.map(({ name, component }) => (
         <Stack.Screen

--- a/packages/mobile/src/screens/signon/SignupHeader.tsx
+++ b/packages/mobile/src/screens/signon/SignupHeader.tsx
@@ -1,32 +1,67 @@
-import { StyleSheet, View } from 'react-native'
+import { View } from 'react-native'
 
 import HeaderLogo from 'app/assets/images/audiusLogoHorizontalDeprecated.svg'
+import IconCaretLeft from 'app/assets/images/iconCaretLeft.svg'
+import { IconButton } from 'app/components/core'
+import { makeStyles } from 'app/styles'
+import { useThemeColors } from 'app/utils/theme'
 
-const styles = StyleSheet.create({
+const useStyles = makeStyles(({ palette, spacing }) => ({
+  container: {
+    zIndex: 15
+  },
   header: {
-    backgroundColor: 'white',
+    backgroundColor: palette.white,
     top: 0,
-    width: '100%',
     height: 39,
-    alignItems: 'center',
     zIndex: 15,
+    width: '100%',
+    justifyContent: 'center',
     borderBottomWidth: 1,
-    borderColor: '#F7F7F9'
+    borderColor: palette.neutralLight9
+  },
+  backButton: {
+    width: spacing(6),
+    height: spacing(6),
+    marginLeft: spacing(4)
+  },
+  backButtonIcon: {
+    width: spacing(6),
+    height: spacing(6)
   },
   audiusLogoHeader: {
     position: 'absolute',
     alignSelf: 'center',
-    top: 8,
-    marginBottom: 16,
+    top: spacing(2),
+    marginBottom: spacing(4),
     zIndex: 3,
-    height: 24
+    height: spacing(6)
   }
-})
+}))
 
-const SignupHeader = () => {
+type SignupHeaderProps = {
+  showBackButton?: boolean
+  onPressBack?: () => void
+}
+
+const SignupHeader = (props: SignupHeaderProps) => {
+  const { showBackButton, onPressBack } = props
+  const styles = useStyles()
+  const { neutralLight4 } = useThemeColors()
   return (
-    <View style={{ backgroundColor: 'white', zIndex: 15 }}>
+    <View style={styles.container}>
       <View style={styles.header}>
+        {showBackButton ? (
+          <IconButton
+            styles={{
+              root: styles.backButton,
+              icon: styles.backButtonIcon
+            }}
+            fill={neutralLight4}
+            icon={IconCaretLeft}
+            onPress={onPressBack}
+          />
+        ) : null}
         <HeaderLogo style={styles.audiusLogoHeader} fill={'#C2C0CC'} />
       </View>
     </View>


### PR DESCRIPTION
### Description
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-18 at 17 00 46](https://user-images.githubusercontent.com/19916043/213314620-fbc7fc23-3bd8-4151-a781-f90c5e177476.png)

We were missing the back button on this screen on mobile

### Dragons

Touches sign up navigation! Had to switch most of the navigation actions to push in order to get the replace animation to be a pop

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

