### PR TITLE
Port Input component to Typescript

### DIFF
--- a/packages/web/src/components/data-entry/InputV2.module.css
+++ b/packages/web/src/components/data-entry/InputV2.module.css
@@ -1,0 +1,128 @@
+.root {
+  display: flex;
+  align-items: center;
+  gap: var(--unit-2);
+  width: 100%;
+  padding-right: var(--unit-4);
+  border: 1px solid var(--neutral-light-8);
+  border-radius: var(--unit-1);
+  background-color: var(--neutral-light-10);
+  transition: border ease-in-out 0.1s;
+}
+
+.small {
+  --gap: -4px;
+  --font-size: var(--font-s);
+  height: 34px;
+}
+
+.medium {
+  --gap: 0px;
+  --font-size: var(--font-m);
+  height: 50px;
+}
+
+.large {
+  --gap: var(--unit-1);
+  --font-size: var(--font-xl);
+  height: 66px;
+}
+
+.root:hover {
+  border-color: var(--neutral-light-6);
+}
+
+.root:has(input:focus) {
+  border-color: var(--secondary);
+}
+
+.root.warning,
+.root.warning:has(input:focus) {
+  border-color: var(--accent-orange);
+}
+
+.root.error,
+.root.error:has(input:focus) {
+  border-color: var(--accent-red);
+}
+
+.root.error:hover,
+.root.error:hover:has(input:focus) {
+  border-color: var(--accent-red-dark-1);
+}
+
+.root:has(input:disabled) {
+  background-color: var(--neutral-light-9);
+  border-color: var(--neutral-light-8);
+}
+
+.root input {
+  width: 100%;
+  height: 100%;
+  padding-left: var(--unit-4);
+  outline: 0;
+  border: 0;
+  background: none;
+  font-size: var(--font-size);
+}
+
+.root input::placeholder,
+.placeholder {
+  color: var(--neutral-light-4);
+  font-weight: var(--font-medium);
+}
+
+/** 
+ * Flex container so that the absolutely positioned elevated placeholder
+ * starts out centered vertically
+ **/
+.elevatedPlaceholderLabel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  font-size: var(--font-size);
+}
+
+/** Add the "*" to required fields, but have it disappear when elevated **/
+.elevatedPlaceholderLabel:has(input:required:not(:focus))
+  .placeholder:not(.hasValue)::after {
+  content: ' *';
+}
+
+/** Push the input down a bit to make room for the elevated placeholder **/
+.elevatedPlaceholderLabel input {
+  padding-top: calc(var(--font-xs));
+}
+
+/** Position the elevated placeholder absoutely on top of the input **/
+.placeholder {
+  position: absolute;
+  z-index: 2;
+  transition: all 0.3s ease;
+  left: var(--unit-4);
+}
+
+/** Move the elevated placeholder to the top left if focused or has text **/
+.elevatedPlaceholderLabel:has(input:focus) .placeholder,
+.placeholder.hasValue {
+  transform: translate(0px, calc(-1em - var(--gap)));
+  font-size: var(--font-xs);
+}
+
+/** Make a container for the character count... **/
+.characterCount {
+  position: relative;
+  padding-top: var(--unit-2);
+  align-self: flex-start;
+  color: var(--neutral-light-4);
+  font-size: var(--font-xs);
+  font-weight: var(--font-bold);
+}
+
+/** ... then position the actual count absolutely relative to that **/
+.characterCount span {
+  position: absolute;
+  right: 0;
+}

--- a/packages/web/src/components/data-entry/InputV2.tsx
+++ b/packages/web/src/components/data-entry/InputV2.tsx
@@ -1,0 +1,99 @@
+import { ComponentPropsWithoutRef, MutableRefObject } from 'react'
+
+import cn from 'classnames'
+
+import styles from './InputV2.module.css'
+
+export enum InputV2Size {
+  SMALL,
+  MEDIUM,
+  LARGE
+}
+
+export enum InputV2Variant {
+  NORMAL,
+  ELEVATED_PLACEHOLDER
+}
+
+type InputV2Props = Omit<ComponentPropsWithoutRef<'input'>, 'size'> & {
+  size?: InputV2Size
+  variant?: InputV2Variant
+  showMaxLength?: boolean
+  inputRef?: MutableRefObject<HTMLInputElement>
+  warning?: boolean
+  error?: boolean
+  inputClassName?: string
+}
+
+export const InputV2 = (props: InputV2Props) => {
+  const {
+    required,
+    placeholder: placeholderProp,
+    className,
+    maxLength,
+    showMaxLength,
+    size = InputV2Size.MEDIUM,
+    variant = InputV2Variant.NORMAL,
+    inputRef,
+    value,
+    children,
+    warning: warningProp,
+    error,
+    inputClassName,
+    ...other
+  } = props
+
+  const characterCount = value ? `${value}`.length : 0
+  const nearCharacterLimit = maxLength && characterCount >= 0.9 * maxLength
+  const elevatePlaceholder = variant === InputV2Variant.ELEVATED_PLACEHOLDER
+  const placeholder =
+    required && !elevatePlaceholder ? `${placeholderProp} *` : placeholderProp
+
+  const style = {
+    [styles.large]: size === InputV2Size.LARGE,
+    [styles.medium]: size === InputV2Size.MEDIUM,
+    [styles.small]: size === InputV2Size.SMALL,
+    [styles.warning]: warningProp || nearCharacterLimit,
+    [styles.error]: error
+  }
+
+  const input = (
+    <input
+      ref={inputRef}
+      placeholder={!elevatePlaceholder ? placeholder : undefined}
+      required={required}
+      className={inputClassName}
+      value={value}
+      maxLength={maxLength}
+      {...other}
+    />
+  )
+
+  return (
+    <div className={cn(styles.root, style, className)}>
+      {elevatePlaceholder ? (
+        <label className={styles.elevatedPlaceholderLabel}>
+          <span
+            className={cn(styles.placeholder, {
+              [styles.hasValue]: characterCount > 0
+            })}
+          >
+            {placeholder}
+          </span>
+          {input}
+        </label>
+      ) : (
+        input
+      )}
+
+      {showMaxLength && (
+        <div className={styles.characterCount}>
+          <span>
+            {characterCount}/{maxLength}
+          </span>
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
### Description

Changes/differences from existing Input component:
- Typescript!
- Allows for including an icon, button, or anything really as a child inside the boundary of the input
- Uses CSS selectors rather than JS state for managing focus state etc
- Doesn't include the "shaded" variant since I didn't see any usages
- Less absolute positioning magic for elevated placeholders
- No need to manually limit length
- Uses and forwards existing props for an `input` element (but overrides `size`)
- Elevated placeholders look slightly different spacing-wise (will want a design review if in use anywhere, but thought this was sufficient for now...)
- Uses enums instead of strings for variants and sizes (makes it easier to track usages of each variant/size)

Various usages:
![image](https://user-images.githubusercontent.com/3690498/215037463-77b74944-5bc1-4ad6-b4e9-44ffe3c270bf.png)

![image](https://user-images.githubusercontent.com/3690498/215037402-7c31d4a6-6c44-45e2-8716-b9630fa96c4a.png)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

TODO: Add to stems?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

