### PR TITLE
Fix cache types

### DIFF
--- a/packages/common/src/store/cache/collections/selectors.ts
+++ b/packages/common/src/store/cache/collections/selectors.ts
@@ -119,14 +119,20 @@ export const getTracksFromCollection = (
       trackUid.source = `${collectionSource}:${trackUid.source}`
       trackUid.count = i
 
-      if (!tracks[t.track]) {
+      const track = tracks[t.track]
+      if (!track) {
         console.error(`Found empty track ${t.track}`)
+        return null
+      }
+      const user = users[track.owner_id]
+      if (!user) {
+        console.error(`Found empty user ${track.owner_id}`)
         return null
       }
       return {
         ...tracks[t.track],
         uid: trackUid.toString(),
-        user: users[tracks[t.track].owner_id]
+        user
       }
     })
     .filter(Boolean) as EnhancedCollectionTrack[]

--- a/packages/common/src/store/cache/selectors.ts
+++ b/packages/common/src/store/cache/selectors.ts
@@ -86,28 +86,28 @@ export const getEntryTimestamp = (
 export function getAllEntries(
   state: CommonState,
   props: { kind: Kind.USERS }
-): { [id: string]: User }
+): Partial<Record<string, User>>
 export function getAllEntries(
   state: CommonState,
   props: { kind: Kind.COLLECTIONS }
-): { [id: string]: Collection }
+): Partial<Record<string, Collection>>
 export function getAllEntries(
   state: CommonState,
   props: { kind: Kind.TRACKS }
-): { [id: string]: Track }
+): Partial<Record<string, Track>>
 export function getAllEntries(
   state: CommonState,
   props: { kind: Kind.USERS }
 ):
-  | { [id: string]: User }
-  | { [id: string]: Track }
-  | { [id: string]: Collection }
+  | Partial<Record<string, User>>
+  | Partial<Record<string, Track>>
+  | Partial<Record<string, Collection>>
 export function getAllEntries(state: CommonState, props: { kind: Kind }) {
   const entries = getCache(state, props).entries
   return Object.keys(entries).reduce((acc, id) => {
     acc[id] = entries[id as unknown as number].metadata
     return acc
-  }, {} as { [id: string]: Track | Collection | User })
+  }, {} as Partial<Record<string, User>> | Partial<Record<string, Track>> | Partial<Record<string, Collection>>)
 }
 
 export function getCache(

--- a/packages/common/src/store/cache/users/selectors.ts
+++ b/packages/common/src/store/cache/users/selectors.ts
@@ -61,7 +61,9 @@ export const getUsers = (
         getUserByHandle(state, { handle: handle.toLowerCase() }) || {}
       if (id) {
         const user = getUser(state, { id })
-        if (user) users[handle] = user
+        if (user) {
+          users[handle] = user
+        }
       }
     })
     return users

