### PR TITLE
[C-1860][C-1841] Fix disappearing downloaded tracks in lineups

### DIFF
--- a/packages/common/src/store/lineup/actions.ts
+++ b/packages/common/src/store/lineup/actions.ts
@@ -120,8 +120,8 @@ export class LineupActions {
     entries: unknown,
     offset: number,
     limit: number,
-    deleted: boolean,
-    nullCount: boolean,
+    deleted: number,
+    nullCount: number,
     handle?: string
   ) {
     return {

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -170,9 +170,9 @@ export const useOfflineCollectionLineup = (
           lineupActions.fetchLineupMetadatasSucceeded(
             sortedTracks,
             0,
-            lineupTracks.length,
-            false,
-            false
+            sortedTracks.length,
+            0,
+            0
           )
         )
       } else {
@@ -189,8 +189,8 @@ export const useOfflineCollectionLineup = (
             sortedTracks,
             0,
             lineupTracks.length,
-            false,
-            false
+            0,
+            0
           )
         )
       }

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -322,7 +322,6 @@ export const removeAllDownloadedFavorites = async () => {
       }
     })
   )
-  batchDownloadTrack(tracksForDownload)
 
   purgeDownloadedCollection(DOWNLOAD_REASON_FAVORITES)
   batchRemoveTrackDownload(tracksForDownload)

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -17,6 +17,7 @@ import {
   encodeHashId,
   accountSelectors,
   cacheUsersSelectors,
+  cacheActions,
   collectionsSocialActions
 } from '@audius/common'
 import { uniq, isEqual } from 'lodash'
@@ -65,7 +66,6 @@ import {
 const { saveCollection } = collectionsSocialActions
 const { getUserId } = accountSelectors
 const { getUserFromCollection } = cacheUsersSelectors
-
 export const DOWNLOAD_REASON_FAVORITES = 'favorites'
 
 export const downloadAllFavorites = async () => {
@@ -246,6 +246,13 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
         uid: makeUid(Kind.TRACKS, track.track_id),
         ...trackToWrite
       }
+      const cacheTrack = {
+        id: track.track_id,
+        uid: lineupTrack.uid,
+        metadata: lineupTrack
+      }
+      store.dispatch(cacheActions.add(Kind.TRACKS, [cacheTrack], false, true))
+
       store.dispatch(loadTrack(lineupTrack))
       store.dispatch(completeDownload(trackIdStr))
       return
@@ -278,6 +285,12 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
         uid: makeUid(Kind.TRACKS, track.track_id),
         ...trackToWrite
       }
+      const cacheTrack = {
+        id: track.track_id,
+        uid: lineupTrack.uid,
+        metadata: lineupTrack
+      }
+      store.dispatch(cacheActions.add(Kind.TRACKS, [cacheTrack], false, true))
       store.dispatch(loadTrack(lineupTrack))
       store.dispatch(completeDownload(trackIdStr))
       return


### PR DESCRIPTION
### Description

Downloaded tracks were not being added to the cache until subsequent sessions. Adding them to the cache allows the offline lineup to load correctly even in the same session the track was downloaded.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

