### PR TITLE
Update PopupMenu to not have circular icons

### DIFF
--- a/packages/stems/src/components/PopupMenu/PopupMenu.module.css
+++ b/packages/stems/src/components/PopupMenu/PopupMenu.module.css
@@ -9,25 +9,17 @@
 }
 
 .item .icon {
-  height: var(--unit-6);
-  width: var(--unit-6);
+  height: var(--unit-5);
+  width: var(--unit-5);
   display: flex;
   align-items: center;
 
   justify-content: center;
-  border-radius: 100%;
-  background: var(--neutral-light-4);
   margin-right: var(--unit-2);
 }
 
-.item svg {
-  border-radius: 100%;
-  height: var(--unit-4);
-  width: var(--unit-4);
-}
-
 .item path {
-  fill: var(--white);
+  fill: var(--neutral);
 }
 
 .item:hover {
@@ -36,10 +28,6 @@
   background: var(--secondary);
 }
 
-.item:hover svg {
-  background: var(--primary-secondary-text);
-}
-
 .item:hover path {
-  fill: var(--secondary);
+  fill: var(--primary-secondary-text);
 }


### PR DESCRIPTION
### Description

Removes the background circle and increases size of icons in `PopupMenu` components per [Figma](https://www.figma.com/file/hcVGqf35jfxueO7klqXlma/Components-%5BSTEM%5D?node-id=244%3A749&t=LWmQFOJq1JSlZkt8-1)

Note: Doesn't implement design fully, just the icons bit. (Still need a menu header, I think)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Will need Design check-off, and will need to verify that this looks good on all themes, _and_ will double check other PopupMenus, but it looked good for the one use case I was using it for!

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

