### PR TITLE
WIP: Use permalink in frontend routing to fetch playlists

### DIFF
--- a/packages/common/src/models/Collection.ts
+++ b/packages/common/src/models/Collection.ts
@@ -49,6 +49,7 @@ export type CollectionMetadata = {
   playlist_image_multihash?: string
   playlist_image_sizes_multihash?: string
   offline?: OfflineCollectionMetadata
+  permalink: string
 }
 
 // This is available on mobile for offline tracks

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1203,7 +1203,7 @@ export class AudiusAPIClient {
     }
     const splitPermalink = permalink.split('/')
     if (splitPermalink.length !== 4) {
-      throw Error(
+      console.error(
         'Permalink formatted incorrectly. Should follow /<handle>/playlist/<slug> format.'
       )
     }

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -363,8 +363,7 @@ export const makePlaylist = (
     track_count,
     total_play_count,
     playlist_contents: playlistContents,
-    permalink: 'response-adapter-permalink',
-
+    permalink: playlist.permalink,
     // Fields to prune
     id: undefined,
     user_id: undefined,

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -186,6 +186,7 @@ export type APIPlaylist = {
   is_private: boolean
   added_timestamps: APIPlaylistAddedTimestamp[]
   tracks: APITrack[]
+  permalink: string
   track_count: number
   cover_art: Nullable<string>
   cover_art_sizes: Nullable<string>

--- a/packages/common/src/store/account/types.ts
+++ b/packages/common/src/store/account/types.ts
@@ -5,6 +5,7 @@ export type AccountCollection = {
   name: string
   is_album: boolean
   user: { id: ID; handle: string }
+  permalink: string
 }
 
 type AccountPayload<Profile> = {

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -208,7 +208,6 @@ export function* fetchAccountAsync({ isSignUp = false }) {
     )
     return
   }
-
   // Set the userId in the remoteConfigInstance
   remoteConfigInstance.setUserId(account.user_id)
 

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -128,6 +128,7 @@ function* createPlaylistAsync(action) {
       id: playlist.playlist_id,
       name: playlist.playlist_name,
       isAlbum: playlist.is_album,
+      permalink: playlist.permalink,
       user: { id: userId, handle: user.handle }
     })
   )
@@ -228,6 +229,7 @@ function* confirmCreatePlaylist(uid, userId, formFields, source) {
             // may have edited the name before we got the confirmed result back.
             name: reformattedPlaylist.playlist_name,
             isAlbum: confirmedPlaylist.is_album,
+            permalink: confirmedPlaylist.permalink,
             user: {
               id: user.user_id,
               handle: user.handle
@@ -1080,6 +1082,7 @@ function* confirmDeleteAlbum(playlistId, trackIds, userId) {
               id: playlist.playlist_id,
               name: playlist.playlist_name,
               isAlbum: playlist.is_album,
+              permalink: playlist.permalink,
               user: { id: user.user_id, handle: user.handle }
             })
           )
@@ -1155,6 +1158,7 @@ function* confirmDeletePlaylist(userId, playlistId) {
               id: playlist.playlist_id,
               name: playlist.playlist_name,
               isAlbum: playlist.is_album,
+              permalink: playlist.permalink,
               user: { id: user.user_id, handle: user.handle }
             })
           )

