### PR TITLE
[C-1986] Use RNFetchBlob for offline mode

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -20,7 +20,7 @@ import {
   reachabilitySelectors
 } from '@audius/common'
 import { uniq, isEqual } from 'lodash'
-import RNFS, { exists } from 'react-native-fs'
+import RNFetchBlob from 'rn-fetch-blob'
 
 import type { TrackForDownload } from 'app/components/offline-downloads'
 import { createAllImageSources } from 'app/hooks/useContentNodeImage'
@@ -59,9 +59,13 @@ import {
   writeCollectionJson,
   writeFavoritesCollectionJson,
   purgeDownloadedCollection,
-  getLocalCollectionCoverArtDestination
+  getLocalCollectionCoverArtDestination,
+  mkdirSafe
 } from './offline-storage'
 
+const {
+  fs: { exists }
+} = RNFetchBlob
 const { saveCollection } = collectionsSocialActions
 const { getUserId } = accountSelectors
 const { getUserFromCollection } = cacheUsersSelectors
@@ -531,12 +535,11 @@ const downloadIfNotExists = async (
   }
 
   const destinationDirectory = path.dirname(destination)
-  await RNFS.mkdir(destinationDirectory)
+  await mkdirSafe(destinationDirectory)
 
-  const result = await RNFS.downloadFile({
-    fromUrl: uri,
-    toFile: destination
-  })?.promise
+  const result = await RNFetchBlob.config({
+    path: destination
+  }).fetch('GET', uri)
 
-  return result?.statusCode ?? null
+  return result?.info().status ?? null
 }

--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -9,7 +9,6 @@ import type {
   UserTrackMetadata
 } from '@audius/common'
 import { allSettled } from '@audius/common'
-import { readDir } from 'react-native-fs'
 import RNFetchBlob from 'rn-fetch-blob'
 
 import { store } from 'app/store'
