### PR TITLE
[C-1863] filter out missing tracks in offline lineup

### DIFF
--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -35,10 +35,7 @@ import {
 } from '../services/offline-downloader/offline-storage'
 
 import { useIsOfflineModeEnabled } from './useIsOfflineModeEnabled'
-import {
-  useBecomeReachable,
-  useBecomeUnreachable
-} from './useReachabilityState'
+import useReachabilityState from './useReachabilityState'
 const { getCollection } = cacheCollectionsSelectors
 
 export const useLoadOfflineData = () => {
@@ -146,57 +143,58 @@ export const useOfflineCollectionLineup = (
     }
   })
 
-  useBecomeReachable(fetchOnlineContent)
-  useBecomeUnreachable(
-    useCallback(() => {
-      if (isOfflineModeEnabled && collectionId) {
-        const lineupTracks = Object.values(offlineTracks).filter((track) =>
-          track.offline?.reasons_for_download.some(
-            (reason) => reason.collection_id === collectionId.toString()
+  const fetchLocalContent = useCallback(() => {
+    if (isOfflineModeEnabled && collectionId) {
+      const lineupTracks = Object.values(offlineTracks).filter((track) =>
+        track.offline?.reasons_for_download.some(
+          (reason) => reason.collection_id === collectionId.toString()
+        )
+      )
+
+      if (collectionId === DOWNLOAD_REASON_FAVORITES) {
+        // Reorder lineup tracks accorinding to favorite time
+        const sortedTracks = orderBy(
+          lineupTracks,
+          (track) => track.offline?.favorite_created_at,
+          ['desc']
+        )
+        dispatch(
+          lineupActions.fetchLineupMetadatasSucceeded(
+            sortedTracks,
+            0,
+            lineupTracks.length,
+            false,
+            false
           )
         )
+      } else {
+        // Reorder lineup tracks according to the collection
+        // TODO: This may have issues for playlists with duplicate tracks
+        const sortedTracks = collection?.playlist_contents.track_ids
+          .map(({ track: trackId }) =>
+            lineupTracks.find((track) => trackId === track.track_id)
+          )
+          .filter((track) => !!track)
 
-        if (collectionId === DOWNLOAD_REASON_FAVORITES) {
-          // Reorder lineup tracks accorinding to favorite time
-          const sortedTracks = orderBy(
-            lineupTracks,
-            (track) => track.offline?.favorite_created_at,
-            ['desc']
+        dispatch(
+          lineupActions.fetchLineupMetadatasSucceeded(
+            sortedTracks,
+            0,
+            lineupTracks.length,
+            false,
+            false
           )
-          dispatch(
-            lineupActions.fetchLineupMetadatasSucceeded(
-              sortedTracks,
-              0,
-              lineupTracks.length,
-              false,
-              false
-            )
-          )
-        } else {
-          // Reorder lineup tracks according to the collection
-          // TODO: This may have issues for playlists with duplicate tracks
-          const sortedTracks = collection?.playlist_contents.track_ids.map(
-            ({ track: trackId }) =>
-              lineupTracks.find((track) => trackId === track.track_id)
-          )
-          dispatch(
-            lineupActions.fetchLineupMetadatasSucceeded(
-              sortedTracks,
-              0,
-              lineupTracks.length,
-              false,
-              false
-            )
-          )
-        }
+        )
       }
-    }, [
-      collection?.playlist_contents.track_ids,
-      collectionId,
-      dispatch,
-      isOfflineModeEnabled,
-      lineupActions,
-      offlineTracks
-    ])
-  )
+    }
+  }, [
+    collection?.playlist_contents.track_ids,
+    collectionId,
+    dispatch,
+    isOfflineModeEnabled,
+    lineupActions,
+    offlineTracks
+  ])
+
+  useReachabilityState(fetchOnlineContent, fetchLocalContent)
 }


### PR DESCRIPTION
### Description

Lineup was crashing due to sending `undefined` tracks in the `fetchLineupMetadatasSucceeded` action.
