### PR TITLE
[C-1950] Smooth offline<>online playback

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -113,9 +113,9 @@ export const CollectionScreenDetailsTile = ({
 
   const handleFetchLineupOffline = useOfflineCollectionLineup(
     collectionId,
-    handleFetchLineupOnline,
-    tracksActions
+    handleFetchLineupOnline
   )
+
   const handleFetchLineup = useCallback(() => {
     if (isOfflineModeEnabled && !isReachable) {
       handleFetchLineupOffline()

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -27,9 +27,8 @@ import { TrackList } from 'app/components/track-list'
 import type { TrackMetadata } from 'app/components/track-list/types'
 import { WithLoader } from 'app/components/with-loader/WithLoader'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
-import { useOfflineCollectionLineup } from 'app/hooks/useLoadOfflineTracks'
+import { useOfflineFavoritesLineup } from 'app/hooks/useLoadOfflineTracks'
 import { make, track } from 'app/services/analytics'
-import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 
@@ -110,10 +109,8 @@ export const TracksTab = () => {
     debouncedFetchSaves(filterValue)
   }, [debouncedFetchSaves, filterValue])
 
-  const handleFetchSavesOffline = useOfflineCollectionLineup(
-    DOWNLOAD_REASON_FAVORITES,
-    handleFetchSavesOnline,
-    tracksActions
+  const handleFetchSavesOffline = useOfflineFavoritesLineup(
+    handleFetchSavesOnline
   )
 
   const handleFetchSaves = useCallback(() => {

--- a/packages/web/src/common/store/pages/collection/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/collection/lineups/sagas.js
@@ -96,6 +96,7 @@ function* getCollectionTracks() {
 }
 
 const keepDateAdded = (track) => ({
+  id: track.track_id,
   uid: track.uid,
   kind: Kind.TRACKS,
   dateAdded: track.dateAdded


### PR DESCRIPTION
### Description

Fixes playback when switching from offline<>online and vise-versa.
The crux of this PR is to steal (if available) the UIDs from the existing lineup before refreshing the lineup itself.
Don't love all of this code all-in-all, but I think this works fairly well!

@Kyle-Shanks and I also separated the big ole hook into two separate hooks that we should move into the components, but wanted this diff to be smaller. Can be a follow up. Left a TODO

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Favorites lineup & collection lineup:
1. play track
2. dispatch REACHABILITY/SET_UNREACHABLE
3. playback works, prev & next work
4. dispatch REACHABILITY/SET_REACHABLE
5. profit


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