@@ -21,7 +20,7 @@ import {
 import { DOWNLOAD_REASON_FAVORITES } from './offline-downloader'
 
 const {
-  fs: { dirs, exists, mkdir, readFile, unlink, writeFile }
+  fs: { dirs, exists, ls, mkdir, readFile, unlink, writeFile }
 } = RNFetchBlob
 
 export type OfflineCollection = Collection & { user: UserMetadata }
@@ -105,9 +104,7 @@ export const getOfflineCollections = async () => {
   if (!(await exists(collectionsDir))) {
     return []
   }
-  // Using RNFS.readDir because it can syncrouncously filter out directories
-  const files = await readDir(collectionsDir)
-  return files.filter((file) => file.isDirectory()).map((file) => file.name)
+  return await ls(collectionsDir)
 }
 
 export const purgeDownloadedCollection = async (collectionId: string) => {
@@ -165,8 +162,7 @@ export const listTracks = async (): Promise<string[]> => {
   if (!(await exists(tracksDir))) {
     return []
   }
-  const files = await readDir(tracksDir)
-  return files.filter((file) => file.isDirectory()).map((file) => file.name)
+  return await ls(tracksDir)
 }
 
 export const getTrackJson = async (

--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -9,7 +9,8 @@ import type {
   UserTrackMetadata
 } from '@audius/common'
 import { allSettled } from '@audius/common'
-import RNFS, { exists, readDir, readFile } from 'react-native-fs'
+import { readDir } from 'react-native-fs'
+import RNFetchBlob from 'rn-fetch-blob'
 
 import { store } from 'app/store'
 import {
@@ -19,9 +20,13 @@ import {
 
 import { DOWNLOAD_REASON_FAVORITES } from './offline-downloader'
 
+const {
+  fs: { dirs, exists, mkdir, readFile, unlink, writeFile }
+} = RNFetchBlob
+
 export type OfflineCollection = Collection & { user: UserMetadata }
 
-export const downloadsRoot = path.join(RNFS.CachesDirectoryPath, 'downloads')
+export const downloadsRoot = path.join(dirs.CacheDir, 'downloads')
 const IMAGE_FILENAME = '1000x1000.jpg'
 
 export const getPathFromRoot = (string: string) => {
@@ -57,10 +62,10 @@ export const writeCollectionJson = async (
 ) => {
   const pathToWrite = getLocalCollectionJsonPath(collectionId)
   if (await exists(pathToWrite)) {
-    await RNFS.unlink(pathToWrite)
+    await unlink(pathToWrite)
   }
-  await RNFS.mkdir(getLocalCollectionDir(collectionId))
-  await RNFS.write(
+  await mkdirSafe(getLocalCollectionDir(collectionId))
+  await writeFile(
     pathToWrite,
     JSON.stringify({
       ...collectionToWrite,
@@ -73,9 +78,9 @@ export const writeCollectionJson = async (
 export const writeFavoritesCollectionJson = async () => {
   const pathToWrite = getLocalCollectionDir(DOWNLOAD_REASON_FAVORITES)
   if (await exists(pathToWrite)) {
-    await RNFS.unlink(pathToWrite)
+    await unlink(pathToWrite)
   }
-  RNFS.mkdir(pathToWrite)
+  mkdirSafe(pathToWrite)
 }
 
 export const getCollectionJson = async (
@@ -83,7 +88,8 @@ export const getCollectionJson = async (
 ): Promise<OfflineCollection> => {
   try {
     const collectionJson = await readFile(
-      getLocalCollectionJsonPath(collectionId)
+      getLocalCollectionJsonPath(collectionId),
+      'utf8'
     )
     return JSON.parse(collectionJson)
   } catch (e) {
@@ -99,6 +105,7 @@ export const getOfflineCollections = async () => {
   if (!(await exists(collectionsDir))) {
     return []
   }
+  // Using RNFS.readDir because it can syncrouncously filter out directories
   const files = await readDir(collectionsDir)
   return files.filter((file) => file.isDirectory()).map((file) => file.name)
 }
@@ -106,7 +113,7 @@ export const getOfflineCollections = async () => {
 export const purgeDownloadedCollection = async (collectionId: string) => {
   const collectionDir = getLocalCollectionDir(collectionId)
   if (!(await exists(collectionDir))) return
-  await RNFS.unlink(collectionDir)
+  await unlink(collectionDir)
   store.dispatch(removeCollection({ collectionId, isFavoritesDownload: true }))
   store.dispatch(removeCollection({ collectionId, isFavoritesDownload: false }))
 }
@@ -166,7 +173,7 @@ export const getTrackJson = async (
   trackId: string
 ): Promise<Track & UserTrackMetadata> => {
   try {
-    const trackJson = await readFile(getLocalTrackJsonPath(trackId))
+    const trackJson = await readFile(getLocalTrackJsonPath(trackId), 'utf8')
     return JSON.parse(trackJson)
   } catch (e) {
     if (e instanceof SyntaxError) {
@@ -182,9 +189,9 @@ export const writeTrackJson = async (
 ) => {
   const pathToWrite = getLocalTrackJsonPath(trackId)
   if (await exists(pathToWrite)) {
-    await RNFS.unlink(pathToWrite)
+    await unlink(pathToWrite)
   }
-  await RNFS.write(pathToWrite, JSON.stringify(trackToWrite))
+  await writeFile(pathToWrite, JSON.stringify(trackToWrite))
 }
 
 export const verifyTrack = async (
@@ -193,18 +200,18 @@ export const verifyTrack = async (
 ): Promise<boolean> => {
   const audioFile = exists(getLocalAudioPath(trackId))
   const jsonFile = exists(getLocalTrackJsonPath(trackId))
-  const artFile = exists(path.join(getLocalTrackDir(trackId), `1000x1000.jpg`))
+  const artFile = exists(path.join(getLocalTrackDir(trackId), IMAGE_FILENAME))
 
   const results = await allSettled([audioFile, jsonFile, artFile])
   const booleanResults = results.map(
     (result) => result.status === 'fulfilled' && !!result.value
   )
-  const [audioExists, jsonExists, ...artExists] = booleanResults
+  const [audioExists, jsonExists, artExists] = booleanResults
 
   if (expectTrue) {
     !audioExists && console.warn(`Missing audio for ${trackId}`)
     !jsonExists && console.warn(`Missing json for ${trackId}`)
-    !artExists?.length && console.warn(`Missing art for ${trackId}`)
+    !artExists && console.warn(`Missing art for ${trackId}`)
   }
 
   return booleanResults.every((result) => result)
@@ -216,8 +223,8 @@ export const purgeAllDownloads = async (withLogs?: boolean) => {
       console.log(`Before purge:`)
     }
     await readDirRec(downloadsRoot)
-    await RNFS.unlink(downloadsRoot)
-    await RNFS.mkdir(downloadsRoot)
+    await unlink(downloadsRoot)
+    await mkdirSafe(downloadsRoot)
     if (withLogs) {
       console.log(`After purge:`)
     }
@@ -228,13 +235,13 @@ export const purgeAllDownloads = async (withLogs?: boolean) => {
 export const purgeDownloadedTrack = async (trackId: string) => {
   const trackDir = getLocalTrackDir(trackId)
   if (!(await exists(trackDir))) return
-  await RNFS.unlink(trackDir)
+  await unlink(trackDir)
   store.dispatch(unloadTrack(trackId))
 }
 
 /** Debugging method to read cached files */
 export const readDirRec = async (path: string) => {
-  const files = await RNFS.readDir(path)
+  const files = await readDir(path)
   if (files.length === 0) {
     console.log(`${getPathFromRoot(path)} - empty`)
   }
@@ -253,3 +260,9 @@ export const readDirRec = async (path: string) => {
 }
 
 export const readDirRoot = async () => await readDirRec(downloadsRoot)
+
+export const mkdirSafe = async (path: string) => {
+  if (!(await exists(path))) {
+    await mkdir(path)
+  }
+}

--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -20,7 +20,7 @@ import {
 import { DOWNLOAD_REASON_FAVORITES } from './offline-downloader'
 
 const {
-  fs: { dirs, exists, ls, mkdir, readFile, unlink, writeFile }
+  fs: { dirs, exists, ls, lstat, mkdir, readFile, unlink, writeFile }
 } = RNFetchBlob
 
 export type OfflineCollection = Collection & { user: UserMetadata }
@@ -237,18 +237,18 @@ export const purgeDownloadedTrack = async (trackId: string) => {
 
 /** Debugging method to read cached files */
 export const readDirRec = async (path: string) => {
-  const files = await readDir(path)
+  const files = await lstat(path)
   if (files.length === 0) {
     console.log(`${getPathFromRoot(path)} - empty`)
   }
   files.forEach((item) => {
-    if (item.isFile()) {
+    if (item.type === 'file') {
       console.log(`${getPathFromRoot(item.path)} - ${item.size} bytes`)
     }
   })
   await Promise.all(
     files.map(async (item) => {
-      if (item.isDirectory()) {
+      if (item.type === 'directory') {
         await readDirRec(item.path)
       }
     })


### PR DESCRIPTION
### Description

Use RNFetchBlob for all offline mode operations. This should improve performance over RNFS because the encoding is done natively

Also a couple small image fixes in here

### Dragons

In `listTracks` and `getOfflineCollections` we are now using `ls` instead of `readDir` which means we can't check whether or not an item is a file/directory. I believe there should only ever be directories here so it should be ok, @amendelsohn can you confirm?

We could also use `lstat` to get more info about the item, similar to `readDir`, but it is slower than `ls`

### How Has This Been Tested?

Tested downloading, loading, and playing back offline tracks

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

