### PR TITLE
Fix broken loading state for playlist tiles

### DIFF
--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -34,6 +34,7 @@ import { Dispatch } from 'redux'
 
 import { ReactComponent as IconKebabHorizontal } from 'assets/img/iconKebabHorizontal.svg'
 import { TrackEvent, make } from 'common/store/analytics/actions'
+import { confirmSaveCollection } from 'common/store/social/collections/sagas'
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import Draggable from 'components/dragndrop/Draggable'
 import { OwnProps as CollectionkMenuProps } from 'components/menu/CollectionMenu'
@@ -227,7 +228,9 @@ const ConnectedPlaylistTile = memo(
         record
       ]
     )
-    const href = isAlbum
+    const href = isLoading
+      ? ''
+      : isAlbum
       ? albumPage(handle, title, id)
       : playlistPage(handle, title, id)
 
@@ -400,16 +403,12 @@ const ConnectedPlaylistTile = memo(
           kind={isAlbum ? 'album' : 'playlist'}
           id={id}
           isOwner={isOwner}
-          link={
-            isAlbum
-              ? fullAlbumPage(handle, title, id)
-              : fullPlaylistPage(handle, title, id)
-          }
+          link={href}
         >
           {children as any}
         </Draggable>
       ),
-      [id, disableActions, title, isAlbum, handle, isOwner]
+      [id, disableActions, title, isAlbum, isOwner, href]
     )
 
     const renderTrackList = useCallback(() => {

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -288,7 +288,8 @@ export const playlistPage = (
       playlistName
     )}-${playlistId}`
   } else {
-    throw Error('Missing required arguments to get PlaylistPage route.')
+    console.error('Missing required arguments to get PlaylistPage route.')
+    return ''
   }
 }
 export const fullPlaylistPage = (


### PR DESCRIPTION
### Description

Playlist tiles were trying to compute an href to a playlist that doesn't yet exist during the skeleton loading state, causing a crash in the `playlistPage` route util.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

