### PR TITLE
[C-1907, C-1928] Update chromecast icon in NowPlayingDrawer and track name length on track list items

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -4,6 +4,7 @@ import type { Nullable, Track } from '@audius/common'
 import {
   removeNullable,
   FavoriteSource,
+  reachabilitySelectors,
   RepostSource,
   ShareSource,
   castSelectors,
@@ -19,10 +20,12 @@ import { CastButton } from 'react-native-google-cast'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconAirplay from 'app/assets/images/iconAirplay.svg'
+import IconChromecast from 'app/assets/images/iconChromecast.svg'
 import IconKebabHorizontal from 'app/assets/images/iconKebabHorizontal.svg'
 import IconShare from 'app/assets/images/iconShare.svg'
 import { useAirplay } from 'app/components/audio/Airplay'
 import { IconButton } from 'app/components/core'
+import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
@@ -34,6 +37,8 @@ const { repostTrack, saveTrack, undoRepostTrack, unsaveTrack } =
   tracksSocialActions
 const { updateMethod } = castActions
 const { getMethod: getCastMethod, getIsCasting } = castSelectors
+
+const { getIsReachable } = reachabilitySelectors
 
 const useStyles = makeStyles(({ palette, spacing }) => ({
   container: {
@@ -67,8 +72,10 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   const styles = useStyles()
   const castMethod = useSelector(getCastMethod)
   const isCasting = useSelector(getIsCasting)
-  const { neutral, primary } = useThemeColors()
+  const { neutral, neutralLight6, primary } = useThemeColors()
   const dispatch = useDispatch()
+  const isOfflineModeEnabled = useIsOfflineModeEnabled()
+  const isReachable = useSelector(getIsReachable)
 
   useLayoutEffect(() => {
     if (Platform.OS === 'android' && castMethod === 'airplay') {
@@ -139,7 +146,16 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         />
       )
     }
-    return (
+    return isOfflineModeEnabled || !isReachable ? (
+      <View style={{ ...styles.button, width: 24 }}>
+        <IconChromecast
+          fill={neutralLight6}
+          height={30}
+          width={30}
+          style={{ transform: [{ scaleX: -1 }] }}
+        />
+      </View>
+    ) : (
       <CastButton
         style={{
           ...styles.button,

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -56,7 +56,8 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
     justifyContent: 'center'
   },
   topLine: {
-    flexDirection: 'row'
+    flexDirection: 'row',
+    alignItems: 'center'
   },
   trackTitle: {
     flexDirection: 'row',
@@ -68,7 +69,6 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
     color: palette.neutral
   },
   downloadIndicator: {
-    marginTop: -3,
     marginLeft: spacing(1)
   },
   artistName: {
@@ -141,6 +141,11 @@ export const TrackListItem = ({
   const deletedTextWidth = useMemo(
     () => (messages.deleted.length ? 124 : 0),
     [messages]
+  )
+  const titleMaxWidth = useMemo(
+    () =>
+      titleWidth && deletedTextWidth ? titleWidth - deletedTextWidth : '100%',
+    [deletedTextWidth, titleWidth]
   )
 
   const onPressTrack = () => {
@@ -221,21 +226,11 @@ export const TrackListItem = ({
             >
               <Text
                 numberOfLines={1}
-                style={[
-                  styles.trackTitleText,
-                  {
-                    maxWidth: titleWidth
-                      ? titleWidth - deletedTextWidth
-                      : '100%'
-                  }
-                ]}
+                style={[styles.trackTitleText, { maxWidth: titleMaxWidth }]}
               >
                 {title}
               </Text>
-              <Text
-                numberOfLines={1}
-                style={[styles.trackTitleText, { flexBasis: deletedTextWidth }]}
-              >
+              <Text numberOfLines={1} style={[styles.trackTitleText]}>
                 {messages.deleted}
               </Text>
             </View>


### PR DESCRIPTION
### Description
* Add inactive icon for chromecast in offline mode
* Update the width of the track title for track list items to avoid too short error

Before and after for the track list item titles
![IMG_1375 Small](https://user-images.githubusercontent.com/23732287/214686081-2f98ef27-d4f3-472a-8ac0-7ef07236214e.jpeg)
![IMG_1374 Small](https://user-images.githubusercontent.com/23732287/214686123-05c4819f-1ada-4ecf-82ea-1d3dfa026f6b.jpeg)

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

