### PR TITLE
Remove use of iso3 country code

### DIFF
--- a/packages/common/src/services/location.ts
+++ b/packages/common/src/services/location.ts
@@ -12,7 +12,6 @@ export type Location = {
   country: string
   country_calling_code: string
   country_code: string
-  country_code_iso3: string
   country_name: string
   currency: string
   in_eu: boolean

--- a/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletManagementTile.tsx
@@ -289,7 +289,7 @@ const useOnRampProviderInfo = () => {
     [value, stripeAllowedCountries, stripeDeniedRegions]
   )
   // Assume USA is supported, so if in USA but still not supported, it's a state ban
-  const isState = value && value.country_code_iso3 === 'USA'
+  const isState = value && value.country_code === 'US'
 
   return {
     [OnRampProvider.STRIPE]: {


### PR DESCRIPTION
### Description
Remove use of `country_code_iso3`. Fixes bug where disabled stripe buy-audio popup was not showing the specific blocked region, just a generic `stripe is disabled in your region` message.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

