### PR TITLE
Fix button alignment in rewards tiles

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/ChallengeRewardsTile.tsx
@@ -121,7 +121,7 @@ const RewardPanel = ({
   return (
     <div
       className={wm(
-        cn(styles.rewardPanelContainer, hasDisbursed ? styles.completed : '')
+        cn(styles.rewardPanelContainer, hasDisbursed ? styles.disbursed : '')
       )}
       onClick={openRewardModal}
     >
@@ -157,7 +157,7 @@ const RewardPanel = ({
         </div>
         <Button
           className={wm(
-            cn(styles.panelButton, hasDisbursed ? styles.buttonCompleted : '')
+            cn(styles.panelButton, hasDisbursed ? styles.disbursed : '')
           )}
           type={buttonType}
           text={buttonMessage}

--- a/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
+++ b/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
@@ -90,13 +90,8 @@
   }
 }
 
-.completed {
+.disbursed {
   background: var(--neutral-light-10);
-}
-
-.buttonCompleted {
-  background: var(--neutral-light-10);
-  min-height: 38px;
 }
 
 .pillContainer {
@@ -172,7 +167,7 @@
 }
 
 .panelButton {
-  height: auto !important;
+  height: 32px !important;
   width: 100%;
   padding: 8px;
   padding-left: 12px;

--- a/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
+++ b/packages/web/src/pages/audio-rewards-page/RewardsTile.module.css
@@ -167,7 +167,7 @@
 }
 
 .panelButton {
-  height: 32px !important;
+  height: var(--unit-8) !important;
   width: 100%;
   padding: 8px;
   padding-left: 12px;


### PR DESCRIPTION
### Description
Buttons in rewards tiles were very slightly off, this fixes the issue and also sets the height to 32px to match the figma.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

