### PR TITLE
Change react-native-job-queue updateInterval to 500 ms

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -116,10 +116,3 @@ export const cancelQueuedDownloads = async (
   })
   queue.start()
 }
-
-global.queue = queue
-
-setInterval(async () => {
-  const jobs = await queue.getJobs()
-  console.log(`JobQueue - job count`, jobs.length)
-}, 5000)

--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -45,7 +45,7 @@ export const startDownloadWorker = async () => {
   queue.stop()
   queue.configure({
     concurrency: 1,
-    updateInterval: 10
+    updateInterval: 500
   })
 
   // Reset worker to improve devEx. Forces the worker to take code updates across reloads
@@ -116,3 +116,10 @@ export const cancelQueuedDownloads = async (
   })
   queue.start()
 }
+
+global.queue = queue
+
+setInterval(async () => {
+  const jobs = await queue.getJobs()
+  console.log(`JobQueue - job count`, jobs.length)
+}, 5000)


### PR DESCRIPTION
### Description

The job queue checking for new jobs every 10ms adds overhead to the cpu usage anytime the queue is running (which is always when offline mode is enabled)

Bumping the interval to 500ms reduces this overhead considerably

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

