### PR TITLE
Update TextAreaV2 to respect initial height when non-growing

### DIFF
--- a/packages/web/src/components/data-entry/TextAreaV2.module.css
+++ b/packages/web/src/components/data-entry/TextAreaV2.module.css
@@ -50,8 +50,8 @@
 
 .characterCount {
   color: var(--neutral-light-4);
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--font-xs);
+  font-weight: var(--font-medium);
 }
 .characterCount.nearLimit {
   color: var(--accent-orange);

--- a/packages/web/src/components/data-entry/TextAreaV2.tsx
+++ b/packages/web/src/components/data-entry/TextAreaV2.tsx
@@ -19,6 +19,11 @@ const sizeToVerticalPadding: Record<TextAreaSize, number> = {
   [TextAreaSize.SMALL]: 12
 }
 
+const getMaxHeight = (maxVisibleRows: number | undefined, size: TextAreaSize) =>
+  maxVisibleRows !== undefined
+    ? maxVisibleRows * sizeToLineHeight[size] + sizeToVerticalPadding[size]
+    : undefined
+
 type TextAreaV2Props = ComponentPropsWithoutRef<'textarea'> & {
   grows?: boolean
   resize?: boolean
@@ -47,21 +52,14 @@ export const TextAreaV2 = (props: TextAreaV2Props) => {
 
   const ref = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const characterCount = value ? `${value}`.length : 0
+  const nearCharacterLimit =
+    maxLength &&
+    characterCount > CHARACTER_LIMIT_WARN_THRESHOLD_PERCENT * maxLength
 
-  const growTextArea = useCallback(() => {
-    if (textareaRef.current) {
-      const textarea = textareaRef.current
-      textarea.style.height = '1px'
-      textarea.style.height = `${textarea.scrollHeight + (heightBuffer ?? 0)}px`
-      ref.current?.scrollTo({ top: ref.current?.scrollHeight })
-    }
-  }, [textareaRef, heightBuffer])
-
-  useEffect(() => {
-    if (grows) {
-      growTextArea()
-    }
-  }, [grows, growTextArea, value])
+  const maxHeight = grows
+    ? getMaxHeight(maxVisibleRows, size)
+    : ref.current?.offsetHeight // clamp to initial height if non-growing
 
   const style = {
     [styles.noResize]: !resize,
@@ -69,15 +67,20 @@ export const TextAreaV2 = (props: TextAreaV2Props) => {
     [styles.small]: size === TextAreaSize.SMALL
   }
 
-  const nearCharacterLimit = maxLength
-    ? `${value}`.length > CHARACTER_LIMIT_WARN_THRESHOLD_PERCENT * maxLength
-    : false
+  const growTextArea = useCallback(() => {
+    if (textareaRef.current) {
+      const textarea = textareaRef.current
+      textarea.style.height = 'inherit'
+      textarea.style.height = `${textarea.scrollHeight + (heightBuffer ?? 0)}px`
+      ref.current?.scrollTo({ top: ref.current?.scrollHeight })
+    }
+  }, [textareaRef, heightBuffer])
 
-  const maxHeight = maxVisibleRows
-    ? `${
-        maxVisibleRows * sizeToLineHeight[size] + sizeToVerticalPadding[size]
-      }px`
-    : undefined
+  useEffect(() => {
+    // Even though we always "grow" the text area,
+    // the maxHeight of the container will cause a scrollbar to appear if necesary
+    growTextArea()
+  }, [growTextArea, value])
 
   return (
     <div
@@ -100,7 +103,7 @@ export const TextAreaV2 = (props: TextAreaV2Props) => {
                 [styles.nearLimit]: nearCharacterLimit
               })}
             >
-              {`${value}`.length}/{maxLength}
+              {characterCount}/{maxLength}
             </div>
           ) : null}
         </div>

--- a/packages/web/src/components/data-entry/TextAreaV2.tsx
+++ b/packages/web/src/components/data-entry/TextAreaV2.tsx
@@ -19,7 +19,13 @@ const sizeToVerticalPadding: Record<TextAreaSize, number> = {
   [TextAreaSize.SMALL]: 12
 }
 
-const getMaxHeight = (maxVisibleRows: number | undefined, size: TextAreaSize) =>
+const getMaxHeight = ({
+  maxVisibleRows,
+  size
+}: {
+  maxVisibleRows?: number
+  size: TextAreaSize
+}) =>
   maxVisibleRows !== undefined
     ? maxVisibleRows * sizeToLineHeight[size] + sizeToVerticalPadding[size]
     : undefined
@@ -58,7 +64,7 @@ export const TextAreaV2 = (props: TextAreaV2Props) => {
     characterCount > CHARACTER_LIMIT_WARN_THRESHOLD_PERCENT * maxLength
 
   const maxHeight = grows
-    ? getMaxHeight(maxVisibleRows, size)
+    ? getMaxHeight({ maxVisibleRows, size })
     : ref.current?.offsetHeight // clamp to initial height if non-growing
 
   const style = {

--- a/packages/web/src/pages/chat-page/components/ChatComposer.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatComposer.tsx
@@ -67,12 +67,13 @@ export const ChatComposer = (props: ChatComposerProps) => {
     <div className={cn(styles.root, props.className)}>
       <form className={styles.form} onSubmit={handleSubmit}>
         <TextAreaV2
+          rows={1}
           className={styles.input}
           placeholder={messages.sendMessagePlaceholder}
           onKeyDown={handleKeyDown}
           onChange={handleChange}
           value={value}
-          maxVisibleRows={3}
+          maxVisibleRows={10}
           maxLength={10000}
           grows
           resize


### PR DESCRIPTION
### Description

- Updates `TextAreaV2` styles to use CSS variables
- Updates `TextAreaV2` to clamp to the initial rendered height when non-growing, and use the faux scrollbar even when non-growing
- Updates `ChatComposer` to specify the number of initial rows (eg the min height) and increases max visible rows to 10

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Only used in `ChatComposer` right now, so pretty safe.

Maybe belongs in Stems?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested by manually making a textarea with the different options and then deleting the examples.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

