### PR TITLE
[PAY-871] Extend reward buttons to full tile width

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
+++ b/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
@@ -154,6 +154,7 @@
 
 .panelButton {
   height: auto !important;
+  width: 100%;
   padding: 8px;
   padding-left: 12px;
 }


### PR DESCRIPTION
### Description
Extends buttons in reward tiles to full width.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

