### PR TITLE
[C-1828] Defer play count processing until online

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -89,7 +89,8 @@ export const downloadAllFavorites = async () => {
         is_from_favorites: true,
         collection_id: DOWNLOAD_REASON_FAVORITES,
         favorite_created_at: favoriteCreatedAt
-      }
+      },
+      favoriteCreatedAt
     })
   )
   batchDownloadTrack(tracksForDownload)

--- a/packages/mobile/src/services/offline-downloader/workers/index.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/index.ts
@@ -1,0 +1,2 @@
+export * from './playCounterWorker'
+export * from './trackDownloadWorker'

--- a/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
@@ -1,5 +1,5 @@
 import { tracksSocialActions } from '@audius/common'
-import { Worker } from 'react-native-job-queue'
+import queue, { Worker } from 'react-native-job-queue'
 
 import { store } from 'app/store'
 
@@ -11,7 +11,24 @@ export type PlayCountWorkerPayload = { trackId: number }
 
 const countPlay = async (payload: PlayCountWorkerPayload) => {
   const { trackId } = payload
+  console.log('OfflinePlays - listen recorded', trackId)
   store.dispatch(recordListen(trackId))
 }
 
+export const setPlayCounterWorker = async (
+  worker: Worker<PlayCountWorkerPayload>
+) => {
+  queue.stop()
+  queue.removeWorker(PLAY_COUNTER_WORKER)
+  queue.addWorker(worker)
+  await queue.start()
+}
+
 export const playCounterWorker = new Worker(PLAY_COUNTER_WORKER, countPlay)
+export const blockedPlayCounterWorker = new Worker(
+  PLAY_COUNTER_WORKER,
+  countPlay,
+  {
+    concurrency: 0
+  }
+)

--- a/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
@@ -11,7 +11,6 @@ export type PlayCountWorkerPayload = { trackId: number }
 
 const countPlay = async (payload: PlayCountWorkerPayload) => {
   const { trackId } = payload
-  console.log('OfflinePlays - listen recorded', trackId)
   store.dispatch(recordListen(trackId))
 }
 


### PR DESCRIPTION
### Description

PlayCounterWorker was processing jobs while offline. Unfortunately, this queue doesn't have a great way to track that. Changing the concurrency options for the worker is hacky but effective.

Also includes a small fix for favorited tracks sorting.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

