### PR TITLE
Add toggle for message notifs on web + mobile

### DIFF
--- a/packages/common/src/store/pages/settings/reducer.ts
+++ b/packages/common/src/store/pages/settings/reducer.ts
@@ -28,7 +28,8 @@ export const initialState = {
     [BrowserNotificationSetting.Followers]: true,
     [BrowserNotificationSetting.Reposts]: true,
     [BrowserNotificationSetting.Favorites]: true,
-    [BrowserNotificationSetting.Remixes]: true
+    [BrowserNotificationSetting.Remixes]: true,
+    [BrowserNotificationSetting.Messages]: true
   },
   pushNotifications: {
     [PushNotificationSetting.MobilePush]: true,
@@ -36,7 +37,8 @@ export const initialState = {
     [PushNotificationSetting.Followers]: true,
     [PushNotificationSetting.Reposts]: true,
     [PushNotificationSetting.Remixes]: true,
-    [PushNotificationSetting.Favorites]: true
+    [PushNotificationSetting.Favorites]: true,
+    [PushNotificationSetting.Messages]: true
   },
   [emailFrequency]: EmailFrequency.Daily
 }
@@ -53,7 +55,8 @@ const actionsMap: ActionsMap<SettingsPageState> = {
         [BrowserNotificationSetting.Followers]: action.settings.followers,
         [BrowserNotificationSetting.Reposts]: action.settings.reposts,
         [BrowserNotificationSetting.Favorites]: action.settings.favorites,
-        [BrowserNotificationSetting.Remixes]: action.settings.remixes
+        [BrowserNotificationSetting.Remixes]: action.settings.remixes,
+        [BrowserNotificationSetting.Messages]: action.settings.messages
       }
     }
   },
@@ -69,7 +72,8 @@ const actionsMap: ActionsMap<SettingsPageState> = {
         [PushNotificationSetting.Followers]: action.settings.followers,
         [PushNotificationSetting.Reposts]: action.settings.reposts,
         [PushNotificationSetting.Remixes]: action.settings.remixes,
-        [PushNotificationSetting.Favorites]: action.settings.favorites
+        [PushNotificationSetting.Favorites]: action.settings.favorites,
+        [PushNotificationSetting.Messages]: action.settings.messages
       }
     }
   },

