### PR TITLE
[C-1884] Improve top supporters fetching and loading

### DIFF
--- a/packages/common/src/store/tipping/slice.ts
+++ b/packages/common/src/store/tipping/slice.ts
@@ -92,6 +92,10 @@ const slice = createSlice({
       _state,
       _action: PayloadAction<{ userId: ID }>
     ) => {},
+    fetchSupportersForUser: (
+      _state,
+      _action: PayloadAction<{ userId: ID }>
+    ) => {},
     beginTip: (
       state,
       action: PayloadAction<{ user: User | null; source: TipSource }>
@@ -163,6 +167,7 @@ export const {
   setSupportersOverridesForUser,
   refreshSupport,
   fetchSupportingForUser,
+  fetchSupportersForUser,
   beginTip,
   sendTip,
   confirmSendTip,

--- a/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureListSkeleton.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureListSkeleton.tsx
@@ -1,0 +1,42 @@
+import { times } from 'lodash'
+import { View } from 'react-native'
+
+import { makeStyles } from 'app/styles'
+
+const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+  root: {
+    flexDirection: 'row',
+    marginRight: spacing(6)
+  },
+  image: {
+    marginRight: spacing(-2),
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: palette.skeleton
+  },
+  extra: {
+    width: spacing(2)
+  }
+}))
+
+type ProfilePictureListSkeletonProps = {
+  count: number
+  limit: number
+}
+
+export const ProfilePictureListSkeleton = (
+  props: ProfilePictureListSkeletonProps
+) => {
+  const { count, limit } = props
+  const styles = useStyles()
+  return (
+    <View style={styles.root}>
+      {times(Math.min(count, limit)).map((index) => (
+        <View key={index} style={styles.image} />
+      ))}
+      {count >= limit ? <View style={styles.extra} /> : null}
+      <View></View>
+    </View>
+  )
+}

--- a/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureListSkeleton.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/ProfilePictureListSkeleton.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native'
 
 import { makeStyles } from 'app/styles'
 
-const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+const useStyles = makeStyles(({ spacing, palette }) => ({
   root: {
     flexDirection: 'row',
     marginRight: spacing(6)
@@ -36,7 +36,6 @@ export const ProfilePictureListSkeleton = (
         <View key={index} style={styles.image} />
       ))}
       {count >= limit ? <View style={styles.extra} /> : null}
-      <View></View>
     </View>
   )
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingList.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingList.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
-import type { ID, Supporting } from '@audius/common'
+import { ID, Supporting, tippingActions } from '@audius/common'
 import {
   useProxySelector,
   stringWeiToBN,
@@ -16,7 +16,10 @@ import { useSelectProfile } from '../selectors'
 import { SupportingTile } from './SupportingTile'
 import { SupportingTileSkeleton } from './SupportingTileSkeleton'
 import { ViewAllSupportingTile } from './ViewAllSupportingTile'
+import { useDispatch, useSelector } from 'react-redux'
+
 const { getOptimisticSupportingForUser } = tippingSelectors
+const { fetchSupportingForUser } = tippingActions
 
 type ViewAllData = { viewAll: true; supporting: Supporting[] }
 
@@ -37,27 +40,41 @@ export const SupportingList = () => {
     'user_id',
     'supporting_count'
   ])
-  const supportingForUser = useProxySelector(
-    (state) => getOptimisticSupportingForUser(state, user_id),
-    [user_id]
-  )
-  const supportingIdsSorted = useMemo(() => {
-    const ids = (
-      supportingForUser ? Object.keys(supportingForUser) : ([] as unknown)
-    ) as ID[]
-    return ids.sort((id1, id2) => {
-      const amount1BN = stringWeiToBN(supportingForUser[id1].amount)
-      const amount2BN = stringWeiToBN(supportingForUser[id2].amount)
-      return amount1BN.gte(amount2BN) ? -1 : 1
-    })
-  }, [supportingForUser])
 
-  const supportingSorted = useMemo(
-    () =>
-      supportingIdsSorted
+  const dispatch = useDispatch()
+
+  const shouldFetchSupporting = useSelector((state) => {
+    return (
+      !state.tipping.supporting[user_id] &&
+      !state.tipping.supportersOverrides[user_id]
+    )
+  })
+
+  useEffect(() => {
+    if (supporting_count > 0 && shouldFetchSupporting) {
+      dispatch(fetchSupportingForUser({ userId: user_id }))
+    }
+  }, [supporting_count, shouldFetchSupporting, dispatch, user_id])
+
+  const supportingSorted = useProxySelector(
+    (state) => {
+      const supportingForUser = getOptimisticSupportingForUser(state, user_id)
+
+      const ids = (
+        supportingForUser ? Object.keys(supportingForUser) : ([] as unknown)
+      ) as ID[]
+
+      const supportingIdsSorted = ids.sort((id1, id2) => {
+        const amount1BN = stringWeiToBN(supportingForUser[id1].amount)
+        const amount2BN = stringWeiToBN(supportingForUser[id2].amount)
+        return amount1BN.gte(amount2BN) ? -1 : 1
+      })
+
+      return supportingIdsSorted
         .map((supporterId) => supportingForUser[supporterId])
-        .filter(Boolean),
-    [supportingIdsSorted, supportingForUser]
+        .filter(Boolean)
+    },
+    [user_id]
   )
 
   const supportingListData = useMemo(() => {

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingList.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingList.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo } from 'react'
 
-import { ID, Supporting, tippingActions } from '@audius/common'
+import type { ID, Supporting } from '@audius/common'
 import {
+  tippingActions,
   useProxySelector,
   stringWeiToBN,
   tippingSelectors,
   MAX_PROFILE_SUPPORTING_TILES
 } from '@audius/common'
 import { FlatList } from 'react-native'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { makeStyles } from 'app/styles'
 
@@ -16,7 +18,6 @@ import { useSelectProfile } from '../selectors'
 import { SupportingTile } from './SupportingTile'
 import { SupportingTileSkeleton } from './SupportingTileSkeleton'
 import { ViewAllSupportingTile } from './ViewAllSupportingTile'
-import { useDispatch, useSelector } from 'react-redux'
 
 const { getOptimisticSupportingForUser } = tippingSelectors
 const { fetchSupportingForUser } = tippingActions

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useRef, useLayoutEffect } from 'react'
+import { useCallback, useRef, useLayoutEffect, useEffect } from 'react'
 
 import {
   cacheUsersSelectors,
   tippingSelectors,
   useProxySelector,
-  removeNullable
+  removeNullable,
+  tippingActions
 } from '@audius/common'
 import { LayoutAnimation, Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
@@ -17,7 +18,10 @@ import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
 import { useSelectProfile } from '../selectors'
+import { useDispatch, useSelector } from 'react-redux'
+import { ProfilePictureListSkeleton } from 'app/screens/notifications-screen/Notification/ProfilePictureListSkeleton'
 const { getOptimisticSupportersForUser } = tippingSelectors
+const { fetchSupportersForUser } = tippingActions
 const { getUsers } = cacheUsersSelectors
 
 const messages = {
@@ -65,18 +69,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   }
 }))
 