--- a/packages/common/src/store/pages/explore/selectors.ts
+++ b/packages/common/src/store/pages/explore/selectors.ts
@@ -39,11 +39,12 @@ export const makeGetExplore = () => {
     (explore, collections, users) => {
       const playlists = explore.playlists
         .map((id) => collections[id])
-        .filter(Boolean)
+        .filter(removeNullable)
         .map((collection) => ({
           ...collection,
-          user: users[collection.playlist_owner_id] || {}
+          user: collection ? users[collection.playlist_owner_id] : null
         }))
+        .filter((collection) => collection.user) as UserCollection[]
       const profiles = explore.profiles.map((id) => users[id]).filter(Boolean)
       return {
         playlists,

--- a/packages/common/src/store/pages/profile/selectors.ts
+++ b/packages/common/src/store/pages/profile/selectors.ts
@@ -77,7 +77,7 @@ export const getProfileCollections = createDeepEqualSelector(
   ],
   (userId, users, collections) => {
     if (!userId) return undefined
-    const user: User = users[userId]
+    const user = users[userId]
     if (!user) return undefined
     const { handle, _collectionIds } = user
     const userCollections = _collectionIds
@@ -146,7 +146,7 @@ export const makeGetProfile = () => {
       if (!(userId in users)) return emptyState
 
       // Get playlists & albums.
-      const c = (users[userId]._collectionIds || [])
+      const c = (users?.[userId]?._collectionIds ?? [])
         .map((id) =>
           id in collections ? collections[id as unknown as number] : null
         )
@@ -204,6 +204,8 @@ export const makeGetProfile = () => {
             status: followees?.status ?? Status.IDLE,
             users: followeesPopulated
           }
+        } as User & { followers: { status: Status; users: User[] } } & {
+          followees: { status: Status; users: User[] }
         },
         mostUsedTags,
         playlists,

--- a/packages/common/src/store/pages/search-results/selectors.ts
+++ b/packages/common/src/store/pages/search-results/selectors.ts
@@ -29,7 +29,7 @@ export const makeGetSearchArtists = () => {
   return createSelector(
     [getSearchArtistsIds, getUnsortedSearchArtists],
     (ids, artists) =>
-      ids.map((id) => artists[id]).filter((a) => !a.is_deactivated)
+      ids.map((id) => artists[id]).filter((a) => !a?.is_deactivated)
   )
 }
 
@@ -41,7 +41,7 @@ export const makeGetSearchAlbums = () => {
       .map((album) => {
         return {
           ...album,
-          user: users[album.playlist_owner_id]
+          user: album ? users[album.playlist_owner_id] : null
         }
       })
       .filter((album) => !!album.user && !album.user.is_deactivated)
@@ -58,10 +58,17 @@ export const makeGetSearchPlaylists = () => {
         .map((playlist) => {
           return {
             ...playlist,
-            user: users[playlist.playlist_owner_id],
-            trackCount: (playlist.playlist_contents.track_ids || []).length
+            user: playlist ? users[playlist.playlist_owner_id] : null,
+            trackCount: playlist
+              ? (playlist.playlist_contents.track_ids || []).length
+              : null
           }
         })
-        .filter((playlist) => !!playlist.user && !playlist.user.is_deactivated)
+        .filter(
+          (playlist) =>
+            !!playlist.user &&
+            !playlist.user.is_deactivated &&
+            playlist.trackCount !== null
+        )
   )
 }

--- a/packages/mobile/src/components/add-to-playlist-drawer/AddToPlaylistDrawer.tsx
+++ b/packages/mobile/src/components/add-to-playlist-drawer/AddToPlaylistDrawer.tsx
@@ -6,7 +6,8 @@ import {
   accountSelectors,
   cacheCollectionsActions,
   addToPlaylistUISelectors,
-  newCollectionMetadata
+  newCollectionMetadata,
+  removeNullable
 } from '@audius/common'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
@@ -97,7 +98,7 @@ export const AddToPlaylistDrawer = () => {
         </View>
         <CardList
           contentContainerStyle={styles.cardList}
-          data={userPlaylists}
+          data={userPlaylists.filter(removeNullable)}
           renderItem={({ item }) => (
             <Card
               key={item.playlist_id}

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteNotification.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import type { FavoriteNotification as FavoriteNotificationType } from '@audius/common'
 import {
+  removeNullable,
   formatCount,
   notificationsSelectors,
   useProxySelector
@@ -59,7 +60,7 @@ export const FavoriteNotification = (props: FavoriteNotificationProps) => {
   return (
     <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={IconHeart}>
-        <ProfilePictureList users={users} />
+        <ProfilePictureList users={users.filter(removeNullable)} />
       </NotificationHeader>
       <NotificationText>
         <UserNameLink user={firstUser} />

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FollowNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FollowNotification.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import type { FollowNotification as FollowNotificationType } from '@audius/common'
 import {
+  removeNullable,
   useProxySelector,
   formatCount,
   notificationsSelectors
@@ -52,7 +53,7 @@ export const FollowNotification = (props: FollowNotificationProps) => {
   return (
     <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={IconUser}>
-        <ProfilePictureList users={users} />
+        <ProfilePictureList users={users.filter(removeNullable)} />
       </NotificationHeader>
       <NotificationText>
         <UserNameLink user={firstUser} />

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RepostNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RepostNotification.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import type { RepostNotification as RepostNotificationType } from '@audius/common'
 import {
+  removeNullable,
   useProxySelector,
   formatCount,
   notificationsSelectors
@@ -58,7 +59,7 @@ export const RepostNotification = (props: RepostNotificationProps) => {
   return (
     <NotificationTile notification={notification} onPress={handlePress}>
       <NotificationHeader icon={IconRepost}>
-        <ProfilePictureList users={users} />
+        <ProfilePictureList users={users.filter(removeNullable)} />
       </NotificationHeader>
       <NotificationText>
         <UserNameLink user={firstUser} />

--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -4,6 +4,7 @@ import type {
   UserCollectionMetadata
 } from '@audius/common'
 import {
+  removeNullable,
   collectionPageActions,
   FavoriteSource,
   tracksSocialActions,
@@ -148,7 +149,7 @@ export function* startSync() {
         ([id, isDownloaded]) => isDownloaded && id !== DOWNLOAD_REASON_FAVORITES
       )
       .map(([id, isDownloaded]) => collections[id] ?? null)
-      .filter((collection) => !!collection)
+      .filter(removeNullable)
 
     if (isFavoritesDownloadEnabled) {
       // Individual tracks
@@ -163,7 +164,7 @@ export function* startSync() {
       const updatedCollections = yield* select(getCollections)
       const updatedAccountCollections = accountCollectionIds
         .map((id) => updatedCollections[id])
-        .filter((collection) => !!collection)
+        .filter(removeNullable)
 
       yield* call(
         syncFavoritedCollections,

--- a/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
+++ b/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
@@ -1,6 +1,5 @@
 import {
   ID,
-  Collection,
   CollectionMetadata,
   UserCollectionMetadata,
   Kind,
@@ -37,7 +36,7 @@ function* markCollectionDeleted(
     if (!(metadata.playlist_id in collections)) return metadata
     return {
       ...metadata,
-      _marked_deleted: !!collections[metadata.playlist_id]._marked_deleted
+      _marked_deleted: !!collections?.[metadata.playlist_id]?._marked_deleted
     }
   })
 }
@@ -163,9 +162,10 @@ export function* retrieveCollectionByPermalink(
       if (requiresAllTracks) {
         const keys = Object.keys(cachedCollections) as unknown as number[]
         keys.forEach((collectionId) => {
-          const fullTrackCount = cachedCollections[collectionId].track_count
+          const fullTrackCount =
+            cachedCollections?.[collectionId]?.track_count ?? 0
           const currentTrackCount =
-            cachedCollections[collectionId].tracks?.length ?? 0
+            cachedCollections?.[collectionId]?.tracks?.length ?? 0
           if (currentTrackCount < fullTrackCount) {
             // Remove the collection from the res so retrieve knows to get it from source
             delete cachedCollections[collectionId]
@@ -236,14 +236,12 @@ export function* retrieveCollections(
   const { entries, uids } = yield* call(retrieve, {
     ids: collectionIds,
     selectFromCache: function* (ids: ID[]) {
-      const res: {
-        [id: number]: Collection
-      } = yield* select(getCollections, { ids })
+      const res = yield* select(getCollections, { ids })
       if (requiresAllTracks) {
         const keys = Object.keys(res) as any
         keys.forEach((collectionId: number) => {
-          const fullTrackCount = res[collectionId].track_count
-          const currentTrackCount = res[collectionId].tracks?.length ?? 0
+          const fullTrackCount = res?.[collectionId]?.track_count ?? 0
+          const currentTrackCount = res?.[collectionId]?.tracks?.length ?? 0
           if (currentTrackCount < fullTrackCount) {
             // Remove the collection from the res so retrieve knows to get it from source
             delete res[collectionId]

--- a/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
+++ b/packages/web/src/common/store/pages/trending/lineups/trending/retrieveTrending.ts
@@ -10,7 +10,8 @@ import {
   trendingPageLineupSelectors,
   trendingPageActions,
   trendingPageSelectors,
-  getContext
+  getContext,
+  removeNullable
 } from '@audius/common'
 import { keccak_256 } from 'js-sha3'
 import { call, put, select } from 'redux-saga/effects'
@@ -60,7 +61,7 @@ export function* retrieveTrending({
     const tracksMap: ReturnType<typeof getTracks> = yield select(
       (state: AppState) => getTracks(state, { ids: trackIds })
     )
-    const tracks = trackIds.map((id) => tracksMap[id])
+    const tracks = trackIds.map((id) => tracksMap[id]).filter(removeNullable)
     return tracks
   }
 

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -171,9 +171,13 @@ export function* undoRepostCollectionAsync(
     ids: [action.collectionId]
   })
   const collection = collections[action.collectionId]
+  if (!collection) {
+    console.error(`Missing collection ${action.collectionId}`)
+    return
+  }
 
   const event = make(Name.UNDO_REPOST, {
-    kind: collection.is_album ? 'album' : 'playlist',
+    kind: collection?.is_album ? 'album' : 'playlist',
     source: action.source,
     id: action.collectionId
   })
@@ -313,6 +317,11 @@ export function* saveCollectionAsync(
     ids: [action.collectionId]
   })
   const collection = collections[action.collectionId]
+  if (!collection) {
+    console.error(`Missing collection ${action.collectionId}`)
+    return
+  }
+
   const user = yield* select(getUser, { id: collection.playlist_owner_id })
   if (!user) return
 
@@ -451,6 +460,10 @@ export function* unsaveCollectionAsync(
     ids: [action.collectionId]
   })
   const collection = collections[action.collectionId]
+  if (!collection) {
+    console.error(`Missing collection ${action.collectionId}`)
+    return
+  }
 
   const event = make(Name.UNFAVORITE, {
     kind: collection.is_album ? 'album' : 'playlist',
@@ -524,7 +537,10 @@ export function* watchShareCollection() {
     function* (action: ReturnType<typeof socialActions.shareCollection>) {
       const { collectionId } = action
       const collection = yield* select(getCollection, { id: collectionId })
-      if (!collection) return
+      if (!collection) {
+        console.error(`Missing collection ${action.collectionId}`)
+        return
+      }
 
       const user = yield* select(getUser, { id: collection.playlist_owner_id })
       if (!user) return

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -66,6 +66,10 @@ export function* repostTrackAsync(
 
   const tracks = yield* select(getTracks, { ids: [action.trackId] })
   const track = tracks[action.trackId]
+  if (!track) {
+    console.error(`Missing track ${action.trackId}`)
+    return
+  }
 
   const eagerlyUpdatedMetadata: Partial<Track> = {
     has_current_user_reposted: true,
@@ -210,6 +214,10 @@ export function* undoRepostTrackAsync(
 
   const tracks = yield* select(getTracks, { ids: [action.trackId] })
   const track = tracks[action.trackId]
+  if (!track) {
+    console.error(`Missing track ${action.trackId}`)
+    return
+  }
 
   const eagerlyUpdatedMetadata: Partial<Track> = {
     has_current_user_reposted: false,
@@ -308,6 +316,10 @@ export function* saveTrackAsync(
 
   const tracks = yield* select(getTracks, { ids: [action.trackId] })
   const track = tracks[action.trackId]
+  if (!track) {
+    console.error(`Missing track ${action.trackId}`)
+    return
+  }
 
   if (track.has_current_user_saved) return
 

--- a/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
+++ b/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
@@ -55,16 +55,18 @@ const AddToPlaylistModal = () => {
   const [searchValue, setSearchValue] = useState('')
 
   const filteredPlaylists = useMemo(() => {
-    return (account?.playlists ?? []).filter(
-      (playlist: Collection) =>
-        // Don't allow adding to this playlist if already on this playlist's page.
-        playlist.playlist_id !== currentCollectionId &&
+    const playlists = account?.playlists ?? []
+    return playlists.filter((playlist) => {
+      // Don't allow adding to this playlist if already on this playlist's page.
+      return (
+        playlist?.playlist_id !== currentCollectionId &&
         (searchValue
-          ? playlist.playlist_name
-              .toLowerCase()
+          ? playlist?.playlist_name
+              ?.toLowerCase()
               .includes(searchValue.toLowerCase())
           : true)
-    )
+      )
+    })
   }, [searchValue, account, currentCollectionId])
 
   const handlePlaylistClick = (playlist: Collection) => {
@@ -135,7 +137,7 @@ const AddToPlaylistModal = () => {
             {filteredPlaylists.map((playlist) => (
               <div key={`${playlist.playlist_id}`}>
                 <PlaylistItem
-                  playlist={playlist}
+                  playlist={playlist as Collection}
                   handleClick={handlePlaylistClick}
                 />
               </div>

--- a/packages/web/src/components/notification/Notification/FavoriteNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FavoriteNotification.tsx
@@ -2,7 +2,8 @@ import { MouseEventHandler, useCallback } from 'react'
 
 import {
   notificationsSelectors,
-  FavoriteNotification as FavoriteNotificationType
+  FavoriteNotification as FavoriteNotificationType,
+  removeNullable
 } from '@audius/common'
 import { push } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
@@ -80,7 +81,7 @@ export const FavoriteNotification = (props: FavoriteNotificationProps) => {
     <NotificationTile notification={notification} onClick={handleClick}>
       <NotificationHeader icon={<IconFavorite />}>
         <UserProfilePictureList
-          users={users}
+          users={users.filter(removeNullable)}
           totalUserCount={userIds.length}
           stopPropagation
         />

--- a/packages/web/src/components/notification/Notification/FollowNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FollowNotification.tsx
@@ -2,7 +2,8 @@ import { useCallback } from 'react'
 
 import {
   notificationsSelectors,
-  FollowNotification as FollowNotificationType
+  FollowNotification as FollowNotificationType,
+  removeNullable
 } from '@audius/common'
 import { push } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
@@ -77,7 +78,7 @@ export const FollowNotification = (props: FollowNotificationProps) => {
     <NotificationTile notification={notification} onClick={handleClick}>
       <NotificationHeader icon={<IconFollow />}>
         <UserProfilePictureList
-          users={users}
+          users={users.filter(removeNullable)}
           totalUserCount={userIds.length}
           stopPropagation
         />

--- a/packages/web/src/components/notification/Notification/RepostNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RepostNotification.tsx
@@ -2,6 +2,7 @@ import { MouseEventHandler, useCallback } from 'react'
 
 import {
   notificationsSelectors,
+  removeNullable,
   RepostNotification as RepostNotificationType
 } from '@audius/common'
 import { push } from 'connected-react-router'
@@ -85,7 +86,7 @@ export const RepostNotification = (props: RepostNotificationProps) => {
     >
       <NotificationHeader icon={<IconRepost />}>
         <UserProfilePictureList
-          users={users}
+          users={users.filter(removeNullable)}
           totalUserCount={userIds.length}
           stopPropagation
         />

--- a/packages/web/src/pages/explore-page/ExploreCollectionsPageProvider.tsx
+++ b/packages/web/src/pages/explore-page/ExploreCollectionsPageProvider.tsx
@@ -8,7 +8,8 @@ import {
   explorePageCollectionsActions,
   RepostType,
   repostsUserListActions,
-  favoritesUserListActions
+  favoritesUserListActions,
+  removeNullable
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -145,7 +146,7 @@ const ExploreCollectionsPageProvider = ({
   const childProps = {
     title,
     description,
-    collections,
+    collections: collections.filter(removeNullable),
     status,
     onClickReposts,
     onClickFavorites,

--- a/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
+++ b/packages/web/src/pages/explore-page/ExplorePageProvider.tsx
@@ -4,7 +4,8 @@ import {
   formatCount,
   accountSelectors,
   explorePageActions,
-  explorePageSelectors
+  explorePageSelectors,
+  removeNullable
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -66,7 +67,7 @@ const ExplorePage = ({
     // Props from AppState
     account,
     playlists: explore.playlists,
-    profiles: explore.profiles,
+    profiles: explore.profiles.filter(removeNullable),
     status: explore.status,
     formatPlaylistCardSecondaryText,
     formatProfileCardSecondaryText,

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -176,6 +176,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       !activeTab &&
       profile &&
       profile.profile &&
+      profile.profile.track_count !== undefined &&
       artistTracks!.status === Status.SUCCESS
     ) {
       if (profile.profile.track_count > 0) {
@@ -191,6 +192,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       !activeTab &&
       profile &&
       profile.profile &&
+      profile.profile.track_count !== undefined &&
       !(profile.profile.track_count > 0)
     ) {
       this.setState({
@@ -203,7 +205,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       const params = parseUserRoute(pathname)
       if (params) {
         const { handle } = params
-        if (handle === null) {
+        if (handle === null && profile.profile.handle) {
           const newPath = profilePage(profile.profile.handle)
           this.props.replaceRoute(newPath)
         }
@@ -222,7 +224,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     const {
       profile: { profile }
     } = this.props
-    if (!profile) return
+    if (!profile || !profile.user_id) return
     this.props.onFollow(profile.user_id)
     if (this.props.account) {
       this.props.updateCurrentUserFollows(true)
@@ -236,10 +238,9 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     const {
       profile: { profile }
     } = this.props
-    if (!profile) return
-    const userId = profile.user_id
-    this.props.onUnfollow(userId)
-    this.props.setNotificationSubscription(userId, false)
+    if (!profile || !profile.user_id) return
+    this.props.onUnfollow(profile.user_id)
+    this.props.setNotificationSubscription(profile.user_id, false)
 
     if (this.props.account) {
       this.props.updateCurrentUserFollows(false)
@@ -481,7 +482,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     const {
       profile: { profile }
     } = this.props
-    if (!profile) return
+    if (!profile || !profile.user_id) return
     this.props.onShare(profile.user_id)
   }
 
@@ -507,10 +508,10 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     let followingCount = 0
 
     if (profile) {
-      trackCount = profile.track_count
-      playlistCount = profile.playlist_count
-      followerCount = profile.follower_count
-      followingCount = profile.followee_count
+      trackCount = profile.track_count || 0
+      playlistCount = profile.playlist_count || 0
+      followerCount = profile.follower_count || 0
+      followingCount = profile.followee_count || 0
     }
 
     return isArtist
@@ -549,7 +550,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       profile: { profile },
       trackUpdateSort
     } = this.props
-    if (!profile) return
+    if (!profile || !profile.user_id) return
     this.setState({ tracksLineupOrder: TracksSortMode.RECENT })
     updateCollectionOrder(CollectionSortMode.TIMESTAMP)
     trackUpdateSort('recent')
@@ -568,7 +569,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       profile: { profile },
       trackUpdateSort
     } = this.props
-    if (!profile) return
+    if (!profile || !profile.user_id) return
     this.setState({ tracksLineupOrder: TracksSortMode.POPULAR })
     this.props.loadMoreArtistTracks(
       0,
@@ -584,7 +585,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     const {
       profile: { profile }
     } = this.props
-    if (!profile) return
+    if (!profile || !profile.user_id) return
     this.props.loadMoreArtistTracks(
       offset,
       limit,
@@ -600,7 +601,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     } = this.props
     if (profile) {
       let tab = `/${currLabel.toLowerCase()}`
-      if (profile.track_count > 0) {
+      if (profile.track_count !== undefined && profile.track_count > 0) {
         // An artist, default route is tracks
         if (currLabel === ProfilePageTabs.TRACKS) {
           tab = ''
@@ -625,7 +626,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
     const {
       profile: { profile }
     } = this.props
-    if (!profile) return
+    if (!profile || !profile.user_id) return
     this.props.loadMoreUserFeed(offset, limit, profile.user_id)
   }
 
@@ -672,7 +673,9 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
 
   getIsArtist = () => {
     const { profile } = this.props.profile
-    return !!profile && profile.track_count > 0
+    return (
+      !!profile && profile.track_count !== undefined && profile.track_count > 0
+    )
   }
 
   getIsOwner = () => {


### PR DESCRIPTION
### Description

These types are hard, but this fixes them partially.
Getting cache entries in bulk were lying that they were Record<string, User|Track|Collection>, but it's really a partial since for whatever reason the value may not actually end up in the cache.

This deserves a bit better of a cleanup, but hopefully this can prevent some errors like missing user_ids on undefined in downstream components, etc.

I think we may consider filtering undefined's out when coming back from the cache too, but that also probably leads to some undefined behaviors and I felt that doing them in the downstream selectors / components was safer.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Ran all type checks & ran app locally web & mobile

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

