### PR TITLE
[C-1938] Remove tracks within collections when toggling off favorites

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -366,6 +366,26 @@ export const removeAllDownloadedFavorites = async () => {
   // remove collections if they're not also downloaded separately
   Object.entries(favoritedDownloadedCollections).forEach(
     ([collectionId, isDownloaded]) => {
+      // Find any tracks from downloaded collections and mark them
+      // to be removed.
+      tracksForDownload.push(
+        ...Object.values(offlineTracks)
+          .filter((track) =>
+            track.offline?.reasons_for_download.some(
+              (reason) =>
+                reason.collection_id === collectionId &&
+                reason.is_from_favorites
+            )
+          )
+          .map((track) => ({
+            trackId: track.track_id,
+            downloadReason: {
+              is_from_favorites: true,
+              collection_id: collectionId
+            }
+          }))
+      )
+
       if (!isDownloaded) return
       if (downloadedCollections[collectionId]) {
         store.dispatch(


### PR DESCRIPTION
### Description

When toggling off favorites download, we don't clear all the tracks that could have been downloaded within collections.
This makes that possible, but it's still very slow. Needs something like https://linear.app/audius/issue/C-1974/batch-cancel-downloads-instead-of-1-by-1 to make that better.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Before change:
Downloaded all faves => turned off downloads => some tracks remain downloaded inside collections

After change:
Downloaded all faves => turned off downloads => empty

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

