### PR TITLE
[PAY-868] Handle follow and tip send states across

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -105,6 +105,8 @@ export type SolCollectionMap = {
   }
 }
 
+export type PremiumTrackStatus = null | 'UNLOCKING' | 'UNLOCKED' | 'LOCKED'
+
 export type TrackMetadata = {
   blocknumber: number
   activity_timestamp?: string

--- a/packages/common/src/store/premium-content/selectors.ts
+++ b/packages/common/src/store/premium-content/selectors.ts
@@ -3,5 +3,5 @@ import { CommonState } from '../commonStore'
 export const getPremiumTrackSignatureMap = (state: CommonState) =>
   state.premiumContent.premiumTrackSignatureMap
 
-export const getPremiumTrackStatus = (state: CommonState) =>
-  state.premiumContent.status
+export const getPremiumTrackStatusMap = (state: CommonState) =>
+  state.premiumContent.statusMap

--- a/packages/common/src/store/premium-content/slice.ts
+++ b/packages/common/src/store/premium-content/slice.ts
@@ -1,30 +1,33 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { ID, PremiumContentSignature } from 'models'
+import { ID, PremiumContentSignature, PremiumTrackStatus } from 'models'
 import { Nullable } from 'utils'
-
-type PremiumTrackStatus = null | 'UNLOCKING' | 'UNLOCKED' | 'LOCKED'
 
 type PremiumContentState = {
   premiumTrackSignatureMap: { [id: ID]: Nullable<PremiumContentSignature> }
-  status: PremiumTrackStatus
+  statusMap: { [id: ID]: PremiumTrackStatus }
 }
 
 const initialState: PremiumContentState = {
   premiumTrackSignatureMap: {},
-  status: null
+  statusMap: {}
 }
 
 type UpdatePremiumContentSignaturesPayload = {
   [id: ID]: Nullable<PremiumContentSignature>
 }
 
-type RemovePremiumContentSignaturePayload = {
-  trackId: ID
+type RemovePremiumContentSignaturesPayload = {
+  trackIds: ID[]
 }
 
 type UpdatePremiumTrackStatusPayload = {
+  trackId: ID
   status: PremiumTrackStatus
+}
+
+type UpdatePremiumTrackStatusesPayload = {
+  [id: ID]: PremiumTrackStatus
 }
 
 type RefreshPremiumTrackPayload = {
@@ -48,11 +51,19 @@ const slice = createSlice({
         ...action.payload
       }
     },
-    removePremiumContentSignature: (state, action: PayloadAction<RemovePremiumContentSignaturePayload>) => {
-      delete state.premiumTrackSignatureMap[action.payload.trackId]
+    removePremiumContentSignatures: (state, action: PayloadAction<RemovePremiumContentSignaturesPayload>) => {
+      action.payload.trackIds.forEach(trackId => {
+        delete state.premiumTrackSignatureMap[trackId]
+      })
     },
     updatePremiumTrackStatus: (state, action: PayloadAction<UpdatePremiumTrackStatusPayload>) => {
-      state.status = action.payload.status
+      state.statusMap[action.payload.trackId] = action.payload.status
+    },
+    updatePremiumTrackStatuses: (state, action: PayloadAction<UpdatePremiumTrackStatusesPayload>) => {
+      state.statusMap = {
+        ...state.statusMap,
+        ...action.payload
+      }
     },
     refreshPremiumTrack: (
       _,
@@ -63,7 +74,9 @@ const slice = createSlice({
 
 export const {
   updatePremiumContentSignatures,
+  removePremiumContentSignatures,
   updatePremiumTrackStatus,
+  updatePremiumTrackStatuses,
   refreshPremiumTrack
 } = slice.actions
 

--- a/packages/common/src/store/tipping/slice.ts
+++ b/packages/common/src/store/tipping/slice.ts
@@ -156,6 +156,9 @@ const slice = createSlice({
     },
     setShowTip: (state, action: PayloadAction<{ show: boolean }>) => {
       state.showTip = action.payload.show
+    },
+    refreshTipGatedTracks: (_state, _action: PayloadAction<{ userId: ID }>) => {
+      // triggers saga
     }
   }
 })
@@ -178,7 +181,8 @@ export const {
   fetchRecentTips,
   fetchUserSupporter,
   setTipToDisplay,
-  setShowTip
+  setShowTip,
+  refreshTipGatedTracks
 } = slice.actions
 
 export const actions = slice.actions

--- a/packages/web/src/common/store/tipping/sagas.ts
+++ b/packages/web/src/common/store/tipping/sagas.ts
@@ -65,7 +65,8 @@ const {
   setShowTip,
   setSupportingOverridesForUser,
   setSupportersOverridesForUser,
-  fetchUserSupporter
+  fetchUserSupporter,
+  refreshTipGatedTracks
 } = tippingActions
 const {
   getOptimisticSupporters,
@@ -287,6 +288,7 @@ function* sendTipAsync() {
         source
       })
     )
+    yield put(refreshTipGatedTracks({ userId: recipient.user_id }))
 
     /**
      * Store optimistically updated supporting value for sender

--- a/packages/web/src/components/artist/ArtistCard.tsx
+++ b/packages/web/src/components/artist/ArtistCard.tsx
@@ -20,12 +20,10 @@ const { setNotificationSubscription } = profilePageActions
 type ArtistCardProps = {
   artist: User
   onNavigateAway: () => void
-  onFollow?: () => void
-  onUnfollow?: () => void
 }
 
 export const ArtistCard = (props: ArtistCardProps) => {
-  const { artist, onNavigateAway, onFollow, onUnfollow } = props
+  const { artist, onNavigateAway } = props
   const {
     user_id,
     bio,
@@ -76,18 +74,12 @@ export const ArtistCard = (props: ArtistCardProps) => {
 
   const handleFollow = useCallback(() => {
     dispatch(followUser(user_id, FollowSource.HOVER_TILE))
-    if (onFollow) {
-      onFollow()
-    }
-  }, [dispatch, user_id, onFollow])
+  }, [dispatch, user_id])
 
   const handleUnfollow = useCallback(() => {
     dispatch(unfollowUser(user_id, FollowSource.HOVER_TILE))
     dispatch(setNotificationSubscription(user_id, false, true))
-    if (onUnfollow) {
-      onUnfollow()
-    }
-  }, [dispatch, user_id, onUnfollow])
+  }, [dispatch, user_id])
 
   return (
     <div className={styles.popoverContainer} onClick={handleClick}>

--- a/packages/web/src/components/artist/ArtistPopover.tsx
+++ b/packages/web/src/components/artist/ArtistPopover.tsx
@@ -43,8 +43,6 @@ type ArtistPopoverProps = {
   mouseEnterDelay?: number
   component?: 'div' | 'span'
   onNavigateAway?: () => void
-  onFollow?: () => void
-  onUnfollow?: () => void
 }
 
 export const ArtistPopover = ({
@@ -54,9 +52,7 @@ export const ArtistPopover = ({
   mount = MountPlacement.PAGE,
   mouseEnterDelay = 0.5,
   component: Component = 'div',
-  onNavigateAway,
-  onFollow,
-  onUnfollow
+  onNavigateAway
 }: ArtistPopoverProps) => {
   const [isPopupVisible, setIsPopupVisible] = useState(false)
   const creator = useSelector((state: CommonState) =>
@@ -90,8 +86,6 @@ export const ArtistPopover = ({
           setIsPopupVisible(false)
           onNavigateAway?.()
         }}
-        onFollow={onFollow}
-        onUnfollow={onUnfollow}
       />
     ) : null
 

--- a/packages/web/src/components/track/GiantTrackTile.js
+++ b/packages/web/src/components/track/GiantTrackTile.js
@@ -337,21 +337,6 @@ class GiantTrackTile extends PureComponent {
     )
   }
 
-  handleFollow = () => {
-    const { doesUserHaveAccess, premiumConditions, onUnlock } = this.props
-    if (!doesUserHaveAccess && premiumConditions.follow_user_id) {
-      onUnlock()
-    }
-  }
-
-  handleUnfollow = () => {
-    const { doesUserHaveAccess, premiumConditions, onLock, trackId } =
-      this.props
-    if (doesUserHaveAccess && premiumConditions.follow_user_id) {
-      onLock(trackId)
-    }
-  }
-
   render() {
     const {
       playing,
@@ -444,11 +429,7 @@ class GiantTrackTile extends PureComponent {
               <div className={styles.artistWrapper}>
                 <div className={cn(fadeIn)}>
                   <span>By</span>
-                  <ArtistPopover
-                    handle={artistHandle}
-                    onFollow={this.handleFollow}
-                    onUnfollow={this.handleUnfollow}
-                  >
+                  <ArtistPopover handle={artistHandle}>
                     <h2 className={styles.artist} onClick={onClickArtistName}>
                       {artistName}
                       <UserBadges
@@ -597,8 +578,6 @@ GiantTrackTile.propTypes = {
   onRepost: PropTypes.func,
   onSave: PropTypes.func,
   following: PropTypes.bool,
-  onUnlock: PropTypes.func,
-  onLock: PropTypes.func,
   onFollow: PropTypes.func,
   onUnfollow: PropTypes.func,
   onDownload: PropTypes.func
@@ -629,8 +608,6 @@ GiantTrackTile.defaultProps = {
   onRepost: () => {},
   onSave: () => {},
   onFollow: () => {},
-  onUnlock: () => {},
-  onLock: () => {},
   onDownload: () => {}
 }
 

--- a/packages/web/src/components/track/desktop/BottomRow.tsx
+++ b/packages/web/src/components/track/desktop/BottomRow.tsx
@@ -1,20 +1,30 @@
 import { ReactNode, useCallback } from 'react'
 
-import { FeatureFlags, FieldVisibility } from '@audius/common'
+import {
+  FeatureFlags,
+  FieldVisibility,
+  premiumContentSelectors,
+  ID
+} from '@audius/common'
 import { IconLock } from '@audius/stems'
 import cn from 'classnames'
+import { useSelector } from 'react-redux'
 
 import FavoriteButton from 'components/alt-button/FavoriteButton'
 import RepostButton from 'components/alt-button/RepostButton'
 import ShareButton from 'components/alt-button/ShareButton'
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import Tooltip from 'components/tooltip/Tooltip'
 import { useFlag } from 'hooks/useRemoteConfig'
 
 import styles from './TrackTile.module.css'
 
+const { getPremiumTrackStatusMap } = premiumContentSelectors
+
 const messages = {
   repostLabel: 'Repost',
   unrepostLabel: 'Unrepost',
+  unlocking: 'UNLOCKING',
   locked: 'LOCKED'
 }
 
@@ -33,6 +43,7 @@ type BottomRowProps = {
   isMatrixMode: boolean
   showIconButtons?: boolean
   isTrack?: boolean
+  trackId?: ID
   onClickRepost: (e?: any) => void
   onClickFavorite: (e?: any) => void
   onClickShare: (e?: any) => void
@@ -53,6 +64,7 @@ export const BottomRow = ({
   isMatrixMode,
   showIconButtons,
   isTrack,
+  trackId,
   onClickRepost,
   onClickFavorite,
   onClickShare
@@ -60,6 +72,8 @@ export const BottomRow = ({
   const { isEnabled: isPremiumContentEnabled } = useFlag(
     FeatureFlags.PREMIUM_CONTENT_ENABLED
   )
+  const premiumTrackStatusMap = useSelector(getPremiumTrackStatusMap)
+  const premiumTrackStatus = trackId && premiumTrackStatusMap[trackId]
 
   const repostLabel = isReposted ? messages.unrepostLabel : messages.repostLabel
 
@@ -96,7 +110,12 @@ export const BottomRow = ({
   }
 
   if (isPremiumContentEnabled && isTrack && !isLoading && !doesUserHaveAccess) {
-    return (
+    return premiumTrackStatus === 'UNLOCKING' ? (
+      <div className={cn(styles.premiumContent, styles.bottomRow)}>
+        <LoadingSpinner className={styles.spinner} />
+        {messages.unlocking}
+      </div>
+    ) : (
       <div className={cn(styles.premiumContent, styles.bottomRow)}>
         <IconLock />
         {messages.locked}

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -393,6 +393,7 @@ const ConnectedTrackTile = memo(
           isTrending={isTrending}
           showRankIcon={showRankIcon}
           permalink={permalink}
+          trackId={trackId}
           isTrack
         />
       </Draggable>

--- a/packages/web/src/components/track/desktop/TrackTile.module.css
+++ b/packages/web/src/components/track/desktop/TrackTile.module.css
@@ -450,3 +450,9 @@
 .menuContainer:active {
   transform: scale3d(0.95, 0.95, 0.95);
 }
+
+.spinner {
+  margin-right: 8px;
+  height: 16px;
+  width: 16px;
+}

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -93,7 +93,8 @@ const TrackTile = memo(
     onTogglePlay,
     showRankIcon,
     permalink,
-    isTrack
+    isTrack,
+    trackId
   }: TrackTileProps) => {
     const hasOrdering = order !== undefined
 
@@ -266,6 +267,7 @@ const TrackTile = memo(
             onClickFavorite={onClickFavorite}
             onClickShare={onClickShare}
             isTrack={isTrack}
+            trackId={trackId}
           />
         </div>
       </div>

--- a/packages/web/src/components/track/types.ts
+++ b/packages/web/src/components/track/types.ts
@@ -213,6 +213,9 @@ export type DesktopTrackTileProps = {
 
   /** Whether the tile is for a track */
   isTrack?: boolean
+
+  /** Track id if track tile */
+  trackId?: ID
 }
 
 export type DesktopPlaylistTileProps = {

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -32,7 +32,6 @@ import {
   usersSocialActions as socialUsersActions,
   playerSelectors,
   queueSelectors,
-  premiumContentActions,
   premiumContentSelectors
 } from '@audius/common'
 import { push as pushRoute, replace } from 'connected-react-router'
@@ -76,8 +75,6 @@ const { setRepost } = repostsUserListActions
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { open } = mobileOverflowMenuUIActions
 const { tracksActions } = trackPageLineupActions
-const { updatePremiumTrackStatus, removePremiumContentSignature } =
-  premiumContentActions
 const { getPremiumTrackSignatureMap } = premiumContentSelectors
 const {
   getUser,
@@ -413,8 +410,6 @@ class TrackPageProvider extends Component<
       // Follow Props
       onFollow: this.onFollow,
       onUnfollow: this.onUnfollow,
-      onUnlock: this.props.onUnlock,
-      onLock: this.props.onLock,
       makePublic: this.props.makeTrackPublic,
       onClickReposts: this.onClickReposts,
       onClickFavorites: this.onClickFavorites
@@ -594,11 +589,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
       ),
     editTrack: (trackId: ID, formFields: any) =>
       dispatch(cacheTrackActions.editTrack(trackId, formFields)),
-    onUnlock: () => dispatch(updatePremiumTrackStatus({ status: 'UNLOCKING' })),
-    onLock: (trackId: ID) => {
-      dispatch(updatePremiumTrackStatus({ status: 'LOCKED' }))
-      dispatch(removePremiumContentSignature({ trackId }))
-    },
     onFollow: (userId: ID) =>
       dispatch(socialUsersActions.followUser(userId, FollowSource.TRACK_PAGE)),
     onUnfollow: (userId: ID) =>

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -53,8 +53,6 @@ export type OwnProps = {
   onHeroRepost: (isReposted: boolean, trackId: ID) => void
   onFollow: () => void
   onUnfollow: () => void
-  onUnlock: () => void
-  onLock: (trackId: ID) => void
   onClickReposts: () => void
   onClickFavorites: () => void
 
@@ -99,8 +97,6 @@ const TrackPage = ({
   onSaveTrack,
   onFollow,
   onUnfollow,
-  onUnlock,
-  onLock,
   onDownloadTrack,
   makePublic,
   onExternalLinkClick,
@@ -202,8 +198,6 @@ const TrackPage = ({
       following={following}
       onFollow={onFollow}
       onUnfollow={onUnfollow}
-      onUnlock={onUnlock}
-      onLock={onLock}
       download={defaults.download}
       onDownload={onDownload}
       makePublic={makePublic}


### PR DESCRIPTION
### Description
Make sure follow / unfollow across app updates premium track access accordingly.
Same for tipping.

This is to show correct locked/unlocking/unlocked states for premium tracks across entire app as user may follow/unfollow or send tip from multiple places in app.

### Dragons

n/a

### How Has This Been Tested?

local dapp v stage

### How will this change be monitored?

n/a

### Feature Flags ###

existing feature flags

