### PR TITLE
Fix lineups not loading in Offline Mode (C-1945, C-1882, C-1803)

### DIFF
--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -1,12 +1,11 @@
 import { useCallback } from 'react'
 
-import {
+import type {
   CollectionMetadata,
   Track,
   UserMetadata,
   lineupActions,
   UserTrackMetadata,
-  collectionPageActions,
   SmartCollectionVariant
 } from '@audius/common'
 import {
@@ -141,7 +140,11 @@ export const useLoadOfflineData = () => {
  * @param lineupActions the actions instance for the lineup
  */
 export const useOfflineCollectionLineup = (
-  collectionId: typeof DOWNLOAD_REASON_FAVORITES | number | SmartCollectionVariant | null,
+  collectionId:
+    | typeof DOWNLOAD_REASON_FAVORITES
+    | number
+    | SmartCollectionVariant
+    | null,
   fetchOnlineContent: () => void,
   lineupActions: lineupActions.LineupActions
 ) => {

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -226,4 +226,5 @@ export const useOfflineCollectionLineup = (
   ])
 
   useReachabilityState(fetchOnlineContent, fetchLocalContent)
+  return fetchLocalContent
 }

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -153,12 +153,19 @@ export const useOfflineCollectionLineup = (
   })
 
   const fetchLocalContent = useCallback(() => {
+    const collectionTrackIds = new Set(
+      collection?.playlist_contents?.track_ids?.map(
+        (trackData) => trackData.track
+      ) ?? []
+    )
+
     if (isOfflineModeEnabled && collectionId) {
       const lineupTracks = Object.values(offlineTracks)
-        .filter((track) =>
-          track.offline?.reasons_for_download.some(
-            (reason) => reason.collection_id === collectionId.toString()
-          )
+        .filter(
+          (track) =>
+            track.offline?.reasons_for_download.some(
+              (reason) => reason.collection_id === collectionId.toString()
+            ) || collectionTrackIds.has(track.track_id)
         )
         .map((track) => ({
           uid: makeUid(Kind.TRACKS, track.track_id),
@@ -174,7 +181,7 @@ export const useOfflineCollectionLineup = (
       store.dispatch(cacheActions.add(Kind.TRACKS, cacheTracks, false, true))
 
       if (collectionId === DOWNLOAD_REASON_FAVORITES) {
-        // Reorder lineup tracks accorinding to favorite time
+        // Reorder lineup tracks according to favorite time
         const sortedTracks = orderBy(
           lineupTracks,
           (track) => track.offline?.favorite_created_at,

--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -1,11 +1,13 @@
 import { useCallback } from 'react'
 
-import type {
+import {
   CollectionMetadata,
   Track,
   UserMetadata,
   lineupActions,
-  UserTrackMetadata
+  UserTrackMetadata,
+  collectionPageActions,
+  SmartCollectionVariant
 } from '@audius/common'
 import {
   Kind,
@@ -139,7 +141,7 @@ export const useLoadOfflineData = () => {
  * @param lineupActions the actions instance for the lineup
  */
 export const useOfflineCollectionLineup = (
-  collectionId: typeof DOWNLOAD_REASON_FAVORITES | number | null,
+  collectionId: typeof DOWNLOAD_REASON_FAVORITES | number | SmartCollectionVariant | null,
   fetchOnlineContent: () => void,
   lineupActions: lineupActions.LineupActions
 ) => {

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -262,6 +262,7 @@ const CollectionScreenComponent = (props: CollectionScreenComponentProps) => {
             hasReposted={has_current_user_reposted}
             hasSaved={has_current_user_saved}
             isAlbum={is_album}
+            collectionId={playlist_id}
             isPrivate={is_private}
             isPublishing={_is_publishing ?? false}
             onPressFavorites={handlePressFavorites}

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -71,7 +71,7 @@ type CollectionScreenDetailsTileProps = {
   isPrivate?: boolean
   isPublishing?: boolean
   extraDetails?: DetailsTileDetail[]
-  collectionId: number
+  collectionId: number | SmartCollectionVariant
 } & Omit<
   DetailsTileProps,
   'descriptionLinkPressSource' | 'details' | 'headerText' | 'onPressPlay'

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -72,6 +72,7 @@ type CollectionScreenDetailsTileProps = {
   isPrivate?: boolean
   isPublishing?: boolean
   extraDetails?: DetailsTileDetail[]
+  collectionId: number
 } & Omit<
   DetailsTileProps,
   'descriptionLinkPressSource' | 'details' | 'headerText' | 'onPressPlay'

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -113,18 +113,35 @@ export const CollectionScreenDetailsTile = ({
   const tracksLoading = status === Status.LOADING
   const numTracks = entries.length
 
-  const handleFetchLineup = useCallback(() => {
+  const handleFetchLineupOnline = useCallback(() => {
     dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined))
   }, [dispatch])
+
+  const handleFetchLineupOffline = useOfflineCollectionLineup(
+    collectionId,
+    handleFetchLineupOnline,
+    tracksActions
+  )
+  const handleFetchLineup = useCallback(() => {
+    if (isOfflineModeEnabled && !isReachable) {
+      handleFetchLineupOffline()
+    } else {
+      handleFetchLineupOnline()
+    }
+  }, [
+    handleFetchLineupOffline,
+    handleFetchLineupOnline,
+    isOfflineModeEnabled,
+    isReachable
+  ])
 
   const handleFetchCollectionLineup = useCallback(() => {
     dispatch(resetCollection(collectionUid, userUid))
     handleFetchLineup()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, handleFetchLineup])
+  }, [dispatch, handleFetchLineupOnline])
 
   useFocusEffect(handleFetchCollectionLineup)
-  useOfflineCollectionLineup(collectionId, handleFetchLineup, tracksActions)
 
   const duration = entries?.reduce(
     (duration, entry) => duration + entry.duration,

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -92,6 +92,7 @@ const recordPlay = (id: Maybe<number>, play = true) => {
 export const CollectionScreenDetailsTile = ({
   description,
   extraDetails = [],
+  collectionId,
   isAlbum,
   isPrivate,
   isPublishing,
@@ -106,7 +107,6 @@ export const CollectionScreenDetailsTile = ({
 
   const collection = useSelector(getCollection)
   const collectionUid = useSelector(getCollectionUid)
-  const collectionId = useSelector(getCollectionId)
   const userUid = useSelector(getUserUid)
   const { entries, status } = useProxySelector(getTracksLineup, [isReachable])
   const tracksLoading = status === Status.LOADING

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -35,7 +35,6 @@ import { formatCount } from 'app/utils/format'
 const {
   getCollection,
   getCollectionTracksLineup,
-  getCollectionId,
   getCollectionUid,
   getUserUid
 } = collectionPageSelectors

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import type { ID, Maybe, UID } from '@audius/common'
+import type { ID, Maybe, SmartCollectionVariant, UID } from '@audius/common'
 import {
   Variant,
   useProxySelector,

--- a/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
@@ -55,7 +55,7 @@ export const AlbumsTab = () => {
         return true
       })
     },
-    [filterValue]
+    [filterValue, isReachable, isOfflineModeEnabled]
   )
 
   return (

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -70,16 +70,30 @@ export const TracksTab = () => {
   const isReachable = useSelector(getIsReachable)
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
 
-  const handleFetchSaves = useCallback(() => {
+  const handleFetchSavesOnline = useCallback(() => {
     dispatch(fetchSaves())
   }, [dispatch])
 
-  useFocusEffect(handleFetchSaves)
-  useOfflineCollectionLineup(
+  const handleFetchSavesOffline = useOfflineCollectionLineup(
     DOWNLOAD_REASON_FAVORITES,
-    handleFetchSaves,
+    handleFetchSavesOnline,
     tracksActions
   )
+
+  const handleFetchSaves = useCallback(() => {
+    if (isOfflineModeEnabled && !isReachable) {
+      handleFetchSavesOffline()
+    } else {
+      handleFetchSavesOnline()
+    }
+  }, [
+    handleFetchSavesOffline,
+    handleFetchSavesOnline,
+    isOfflineModeEnabled,
+    isReachable
+  ])
+
+  useFocusEffect(handleFetchSaves)
 
   const [filterValue, setFilterValue] = useState('')
   const isPlaying = useSelector(getPlaying)

--- a/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
+++ b/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
@@ -105,6 +105,7 @@ export const SmartCollectionScreen = (props: SmartCollectionScreenProps) => {
       style={styles.root}
     >
       <CollectionScreenDetailsTile
+        collectionId={variant}
         description={playlistDescription}
         hasSaved={isSaved}
         hideFavoriteCount


### PR DESCRIPTION
### Description
After the perf improvements, the `useReachabilityState` callbacks were not being fired on every render anymore. This is a good thing, but it ended up revealing issues with how/when we were loading the lineup on the favorited tracks tab and all the favorited collection screens.

If you were offline and then loaded any of these screens, the lineup simply would not load. This is because the call to fetch local tracks was ONLY triggered when going from online -> offline. So this PR makes sure that we fetch local tracks on first render as well.

However this was not the only fix needed. We were also not updating our `state.pages.collection` (https://github.com/AudiusProject/audius-client/blob/main/packages/common/src/store/pages/collection/selectors.ts#L2) slice when navigating to a collection screen while offline, so the collection id passed to `useOfflineCollectionLineup` was always empty. I put in a quick fix for this but we should probably add logic to update that part of the store correctly when loading the offline lineup.

The last fix implemented here was that we were filtering out tracks needlessly from offline collection lineups because their downloaded tracks' data did not yet have the collection as a reason for download.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

