### PR TITLE
Update undownload favorites to hide progress earlier

### DIFF
--- a/packages/mobile/src/screens/favorites-screen/DownloadProgress.tsx
+++ b/packages/mobile/src/screens/favorites-screen/DownloadProgress.tsx
@@ -3,7 +3,11 @@ import { useSelector } from 'react-redux'
 
 import { Text } from 'app/components/core'
 import { ProgressBar } from 'app/components/progress-bar'
-import { getOfflineDownloadStatus } from 'app/store/offline-downloads/selectors'
+import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
+import {
+  getIsCollectionMarkedForDownload,
+  getOfflineDownloadStatus
+} from 'app/store/offline-downloads/selectors'
 import { OfflineDownloadStatus } from 'app/store/offline-downloads/slice'
 import { makeStyles } from 'app/styles'
 
@@ -36,8 +40,12 @@ export const DownloadProgress = () => {
       status === OfflineDownloadStatus.ERROR
   ).length
 
+  const isMarkedForDownload = useSelector(
+    getIsCollectionMarkedForDownload(DOWNLOAD_REASON_FAVORITES)
+  )
+
   // Only render if there are active downloads
-  if (numDownloadsComplete === numDownloads) return null
+  if (numDownloadsComplete === numDownloads || !isMarkedForDownload) return null
 
   return (
     <View style={styles.root}>

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -344,6 +344,8 @@ export const removeAllDownloadedFavorites = async () => {
       favoriteCreatedAt: track.offline?.favorite_created_at
     }))
 
+  purgeDownloadedCollection(DOWNLOAD_REASON_FAVORITES)
+
   const allFavoritedTracks = isReachable
     ? [
         ...(await fetchAllFavoritedTracks(currentUserId)),
@@ -360,8 +362,6 @@ export const removeAllDownloadedFavorites = async () => {
       }
     })
   )
-
-  purgeDownloadedCollection(DOWNLOAD_REASON_FAVORITES)
 
   // remove collections if they're not also downloaded separately
   Object.entries(favoritedDownloadedCollections).forEach(


### PR DESCRIPTION
### Description
Update the placement of the purgecollection call for the favorites to mark it as false for downloaded collection so that the progress indicator goes away earlier when undownloading favorites

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

