### PR TITLE
[C-1838] Remove global progress, improve Audio performance

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -115,7 +115,6 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   const styles = useStyles()
 
   const { isOpen, onOpen, onClose } = useDrawer('NowPlaying')
-  console.log('isOpen?', isOpen)
   const playCounter = useSelector(getCounter)
   const currentUid = useSelector(getUid)
   const isPlaying = useSelector(getPlaying)

--- a/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/NowPlayingDrawer.tsx
@@ -21,6 +21,7 @@ import type {
 } from 'react-native'
 import { Platform, View, StatusBar, Pressable } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import TrackPlayer from 'react-native-track-player'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { BOTTOM_BAR_HEIGHT } from 'app/components/bottom-tab-bar'
@@ -114,6 +115,7 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
   const styles = useStyles()
 
   const { isOpen, onOpen, onClose } = useDrawer('NowPlaying')
+  console.log('isOpen?', isOpen)
   const playCounter = useSelector(getCounter)
   const currentUid = useSelector(getUid)
   const isPlaying = useSelector(getPlaying)
@@ -206,6 +208,7 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
 
   const track = useSelector(getCurrentTrack)
   const trackId = track?.track_id
+  const trackDuration = track?.duration ?? 0
 
   const user = useSelector((state) =>
     getUser(state, track ? { id: track.owner_id } : {})
@@ -216,29 +219,24 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
     setMediaKey((mediaKey) => mediaKey + 1)
   }, [playCounter, currentUid])
 
