### PR TITLE
[DMs] Update DMs store, sagas and selectors to be optimistic

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -1,4 +1,6 @@
 import type { UserChat } from '@audius/sdk'
+import dayjs from 'dayjs'
+import { createSelector } from 'reselect'
 
 import { Status } from 'models/Status'
 import { accountSelectors } from 'store/account'
@@ -13,7 +15,8 @@ export const getChat = (state: CommonState, chatId?: string) =>
     ? state.pages.chat.chatList.data?.find((chat) => chat.chat_id === chatId)
     : undefined
 
-export const getChats = (state: CommonState) => state.pages.chat.chatList.data
+export const getChatsRaw = (state: CommonState) =>
+  state.pages.chat.chatList.data
 
 export const getChatsStatus = (state: CommonState) =>
   state.pages.chat.chatList.status
@@ -21,14 +24,70 @@ export const getChatsStatus = (state: CommonState) =>
 export const getChatsSummary = (state: CommonState) =>
   state.pages.chat.chatList.summary
 
+export const getOptimisticReads = (state: CommonState) =>
+  state.pages.chat.optimisticChatRead
+
+export const getAllChatMessages = (state: CommonState) =>
+  state.pages.chat.chatMessages
+
 export const getChatMessagesSummary = (state: CommonState, chatId: string) =>
   state.pages.chat.chatMessages[chatId]?.summary
 
-export const getChatMessages = (state: CommonState, chatId: string) =>
+export const getChatMessagesRaw = (state: CommonState, chatId: string) =>
   state.pages.chat.chatMessages[chatId]?.data
 
 export const getChatMessagesStatus = (state: CommonState, chatId: string) =>
   state.pages.chat.chatMessages[chatId]?.status ?? Status.IDLE
+
+export const getOptimisticReactions = (state: CommonState) =>
+  state.pages.chat.optimisticReactions
+
+export const getChats = createSelector(
+  [getChatsRaw, getAllChatMessages, getOptimisticReads],
+  (chats, allMessages, optimisticReads) => {
+    return chats?.map((chat) => {
+      const chatMessages = allMessages[chat.chat_id]?.data
+      if (
+        chatMessages &&
+        chatMessages.length > 0 &&
+        chatMessages[0] &&
+        dayjs(chatMessages[0].created_at).isAfter(chat.last_message_at)
+      ) {
+        return {
+          ...chat,
+          ...optimisticReads[chat.chat_id],
+          last_message_at: chatMessages[0].created_at,
+          last_message: chatMessages[0].message
+        }
+      }
+
+      return {
+        ...chat,
+        ...optimisticReads[chat.chat_id]
+      }
+    })
+  }
+)
+export const getChatMessages = createSelector(
+  [getChatMessagesRaw, getOptimisticReactions],
+  (messages, optimisticReactions) => {
+    return messages?.map((message) => {
+      const optimisticReaction = optimisticReactions[message.message_id]
+      if (optimisticReaction) {
+        return {
+          ...message,
+          reactions: [
+            optimisticReaction,
+            ...(message.reactions?.filter(
+              (reaction) => optimisticReaction.user_id !== reaction.user_id
+            ) ?? [])
+          ]
+        }
+      }
+      return message
+    })
+  }
+)
 
 export const getOtherChatUsersFromChat = (
   state: CommonState,

--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
@@ -55,16 +55,19 @@ export const ChatMessageListItem = (props: ChatMessageListItemProps) => {
   )
   const handleReactionSelected = useCallback(
     (reaction: ReactionTypes) => {
-      dispatch(
-        setMessageReaction({
-          chatId,
-          messageId: message.message_id,
-          reaction
-        })
-      )
+      if (userId) {
+        dispatch(
+          setMessageReaction({
+            userId,
+            chatId,
+            messageId: message.message_id,
+            reaction
+          })
+        )
+      }
       handleCloseReactionPopup()
     },
-    [dispatch, handleCloseReactionPopup, chatId, message]
+    [dispatch, handleCloseReactionPopup, userId, chatId, message]
   )
 
   return (


### PR DESCRIPTION
### Description

- Makes sending messages, reactions, and marking chats as read optimistic, giving the illusion of speed
- Undoes the optimistic changes if request fails
- Adds a saga that fetches chats if messages are being added from a chat we haven't fetched yet

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

