### PR TITLE
[PAY-853] Premium content fixes on web

### DIFF
--- a/packages/common/src/store/pages/track/actions.ts
+++ b/packages/common/src/store/pages/track/actions.ts
@@ -38,13 +38,15 @@ export const fetchTrack = (
   trackId: Nullable<number>,
   slug?: string,
   handle?: string,
-  canBeUnlisted?: boolean
+  canBeUnlisted?: boolean,
+  forceRetrieveFromSource?: boolean
 ) => ({
   type: FETCH_TRACK,
   trackId,
   slug,
   handle,
-  canBeUnlisted
+  canBeUnlisted,
+  forceRetrieveFromSource
 })
 export const fetchTrackSucceeded = (trackId) => ({
   type: FETCH_TRACK_SUCCEEDED,

--- a/packages/common/src/store/premium-content/slice.ts
+++ b/packages/common/src/store/premium-content/slice.ts
@@ -27,6 +27,7 @@ type UpdatePremiumTrackStatusPayload = {
 }
 
 type RefreshPremiumTrackPayload = {
+  trackId: ID
   trackParams:
     | { slug: string; trackId: null; handle: string }
     | { slug: null; trackId: ID; handle: null }

--- a/packages/common/src/store/premium-content/slice.ts
+++ b/packages/common/src/store/premium-content/slice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { ID, PremiumContentSignature } from 'models'
 
-type PremiumTrackStatus = null | 'UNLOCKING' | 'UNLOCKED'
+type PremiumTrackStatus = null | 'UNLOCKING' | 'UNLOCKED' | 'LOCKED'
 
 type PremiumContentState = {
   premiumTrackSignatureMap: { [id: ID]: PremiumContentSignature }
@@ -16,6 +16,10 @@ const initialState: PremiumContentState = {
 
 type UpdatePremiumContentSignaturesPayload = {
   [id: ID]: PremiumContentSignature
+}
+
+type RemovePremiumContentSignaturePayload = {
+  trackId: ID
 }
 
 type UpdatePremiumTrackStatusPayload = {
@@ -42,10 +46,10 @@ const slice = createSlice({
         ...action.payload
       }
     },
-    updatePremiumTrackStatus: (
-      state,
-      action: PayloadAction<UpdatePremiumTrackStatusPayload>
-    ) => {
+    removePremiumContentSignature: (state, action: PayloadAction<RemovePremiumContentSignaturePayload>) => {
+      delete state.premiumTrackSignatureMap[action.payload.trackId]
+    },
+    updatePremiumTrackStatus: (state, action: PayloadAction<UpdatePremiumTrackStatusPayload>) => {
       state.status = action.payload.status
     },
     refreshPremiumTrack: (

--- a/packages/web/src/common/store/cache/sagas.js
+++ b/packages/web/src/common/store/cache/sagas.js
@@ -20,6 +20,7 @@ import {
 import { getConfirmCalls } from 'common/store/confirmer/selectors'
 const { CACHE_PRUNE_MIN } = cacheConfig
 const { getCache } = cacheSelectors
+const { add: addToCache } = cacheActions
 
 const DEFAULT_ENTRY_TTL = 5 /* min */ * 60 /* seconds */ * 1000 /* ms */
 
@@ -178,14 +179,15 @@ function* retrieveFromSourceThenCache({
       metadata: m
     }))
 
-    yield call(
-      add,
-      kind,
-      cacheMetadata,
-      // Rewrite the cache entry if we forced retrieving it from source
-      deleteExistingEntry,
-      // Always cache it persistently
-      true
+    yield put(
+      addToCache(
+        kind,
+        cacheMetadata,
+        // Rewrite the cache entry if we forced retrieving it from source
+        deleteExistingEntry,
+        // Always cache it persistently
+        true
+      )
     )
 
     // Perform any side effects

--- a/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/retrieveTracks.ts
@@ -43,6 +43,7 @@ type RetrieveTrackByHandleAndSlugArgs = {
   withStems?: boolean
   withRemixes?: boolean
   withRemixParents?: boolean
+  forceRetrieveFromSource?: boolean
 }
 
 export function* retrieveTrackByHandleAndSlug({
@@ -50,7 +51,8 @@ export function* retrieveTrackByHandleAndSlug({
   slug,
   withStems,
   withRemixes,
-  withRemixParents
+  withRemixParents,
+  forceRetrieveFromSource = false
 }: RetrieveTrackByHandleAndSlugArgs) {
   const permalink = `/${handle}/${slug}`
   const tracks = (yield* call(
@@ -82,7 +84,7 @@ export function* retrieveTrackByHandleAndSlug({
       },
       kind: Kind.TRACKS,
       idField: 'track_id',
-      forceRetrieveFromSource: false,
+      forceRetrieveFromSource,
       shouldSetLoading: true,
       deleteExistingEntry: false,
       getEntriesTimestamp: function* (ids: ID[]) {

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -134,16 +134,19 @@ function* getRestOfLineup(permalink, ownerHandle) {
 
 function* watchFetchTrack() {
   yield takeEvery(trackPageActions.FETCH_TRACK, function* (action) {
-    const { trackId, handle, slug, canBeUnlisted } = action
+    const { trackId, handle, slug, canBeUnlisted, forceRetrieveFromSource } =
+      action
     try {
       let track
       if (!trackId) {
+        console.log('not track id', handle, slug)
         track = yield call(retrieveTrackByHandleAndSlug, {
           handle,
           slug,
           withStems: true,
           withRemixes: true,
-          withRemixParents: true
+          withRemixParents: true,
+          forceRetrieveFromSource
         })
       } else {
         const ids = canBeUnlisted

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -139,7 +139,6 @@ function* watchFetchTrack() {
     try {
       let track
       if (!trackId) {
-        console.log('not track id', handle, slug)
         track = yield call(retrieveTrackByHandleAndSlug, {
           handle,
           slug,

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -180,7 +180,6 @@ function* updateNewPremiumContentSignatures({
  * Halts if not all nfts have been fetched yet. Similarly, does not proceed if no tracks are in the cache yet.
  * Skips tracks whose signatures have already been previously obtained.
  */
-let index = 0
 function* updateCollectibleGatedTrackAccess(
   action:
     | ReturnType<typeof updateUserEthCollectibles>

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -17,7 +17,7 @@ import {
   trackPageActions,
   TrackMetadata
 } from '@audius/common'
-import { takeLatest, select, call, put, delay } from 'typed-redux-saga'
+import { takeEvery, select, call, put, delay } from 'typed-redux-saga'
 
 import { TrackRouteParams } from 'utils/route/trackRouteParser'
 import { waitForWrite } from 'utils/sagaHelpers'
@@ -180,11 +180,13 @@ function* updateNewPremiumContentSignatures({
  * Halts if not all nfts have been fetched yet. Similarly, does not proceed if no tracks are in the cache yet.
  * Skips tracks whose signatures have already been previously obtained.
  */
+let index = 0
 function* updateCollectibleGatedTrackAccess(
   action:
     | ReturnType<typeof updateUserEthCollectibles>
     | ReturnType<typeof updateUserSolCollectibles>
     | ReturnType<typeof cacheActions.add>
+    | ReturnType<typeof cacheActions.update>
 ) {
   // Halt if premium content not enabled
   yield* waitForWrite()
@@ -331,9 +333,10 @@ function* refreshPremiumTrackAccess(
 }
 
 function* watchCollectibleGatedTracks() {
-  yield* takeLatest(
+  yield* takeEvery(
     [
       cacheActions.ADD,
+      cacheActions.UPDATE,
       updateUserEthCollectibles.type,
       updateUserSolCollectibles.type
     ],
@@ -342,7 +345,7 @@ function* watchCollectibleGatedTracks() {
 }
 
 function* watchRefreshPremiumTrack() {
-  yield* takeLatest(refreshPremiumTrack.type, refreshPremiumTrackAccess)
+  yield* takeEvery(refreshPremiumTrack.type, refreshPremiumTrackAccess)
 }
 
 const sagas = () => {

--- a/packages/web/src/common/store/premiumContent/sagas.ts
+++ b/packages/web/src/common/store/premiumContent/sagas.ts
@@ -294,7 +294,7 @@ function* updateCollectibleGatedTrackAccess(
   }
 }
 
-const PREMIUM_TRACK_POLL_FREQUENCY = 2000
+const PREMIUM_TRACK_POLL_FREQUENCY = 3000
 
 function* pollPremiumTrack({
   trackParams,
@@ -315,7 +315,8 @@ function* pollPremiumTrack({
         trackId,
         slug ?? undefined,
         handle ?? undefined,
-        false
+        false,
+        true
       )
     )
     yield* delay(frequency)

--- a/packages/web/src/components/artist/ArtistCard.tsx
+++ b/packages/web/src/components/artist/ArtistCard.tsx
@@ -21,10 +21,11 @@ type ArtistCardProps = {
   artist: User
   onNavigateAway: () => void
   onFollow?: () => void
+  onUnfollow?: () => void
 }
 
 export const ArtistCard = (props: ArtistCardProps) => {
-  const { artist, onNavigateAway, onFollow } = props
+  const { artist, onNavigateAway, onFollow, onUnfollow } = props
   const {
     user_id,
     bio,
@@ -83,7 +84,10 @@ export const ArtistCard = (props: ArtistCardProps) => {
   const handleUnfollow = useCallback(() => {
     dispatch(unfollowUser(user_id, FollowSource.HOVER_TILE))
     dispatch(setNotificationSubscription(user_id, false, true))
-  }, [dispatch, user_id])
+    if (onUnfollow) {
+      onUnfollow()
+    }
+  }, [dispatch, user_id, onUnfollow])
 
   return (
     <div className={styles.popoverContainer} onClick={handleClick}>

--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -44,6 +44,7 @@ type ArtistPopoverProps = {
   component?: 'div' | 'span'
   onNavigateAway?: () => void
   onFollow?: () => void
+  onUnfollow?: () => void
 }
 
 export const ArtistPopover = ({
@@ -54,7 +55,8 @@ export const ArtistPopover = ({
   mouseEnterDelay = 0.5,
   component: Component = 'div',
   onNavigateAway,
-  onFollow
+  onFollow,
+  onUnfollow
 }: ArtistPopoverProps) => {
   const [isPopupVisible, setIsPopupVisible] = useState(false)
   const creator = useSelector((state: CommonState) =>
@@ -89,6 +91,7 @@ export const ArtistPopover = ({
           onNavigateAway?.()
         }}
         onFollow={onFollow}
+        onUnfollow={onUnfollow}
       />
     ) : null
 

--- a/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
+++ b/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
@@ -99,7 +99,9 @@ export const CollectibleGatedAvailability = ({
   }, [collectibles])
 
   const ethCollectibleItems = useMemo(() => {
-    return Object.keys(ethCollectionMap).map((slug) => ({
+    return Object.keys(ethCollectionMap)
+      .sort((s1, s2) => ethCollectionMap[s1].name.localeCompare(ethCollectionMap[s2].name))
+      .map((slug) => ({
       text: ethCollectionMap[slug].name,
       el: (
         <div className={styles.dropdownRow}>
@@ -147,7 +149,9 @@ export const CollectibleGatedAvailability = ({
   }, [collectibles, solCollections])
 
   const solCollectibleItems = useMemo(() => {
-    return Object.keys(solCollectionMap).map((mint) => ({
+    return Object.keys(solCollectionMap)
+      .sort((m1, m2) => solCollectionMap[m1].name.localeCompare(solCollectionMap[m2].name))
+      .map((mint) => ({
       text: solCollectionMap[mint].name,
       el: (
         <div className={styles.dropdownRow}>

--- a/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
+++ b/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
@@ -100,22 +100,24 @@ export const CollectibleGatedAvailability = ({
 
   const ethCollectibleItems = useMemo(() => {
     return Object.keys(ethCollectionMap)
-      .sort((s1, s2) => ethCollectionMap[s1].name.localeCompare(ethCollectionMap[s2].name))
+      .sort((s1, s2) =>
+        ethCollectionMap[s1].name.localeCompare(ethCollectionMap[s2].name)
+      )
       .map((slug) => ({
-      text: ethCollectionMap[slug].name,
-      el: (
-        <div className={styles.dropdownRow}>
-          {!!ethCollectionMap[slug].img && (
-            <img
-              src={ethCollectionMap[slug].img!}
-              alt={ethCollectionMap[slug].name}
-            />
-          )}
-          <span>{ethCollectionMap[slug].name}</span>
-        </div>
-      ),
-      value: slug
-    }))
+        text: ethCollectionMap[slug].name,
+        el: (
+          <div className={styles.dropdownRow}>
+            {!!ethCollectionMap[slug].img && (
+              <img
+                src={ethCollectionMap[slug].img!}
+                alt={ethCollectionMap[slug].name}
+              />
+            )}
+            <span>{ethCollectionMap[slug].name}</span>
+          </div>
+        ),
+        value: slug
+      }))
   }, [ethCollectionMap])
 
   // Solana collections
@@ -150,22 +152,24 @@ export const CollectibleGatedAvailability = ({
 
   const solCollectibleItems = useMemo(() => {
     return Object.keys(solCollectionMap)
-      .sort((m1, m2) => solCollectionMap[m1].name.localeCompare(solCollectionMap[m2].name))
+      .sort((m1, m2) =>
+        solCollectionMap[m1].name.localeCompare(solCollectionMap[m2].name)
+      )
       .map((mint) => ({
-      text: solCollectionMap[mint].name,
-      el: (
-        <div className={styles.dropdownRow}>
-          {!!solCollectionMap[mint].img && (
-            <img
-              src={solCollectionMap[mint].img!}
-              alt={solCollectionMap[mint].name}
-            />
-          )}
-          <span>{solCollectionMap[mint].name}</span>
-        </div>
-      ),
-      value: mint
-    }))
+        text: solCollectionMap[mint].name,
+        el: (
+          <div className={styles.dropdownRow}>
+            {!!solCollectionMap[mint].img && (
+              <img
+                src={solCollectionMap[mint].img!}
+                alt={solCollectionMap[mint].name}
+              />
+            )}
+            <span>{solCollectionMap[mint].name}</span>
+          </div>
+        ),
+        value: mint
+      }))
   }, [solCollectionMap])
 
   const menuItems = useMemo(

--- a/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
+++ b/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
@@ -28,7 +28,7 @@ const defaultCollectibles = { [Chain.Eth]: [], [Chain.Sol]: [] }
 const messages = {
   collectibleGated: 'Collectible Gated',
   collectibleGatedSubtitle:
-    'Collectible gated content can only be accessed by users with linked wallets containing a collectible from the specified collection. These tracks do not appear on trending or in user feeds.',
+    'Users who own a digital collectible matching your selection will have access to your track. Collectible gated content does not appear on trending or in user feeds.',
   learnMore: 'Learn More',
   pickACollection: 'Pick a Collection'
 }

--- a/packages/web/src/components/track-availability-modal/TrackAvailabilityModal.module.css
+++ b/packages/web/src/components/track-availability-modal/TrackAvailabilityModal.module.css
@@ -142,7 +142,7 @@
 
 .collectibleGated {
   padding: 0;
-  margin-top: 16px;
+  margin-top: 24px;
 }
 
 .hiddenSection {

--- a/packages/web/src/components/track/GiantTrackTile.js
+++ b/packages/web/src/components/track/GiantTrackTile.js
@@ -346,8 +346,13 @@ class GiantTrackTile extends PureComponent {
   }
 
   handleUnfollow = () => {
-    const { doesUserHaveAccess, isPremium, premiumConditions, onLock, trackId } =
-      this.props
+    const {
+      doesUserHaveAccess,
+      isPremium,
+      premiumConditions,
+      onLock,
+      trackId
+    } = this.props
     if (doesUserHaveAccess && isPremium && premiumConditions.follow_user_id) {
       onLock(trackId)
     }

--- a/packages/web/src/components/track/GiantTrackTile.js
+++ b/packages/web/src/components/track/GiantTrackTile.js
@@ -338,20 +338,15 @@ class GiantTrackTile extends PureComponent {
   }
 
   handleFollow = () => {
-    const { doesUserHaveAccess, premiumConditions, onUnlock } =
-      this.props
+    const { doesUserHaveAccess, premiumConditions, onUnlock } = this.props
     if (!doesUserHaveAccess && premiumConditions.follow_user_id) {
       onUnlock()
     }
   }
 
   handleUnfollow = () => {
-    const {
-      doesUserHaveAccess,
-      premiumConditions,
-      onLock,
-      trackId
-    } = this.props
+    const { doesUserHaveAccess, premiumConditions, onLock, trackId } =
+      this.props
     if (doesUserHaveAccess && premiumConditions.follow_user_id) {
       onLock(trackId)
     }

--- a/packages/web/src/components/track/GiantTrackTile.js
+++ b/packages/web/src/components/track/GiantTrackTile.js
@@ -338,9 +338,9 @@ class GiantTrackTile extends PureComponent {
   }
 
   handleFollow = () => {
-    const { doesUserHaveAccess, isPremium, premiumConditions, onUnlock } =
+    const { doesUserHaveAccess, premiumConditions, onUnlock } =
       this.props
-    if (!doesUserHaveAccess && isPremium && premiumConditions.follow_user_id) {
+    if (!doesUserHaveAccess && premiumConditions.follow_user_id) {
       onUnlock()
     }
   }
@@ -348,12 +348,11 @@ class GiantTrackTile extends PureComponent {
   handleUnfollow = () => {
     const {
       doesUserHaveAccess,
-      isPremium,
       premiumConditions,
       onLock,
       trackId
     } = this.props
-    if (doesUserHaveAccess && isPremium && premiumConditions.follow_user_id) {
+    if (doesUserHaveAccess && premiumConditions.follow_user_id) {
       onLock(trackId)
     }
   }

--- a/packages/web/src/components/track/GiantTrackTile.js
+++ b/packages/web/src/components/track/GiantTrackTile.js
@@ -345,6 +345,14 @@ class GiantTrackTile extends PureComponent {
     }
   }
 
+  handleUnfollow = () => {
+    const { doesUserHaveAccess, isPremium, premiumConditions, onLock, trackId } =
+      this.props
+    if (doesUserHaveAccess && isPremium && premiumConditions.follow_user_id) {
+      onLock(trackId)
+    }
+  }
+
   render() {
     const {
       playing,
@@ -436,6 +444,7 @@ class GiantTrackTile extends PureComponent {
                   <ArtistPopover
                     handle={artistHandle}
                     onFollow={this.handleFollow}
+                    onUnfollow={this.handleUnfollow}
                   >
                     <h2 className={styles.artist} onClick={onClickArtistName}>
                       {artistName}
@@ -585,6 +594,7 @@ GiantTrackTile.propTypes = {
   onSave: PropTypes.func,
   following: PropTypes.bool,
   onUnlock: PropTypes.func,
+  onLock: PropTypes.func,
   onFollow: PropTypes.func,
   onUnfollow: PropTypes.func,
   onDownload: PropTypes.func
@@ -616,6 +626,7 @@ GiantTrackTile.defaultProps = {
   onSave: () => {},
   onFollow: () => {},
   onUnlock: () => {},
+  onLock: () => {},
   onDownload: () => {}
 }
 

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -404,3 +404,13 @@
 .spinner g path {
   stroke: var(--static-white) !important;
 }
+
+.premiumContentSectionDescription .spinner {
+  margin-right: 8px;
+  height: 24px;
+  width: 24px;
+}
+
+.premiumContentSectionDescription .spinner path {
+  stroke: var(--neutral-light-4) !important;
+}

--- a/packages/web/src/components/track/PremiumTrackSection.tsx
+++ b/packages/web/src/components/track/PremiumTrackSection.tsx
@@ -69,12 +69,14 @@ const messages = {
 }
 
 type PremiumTrackAccessSectionProps = {
+  trackId: ID
   premiumConditions: PremiumConditions
   followee: Nullable<User>
   tippedUser: Nullable<User>
 }
 
 const LockedPremiumTrackSection = ({
+  trackId,
   premiumConditions,
   followee,
   tippedUser
@@ -91,7 +93,7 @@ const LockedPremiumTrackSection = ({
 
       // Poll discovery to get user's premium content signature for this track.
       const trackParams = parseTrackRoute(window.location.pathname)
-      dispatch(refreshPremiumTrack({ trackParams }))
+      dispatch(refreshPremiumTrack({ trackParams, trackId }))
     }
   }, [dispatch, previousSendStatus, sendStatus])
 
@@ -118,7 +120,7 @@ const LockedPremiumTrackSection = ({
 
         // Poll discovery to get user's premium content signature for this track.
         const trackParams = parseTrackRoute(window.location.pathname)
-        dispatch(refreshPremiumTrack({ trackParams }))
+        dispatch(refreshPremiumTrack({ trackParams, trackId }))
       }
     } else {
       dispatch(pushRoute(SIGN_UP_PAGE))
@@ -399,12 +401,14 @@ const UnlockedPremiumTrackSection = ({
 
 type PremiumTrackSectionProps = {
   isLoading: boolean
+  trackId: ID
   premiumConditions: PremiumConditions
   doesUserHaveAccess: boolean
 }
 
 export const PremiumTrackSection = ({
   isLoading,
+  trackId,
   premiumConditions,
   doesUserHaveAccess
 }: PremiumTrackSectionProps) => {
@@ -443,6 +447,7 @@ export const PremiumTrackSection = ({
     return (
       <div className={cn(styles.premiumContentSection, fadeIn)}>
         <UnlockedPremiumTrackSection
+          trackId={trackId}
           premiumConditions={premiumConditions}
           followee={followee}
           tippedUser={tippedUser}
@@ -455,6 +460,7 @@ export const PremiumTrackSection = ({
     return (
       <div className={cn(styles.premiumContentSection, fadeIn)}>
         <UnlockingPremiumTrackSection
+          trackId={trackId}
           premiumConditions={premiumConditions}
           followee={followee}
           tippedUser={tippedUser}
@@ -466,6 +472,7 @@ export const PremiumTrackSection = ({
   return (
     <div className={cn(styles.premiumContentSection, fadeIn)}>
       <LockedPremiumTrackSection
+        trackId={trackId}
         premiumConditions={premiumConditions}
         followee={followee}
         tippedUser={tippedUser}

--- a/packages/web/src/components/track/PremiumTrackSection.tsx
+++ b/packages/web/src/components/track/PremiumTrackSection.tsx
@@ -240,12 +240,7 @@ const LockedPremiumTrackSection = ({
 
     // should not reach here
     return null
-  }, [
-    premiumConditions,
-    handleGoToCollection,
-    handleFollow,
-    handleSendTip
-  ])
+  }, [premiumConditions, handleGoToCollection, handleFollow, handleSendTip])
 
   return (
     <div className={styles.premiumContentSectionLocked}>

--- a/packages/web/src/components/track/PremiumTrackSection.tsx
+++ b/packages/web/src/components/track/PremiumTrackSection.tsx
@@ -45,22 +45,26 @@ const { getAccountUser } = accountSelectors
 
 const messages = {
   howToUnlock: 'HOW TO UNLOCK',
-  unlockCollectibleGatedTrack:
-    'To unlock this track, you must link a wallet containing a collectible from:',
-  unlockedCollectibleGatedTrackPrefix: 'A Collectible from ',
-  unlockedCollectibleGatedTrackSuffix:
-    ' was found in a linked wallet. This track is now available.',
+  unlocking: 'UNLOCKING',
+  unlocked: 'UNLOCKED',
   goToCollection: 'Go To Collection',
   sendTip: 'Send Tip',
   followArtist: 'Follow Artist',
+  unlockCollectibleGatedTrack:
+    'To unlock this track, you must link a wallet containing a collectible from:',
+  aCollectibleFrom: 'A Collectible from ',
+  unlockingCollectibleGatedTrackSuffix: ' was found in a linked wallet.',
+  unlockedCollectibleGatedTrackSuffix:
+    ' was found in a linked wallet. This track is now available.',
   unlockFollowGatedTrackPrefix: 'Follow ',
-  unlockedFollowGatedTrackPrefix: 'Thank you for following ',
+  thankYouForFollowing: 'Thank you for following ',
+  unlockingFollowGatedTrackSuffix: '!',
+  unlockedFollowGatedTrackSuffix: '! This track is now available.',
   unlockTipGatedTrackPrefix: 'Send ',
   unlockTipGatedTrackSuffix: ' a tip',
-  unlockedTipGatedTrackPrefix: 'Thank you for tipping ',
-  unlockedSpecialAccessGatedTrackSuffix: '! This track is now available.',
-  unlocked: 'UNLOCKED',
-  unlocking: 'Unlocking'
+  thankYouForSupporting: 'Thank you for supporting ',
+  unlockingTipGatedTrackSuffix: ' by sending them a tip!',
+  unlockedTipGatedTrackSuffix: ' by sending them a tip! This track is now available.'
 }
 
 type PremiumTrackAccessSectionProps = {
@@ -137,6 +141,20 @@ const LockedPremiumTrackSection = ({
 
   const renderLockedDescription = useCallback(() => {
     if (premiumConditions.nft_collection) {
+      if (premiumTrackStatus === 'UNLOCKING') {
+        return (
+          <div className={styles.premiumContentSectionDescription}>
+            <p>
+              <LoadingSpinner className={styles.spinner} />
+              {messages.aCollectibleFrom}
+              <span className={styles.collectibleName}>
+                &nbsp;{premiumConditions.nft_collection.name}&nbsp;
+              </span>
+              {messages.unlockingCollectibleGatedTrackSuffix}
+            </p>
+          </div>
+        )
+      }
       return (
         <div className={styles.premiumContentSectionDescription}>
           <p>{messages.unlockCollectibleGatedTrack}</p>
@@ -154,6 +172,24 @@ const LockedPremiumTrackSection = ({
     }
 
     if (premiumConditions.follow_user_id) {
+      if (premiumTrackStatus === 'UNLOCKING') {
+        return (
+          <div className={styles.premiumContentSectionDescription}>
+            <p>
+              <LoadingSpinner className={styles.spinner} />
+              {messages.thankYouForFollowing}
+              {followee?.name}
+              <UserBadges
+                userId={premiumConditions.follow_user_id}
+                className={styles.badgeIcon}
+                badgeSize={14}
+                useSVGTiers
+                />
+              {messages.unlockingFollowGatedTrackSuffix}
+            </p>
+          </div>
+        )
+      }
       return (
         <div className={styles.premiumContentSectionDescription}>
           <p>
@@ -171,6 +207,24 @@ const LockedPremiumTrackSection = ({
     }
 
     if (premiumConditions.tip_user_id) {
+      if (premiumTrackStatus === 'UNLOCKING') {
+        return (
+          <div className={styles.premiumContentSectionDescription}>
+            <p>
+              <LoadingSpinner className={styles.spinner} />
+              {messages.thankYouForSupporting}
+              {followee?.name}
+              <UserBadges
+                userId={premiumConditions.follow_user_id}
+                className={styles.badgeIcon}
+                badgeSize={14}
+                useSVGTiers
+              />
+              {messages.unlockingTipGatedTrackSuffix}
+            </p>
+          </div>
+        )
+      }
       return (
         <div className={styles.premiumContentSectionDescription}>
           <p>
@@ -194,16 +248,7 @@ const LockedPremiumTrackSection = ({
 
   const renderButton = useCallback(() => {
     if (premiumTrackStatus === 'UNLOCKING') {
-      return (
-        <Button
-          text={messages.unlocking}
-          rightIcon={<LoadingSpinner className={styles.spinner} />}
-          type={ButtonType.PRIMARY_ALT}
-          iconClassName={styles.buttonIcon}
-          textClassName={styles.buttonText}
-          disabled
-        />
-      )
+      return null
     }
 
     if (premiumConditions.nft_collection) {
@@ -262,7 +307,7 @@ const LockedPremiumTrackSection = ({
       <div>
         <div className={styles.premiumContentSectionTitle}>
           <IconLock className={styles.lockedIcon} />
-          {messages.howToUnlock}
+          {premiumTrackStatus === 'UNLOCKING' ? messages.unlocking : messages.howToUnlock}
         </div>
         {renderLockedDescription()}
       </div>
@@ -281,7 +326,7 @@ const UnlockedPremiumTrackSection = ({
       return (
         <p>
           <IconVerifiedGreen className={styles.verifiedGreenIcon} />
-          {messages.unlockedCollectibleGatedTrackPrefix}
+          {messages.aCollectibleFrom}
           <span className={styles.collectibleName}>
             &nbsp;{premiumConditions.nft_collection.name}&nbsp;
           </span>
@@ -294,7 +339,7 @@ const UnlockedPremiumTrackSection = ({
       return (
         <p>
           <IconVerifiedGreen className={styles.verifiedGreenIcon} />
-          {messages.unlockedFollowGatedTrackPrefix}
+          {messages.thankYouForFollowing}
           {followee?.name}
           <UserBadges
             userId={premiumConditions.follow_user_id}
@@ -302,7 +347,7 @@ const UnlockedPremiumTrackSection = ({
             badgeSize={14}
             useSVGTiers
           />
-          {messages.unlockedSpecialAccessGatedTrackSuffix}
+          {messages.unlockedFollowGatedTrackSuffix}
         </p>
       )
     }
@@ -311,7 +356,7 @@ const UnlockedPremiumTrackSection = ({
       return (
         <p>
           <IconVerifiedGreen className={styles.verifiedGreenIcon} />
-          {messages.unlockedTipGatedTrackPrefix}
+          {messages.thankYouForSupporting}
           {tippedUser?.name}
           <UserBadges
             userId={premiumConditions.tip_user_id}
@@ -319,7 +364,7 @@ const UnlockedPremiumTrackSection = ({
             badgeSize={14}
             useSVGTiers
           />
-          {messages.unlockedSpecialAccessGatedTrackSuffix}
+          {messages.unlockedTipGatedTrackSuffix}
         </p>
       )
     }

--- a/packages/web/src/components/track/PremiumTrackSection.tsx
+++ b/packages/web/src/components/track/PremiumTrackSection.tsx
@@ -64,7 +64,8 @@ const messages = {
   unlockTipGatedTrackSuffix: ' a tip',
   thankYouForSupporting: 'Thank you for supporting ',
   unlockingTipGatedTrackSuffix: ' by sending them a tip!',
-  unlockedTipGatedTrackSuffix: ' by sending them a tip! This track is now available.'
+  unlockedTipGatedTrackSuffix:
+    ' by sending them a tip! This track is now available.'
 }
 
 type PremiumTrackAccessSectionProps = {
@@ -81,7 +82,6 @@ const LockedPremiumTrackSection = ({
   const dispatch = useDispatch()
   const sendStatus = useSelector(getSendStatus)
   const previousSendStatus = usePrevious(sendStatus)
-  const premiumTrackStatus = useSelector(getPremiumTrackStatus)
   const account = useSelector(getAccountUser)
 
   // Set unlocking state if send tip is successful and user closed the tip modal.
@@ -141,20 +141,6 @@ const LockedPremiumTrackSection = ({
 
   const renderLockedDescription = useCallback(() => {
     if (premiumConditions.nft_collection) {
-      if (premiumTrackStatus === 'UNLOCKING') {
-        return (
-          <div className={styles.premiumContentSectionDescription}>
-            <p>
-              <LoadingSpinner className={styles.spinner} />
-              {messages.aCollectibleFrom}
-              <span className={styles.collectibleName}>
-                &nbsp;{premiumConditions.nft_collection.name}&nbsp;
-              </span>
-              {messages.unlockingCollectibleGatedTrackSuffix}
-            </p>
-          </div>
-        )
-      }
       return (
         <div className={styles.premiumContentSectionDescription}>
           <p>{messages.unlockCollectibleGatedTrack}</p>
@@ -172,24 +158,6 @@ const LockedPremiumTrackSection = ({
     }
 
     if (premiumConditions.follow_user_id) {
-      if (premiumTrackStatus === 'UNLOCKING') {
-        return (
-          <div className={styles.premiumContentSectionDescription}>
-            <p>
-              <LoadingSpinner className={styles.spinner} />
-              {messages.thankYouForFollowing}
-              {followee?.name}
-              <UserBadges
-                userId={premiumConditions.follow_user_id}
-                className={styles.badgeIcon}
-                badgeSize={14}
-                useSVGTiers
-                />
-              {messages.unlockingFollowGatedTrackSuffix}
-            </p>
-          </div>
-        )
-      }
       return (
         <div className={styles.premiumContentSectionDescription}>
           <p>
@@ -207,24 +175,6 @@ const LockedPremiumTrackSection = ({
     }
 
     if (premiumConditions.tip_user_id) {
-      if (premiumTrackStatus === 'UNLOCKING') {
-        return (
-          <div className={styles.premiumContentSectionDescription}>
-            <p>
-              <LoadingSpinner className={styles.spinner} />
-              {messages.thankYouForSupporting}
-              {followee?.name}
-              <UserBadges
-                userId={premiumConditions.follow_user_id}
-                className={styles.badgeIcon}
-                badgeSize={14}
-                useSVGTiers
-              />
-              {messages.unlockingTipGatedTrackSuffix}
-            </p>
-          </div>
-        )
-      }
       return (
         <div className={styles.premiumContentSectionDescription}>
           <p>
@@ -247,10 +197,6 @@ const LockedPremiumTrackSection = ({
   }, [premiumConditions, followee, tippedUser])
 
   const renderButton = useCallback(() => {
-    if (premiumTrackStatus === 'UNLOCKING') {
-      return null
-    }
-
     if (premiumConditions.nft_collection) {
       return (
         <Button
@@ -298,8 +244,7 @@ const LockedPremiumTrackSection = ({
     premiumConditions,
     handleGoToCollection,
     handleFollow,
-    handleSendTip,
-    premiumTrackStatus
+    handleSendTip
   ])
 
   return (
@@ -307,11 +252,82 @@ const LockedPremiumTrackSection = ({
       <div>
         <div className={styles.premiumContentSectionTitle}>
           <IconLock className={styles.lockedIcon} />
-          {premiumTrackStatus === 'UNLOCKING' ? messages.unlocking : messages.howToUnlock}
+          {messages.howToUnlock}
         </div>
         {renderLockedDescription()}
       </div>
       <div className={styles.premiumContentSectionButton}>{renderButton()}</div>
+    </div>
+  )
+}
+
+const UnlockingPremiumTrackSection = ({
+  premiumConditions,
+  followee,
+  tippedUser
+}: PremiumTrackAccessSectionProps) => {
+  const renderUnlockingDescription = useCallback(() => {
+    if (premiumConditions.nft_collection) {
+      return (
+        <p>
+          <LoadingSpinner className={styles.spinner} />
+          {messages.aCollectibleFrom}
+          <span className={styles.collectibleName}>
+            &nbsp;{premiumConditions.nft_collection.name}&nbsp;
+          </span>
+          {messages.unlockingCollectibleGatedTrackSuffix}
+        </p>
+      )
+    }
+
+    if (premiumConditions.follow_user_id) {
+      return (
+        <p>
+          <LoadingSpinner className={styles.spinner} />
+          {messages.thankYouForFollowing}
+          {followee?.name}
+          <UserBadges
+            userId={premiumConditions.follow_user_id}
+            className={styles.badgeIcon}
+            badgeSize={14}
+            useSVGTiers
+          />
+          {messages.unlockingFollowGatedTrackSuffix}
+        </p>
+      )
+    }
+
+    if (premiumConditions.tip_user_id) {
+      return (
+        <p>
+          <LoadingSpinner className={styles.spinner} />
+          {messages.thankYouForSupporting}
+          {tippedUser?.name}
+          <UserBadges
+            userId={premiumConditions.tip_user_id}
+            className={styles.badgeIcon}
+            badgeSize={14}
+            useSVGTiers
+          />
+          {messages.unlockingTipGatedTrackSuffix}
+        </p>
+      )
+    }
+    // should not reach here
+    return null
+  }, [premiumConditions, followee, tippedUser])
+
+  return (
+    <div className={styles.premiumContentSectionLocked}>
+      <div>
+        <div className={styles.premiumContentSectionTitle}>
+          <IconLock className={styles.lockedIcon} />
+          {messages.unlocking}
+        </div>
+        <div className={styles.premiumContentSectionDescription}>
+          {renderUnlockingDescription()}
+        </div>
+      </div>
     </div>
   )
 }
@@ -400,6 +416,7 @@ export const PremiumTrackSection = ({
   const { isEnabled: isPremiumContentEnabled } = useFlag(
     FeatureFlags.PREMIUM_CONTENT_ENABLED
   )
+  const premiumTrackStatus = useSelector(getPremiumTrackStatus)
   const { follow_user_id: followUserId, tip_user_id: tipUserId } =
     premiumConditions ?? {}
   const users = useSelector<AppState, { [id: ID]: User }>((state) =>
@@ -427,21 +444,37 @@ export const PremiumTrackSection = ({
   if (!premiumConditions) return null
   if (!shouldDisplay) return null
 
-  return (
-    <div className={cn(styles.premiumContentSection, fadeIn)}>
-      {doesUserHaveAccess ? (
+  if (doesUserHaveAccess) {
+    return (
+      <div className={cn(styles.premiumContentSection, fadeIn)}>
         <UnlockedPremiumTrackSection
           premiumConditions={premiumConditions}
           followee={followee}
           tippedUser={tippedUser}
         />
-      ) : (
-        <LockedPremiumTrackSection
+      </div>
+    )
+  }
+
+  if (premiumTrackStatus === 'UNLOCKING') {
+    return (
+      <div className={cn(styles.premiumContentSection, fadeIn)}>
+        <UnlockingPremiumTrackSection
           premiumConditions={premiumConditions}
           followee={followee}
           tippedUser={tippedUser}
         />
-      )}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn(styles.premiumContentSection, fadeIn)}>
+      <LockedPremiumTrackSection
+        premiumConditions={premiumConditions}
+        followee={followee}
+        tippedUser={tippedUser}
+      />
     </div>
   )
 }

--- a/packages/web/src/components/track/desktop/Artwork.tsx
+++ b/packages/web/src/components/track/desktop/Artwork.tsx
@@ -52,18 +52,20 @@ type TileArtworkProps = {
 const ArtworkIcon = ({
   playStatus,
   artworkIconClassName,
-  doesUserHaveAccess
+  doesUserHaveAccess,
+  isTrack
 }: {
   playStatus: PlayStatus
   artworkIconClassName?: string
   doesUserHaveAccess?: boolean
+  isTrack?: boolean
 }) => {
   const { isEnabled: isPremiumContentEnabled } = useFlag(
     FeatureFlags.PREMIUM_CONTENT_ENABLED
   )
 
   let artworkIcon
-  if (isPremiumContentEnabled && !doesUserHaveAccess) {
+  if (isPremiumContentEnabled && isTrack && !doesUserHaveAccess) {
     artworkIcon = <IconLock />
   } else if (playStatus === PlayStatus.Buffering) {
     artworkIcon = (
@@ -96,6 +98,7 @@ const ArtworkIcon = ({
 type ArtworkProps = TileArtworkProps & {
   image: any
   label?: string
+  isTrack?: boolean
 }
 
 const Artwork = memo(
@@ -109,7 +112,8 @@ const Artwork = memo(
     image,
     coSign,
     label,
-    doesUserHaveAccess
+    doesUserHaveAccess,
+    isTrack
   }: ArtworkProps) => {
     const playStatus = isBuffering
       ? PlayStatus.Buffering
@@ -132,6 +136,7 @@ const Artwork = memo(
             playStatus={playStatus}
             artworkIconClassName={artworkIconClassName}
             doesUserHaveAccess={doesUserHaveAccess}
+            isTrack={isTrack}
           />
         )}
       </DynamicImage>
@@ -167,7 +172,7 @@ export const TrackArtwork = memo((props: TileArtworkProps) => {
 
   useLoadImageWithTimeout(image, callback)
 
-  return <Artwork {...props} image={image} />
+  return <Artwork {...props} image={image} isTrack />
 })
 
 export const CollectionArtwork = memo((props: TileArtworkProps) => {

--- a/packages/web/src/components/track/desktop/BottomRow.tsx
+++ b/packages/web/src/components/track/desktop/BottomRow.tsx
@@ -32,7 +32,7 @@ type BottomRowProps = {
   isDarkMode?: boolean
   isMatrixMode: boolean
   showIconButtons?: boolean
-  canOverrideBottomBar?: boolean
+  isTrack?: boolean
   onClickRepost: (e?: any) => void
   onClickFavorite: (e?: any) => void
   onClickShare: (e?: any) => void
@@ -52,7 +52,7 @@ export const BottomRow = ({
   isDarkMode,
   isMatrixMode,
   showIconButtons,
-  canOverrideBottomBar,
+  isTrack,
   onClickRepost,
   onClickFavorite,
   onClickShare
@@ -95,7 +95,7 @@ export const BottomRow = ({
     )
   }
 
-  if (isPremiumContentEnabled && canOverrideBottomBar && !doesUserHaveAccess) {
+  if (isPremiumContentEnabled && isTrack && !doesUserHaveAccess) {
     return (
       <div className={cn(styles.premiumContent, styles.bottomRow)}>
         <IconLock />

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -390,7 +390,7 @@ const ConnectedTrackTile = memo(
           isTrending={isTrending}
           showRankIcon={showRankIcon}
           permalink={permalink}
-          canOverrideBottomBar
+          isTrack
         />
       </Draggable>
     )

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -17,13 +17,14 @@ import {
   accountSelectors,
   cacheTracksSelectors,
   cacheUsersSelectors,
+  premiumContentSelectors,
   tracksSocialActions,
   shareModalUIActions,
   playerSelectors
 } from '@audius/common'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
-import { connect } from 'react-redux'
+import { connect, useSelector } from 'react-redux'
 import { Dispatch } from 'redux'
 
 import { ReactComponent as IconKebabHorizontal } from 'assets/img/iconKebabHorizontal.svg'
@@ -60,6 +61,7 @@ const { getUserFromTrack } = cacheUsersSelectors
 const { saveTrack, unsaveTrack, repostTrack, undoRepostTrack } =
   tracksSocialActions
 const { getUserHandle } = accountSelectors
+const { getPremiumTrackSignatureMap } = premiumContentSelectors
 
 type OwnProps = {
   uid: UID
@@ -114,7 +116,6 @@ const ConnectedTrackTile = memo(
       is_unlisted: isUnlisted,
       is_premium: isPremium,
       premium_conditions: premiumConditions,
-      premium_content_signature: premiumContentSignature,
       track_id: trackId,
       title,
       permalink,
@@ -143,8 +144,10 @@ const ConnectedTrackTile = memo(
     const isTrackPlaying = isActive && isPlaying
     const isOwner = handle === userHandle
     const isArtistPick = showArtistPick && _artist_pick === trackId
-    const doesUserHaveAccess =
-      !isPremium || isOwner || !!premiumContentSignature
+
+    const premiumTrackSignatureMap = useSelector(getPremiumTrackSignatureMap)
+    const hasPremiumContentSignature = !!premiumTrackSignatureMap[trackId]
+    const doesUserHaveAccess = !isPremium || hasPremiumContentSignature
 
     const menuRef = useRef<HTMLDivElement>(null)
 

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -124,7 +124,11 @@ const TrackTile = memo(
           // Standalone means that this tile is not w/ a playlist
           [styles.standalone]: !!standalone
         })}
-        onClick={isLoading || isDisabled || !doesUserHaveAccess ? undefined : onTogglePlay}
+        onClick={
+          isLoading || isDisabled || !doesUserHaveAccess
+            ? undefined
+            : onTogglePlay
+        }
       >
         {isPremium && (
           <PremiumTrackCornerTag doesUserHaveAccess={!!doesUserHaveAccess} />

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -93,7 +93,7 @@ const TrackTile = memo(
     onTogglePlay,
     showRankIcon,
     permalink,
-    canOverrideBottomBar
+    isTrack
   }: TrackTileProps) => {
     const hasOrdering = order !== undefined
 
@@ -255,7 +255,7 @@ const TrackTile = memo(
             onClickRepost={onClickRepost}
             onClickFavorite={onClickFavorite}
             onClickShare={onClickShare}
-            canOverrideBottomBar={canOverrideBottomBar}
+            isTrack={isTrack}
           />
         </div>
       </div>

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -124,7 +124,7 @@ const TrackTile = memo(
           // Standalone means that this tile is not w/ a playlist
           [styles.standalone]: !!standalone
         })}
-        onClick={isLoading || isDisabled ? undefined : onTogglePlay}
+        onClick={isLoading || isDisabled || !doesUserHaveAccess ? undefined : onTogglePlay}
       >
         {isPremium && (
           <PremiumTrackCornerTag doesUserHaveAccess={!!doesUserHaveAccess} />

--- a/packages/web/src/components/track/types.ts
+++ b/packages/web/src/components/track/types.ts
@@ -211,8 +211,8 @@ export type DesktopTrackTileProps = {
   /** The relative link of the track */
   permalink: string
 
-  /** Whether the bottom bar can be overridden */
-  canOverrideBottomBar?: boolean
+  /** Whether the tile is for a track */
+  isTrack?: boolean
 }
 
 export type DesktopPlaylistTileProps = {

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -408,13 +408,11 @@ class TrackPageProvider extends Component<
         : trackRank.week && trackRank.week <= TRENDING_BADGE_LIMIT
         ? `#${trackRank.week} This Week`
         : null
-    const isOwner = track?.owner_id === userId ?? false
+
     const isPremium = !!track?.is_premium
-    // const hasPremiumContentSignature = !!track?.premium_content_signature
     const hasPremiumContentSignature =
       !!this.props.premiumTrackSignatureMap[track?.track_id]
-    const doesUserHaveAccess =
-      !isPremium || isOwner || hasPremiumContentSignature
+    const doesUserHaveAccess = !isPremium || hasPremiumContentSignature
 
     const desktopProps = {
       // Follow Props

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -410,8 +410,9 @@ class TrackPageProvider extends Component<
         : null
 
     const isPremium = !!track?.is_premium
-    const hasPremiumContentSignature =
-      !!this.props.premiumTrackSignatureMap[track?.track_id]
+    const hasPremiumContentSignature = !!(
+      track?.track_id && this.props.premiumTrackSignatureMap[track.track_id]
+    )
     const doesUserHaveAccess = !isPremium || hasPremiumContentSignature
 
     const desktopProps = {

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -76,7 +76,8 @@ const { setRepost } = repostsUserListActions
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { open } = mobileOverflowMenuUIActions
 const { tracksActions } = trackPageLineupActions
-const { updatePremiumTrackStatus, removePremiumContentSignature } = premiumContentActions
+const { updatePremiumTrackStatus, removePremiumContentSignature } =
+  premiumContentActions
 const { getPremiumTrackSignatureMap } = premiumContentSelectors
 const {
   getUser,
@@ -410,9 +411,10 @@ class TrackPageProvider extends Component<
     const isOwner = track?.owner_id === userId ?? false
     const isPremium = !!track?.is_premium
     // const hasPremiumContentSignature = !!track?.premium_content_signature
-    const hasPremiumContentSignature = !!this.props.premiumTrackSignatureMap[track?.track_id]
-    console.log('yolo',this.props.premiumTrackSignatureMap)
-    const doesUserHaveAccess = !isPremium || isOwner || hasPremiumContentSignature
+    const hasPremiumContentSignature =
+      !!this.props.premiumTrackSignatureMap[track?.track_id]
+    const doesUserHaveAccess =
+      !isPremium || isOwner || hasPremiumContentSignature
 
     const desktopProps = {
       // Follow Props

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -42,6 +42,7 @@ export type OwnProps = {
   heroPlaying: boolean
   userId: ID | null
   badge: string | null
+  doesUserHaveAccess: boolean
   onHeroPlay: (isPlaying: boolean) => void
   goToProfilePage: (handle: string) => void
   goToSearchResultsPage: (tag: string) => void
@@ -52,6 +53,7 @@ export type OwnProps = {
   onFollow: () => void
   onUnfollow: () => void
   onUnlock: () => void
+  onLock: (trackId: ID) => void
   onClickReposts: () => void
   onClickFavorites: () => void
 
@@ -86,6 +88,7 @@ const TrackPage = ({
   heroPlaying,
   userId,
   badge,
+  doesUserHaveAccess,
   onHeroPlay,
   goToProfilePage,
   goToSearchResultsPage,
@@ -97,6 +100,7 @@ const TrackPage = ({
   onFollow,
   onUnfollow,
   onUnlock,
+  onLock,
   onDownloadTrack,
   makePublic,
   onExternalLinkClick,
@@ -117,8 +121,6 @@ const TrackPage = ({
   const isSaved = heroTrack?.has_current_user_saved ?? false
   const isReposted = heroTrack?.has_current_user_reposted ?? false
   const loading = !heroTrack
-  const doesUserHaveAccess =
-    !heroTrack?.is_premium || isOwner || !!heroTrack?.premium_content_signature
 
   const onPlay = () => onHeroPlay(heroPlaying)
   const onSave = isOwner
@@ -198,6 +200,7 @@ const TrackPage = ({
       onFollow={onFollow}
       onUnfollow={onUnfollow}
       onUnlock={onUnlock}
+      onLock={onLock}
       download={defaults.download}
       onDownload={onDownload}
       makePublic={makePublic}


### PR DESCRIPTION
### Description

Fix some bugs introduced in premium PRs and add more functionality:
- poll for premium track access on unlock
- handle follow/unfollow, unlock/lock of follow-gated  tracks
- update unlocking state as per design
- sort nft collections in track upload
- disable clicking/playing locked premium track
- fix playlist tile hover icon bug
- update copy
- some refactor (more to come)

### Dragons

Touches tracks, but should be okay. also gated behind feature flags.

### How Has This Been Tested?

Local dapp vs stage and vs prod

### How will this change be monitored?

N/A

### Feature Flags ###

Existing premium content feature flags

