### PR TITLE
[C-1969 C-1967] Don't re-favorite playlist on download

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -130,9 +130,12 @@ export const downloadCollection = async (
   )
 
   if (!user) return
-  store.dispatch(
-    saveCollection(collection.playlist_id, FavoriteSource.OFFLINE_DOWNLOAD)
-  )
+
+  if (!collection.has_current_user_saved) {
+    store.dispatch(
+      saveCollection(collection.playlist_id, FavoriteSource.OFFLINE_DOWNLOAD)
+    )
+  }
   const populatedCollection: Collection = await populateCoverArtSizes({
     ...collection,
     user


### PR DESCRIPTION
### Description

Catches case where we'd re-favorite a playlist when downloading. This logic is needed for cases where we try to download a collection that we havent favorited.
