### PR TITLE
[C-1875] Fix empty favorited tracks lineup on reconnect

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1074,7 +1074,7 @@ export class AudiusAPIClient {
         params
       )
 
-    if (!response) return []
+    if (!response) return null
 
     const adapted = response.data.map(({ item, ...props }) => ({
       timestamp: props.timestamp,


### PR DESCRIPTION
### Description

Same `[]` vs `null` return bug from https://github.com/AudiusProject/audius-client/pull/2625/files#diff-2f1a5ad307b83e3d504719fb91b411a8619a6f7ecaf23a2cf3e17d79f3b811efR1409

### Dragons

This bug could occur elsewhere. Might be worth fixing all the lineup fetches? But impact of that is not known, so taking it one at a time for now.