-  const onNext = useCallback(() => {
+  const onNext = useCallback(async () => {
     if (track?.genre === Genre.PODCASTS) {
-      if (global.progress) {
-        const { currentTime } = global.progress
-        const newPosition = currentTime + SKIP_DURATION_SEC
-        dispatch(seek({ seconds: Math.min(track.duration, newPosition) }))
-      }
+      const currentPosition = await TrackPlayer.getPosition()
+      const newPosition = currentPosition + SKIP_DURATION_SEC
+      dispatch(seek({ seconds: Math.min(track.duration, newPosition) }))
     } else {
       dispatch(next({ skip: true }))
       setMediaKey((mediaKey) => mediaKey + 1)
     }
   }, [dispatch, setMediaKey, track])
 
-  const onPrevious = useCallback(() => {
+  const onPrevious = useCallback(async () => {
+    const currentPosition = await TrackPlayer.getPosition()
     if (track?.genre === Genre.PODCASTS) {
-      if (global.progress) {
-        const { currentTime } = global.progress
-        const newPosition = currentTime - SKIP_DURATION_SEC
-        dispatch(seek({ seconds: Math.max(0, newPosition) }))
-      }
+      const newPosition = currentPosition - SKIP_DURATION_SEC
+      dispatch(seek({ seconds: Math.max(0, newPosition) }))
     } else {
-      const shouldGoToPrevious =
-        global.progress?.currentTime < RESTART_THRESHOLD_SEC
+      const shouldGoToPrevious = currentPosition < RESTART_THRESHOLD_SEC
       if (shouldGoToPrevious) {
         dispatch(previous())
         setMediaKey((mediaKey) => mediaKey + 1)
@@ -303,6 +301,7 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
       >
         <View style={styles.playBarContainer}>
           <PlayBar
+            mediaKey={`${mediaKey}`}
             track={track}
             user={user}
             onPress={onDrawerOpen}
@@ -330,7 +329,7 @@ export const NowPlayingDrawer = memo(function NowPlayingDrawer(
             isPlaying={isPlaying}
             onPressIn={onPressScrubberIn}
             onPressOut={onPressScrubberOut}
-            duration={track?.duration ?? 0}
+            duration={trackDuration}
           />
         </View>
         <View style={styles.controlsContainer}>

--- a/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
@@ -83,14 +83,11 @@ type PlayBarProps = {
   user: Nullable<User>
   onPress: () => void
   translationAnim: Animated.Value
+  mediaKey: string
 }
 
-export const PlayBar = ({
-  track,
-  user,
-  onPress,
-  translationAnim
-}: PlayBarProps) => {
+export const PlayBar = (props: PlayBarProps) => {
+  const { track, user, onPress, translationAnim, mediaKey } = props
   const styles = useStyles()
   const dispatch = useDispatch()
 
@@ -114,26 +111,25 @@ export const PlayBar = ({
     )
   }
 
+  const rootOpacityAnimation = translationAnim.interpolate({
+    // Interpolate the animation such that the play bar fades out
+    // at 25% up the screen.
+    inputRange: [
+      0,
+      0.75 * (NOW_PLAYING_HEIGHT - PLAY_BAR_HEIGHT),
+      NOW_PLAYING_HEIGHT - PLAY_BAR_HEIGHT
+    ],
+    outputRange: [0, 0, 1],
+    extrapolate: 'extend'
+  })
+
   return (
-    <Animated.View
-      style={[
-        styles.root,
-        {
-          opacity: translationAnim.interpolate({
-            // Interpolate the animation such that the play bar fades out
-            // at 25% up the screen.
-            inputRange: [
-              0,
-              0.75 * (NOW_PLAYING_HEIGHT - PLAY_BAR_HEIGHT),
-              NOW_PLAYING_HEIGHT - PLAY_BAR_HEIGHT
-            ],
-            outputRange: [0, 0, 1],
-            extrapolate: 'extend'
-          })
-        }
-      ]}
-    >
-      <TrackingBar translationAnim={translationAnim} />
+    <Animated.View style={[styles.root, { opacity: rootOpacityAnimation }]}>
+      <TrackingBar
+        duration={track?.duration ?? 0}
+        mediaKey={mediaKey}
+        translateYAnimation={translationAnim}
+      />
       <View style={styles.container}>
         {renderFavoriteButton()}
         <TouchableOpacity

--- a/packages/mobile/src/components/scrubber/PositionTimestamp.tsx
+++ b/packages/mobile/src/components/scrubber/PositionTimestamp.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react'
+
+import type { Nullable } from '@audius/common'
+import { formatSeconds } from '@audius/common'
+import { useStreamPosition } from 'react-native-google-cast'
+import { useProgress } from 'react-native-track-player'
+
+import { Text } from 'app/components/core'
+import { makeStyles } from 'app/styles'
+
+type PositionTimestampProps = {
+  dragSeconds: Nullable<string>
+  setDragSeconds: (seconds: Nullable<string>) => void
+}
+
+const useStyles = makeStyles(({ palette }) => ({
+  timestamp: {
+    width: 50,
+    color: palette.neutral,
+    fontSize: 12,
+    flexShrink: 1,
+    textAlign: 'right'
+  }
+}))
+
+export const PositionTimestamp = (props: PositionTimestampProps) => {
+  const { dragSeconds, setDragSeconds } = props
+  const styles = useStyles()
+  const { position: trackPlayerPosition, duration: progressDuration } =
+    useProgress(1000)
+
+  const streamPosition = useStreamPosition(1000)
+
+  useEffect(() => {
+    setDragSeconds(null)
+  }, [progressDuration, streamPosition, setDragSeconds])
+
+  const position = streamPosition ?? trackPlayerPosition
+
+  return (
+    <Text
+      style={[styles.timestamp, { textAlign: 'right' }]}
+      fontSize='xs'
+      weight='regular'
+      numberOfLines={1}
+    >
+      {dragSeconds || formatSeconds(position)}
+    </Text>
+  )
+}


### PR DESCRIPTION
### Description

- Removes global.progress usage throughout mobile app
- Removes tons of unecessary rerenders over the course of an app lifecycle by removing the `useProgress` hook in `Audio`. This was churning through 5 rerenders a second whether or not music was playing, yikes!
- Drastically improves TrackingBar performance by removing the 5 rerenders every second to a single rerender per track (same major issue as audio, but at least it only churned when music was playing)

### Dragons

Touches Audio.tsx. I think this should improve it overall since it stabilizes it's rerenders.

