### PR TITLE
[C-1868] Fix android test app installs

### DIFF
--- a/packages/mobile/android/app/src/releaseCandidate/res/values/strings.xml
+++ b/packages/mobile/android/app/src/releaseCandidate/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="app_name">Audius Music (Release Candidate)</string>
+    <string name="app_name">RC Prod (Audius)</string>
+    <string name="blob_provider_authority">co.audius.app.releasecandidate.blob</string>
 </resources>

--- a/packages/mobile/android/app/src/staging/res/values/strings.xml
+++ b/packages/mobile/android/app/src/staging/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="app_name">Audius Music (Staging)</string>
+    <string name="app_name">Staging (Audius)</string>
+    <string name="blob_provider_authority">co.audius.app.staging.blob</string>
 </resources>

--- a/packages/mobile/android/app/src/stagingReleaseCandidate/values/strings.xml
+++ b/packages/mobile/android/app/src/stagingReleaseCandidate/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">RC Staging (Audius)</string>
+    <string name="blob_provider_authority">co.audius.app.staging.releasecandidate.blob</string>
+</resources>


### PR DESCRIPTION
### Description

Was running into an issue updating/installing android test apps and getting this error:
```
Can't install because provider name co.audius.app.blob (in package co.audius.app.releasecandidate) is already used by co.audius.app
```

* Fix blob providers to be unique to each bundle
* Update app names to match iOS

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