-const useLoadingAnimation = (isDepLoaded: () => boolean, dependency: any) => {
-  // Prevents multiple re-renders if the dependency changes.
-  const isLoaded = useRef(false)
-
-  useLayoutEffect(() => {
-    if (isDepLoaded() && !isLoaded.current) {
-      isLoaded.current = true
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-    }
-  }, [dependency, isDepLoaded])
-}
-
 const useSelectTopSupporters = (userId: number) =>
   useProxySelector(
     (state) => {
@@ -107,26 +99,46 @@ export const TopSupporters = () => {
     'supporter_count'
   ])
 
+  const dispatch = useDispatch()
+
+  const shouldFetchSupporters = useSelector((state) => {
+    return (
+      !state.tipping.supporters[user_id] &&
+      !state.tipping.supportersOverrides[user_id]
+    )
+  })
+
+  useEffect(() => {
+    if (supporter_count > 0 && shouldFetchSupporters) {
+      dispatch(fetchSupportersForUser({ userId: user_id }))
+    }
+  }, [supporter_count, shouldFetchSupporters, dispatch, user_id])
+
   const topSupporters = useSelectTopSupporters(user_id)
 
   const handlePress = useCallback(() => {
     navigation.push('TopSupporters', { userId: user_id, source: 'profile' })
   }, [navigation, user_id])
 
-  useLoadingAnimation(() => topSupporters.length > 0, topSupporters)
-
-  return topSupporters.length ? (
+  return supporter_count ? (
     <View style={styles.root} pointerEvents='box-none'>
       <TouchableOpacity style={styles.touchableRoot} onPress={handlePress}>
-        <ProfilePictureList
-          users={topSupporters}
-          totalUserCount={supporter_count}
-          limit={MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS}
-          style={styles.profilePictureList}
-          navigationType='push'
-          interactive={false}
-          imageStyles={styles.profilePicture}
-        />
+        {topSupporters.length > 0 ? (
+          <ProfilePictureList
+            users={topSupporters}
+            totalUserCount={supporter_count}
+            limit={MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS}
+            style={styles.profilePictureList}
+            navigationType='push'
+            interactive={false}
+            imageStyles={styles.profilePicture}
+          />
+        ) : (
+          <ProfilePictureListSkeleton
+            count={supporter_count}
+            limit={MAX_PROFILE_SUPPORTERS_VIEW_ALL_USERS}
+          />
+        )}
         <View style={styles.alignRowCenter}>
           <IconTrophy style={styles.icon} fill={neutral} />
           <Text style={styles.viewTopSupportersText}>

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useLayoutEffect, useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import {
   cacheUsersSelectors,
@@ -7,19 +7,19 @@ import {
   removeNullable,
   tippingActions
 } from '@audius/common'
-import { LayoutAnimation, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
+import { useDispatch, useSelector } from 'react-redux'
 
 import IconCaretRight from 'app/assets/images/iconCaretRight.svg'
 import IconTrophy from 'app/assets/images/iconTrophy.svg'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { ProfilePictureList } from 'app/screens/notifications-screen/Notification'
+import { ProfilePictureListSkeleton } from 'app/screens/notifications-screen/Notification/ProfilePictureListSkeleton'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
 import { useSelectProfile } from '../selectors'
-import { useDispatch, useSelector } from 'react-redux'
-import { ProfilePictureListSkeleton } from 'app/screens/notifications-screen/Notification/ProfilePictureListSkeleton'
 const { getOptimisticSupportersForUser } = tippingSelectors
 const { fetchSupportersForUser } = tippingActions
 const { getUsers } = cacheUsersSelectors

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -294,7 +294,9 @@ function* fetchProfileAsync(action) {
     yield fork(fetchUserSocials, action)
     yield fork(fetchUserCollections, user.user_id)
 
-    yield fork(fetchSupportersAndSupporting, user.user_id)
+    if (!isNativeMobile) {
+      yield fork(fetchSupportersAndSupporting, user.user_id)
+    }
 
     yield fork(fetchProfileCustomizedCollectibles, user)
     yield fork(fetchOpenSeaAssets, user)

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -29,6 +29,7 @@ import {
   LastDismissedTip,
   LocalStorage
 } from '@audius/common'
+import { PayloadAction } from '@reduxjs/toolkit'
 import BN from 'bn.js'
 import {
   call,
@@ -54,6 +55,7 @@ const {
   convert,
   fetchRecentTips,
   fetchSupportingForUser,
+  fetchSupportersForUser,
   refreshSupport,
   sendTipFailed,
   sendTipSucceeded,
@@ -411,6 +413,52 @@ function* refreshSupportAsync({
   )
 }
 
+type FetchSupportingAction = PayloadAction<{ userId: ID }>
+
+function* fetchSupportersForUserAsync(action: FetchSupportingAction) {
+  const {
+    payload: { userId }
+  } = action
+  yield* waitForRead()
+  const apiClient = yield* getContext('apiClient')
+
+  const supportersParams: GetSupportersArgs = {
+    userId,
+    limit: MAX_PROFILE_TOP_SUPPORTERS + 1
+  }
+
+  const supportersForReceiverList = yield* call(
+    [apiClient, apiClient.getSupporters],
+    supportersParams
+  )
+
+  const userIds = supportersForReceiverList?.map((supporter) =>
+    decodeHashId(supporter.sender.id)
+  )
+
+  yield call(fetchUsers, userIds)
+
+  const supportersForReceiverMap: Record<string, Supporter> = {}
+
+  supportersForReceiverList?.forEach((supporter) => {
+    const supporterUserId = decodeHashId(supporter.sender.id)
+    if (supporterUserId) {
+      supportersForReceiverMap[supporterUserId] = {
+        sender_id: supporterUserId,
+        rank: supporter.rank,
+        amount: supporter.amount
+      }
+    }
+  })
+
+  yield put(
+    setSupportersForUser({
+      id: userId,
+      supportersForUser: supportersForReceiverMap
+    })
+  )
+}
+
 function* fetchSupportingForUserAsync({
   payload: { userId }
 }: {
@@ -599,6 +647,10 @@ function* watchFetchSupportingForUser() {
   yield* takeEvery(fetchSupportingForUser.type, fetchSupportingForUserAsync)
 }
 
+function* watchFetchSupportersForUser() {
+  yield takeEvery(fetchSupportersForUser.type, fetchSupportersForUserAsync)
+}
+
 function* watchRefreshSupport() {
   yield* takeEvery(refreshSupport.type, refreshSupportAsync)
 }
@@ -618,6 +670,7 @@ function* watchFetchUserSupporter() {
 const sagas = () => {
   return [
     watchFetchSupportingForUser,
+    watchFetchSupportersForUser,
     watchRefreshSupport,
     watchConfirmSendTip,
     watchFetchRecentTips,

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -435,7 +435,7 @@ function* fetchSupportersForUserAsync(action: FetchSupportingAction) {
   const userIds = supportersForReceiverList?.map((supporter) =>
     decodeHashId(supporter.sender.id)
   )
-
+  if (!userIds) return
   yield call(fetchUsers, userIds)
 
   const supportersForReceiverMap: Record<string, Supporter> = {}


### PR DESCRIPTION
### Description

Improves top-supporters/supporting flow by moving fetching logic from sagas to top-supporters components, and removing CLS by using `top_supporters` user value to crate a loading skeleton that exactly matches loaded-in top-supporters component.

### Dragons

There are potential issues with this related to the other ways top-supporters are used, ie in tipping flow etc. we should make sure there are no regressions on those areas.