### PR TITLE
[C-1977] Hide more by this artist when offline

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -4,7 +4,8 @@ import {
   trackPageLineupActions,
   trackPageActions,
   trackPageSelectors,
-  useProxySelector
+  useProxySelector,
+  reachabilitySelectors
 } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import { Text, View } from 'react-native'
@@ -22,6 +23,7 @@ import { TrackScreenMainContent } from './TrackScreenMainContent'
 const { fetchTrack } = trackPageActions
 const { tracksActions } = trackPageLineupActions
 const { getLineup, getRemixParentTrack, getTrack, getUser } = trackPageSelectors
+const { getIsReachable } = reachabilitySelectors
 
 const messages = {
   moreBy: 'More By',
@@ -54,6 +56,7 @@ export const TrackScreen = () => {
   const { params } = useRoute<'Track'>()
   const dispatch = useDispatch()
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
+  const isReachable = useSelector(getIsReachable)
 
   const { searchTrack, id, canBeUnlisted = true, handle, slug } = params ?? {}
 
@@ -101,8 +104,9 @@ export const TrackScreen = () => {
 
   const remixParentTrackId = track.remix_of?.tracks?.[0]?.parent_track_id
   const showMoreByArtistTitle =
-    (remixParentTrackId && lineup.entries.length > 2) ||
-    (!remixParentTrackId && lineup.entries.length > 1)
+    isReachable &&
+    ((remixParentTrackId && lineup.entries.length > 2) ||
+      (!remixParentTrackId && lineup.entries.length > 1))
 
   const hasValidRemixParent =
     !!remixParentTrackId &&
@@ -125,7 +129,7 @@ export const TrackScreen = () => {
       <ScreenContent isOfflineCapable={isOfflineModeEnabled}>
         <Lineup
           actions={tracksActions}
-          count={6}
+          count={isReachable ? 6 : 0}
           header={
             <TrackScreenMainContent
               lineup={lineup}

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -129,6 +129,8 @@ export const TrackScreen = () => {
       <ScreenContent isOfflineCapable={isOfflineModeEnabled}>
         <Lineup
           actions={tracksActions}
+          // When offline, we don't want to render any tiles here and the
+          // current solution is to hard-code a count to show skeletons
           count={isReachable ? 6 : 0}
           header={
             <TrackScreenMainContent

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -160,8 +160,8 @@ function* watchFetchTrack() {
         })
         track = tracks && tracks.length === 1 ? tracks[0] : null
       }
+      const isReachable = yield select(getIsReachable)
       if (!track) {
-        const isReachable = yield select(getIsReachable)
         if (isReachable) {
           yield put(pushRoute(NOT_FOUND_PAGE))
           return
@@ -171,12 +171,14 @@ function* watchFetchTrack() {
         // Add hero track to lineup early so that we can play it ASAP
         // (instead of waiting for the entire lineup to load)
         yield call(addTrackToLineup, track)
-        yield fork(
-          getRestOfLineup,
-          track.permalink,
-          handle || track.permalink.split('/')?.[1]
-        )
-        yield fork(getTrackRanks, track.track_id)
+        if (isReachable) {
+          yield fork(
+            getRestOfLineup,
+            track.permalink,
+            handle || track.permalink.split('/')?.[1]
+          )
+          yield fork(getTrackRanks, track.track_id)
+        }
         yield put(trackPageActions.fetchTrackSucceeded(track.track_id))
       }
     } catch (e) {


### PR DESCRIPTION
### Description

Hide more by this artist section on track page when offline.
This is a bit cumbersome to use the count artificially here to prevent loading skeletons, but the count itself is already a kind of hacky way that we make track pages work currently.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

On simulator in unreachable state -- lineup doesn't show other than "hero" track

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