--- a/packages/common/src/store/pages/settings/types.ts
+++ b/packages/common/src/store/pages/settings/types.ts
@@ -7,7 +7,8 @@ export enum BrowserNotificationSetting {
   Reposts = 'reposts',
   Favorites = 'favorites',
   Permission = 'permission',
-  Remixes = 'remixes'
+  Remixes = 'remixes',
+  Messages = 'messages'
 }
 
 export enum PushNotificationSetting {
@@ -16,7 +17,8 @@ export enum PushNotificationSetting {
   Followers = 'followers',
   Reposts = 'reposts',
   Favorites = 'favorites',
-  Remixes = 'remixes'
+  Remixes = 'remixes',
+  Messages = 'messages'
 }
 
 export enum EmailFrequency {
@@ -36,6 +38,7 @@ export type Notifications = {
   [BrowserNotificationSetting.Reposts]: boolean
   [BrowserNotificationSetting.Favorites]: boolean
   [BrowserNotificationSetting.Remixes]: boolean
+  [BrowserNotificationSetting.Messages]: boolean
 }
 
 export type PushNotifications = {
@@ -45,6 +48,7 @@ export type PushNotifications = {
   [PushNotificationSetting.Reposts]: boolean
   [PushNotificationSetting.Favorites]: boolean
   [PushNotificationSetting.Remixes]: boolean
+  [PushNotificationSetting.Messages]: boolean
 }
 
 export enum Cast {

--- a/packages/mobile/src/screens/settings-screen/NotificationSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/NotificationSettingsScreen.tsx
@@ -1,4 +1,8 @@
-import { FeatureFlags, PushNotificationSetting, settingsPageActions } from '@audius/common'
+import {
+  FeatureFlags,
+  PushNotificationSetting,
+  settingsPageActions
+} from '@audius/common'
 import { useDispatch } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
@@ -66,7 +70,6 @@ export const NotificationSettingsScreen = () => {
             label={messages.messages}
             type={PushNotificationSetting.Messages}
           />
-
         ) : null}
         <Divider />
         <EmailFrequencyControlRow />

--- a/packages/mobile/src/screens/settings-screen/NotificationSettingsScreen.tsx
+++ b/packages/mobile/src/screens/settings-screen/NotificationSettingsScreen.tsx
@@ -1,9 +1,10 @@
-import { PushNotificationSetting, settingsPageActions } from '@audius/common'
+import { FeatureFlags, PushNotificationSetting, settingsPageActions } from '@audius/common'
 import { useDispatch } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
 import { Screen, ScreenContent } from 'app/components/core'
 import { remindUserToTurnOnNotifications } from 'app/components/notification-reminder/NotificationReminder'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 
 import { Divider } from './Divider'
 import { EmailFrequencyControlRow } from './EmailFrequencyControlRow'
@@ -19,11 +20,13 @@ const messages = {
   followers: 'New Followers',
   reposts: 'Reposts',
   favorites: 'Favorites',
-  remixes: 'Remixes of My Tracks'
+  remixes: 'Remixes of My Tracks',
+  messages: 'Messages'
 }
 
 export const NotificationSettingsScreen = () => {
   const dispatch = useDispatch()
+  const { isEnabled: isChatEnabled } = useFeatureFlag(FeatureFlags.CHAT_ENABLED)
 
   useEffectOnce(() => {
     dispatch(getPushNotificationSettings())
@@ -58,6 +61,13 @@ export const NotificationSettingsScreen = () => {
           label={messages.remixes}
           type={PushNotificationSetting.Remixes}
         />
+        {isChatEnabled ? (
+          <NotificationRow
+            label={messages.messages}
+            type={PushNotificationSetting.Messages}
+          />
+
+        ) : null}
         <Divider />
         <EmailFrequencyControlRow />
       </ScreenContent>

--- a/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
@@ -76,7 +76,6 @@ const NotificationSettings = (props: NotificationSettingsProps) => {
   const { isEnabled: isChatEnabled } = useFlag(FeatureFlags.CHAT_ENABLED)
   const browserPushEnabled =
     props.settings[BrowserNotificationSetting.BrowserPush]
-
   const notificationToggles = [
     {
       text: messages.milestonesAndAchievements,

--- a/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 
 import {
+  FeatureFlags,
   Notifications,
   BrowserNotificationSetting,
   EmailFrequency
@@ -13,6 +14,7 @@ import TabSlider from 'components/data-entry/TabSlider'
 import Switch from 'components/switch/Switch'
 import { Permission } from 'utils/browserNotifications'
 import { isElectron } from 'utils/clientUtil'
+import { useFlag } from 'hooks/useRemoteConfig'
 
 import styles from './NotificationSettings.module.css'
 
@@ -24,6 +26,7 @@ const messages = {
   reposts: 'Reposts',
   favorites: 'Favorites',
   remixes: 'Remixes of My Tracks',
+  messages: 'Messages',
   emailFrequency: '‘What You Missed’ Email Frequency',
   enablePermissions:
     'Notifications for Audius are blocked. Please enable in your browser settings and reload the page.'
@@ -70,8 +73,10 @@ type NotificationSettingsProps = {
 }
 
 const NotificationSettings = (props: NotificationSettingsProps) => {
+  const { isEnabled: isChatEnabled } = useFlag(FeatureFlags.CHAT_ENABLED)
   const browserPushEnabled =
     props.settings[BrowserNotificationSetting.BrowserPush]
+
   const notificationToggles = [
     {
       text: messages.milestonesAndAchievements,
@@ -109,6 +114,17 @@ const NotificationSettings = (props: NotificationSettingsProps) => {
       type: BrowserNotificationSetting.Remixes
     }
   ]
+  if (isChatEnabled) {
+    notificationToggles.push(
+      {
+        text: messages.messages,
+        isOn:
+          browserPushEnabled &&
+          props.settings[BrowserNotificationSetting.Messages],
+        type: BrowserNotificationSetting.Messages
+      }
+    )
+  }
 
   const emailOptions = [
     { key: EmailFrequency.Live, text: 'Live' },

--- a/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
+++ b/packages/web/src/pages/settings-page/components/desktop/NotificationSettings.tsx
@@ -12,9 +12,9 @@ import cn from 'classnames'
 import { ReactComponent as IconRemove } from 'assets/img/iconRemove.svg'
 import TabSlider from 'components/data-entry/TabSlider'
 import Switch from 'components/switch/Switch'
+import { useFlag } from 'hooks/useRemoteConfig'
 import { Permission } from 'utils/browserNotifications'
 import { isElectron } from 'utils/clientUtil'
-import { useFlag } from 'hooks/useRemoteConfig'
 
 import styles from './NotificationSettings.module.css'
 
@@ -114,15 +114,13 @@ const NotificationSettings = (props: NotificationSettingsProps) => {
     }
   ]
   if (isChatEnabled) {
-    notificationToggles.push(
-      {
-        text: messages.messages,
-        isOn:
-          browserPushEnabled &&
-          props.settings[BrowserNotificationSetting.Messages],
-        type: BrowserNotificationSetting.Messages
-      }
-    )
+    notificationToggles.push({
+      text: messages.messages,
+      isOn:
+        browserPushEnabled &&
+        props.settings[BrowserNotificationSetting.Messages],
+      type: BrowserNotificationSetting.Messages
+    })
   }
 
   const emailOptions = [

--- a/packages/web/src/pages/settings-page/store/sagas.ts
+++ b/packages/web/src/pages/settings-page/store/sagas.ts
@@ -147,7 +147,8 @@ function* watchSetBrowserNotificationSettingsOn() {
           [BrowserNotificationSetting.Followers]: true,
           [BrowserNotificationSetting.Reposts]: true,
           [BrowserNotificationSetting.Favorites]: true,
-          [BrowserNotificationSetting.Remixes]: true
+          [BrowserNotificationSetting.Remixes]: true,
+          [BrowserNotificationSetting.Messages]: true
         }
         yield* put(actions.setNotificationSettings(updatedSettings))
         yield* call(


### PR DESCRIPTION
### Description
Behind existing `CHAT_ENABLED` feature flag

### Dragons

### How Has This Been Tested?
Manually verified flag showed/hid message toggle, verified could toggle on and off and persist with corresponding backend changes, verified bulk toggle on/off worked.
<img width="491" alt="image" src="https://user-images.githubusercontent.com/25782182/215025935-a300eabc-40fa-4086-aeb1-db587df465b8.png">
<img width="560" alt="image" src="https://user-images.githubusercontent.com/25782182/215025968-29386ae4-b221-45a9-8854-53d0b33b93e8.png">


### How will this change be monitored?

### Feature Flags ###

