### PR TITLE
[C-1811] Fetch feed on reconnect while in background

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1406,7 +1406,7 @@ export class AudiusAPIClient {
         PathType.RootPath,
         headers
       )
-    if (!response) return []
+    if (!response) return null
     return response.data
   }
 

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -14,6 +14,7 @@ import {
   TrackTile,
   LineupTileSkeleton
 } from 'app/components/lineup-tile'
+import { useBecomeReachable } from 'app/hooks/useReachabilityState'
 import { useScrollToTop } from 'app/hooks/useScrollToTop'
 
 import { Delineator } from './Delineator'
@@ -319,6 +320,35 @@ export const Lineup = ({
     pageItemCount,
     extraFetchOptions
   ])
+
+  useBecomeReachable(
+    useCallback(() => {
+      if (entries?.length > 0) return
+      const offset = 0
+      const limit = itemCounts.initial
+      if (loadMore) {
+        loadMore(offset, limit, true)
+      } else {
+        dispatch(
+          actions.fetchLineupMetadatas(
+            offset,
+            limit,
+            true,
+            fetchPayload,
+            extraFetchOptions
+          )
+        )
+      }
+    }, [
+      actions,
+      dispatch,
+      entries?.length,
+      extraFetchOptions,
+      fetchPayload,
+      itemCounts.initial,
+      loadMore
+    ])
+  )
 
   // When scrolled past the end threshold of the lineup and the lineup is not loading,
   // trigger another load

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -516,7 +516,7 @@ export const Lineup = ({
           lineup.hasMore ? <View style={{ height: 16 }} /> : ListFooterComponent
         }
         ListEmptyComponent={LineupEmptyComponent}
-        onEndReached={handleLoadMore}
+        onEndReached={handleLoadMore as () => void}
         onEndReachedThreshold={LOAD_MORE_THRESHOLD}
         sections={sections}
         stickySectionHeadersEnabled={false}

--- a/packages/web/src/common/store/lineup/sagas.d.ts
+++ b/packages/web/src/common/store/lineup/sagas.d.ts
@@ -14,7 +14,7 @@ export class LineupSagas {
       offset: number
       limit: number
       payload: any
-    }) => Generator<any, any[], any>,
+    }) => Generator<any, any[] | null, any>,
     retainSelector?: (entry: (LineupTrack | Collection) & { uid: string }) => {
       uid: string
       kind: string

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -145,7 +145,9 @@ function* fetchLineupMetadatasAsync(
 
       const lineupMetadatasResponse = yield call(lineupMetadatasCall, action)
 
-      if (lineupMetadatasResponse === null) return
+      if (lineupMetadatasResponse === null) {
+        yield put(lineupActions.fetchLineupMetadatasFailed())
+      }
       const lineup = yield select((state) =>
         lineupSelector(state, action.handle?.toLowerCase())
       )

--- a/packages/web/src/common/store/pages/feed/lineup/sagas.ts
+++ b/packages/web/src/common/store/pages/feed/lineup/sagas.ts
@@ -38,7 +38,7 @@ function* getTracks({
 }: {
   offset: number
   limit: number
-}): Generator<any, FeedItem[], any> {
+}): Generator<any, FeedItem[] | null, any> {
   yield* waitForRead()
   const currentUser = yield select(getAccountUser)
   if (!currentUser) return []
@@ -67,6 +67,7 @@ function* getTracks({
   const feed: (UserTrackMetadata | UserCollectionMetadata)[] =
     yield apiClient.getSocialFeed(params)
 
+  if (feed === null) return null
   const filteredFeed = feed.filter((record) => !record.user.is_deactivated)
   const [tracks, collections] = getTracksAndCollections(filteredFeed)
   const trackIds = tracks.map((t) => t.track_id)


### PR DESCRIPTION
### Description

`ApiClient.getSocialFeed` was returning `[]` when the request failed. This caused the lineup to load "successfully" with 0 entries, meaning we display the suggested follows instead of feed.

Lineup now also re-requests on reconnect.

### Dragons

This requires a change to the ApiClient return pattern. Imo, `null` is a much more useful response for a failed request than `[]` or `{}` which both lie to you.

Question for reviewers: Should we change the other ApiClient methods to match? This would keep consistency and prevent such bugs in the future, but comes at a higher risk of failure now.

### How Has This Been Tested?

Launch app offline
Background (but do not close) the app
Turn wifi back on
Open the app
Feed now loads properly where it would display the suggested first follows before

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