--- a/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
+++ b/packages/web/src/common/store/cache/collections/utils/retrieveCollections.ts
@@ -256,7 +256,6 @@ export function* retrieveCollections(
     retrieveFromSource: function* (ids: ID[]) {
       const audiusBackendInstance = yield* getContext('audiusBackendInstance')
       let metadatas
-
       if (ids.length === 1) {
         metadatas = yield* call(retrieveCollection, { playlistId: ids[0] })
       } else {

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -41,7 +41,9 @@ function* watchFetchCollection() {
       yield put(collectionActions.fetchCollectionFailed())
       return
     }
-    const collection = collections[collectionId]
+    const collection = permalink
+      ? collections[permalink]
+      : collections[collectionId]
     const userUid = makeUid(Kind.USERS, collection.playlist_owner_id)
     const collectionUid = collectionUids[collectionId]
     if (collection) {

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -351,6 +351,7 @@ export function* saveCollectionAsync(
       id: collection.playlist_id,
       name: collection.playlist_name,
       is_album: collection.is_album,
+      permalink: collection.permalink,
       user: { id: user.user_id, handle: user.handle }
     })
   )
@@ -538,7 +539,8 @@ export function* watchShareCollection() {
         : playlistPage(
             user.handle,
             collection.playlist_name,
-            collection.playlist_id
+            collection.playlist_id,
+            collection.permalink
           )
 
       const share = yield* getContext('share')

--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -793,6 +793,7 @@ function* uploadCollection(tracks, userId, collectionMetadata, isAlbum) {
             id: confirmedPlaylist.playlist_id,
             name: confirmedPlaylist.playlist_name,
             is_album: confirmedPlaylist.is_album,
+            permalink: confirmedPlaylist.permalink,
             user: {
               id: user.user_id,
               handle: user.handle

--- a/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
+++ b/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
@@ -74,7 +74,12 @@ const AddToPlaylistModal = () => {
         <ToastLinkContent
           text={messages.addedToast}
           linkText={messages.view}
-          link={playlistPage(account.handle, trackTitle, playlist.playlist_id)}
+          link={playlistPage(
+            account.handle,
+            trackTitle,
+            playlist.playlist_id,
+            playlist.permalink
+          )}
         />
       )
     }

--- a/packages/web/src/components/card/desktop/CollectionArtCard.tsx
+++ b/packages/web/src/components/card/desktop/CollectionArtCard.tsx
@@ -84,6 +84,7 @@ const CollectionArtCard = g(
       has_current_user_reposted,
       has_current_user_saved,
       repost_count,
+      permalink,
       save_count
     } = collection
     const { user_id, name, handle } = user
@@ -94,7 +95,7 @@ const CollectionArtCard = g(
       if (isPerspectiveDisabled) return
       const link = is_album
         ? albumPage(handle, playlist_name, playlist_id)
-        : playlistPage(handle, playlist_name, playlist_id)
+        : playlistPage(handle, playlist_name, playlist_id, permalink)
       goToRoute(link)
     }, [
       is_album,
@@ -102,6 +103,7 @@ const CollectionArtCard = g(
       playlist_name,
       playlist_id,
       goToRoute,
+      permalink,
       isPerspectiveDisabled
     ])
 

--- a/packages/web/src/components/collection/desktop/CollectionHeader.js
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.js
@@ -453,6 +453,7 @@ const Artwork = ({
     coverArtSizes,
     SquareSizes.SIZE_1000_BY_1000
   )
+
   useEffect(() => {
     // If there's a gradient, this is a smart collection. Just immediately call back
     if (image || gradient || imageOverride) callback()
@@ -562,7 +563,6 @@ class CollectionHeader extends PureComponent {
       [styles.show]: !isLoading,
       [styles.hide]: isLoading
     }
-
     return (
       <div className={styles.collectionHeader}>
         <div className={styles.topSection}>

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -75,7 +75,8 @@ const EditPlaylistModal = ({
     playlist_id: playlistId,
     is_album: isAlbum,
     playlist_name: title,
-    user
+    user,
+    permalink
   } = collection || {}
   const { handle } = user || {}
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
@@ -86,7 +87,7 @@ const EditPlaylistModal = ({
     onClose()
     deletePlaylist(playlistId!)
     if (handle && title) {
-      const playlistRoute = playlistPage(handle, title, playlistId!)
+      const playlistRoute = playlistPage(handle, title, playlistId!, permalink)
       // If on the playlist page, direct user to feed
       if (getPathname(location) === playlistRoute) goToRoute(FEED_PAGE)
     }

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -289,8 +289,8 @@ const PlaylistLibrary = ({
   const renderPlaylist = (playlistId: ID, level = 0) => {
     const playlist = playlists[playlistId]
     if (!account || !playlist) return null
-    const { id, name } = playlist
-    const url = playlistPage(playlist.user.handle, name, id)
+    const { id, name, permalink } = playlist
+    const url = playlistPage(playlist.user.handle, name, id, permalink)
     const addTrack = (trackId: ID) => dispatch(addTrackToPlaylist(trackId, id))
     const isOwner = playlist.user.handle === account.handle
     const hasUpdate = updatesSet.has(id)

--- a/packages/web/src/components/search-bar/ConnectedSearchBar.js
+++ b/packages/web/src/components/search-bar/ConnectedSearchBar.js
@@ -102,7 +102,12 @@ class ConnectedSearchBar extends Component {
         (p) =>
           value ===
           (p.user
-            ? playlistPage(p.user.handle, p.playlist_name, p.playlist_id)
+            ? playlistPage(
+                p.user.handle,
+                p.playlist_name,
+                p.playlist_id,
+                p.permalink
+              )
             : '')
       )
       if (selectedPlaylist)
@@ -181,7 +186,8 @@ class ConnectedSearchBar extends Component {
                 ? playlistPage(
                     playlist.user.handle,
                     playlist.playlist_name,
-                    playlist.playlist_id
+                    playlist.playlist_id,
+                    playlist.permalink
                   )
                 : '',
               id: playlist.playlist_id,

--- a/packages/web/src/components/share-modal/utils.ts
+++ b/packages/web/src/components/share-modal/utils.ts
@@ -51,11 +51,11 @@ export const getTwitterShareText = (
     }
     case 'playlist': {
       const {
-        playlist: { playlist_name, playlist_id },
+        playlist: { playlist_name, playlist_id, permalink },
         creator: { handle }
       } = content
       twitterText = messages.playlistShareText(playlist_name, handle)
-      link = fullPlaylistPage(handle, playlist_name, playlist_id)
+      link = fullPlaylistPage(handle, playlist_name, playlist_id, permalink)
       analyticsEvent = { kind: 'playlist', id: playlist_id, url: link }
       break
     }

--- a/packages/web/src/components/track-overflow-modal/ConnectedMobileOverflowModal.tsx
+++ b/packages/web/src/components/track-overflow-modal/ConnectedMobileOverflowModal.tsx
@@ -83,7 +83,8 @@ const ConnectedMobileOverflowModal = ({
   handle,
   artistName,
   title,
-  permalink,
+  permalink, // trackPermalink
+  playlistPermalink,
   isAlbum,
   shareCollection,
   repostTrack,
@@ -175,12 +176,11 @@ const ConnectedMobileOverflowModal = ({
           onUnfavorite: () => unsaveCollection(id as ID),
           onShare: () => shareCollection(id as ID),
           onVisitArtistPage: () => visitArtistPage(handle),
-          onVisitCollectionPage: () =>
-            (isAlbum ? visitAlbumPage : visitPlaylistPage)(
-              id as ID,
-              handle,
-              title
-            ),
+          onVisitCollectionPage: () => {
+            return isAlbum
+              ? visitAlbumPage(id as ID, handle, title)
+              : visitPlaylistPage(id as ID, handle, title, playlistPermalink)
+          },
           onVisitCollectiblePage: () =>
             visitCollectiblePage(handle, id as string),
           onEditPlaylist: isAlbum ? () => {} : () => editPlaylist(id as ID),
@@ -253,6 +253,7 @@ const getAdditionalInfo = ({
   artistName?: string
   title?: string
   permalink?: string
+  playlistPermalink?: string
   isAlbum?: boolean
   notification?: Notification
   ownerId?: ID
@@ -297,7 +298,8 @@ const getAdditionalInfo = ({
         handle: user.handle,
         artistName: user.name,
         title: col.playlist_name,
-        isAlbum: col.is_album
+        isAlbum: col.is_album,
+        playlistPermalink: col.permalink
       }
     }
     case OverflowSource.PROFILE: {
@@ -383,8 +385,12 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
     visitPlaylistPage: (
       playlistId: ID,
       handle: string,
-      playlistTitle: string
-    ) => dispatch(pushRoute(playlistPage(handle, playlistTitle, playlistId))),
+      playlistTitle: string,
+      permalink: string
+    ) =>
+      dispatch(
+        pushRoute(playlistPage(handle, playlistTitle, playlistId, permalink))
+      ),
     visitAlbumPage: (albumId: ID, handle: string, albumTitle: string) =>
       dispatch(pushRoute(albumPage(handle, albumTitle, albumId)))
   }

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -148,7 +148,8 @@ const ConnectedPlaylistTile = memo(
       followee_saves: followeeSaves,
       has_current_user_reposted: isReposted,
       has_current_user_saved: isFavorited,
-      track_count: trackCount
+      track_count: trackCount,
+      permalink
     } = getCollectionWithFallback(collection)
 
     const {
@@ -231,13 +232,13 @@ const ConnectedPlaylistTile = memo(
       ? ''
       : isAlbum
       ? albumPage(handle, title, id)
-      : playlistPage(handle, title, id)
+      : playlistPage(handle, title, id, permalink)
 
     const fullHref = isLoading
       ? ''
       : isAlbum
       ? fullAlbumPage(handle, title, id)
-      : fullPlaylistPage(handle, title, id)
+      : fullPlaylistPage(handle, title, id, permalink)
 
     const onClickTitle = useCallback(
       (e: MouseEvent) => {

--- a/packages/web/src/components/track/helpers.ts
+++ b/packages/web/src/components/track/helpers.ts
@@ -56,6 +56,7 @@ export const getCollectionWithFallback = (collection: Collection | null) => {
       has_current_user_saved: false,
       is_private: true,
       is_album: false,
+      permalink: '',
       is_delete: false,
       activity_timestamp: '',
       _co_sign: undefined,

--- a/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -129,7 +129,8 @@ const ConnectedPlaylistTile = memo(
         : playlistPage(
             user.handle,
             collection.playlist_name,
-            collection.playlist_id
+            collection.playlist_id,
+            collection.permalink
           )
     }, [collection, user])
 

--- a/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/CollectionPage.tsx
@@ -111,6 +111,7 @@ const CollectionPage = ({
   playing,
   type,
   collection: { status, metadata, user },
+  collection,
   columns,
   tracks,
   userId,

--- a/packages/web/src/pages/explore-page/components/desktop/CollectionsPage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/CollectionsPage.tsx
@@ -102,7 +102,8 @@ const CollectionsPage = ({
             : fullPlaylistPage(
                 playlist.user.handle,
                 playlist.playlist_name,
-                playlist.playlist_id
+                playlist.playlist_id,
+                playlist.permalink
               )
         }
         reposts={playlist.repost_count}
@@ -124,7 +125,8 @@ const CollectionsPage = ({
                 playlistPage(
                   playlist.user.handle,
                   playlist.playlist_name,
-                  playlist.playlist_id
+                  playlist.playlist_id,
+                  playlist.permalink
                 )
               )
         }}

--- a/packages/web/src/pages/explore-page/components/mobile/CollectionsPage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/CollectionsPage.tsx
@@ -63,7 +63,8 @@ const ExplorePage = ({
                 playlistPage(
                   playlist.user.handle,
                   playlist.playlist_name,
-                  playlist.playlist_id
+                  playlist.playlist_id,
+                  playlist.permalink
                 )
               )
         }}

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
@@ -206,7 +206,8 @@ const ExplorePage = ({
         : playlistPage(
             playlist.user.handle,
             playlist.playlist_name,
-            playlist.playlist_id
+            playlist.playlist_id,
+            playlist.permalink
           )
 
       return (

--- a/packages/web/src/pages/landing-page/components/FeaturedContent.tsx
+++ b/packages/web/src/pages/landing-page/components/FeaturedContent.tsx
@@ -200,7 +200,8 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                       playlistPage(
                         p.user.handle,
                         p.playlist_name,
-                        p.playlist_id
+                        p.playlist_id,
+                        p.permalink
                       ),
                       props.setRenderPublicSite
                     )}
@@ -254,7 +255,8 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                       playlistPage(
                         p.user.handle,
                         p.playlist_name,
-                        p.playlist_id
+                        p.playlist_id,
+                        p.permalink
                       ),
                       props.setRenderPublicSite
                     )}

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -315,9 +315,7 @@ const ProfilePage = ({
         id={playlist.playlist_id}
         imageSize={playlist._cover_art_sizes}
         isPublic={!playlist.is_private}
-        // isAlbum={playlist.is_album}
         primaryText={playlist.playlist_name}
-        // link={fullPlaylistPage(profile.handle, playlist.playlist_name, playlist.playlist_id)}
         secondaryText={formatCardSecondaryText(
           playlist.save_count,
           playlist.playlist_contents.track_ids.length,
@@ -329,7 +327,8 @@ const ProfilePage = ({
         href={playlistPage(
           profile.handle,
           playlist.playlist_name,
-          playlist.playlist_id
+          playlist.playlist_id,
+          playlist.permalink
         )}
         onClick={(e: MouseEvent) => {
           e.preventDefault()
@@ -337,7 +336,8 @@ const ProfilePage = ({
             playlistPage(
               profile.handle,
               playlist.playlist_name,
-              playlist.playlist_id
+              playlist.playlist_id,
+              playlist.permalink
             )
           )
         }}
@@ -513,21 +513,20 @@ const ProfilePage = ({
         playlistId={playlist.playlist_id}
         isPublic={!playlist.is_private}
         playlistName={playlist.playlist_name}
-        // isAlbum={playlist.is_album}
         primaryText={playlist.playlist_name}
         secondaryText={formatCardSecondaryText(
           playlist.save_count,
           playlist.playlist_contents.track_ids.length,
           playlist.is_private
         )}
-        // link={fullPlaylistPage(profile.handle, playlist.playlist_name, playlist.playlist_id)}
         isReposted={playlist.has_current_user_reposted}
         isSaved={playlist.has_current_user_saved}
         cardCoverImageSizes={playlist._cover_art_sizes}
         href={playlistPage(
           profile.handle,
           playlist.playlist_name,
-          playlist.playlist_id
+          playlist.playlist_id,
+          playlist.permalink
         )}
         onClick={(e: MouseEvent) => {
           e.preventDefault()
@@ -535,7 +534,8 @@ const ProfilePage = ({
             playlistPage(
               profile.handle,
               playlist.playlist_name,
-              playlist.playlist_id
+              playlist.playlist_id,
+              playlist.permalink
             )
           )
         }}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -395,7 +395,8 @@ const ProfilePage = g(
           href={playlistPage(
             profile.handle,
             playlist.playlist_name,
-            playlist.playlist_id
+            playlist.playlist_id,
+            playlist.permalink
           )}
           onClick={(e: MouseEvent) => {
             e.preventDefault()
@@ -403,7 +404,8 @@ const ProfilePage = g(
               playlistPage(
                 profile.handle,
                 playlist.playlist_name,
-                playlist.playlist_id
+                playlist.playlist_id,
+                playlist.permalink
               )
             )
           }}

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -289,7 +289,8 @@ const PlaylistCardLineup = ({
             playlistPage(
               playlist.ownerHandle,
               playlist.playlist_name,
-              playlist.playlist_id
+              playlist.playlist_id,
+              playlist.permalink
             )
           )
           updatePlaylistLastViewedAt(playlist.playlist_id)

--- a/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
+++ b/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
@@ -177,7 +177,8 @@ class SearchPageContent extends Component {
           playlistPage(
             playlist.user.handle,
             playlist.playlist_name,
-            playlist.playlist_id
+            playlist.playlist_id,
+            playlist.permalink
           )
         )
         recordSearchResultClick({
@@ -203,7 +204,8 @@ class SearchPageContent extends Component {
           link={fullPlaylistPage(
             playlist.user.handle,
             playlist.playlist_name,
-            playlist.playlist_id
+            playlist.playlist_id,
+            playlist.permalink
           )}
           primaryText={playlist.playlist_name}
           firesOnClick={false}

--- a/packages/web/src/utils/route/collectionRouteParser.ts
+++ b/packages/web/src/utils/route/collectionRouteParser.ts
@@ -1,7 +1,12 @@
 import { ID, decodeHashId } from '@audius/common'
 import { matchPath } from 'react-router-dom'
 
-import { PLAYLIST_PAGE, ALBUM_PAGE, PLAYLIST_ID_PAGE } from 'utils/route'
+import {
+  PLAYLIST_PAGE,
+  ALBUM_PAGE,
+  PLAYLIST_ID_PAGE,
+  PLAYLIST_BY_PERMALINK_PAGE
+} from 'utils/route'
 
 type CollectionRouteParams =
   | {
@@ -43,25 +48,24 @@ export const parseCollectionRoute = (route: string): CollectionRouteParams => {
     return { collectionId, handle: null, collectionType: null, title: null }
   }
 
-  // const playlistByPermalinkMatch = matchPath<{
-  //   handle: string
-  //   slug: string
-  // }>(route, {
-  //   path: PLAYLIST_BY_PERMALINK_PAGE,
-  //   exact: true
-  // })
-  // if (playlistByPermalinkMatch) {
-  //   const { handle, slug } = playlistByPermalinkMatch.params
-  //   const permalink = `${handle}/playlist/${slug}`
-  //   console.log('matched to permalink route')
-  //   return {
-  //     title: null,
-  //     collectionId: null,
-  //     permalink,
-  //     handle: null,
-  //     collectionType: 'playlist'
-  //   }
-  // }
+  const playlistByPermalinkMatch = matchPath<{
+    handle: string
+    slug: string
+  }>(route, {
+    path: PLAYLIST_BY_PERMALINK_PAGE,
+    exact: true
+  })
+  if (playlistByPermalinkMatch) {
+    const { handle, slug } = playlistByPermalinkMatch.params
+    const permalink = `/${handle}/playlist/${slug}`
+    return {
+      title: null,
+      collectionId: null,
+      permalink,
+      handle: null,
+      collectionType: 'playlist'
+    }
+  }
 
   const playlistPageMatch = matchPath<{
     handle: string

--- a/packages/web/src/utils/seo.ts
+++ b/packages/web/src/utils/seo.ts
@@ -111,12 +111,14 @@ export const getCollectionPageSEOFields = ({
   playlistId,
   userName,
   userHandle,
+  permalink,
   isAlbum
 }: {
   playlistName?: string
   playlistId?: number
   userName?: string
   userHandle?: string
+  permalink?: string
   isAlbum?: boolean
 }) => {
   if (!playlistName || !playlistId || !userName || !userHandle) return {}
@@ -127,7 +129,7 @@ export const getCollectionPageSEOFields = ({
   )
   const canonicalUrl = isAlbum
     ? fullAlbumPage(userHandle, playlistName, playlistId)
-    : fullPlaylistPage(userHandle, playlistName, playlistId)
+    : fullPlaylistPage(userHandle, playlistName, playlistId, permalink)
   const structuredData = {
     '@context': 'http://schema.googleapis.com/',
     '@type': 'MusicAlbum',


### PR DESCRIPTION
### Description
Replace front end routing to playlists with new `:handle/playlist/:slug` format. This updates all calls to PlaylistPage() route with a permalink to fetch a playlist via permalink instead of playlist id. 

Note: some things still broken rn
- have to update the use of `this.state.playlistId` throughout CollectionPageProvider since that lots of things still depend on this (editing, sharing, etc a playlist).
- have to solidify the flow for when a playlist is created or edited
- 
### Dragons
This is a big frontend change and will require thorough testing regarding playlists. We'll want to check:
- searching and selecting playlists
- creating playlists
- editing/sharing/liking playlists
- trending playlists/explore page playlists
- user playlists
- playlists loaded from the cache vs retrieved from backend

### How Has This Been Tested?
still being tested against the above cases
