### PR TITLE
[C-1755] Fix repeat jobs and sync inefficiencies

### DIFF
--- a/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
@@ -130,12 +130,10 @@ export const DownloadToggle = ({
     (isDownloadEnabled: boolean) => {
       if (!collection && !isAllFavoritesToggle) return
       if (isDownloadEnabled) {
-        if (isAllFavoritesToggle) {
-          downloadAllFavorites()
-        } else if (collection) {
-          downloadCollection(collection, /* isFavoritesDownload */ false)
-          batchDownloadTrack(tracksForDownload)
-        }
+        isAllFavoritesToggle
+          ? downloadAllFavorites()
+          : collection &&
+            downloadCollection(collection, /* isFavoritesDownload */ false)
       } else {
         if (!isAllFavoritesToggle && collectionIdStr) {
           // we are trying to remove download from a collection page

--- a/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadToggle.tsx
@@ -7,7 +7,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import { Switch, Text } from 'app/components/core'
 import { getAccountCollections } from 'app/screens/favorites-screen/selectors'
 import {
-  batchDownloadTrack,
   downloadAllFavorites,
   downloadCollection,
   DOWNLOAD_REASON_FAVORITES

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -93,6 +93,7 @@ export const downloadAllFavorites = async () => {
       favoriteCreatedAt
     })
   )
+
   batchDownloadTrack(tracksForDownload)
 
   // @ts-ignore state is CommonState
@@ -104,7 +105,8 @@ export const downloadAllFavorites = async () => {
 
 export const downloadCollection = async (
   collection: CollectionMetadata,
-  isFavoritesDownload?: boolean
+  isFavoritesDownload?: boolean,
+  skipTracks?: boolean
 ) => {
   const state = store.getState()
   const currentUserId = getUserId(state)
@@ -153,7 +155,10 @@ export const downloadCollection = async (
       }
     })
   )
-  batchDownloadTrack(tracksForDownload)
+
+  if (!skipTracks) {
+    batchDownloadTrack(tracksForDownload)
+  }
 }
 
 export const batchDownloadTrack = (tracksForDownload: TrackForDownload[]) => {

--- a/packages/mobile/src/services/offline-downloader/offline-sync.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-sync.ts
@@ -23,7 +23,6 @@ import {
   downloadCollectionCoverArt,
   downloadTrackCoverArt,
   DOWNLOAD_REASON_FAVORITES,
-  removeCollectionDownload,
   removeDownloadedCollectionFromFavorites
 } from './offline-downloader'
 import { purgeDownloadedTrack, writeTrackJson } from './offline-storage'

--- a/packages/mobile/src/services/offline-downloader/offline-sync.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-sync.ts
@@ -170,7 +170,11 @@ export const syncCollectionTracks = async (
     updatedCollection
   )
 
-  downloadCollection(updatedCollectionWithArt)
+  downloadCollection(
+    updatedCollectionWithArt,
+    /* isFavoritesDownload */ false,
+    /* skipTracks */ true
+  )
   if (
     updatedCollectionWithArt.cover_art_sizes !==
     offlineCollection.cover_art_sizes
@@ -200,7 +204,7 @@ export const syncCollectionTracks = async (
       }
     })
   )
-  removeCollectionDownload(collectionIdStr, tracksForDelete)
+  batchRemoveTrackDownload(tracksForDelete)
 
   // TODO: known bug here we should track multiple download reasons for the collection
   // and apply each download reason to the sync'd tracks.

--- a/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
@@ -3,10 +3,7 @@ import { Worker } from 'react-native-job-queue'
 
 import type { TrackForDownload } from 'app/components/offline-downloads'
 import { store } from 'app/store'
-import {
-  errorDownload,
-  removeDownload
-} from 'app/store/offline-downloads/slice'
+import { errorDownload } from 'app/store/offline-downloads/slice'
 
 import { batchRemoveTrackDownload, downloadTrack } from '../offline-downloader'
 
@@ -21,7 +18,7 @@ const executor = (payload: TrackDownloadWorkerPayload) => {
   const promise: CancellablePromise<void> = downloadTrack(payload)
   promise.rn_job_queue_cancel = () => {
     promise.finally(() => {
-      store.dispatch(removeDownload(payload.trackId.toString()))
+      store.dispatch(errorDownload(payload.trackId.toString()))
       batchRemoveTrackDownload([payload])
     })
   }


### PR DESCRIPTION
### Description

Fixes several cases where downloads would be queued multiple times or sync would do unnecessary work.

1. Collections were always syncing every track after the last refactor
2. Downloads were queuing twice for favorited collections
3. Tracks removed from collections were being wrongly queued for download
4. Tracks were being queued for download twice in collection sync

This (mostly) fixes the issue with "infinite" loading spinner on downloads. It was not infinite, but tracks that are invalid downloads (e.g. missing files or unavailable) would fail 3 times per associated job.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

