### PR TITLE
[QA-308] Fix explore page crash

### DIFF
--- a/packages/common/src/store/pages/explore/selectors.ts
+++ b/packages/common/src/store/pages/explore/selectors.ts
@@ -13,7 +13,7 @@ export const getExplorePlaylists = createSelector(
   (state: CommonState) => state.pages.explore.playlists,
   (state: CommonState) => state.collections.entries,
   (playlists, collections) =>
-    playlists.map((id) => collections[id].metadata).filter(removeNullable)
+    playlists.map((id) => collections[id]?.metadata).filter(removeNullable)
 )
 
 export const getExploreArtists = createSelector(


### PR DESCRIPTION
### Description

We filter nullable, but don't allow the absence of the cached collection to make it through the map safely.

### Dragons

Could be hiding bugs with loading and cacheing the collections. Not sure why this started happening now.
