### PR TITLE
[C-1963] Add download progress bar

### DIFF
--- a/packages/mobile/src/components/offline-downloads/DownloadProgress.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadProgress.tsx
@@ -1,0 +1,56 @@
+import { View } from 'react-native'
+import { useSelector } from 'react-redux'
+
+import { Text } from 'app/components/core'
+import { ProgressBar } from 'app/components/progress-bar'
+import { getOfflineDownloadStatus } from 'app/store/offline-downloads/selectors'
+import { OfflineTrackDownloadStatus } from 'app/store/offline-downloads/slice'
+import { makeStyles } from 'app/styles'
+
+const useStyles = makeStyles(({ palette, spacing }) => ({
+  root: {
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    marginRight: spacing(2)
+  },
+  text: {
+    marginBottom: 2
+  },
+  progressBar: {
+    width: 98,
+    height: spacing(1),
+    borderRadius: 8,
+    marginVertical: 0,
+    backgroundColor: palette.neutralLight4
+  }
+}))
+
+export const DownloadProgress = () => {
+  const styles = useStyles()
+  const downloadStatus = useSelector(getOfflineDownloadStatus)
+  const numDownloads = Object.keys(downloadStatus).length
+  const numDownloadsComplete = Object.values(downloadStatus).filter(
+    (status) =>
+      status === OfflineTrackDownloadStatus.SUCCESS ||
+      status === OfflineTrackDownloadStatus.ERROR
+  ).length
+
+  // Only render if there are active downloads
+  if (numDownloadsComplete - numDownloadsComplete === 0) return null
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.text} color='neutral' weight='demiBold' fontSize='xs'>
+        {`${numDownloadsComplete}/${numDownloads}`}
+      </Text>
+      <ProgressBar
+        style={{
+          root: styles.progressBar
+        }}
+        progress={numDownloadsComplete}
+        max={numDownloads}
+      />
+    </View>
+  )
+}

--- a/packages/mobile/src/components/offline-downloads/DownloadProgress.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadProgress.tsx
@@ -37,7 +37,7 @@ export const DownloadProgress = () => {
   ).length
 
   // Only render if there are active downloads
-  if (numDownloadsComplete - numDownloadsComplete === 0) return null
+  if (numDownloadsComplete === numDownloads) return null
 
   return (
     <View style={styles.root}>

--- a/packages/mobile/src/components/progress-bar/ProgressBar.tsx
+++ b/packages/mobile/src/components/progress-bar/ProgressBar.tsx
@@ -1,11 +1,13 @@
+import type { ViewStyle } from 'react-native'
 import { View } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 
+import type { StylesProp } from 'app/styles'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
-const useStyles = makeStyles(({ spacing, typography, palette }) => ({
-  progressBarContainer: {
+const useStyles = makeStyles(({ spacing, palette }) => ({
+  root: {
     backgroundColor: palette.neutralLight9,
     borderRadius: 22,
     height: spacing(6),
@@ -51,12 +53,20 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   }
 }))
 
-export const ProgressBar = ({ progress, max }) => {
+type ProgressBarProps = {
+  progress: number
+  max: number
+  style?: StylesProp<{
+    root: ViewStyle
+  }>
+}
+
+export const ProgressBar = ({ progress, max, style }: ProgressBarProps) => {
   const styles = useStyles()
   const { pageHeaderGradientColor1, pageHeaderGradientColor2 } =
     useThemeColors()
   return (
-    <View style={styles.progressBarContainer}>
+    <View style={[styles.root, style?.root]}>
       <LinearGradient
         colors={[pageHeaderGradientColor1, pageHeaderGradientColor2]}
         useAngle={true}

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -118,7 +118,7 @@ export const FavoritesScreen = () => {
         styles={{ icon: { marginLeft: 3 } }}
       >
         {isOfflineModeEnabled && (
-          <View style={{ display: 'flex', flexDirection: 'row' }}>
+          <View style={{ flexDirection: 'row' }}>
             <DownloadProgress />
             <DownloadToggle
               tracksForDownload={tracksForDownload}

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -6,6 +6,7 @@ import {
   useProxySelector,
   reachabilitySelectors
 } from '@audius/common'
+import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
@@ -16,6 +17,7 @@ import IconPlaylists from 'app/assets/images/iconPlaylists.svg'
 import { Screen, ScreenContent, ScreenHeader } from 'app/components/core'
 import type { TrackForDownload } from 'app/components/offline-downloads'
 import { DownloadToggle } from 'app/components/offline-downloads'
+import { DownloadProgress } from 'app/components/offline-downloads/DownloadProgress'
 import { TopTabNavigator } from 'app/components/top-tab-bar'
 import { useAppTabScreen } from 'app/hooks/useAppTabScreen'
 import { useFetchAllFavoritedTracks } from 'app/hooks/useFetchAllFavoritedTracks'
@@ -116,10 +118,13 @@ export const FavoritesScreen = () => {
         styles={{ icon: { marginLeft: 3 } }}
       >
         {isOfflineModeEnabled && (
-          <DownloadToggle
-            tracksForDownload={tracksForDownload}
-            isFavoritesDownload
-          />
+          <View style={{ display: 'flex', flexDirection: 'row' }}>
+            <DownloadProgress />
+            <DownloadToggle
+              tracksForDownload={tracksForDownload}
+              isFavoritesDownload
+            />
+          </View>
         )}
       </ScreenHeader>
       <ScreenContent isOfflineCapable={isOfflineModeEnabled}>


### PR DESCRIPTION
### Description

Add progress bar for downloads. Only shows when actively downloading, SUCCESS & ERROR count as "complete" as far as the progress bar cares, so the user doesn't see it forever if something has failed.

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-30 at 13 48 13](https://user-images.githubusercontent.com/2731362/215604291-792e2ef7-c2de-4cd3-84a5-8c52a472f058.png)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally on simulator vs. staging env

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

