### PR TITLE
Use 2-letter country codes in buy-audio location

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -68,7 +68,9 @@ export const remoteConfigStringDefaults: {
   [StringKeys.COINBASE_PAY_ALLOWED_COUNTRIES]: '',
   [StringKeys.COINBASE_PAY_DENIED_REGIONS]: '',
   [StringKeys.STRIPE_ALLOWED_COUNTRIES]: '',
-  [StringKeys.STRIPE_DENIED_REGIONS]: ''
+  [StringKeys.STRIPE_DENIED_REGIONS]: '',
+  [StringKeys.COINBASE_PAY_ALLOWED_COUNTRIES_2_LETTER]: '',
+  [StringKeys.STRIPE_ALLOWED_COUNTRIES_2_LETTER]: ''
 }
 
 export const remoteConfigDoubleDefaults: {

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -309,7 +309,13 @@ export enum StringKeys {
   STRIPE_ALLOWED_COUNTRIES = 'STRIPE_ALLOWED_COUNTRIES',
 
   /** Denied Regions for Link by Stripe */
-  STRIPE_DENIED_REGIONS = 'STRIPE_DENIED_REGIONS'
+  STRIPE_DENIED_REGIONS = 'STRIPE_DENIED_REGIONS',
+
+  /** 2-Letter ISO Country Codes of Allowed Countries for Coinbase Pay */
+  COINBASE_PAY_ALLOWED_COUNTRIES_2_LETTER = 'COINBASE_PAY_ALLOWED_COUNTRIES_2_LETTER',
+
+  /** 2-Letter ISO Country Codes of Allowed Countries for Link by Stripe */
+  STRIPE_ALLOWED_COUNTRIES_2_LETTER = 'STRIPE_ALLOWED_COUNTRIES_2_LETTER'
 }
 
 export type AllRemoteConfigKeys =

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -243,7 +243,7 @@ const isLocationSupported = ({
 }) => {
   return (
     !location ||
-    (allowedCountries.some((c) => c === location.country_code_iso3) &&
+    (allowedCountries.some((c) => c === location.country_code) &&
       !deniedRegions.some((r) => r === location.region_code))
   )
 }
@@ -256,13 +256,13 @@ const useOnRampProviderInfo = () => {
     FeatureFlags.BUY_AUDIO_STRIPE_ENABLED
   )
   const coinbaseAllowedCountries = (
-    useRemoteVar(StringKeys.COINBASE_PAY_ALLOWED_COUNTRIES) ?? ''
+    useRemoteVar(StringKeys.COINBASE_PAY_ALLOWED_COUNTRIES_2_LETTER) ?? ''
   ).split(',')
   const coinbaseDeniedRegions = (
     useRemoteVar(StringKeys.COINBASE_PAY_DENIED_REGIONS) ?? ''
   ).split(',')
   const stripeAllowedCountries = (
-    useRemoteVar(StringKeys.STRIPE_ALLOWED_COUNTRIES) ?? ''
+    useRemoteVar(StringKeys.STRIPE_ALLOWED_COUNTRIES_2_LETTER) ?? ''
   ).split(',')
   const stripeDeniedRegions = (
     useRemoteVar(StringKeys.STRIPE_DENIED_REGIONS) ?? ''


### PR DESCRIPTION
### Description
Added 2-letter country code allow lists for coinbase and stripe in optimizely, and this commit updates the client to use those to verify that the user is allowed to buy audio using stripe or coinbase instead of the 3-letter country codes. This is to prepare for the switch to ipdata instead of ipapi.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web + vpn

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

