### PR TITLE
[C-1937, C-1964] Add pagination to the mobile favorites screen and fix the title width for deleted track list items

### DIFF
--- a/packages/common/src/store/pages/saved-page/reducer.ts
+++ b/packages/common/src/store/pages/saved-page/reducer.ts
@@ -6,6 +6,7 @@ import {
   FETCH_SAVES_REQUESTED,
   FETCH_SAVES_SUCCEEDED,
   FETCH_SAVES_FAILED,
+  FETCH_MORE_SAVES,
   FETCH_MORE_SAVES_SUCCEEDED,
   FETCH_MORE_SAVES_FAILED,
   ADD_LOCAL_SAVE,
@@ -21,7 +22,8 @@ const initialState = {
   localSaves: {},
   saves: [],
   initialFetch: false,
-  hasReachedEnd: false
+  hasReachedEnd: false,
+  fetchingMore: false
 }
 
 const actionsMap = {
@@ -44,9 +46,16 @@ const actionsMap = {
       initialFetch: false
     }
   },
+  [FETCH_MORE_SAVES](state, action) {
+    return {
+      ...state,
+      fetchingMore: true
+    }
+  },
   [FETCH_SAVES_FAILED](state, action) {
     return {
       ...state,
+      fetchingMore: false,
       saves: []
     }
   },
@@ -56,6 +65,7 @@ const actionsMap = {
 
     return {
       ...state,
+      fetchingMore: false,
       saves: savesCopy
     }
   },

--- a/packages/common/src/store/pages/saved-page/selectors.ts
+++ b/packages/common/src/store/pages/saved-page/selectors.ts
@@ -10,6 +10,8 @@ export const getLocalSave = (state: CommonState, props: { id: ID }) =>
   state.pages.savedPage.localSaves[props.id]
 export const getInitialFetchStatus = (state: CommonState) =>
   state.pages.savedPage.initialFetch
+export const getIsFetchingMore = (state: CommonState) =>
+  state.pages.savedPage.fetchingMore
 export const hasReachedEnd = (state: CommonState) =>
   state.pages.savedPage.hasReachedEnd
 

--- a/packages/common/src/store/pages/saved-page/types.ts
+++ b/packages/common/src/store/pages/saved-page/types.ts
@@ -15,6 +15,7 @@ export interface SavedPageState {
   saves: Favorite[]
   hasReachedEnd: boolean
   initialFetch: boolean
+  fetchingMore: boolean
 }
 
 export enum SavedPageTabs {

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -146,7 +146,7 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
         />
       )
     }
-    return isOfflineModeEnabled || !isReachable ? (
+    return isOfflineModeEnabled && !isReachable ? (
       <View style={{ ...styles.button, width: 24 }}>
         <IconChromecast
           fill={neutralLight6}

--- a/packages/mobile/src/components/track-list/TrackList.tsx
+++ b/packages/mobile/src/components/track-list/TrackList.tsx
@@ -125,13 +125,14 @@ export const TrackList = ({
   const renderTrack: FlatListProps<TrackMetadata>['renderItem'] = ({
     item,
     index
-  }) =>
-    renderDraggableTrack({
+  }) => {
+    return renderDraggableTrack({
       item,
       index,
       drag: () => {},
       isActive: false
     }) as ReactElement
+  }
 
   if (showSkeleton)
     return (

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -222,11 +222,11 @@ export const TrackListItem = ({
         ) : null}
         {isReorderable && <IconDrag style={styles.dragIcon} />}
         <View style={styles.nameArtistContainer}>
-          <View style={styles.topLine}>
-            <View
-              style={styles.trackTitle}
-              onLayout={(e) => setTitleWidth(e.nativeEvent.layout.width)}
-            >
+          <View
+            style={styles.topLine}
+            onLayout={(e) => setTitleWidth(e.nativeEvent.layout.width)}
+          >
+            <View style={styles.trackTitle}>
               <Text
                 numberOfLines={1}
                 style={[styles.trackTitleText, { maxWidth: titleMaxWidth }]}


### PR DESCRIPTION
### Description
* Update mobile favorites page to use the sagas in common that were set up for pagination on web to allow for paginated requests
* Add spinner at the bottom when we are fetching more so that the user know that there are more tracks in the list
* Update the component that we have the layout change callback on to fix the deleted track text disappearing bug

### Dragons

This is a sizable update to how favorites are loaded to there is some risk of introducing weird errors states

### How Has This Been Tested?

Lots of manual testing

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

