### PR TITLE
Hide buttons on profiles when offline and remove timeout

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -1,4 +1,8 @@
-import { accountSelectors, FollowSource } from '@audius/common'
+import {
+  accountSelectors,
+  FollowSource,
+  reachabilitySelectors
+} from '@audius/common'
 import { View, Text } from 'react-native'
 import { useSelector } from 'react-redux'
 
@@ -81,6 +85,8 @@ type ProfileInfoProps = {
 export const ProfileInfo = (props: ProfileInfoProps) => {
   const { onFollow } = props
   const { params } = useRoute<'Profile'>()
+  const { getIsReachable } = reachabilitySelectors
+  const isReachable = useSelector(getIsReachable)
   const accountHandle = useSelector(getUserHandle)
   const styles = useStyles()
 
@@ -139,7 +145,9 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
           {does_follow_current_user ? <FollowsYouChip /> : null}
         </View>
       </View>
-      <View style={styles.actionButtons}>{actionButtons}</View>
+      {isReachable ? (
+        <View style={styles.actionButtons}>{actionButtons}</View>
+      ) : null}
     </View>
   )
 }

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -301,9 +301,6 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
   } catch (e) {
     throw failJob(e.message)
   } finally {
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1000)
-    })
     if (shouldAbortDownload(downloadReason)) {
       removeTrackDownload(trackForDownload)
     }


### PR DESCRIPTION
### Description

Two small changes:
* Hide follow/sub buttons on profiles when offline
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-31 at 18 12 41](https://user-images.githubusercontent.com/2731362/215928636-37358c2f-f594-4757-828a-dc35befc5c1f.png)


* Remove 1s delay between jobs. Seems to have no noticeable perf impact now, I randomly took a few measurements while downloading with the 1s delay and without the 1s delay and it all basically looked like this. The 7x one is with the 1s delay removed

<img width="1231" alt="Screenshot 2023-01-31 at 6 08 30 PM" src="https://user-images.githubusercontent.com/2731362/215928587-67ce31a7-6435-4b74-9121-24d43b803bfe.png">
<img width="1225" alt="Screenshot 2023-01-31 at 6 05 14 PM" src="https://user-images.githubusercontent.com/2731362/215928595-0065eef6-8712-40b1-81d7-1fb89dca56ef.png">


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

