### PR TITLE
[C-1881] Allow removing downloads while offline

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -18,7 +18,8 @@ import {
   accountSelectors,
   cacheUsersSelectors,
   cacheActions,
-  collectionsSocialActions
+  collectionsSocialActions,
+  reachabilitySelectors
 } from '@audius/common'
 import { uniq, isEqual } from 'lodash'
 import RNFS, { exists } from 'react-native-fs'
@@ -66,6 +67,7 @@ import {
 const { saveCollection } = collectionsSocialActions
 const { getUserId } = accountSelectors
 const { getUserFromCollection } = cacheUsersSelectors
+const { getIsReachable } = reachabilitySelectors
 export const DOWNLOAD_REASON_FAVORITES = 'favorites'
 
 export const downloadAllFavorites = async () => {
@@ -336,11 +338,20 @@ const shouldAbortDownload = ({
 export const removeAllDownloadedFavorites = async () => {
   const state = store.getState()
   const currentUserId = getUserId(state)
+  const isReachable = getIsReachable(state)
   if (!currentUserId) return
   const downloadedCollections = getOfflineCollections(state)
   const favoritedDownloadedCollections = getOfflineFavoritedCollections(state)
+  const offlineTracks = getOfflineTracks(state)
 
-  const allFavoritedTracks = await fetchAllFavoritedTracks(currentUserId)
+  const allFavoritedTracks = isReachable
+    ? await fetchAllFavoritedTracks(currentUserId)
+    : Object.values(offlineTracks)
+        .filter((track) => !!track.offline?.favorite_created_at)
+        .map((track) => ({
+          trackId: track.track_id,
+          favoriteCreatedAt: track.offline?.favorite_created_at
+        }))
   const tracksForDownload: TrackForDownload[] = allFavoritedTracks.map(
     ({ trackId, favoriteCreatedAt }) => ({
       trackId,

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -344,14 +344,19 @@ export const removeAllDownloadedFavorites = async () => {
   const favoritedDownloadedCollections = getOfflineFavoritedCollections(state)
   const offlineTracks = getOfflineTracks(state)
 
+  const downloadedFavoritedTracks = Object.values(offlineTracks)
+    .filter((track) => !!track.offline?.favorite_created_at)
+    .map((track) => ({
+      trackId: track.track_id,
+      favoriteCreatedAt: track.offline?.favorite_created_at
+    }))
+
   const allFavoritedTracks = isReachable
-    ? await fetchAllFavoritedTracks(currentUserId)
-    : Object.values(offlineTracks)
-        .filter((track) => !!track.offline?.favorite_created_at)
-        .map((track) => ({
-          trackId: track.track_id,
-          favoriteCreatedAt: track.offline?.favorite_created_at
-        }))
+    ? [
+        ...(await fetchAllFavoritedTracks(currentUserId)),
+        ...downloadedFavoritedTracks
+      ]
+    : downloadedFavoritedTracks
   const tracksForDownload: TrackForDownload[] = allFavoritedTracks.map(
     ({ trackId, favoriteCreatedAt }) => ({
       trackId,


### PR DESCRIPTION
### Description

We were using a fetch to check the latest tracks. This helps to include tracks that are in the queue but haven't started downloading.

When we're offline, we fail to fetch and don't finish the process. This change skips the fetch if we're offline, as we know the list we have is good in that case.


