### PR TITLE
[C-1876] Hide download indicator on deleted tracks

### DIFF
--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -240,9 +240,11 @@ export const TrackListItem = ({
               </Text>
             </View>
 
-            <View style={styles.downloadIndicator}>
-              <DownloadStatusIndicator trackId={track_id} size={18} />
-            </View>
+            {!isDeleted && (
+              <View style={styles.downloadIndicator}>
+                <DownloadStatusIndicator trackId={track_id} size={18} />
+              </View>
+            )}
           </View>
           <Text numberOfLines={1} style={styles.artistName}>
             {name}


### PR DESCRIPTION
### Description

I spent some time trying to filter out deleted tracks from the download queue, but because we are only pulling the `favorites` endpoint we don't have the data to know if the track is deleted. Fetching that data would require extra calls for each batch of tracks in `fetchAllFavoritedTracks` etc and seemed like it would add quite a bit of complexity

This is the simple solution, the download fails silently in the background and the deleted track doesn't show up when offline

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

