### PR TITLE
[C-2000] Fix collections not downloading on favorites download

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -83,7 +83,7 @@ export const downloadAllFavorites = async () => {
       isFavoritesDownload: false
     })
   )
-  writeFavoritesCollectionJson()
+  await writeFavoritesCollectionJson()
 
   const allFavoritedTracks = await fetchAllFavoritedTracks(currentUserId)
   const tracksForDownload: TrackForDownload[] = allFavoritedTracks.map(
@@ -148,7 +148,7 @@ export const downloadCollection = async (
     user
   }
 
-  downloadCollectionCoverArt(collectionWithUser)
+  await downloadCollectionCoverArt(collectionWithUser)
 
   const collectionToWrite: CollectionMetadata = {
     ...collectionWithUser,


### PR DESCRIPTION
### Description

Fixes case where race condition to re-create collection directory prevents collections from downloading when we trigger favorites download.
