### PR TITLE
[C-1968] Fix dequeue track

### DIFF
--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -110,7 +110,8 @@ export const useLoadOfflineData = () => {
           console.warn('Error verifying track', trackId, e)
         }
         try {
-          const track: Track & UserTrackMetadata = await getTrackJson(trackId)
+          const track = await getTrackJson(trackId)
+          if (!track) return
           const lineupTrack = {
             uid: makeUid(Kind.TRACKS, track.track_id),
             kind: Kind.TRACKS,

--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -191,32 +191,20 @@ export const cancelQueuedCollectionDownloads = async (
 export const cancelQueuedDownloads = async (
   payloadsToCancel: TrackDownloadWorkerPayload[]
 ) => {
-  console.log('cancelling yeah?')
   const payloadsToCancelById = groupBy(
     payloadsToCancel,
     (payload) => payload.trackId
   )
   queue.stop()
   const jobs = await queue.getJobs()
-  console.log('are there jobs?', jobs, payloadsToCancelById, payloadsToCancel)
   const jobsToCancel = jobs.filter(({ workerName, payload }) => {
     try {
       const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(payload)
       return (
         workerName === TRACK_DOWNLOAD_WORKER &&
         (payloadsToCancelById[parsedPayload.trackId] ?? []).some(
-          (payloadToCancel) => {
-            console.log('payload to cancel', payloadToCancel)
-            console.log('parsed paylead', parsedPayload)
-
-            console.log(
-              'equal?',
-
-              isEqualTrackPayload(payloadToCancel, parsedPayload)
-            )
-
-            return isEqualTrackPayload(payloadToCancel, parsedPayload)
-          }
+          (payloadToCancel) =>
+            isEqualTrackPayload(payloadToCancel, parsedPayload)
         )
       )
     } catch (e) {
@@ -224,7 +212,6 @@ export const cancelQueuedDownloads = async (
       return false
     }
   })
-  console.log('got jobs to cancel?', jobsToCancel)
   jobsToCancel.forEach(async (rawJob) => {
     try {
       const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -245,9 +245,11 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
 
   try {
     if (await verifyTrack(trackIdStr, false)) {
+      const trackJson = await getTrackJson(trackIdStr)
+      if (!trackJson) return
+
       // Track is already downloaded, so rewrite the json
       // to include this collection in the reasons_for_download list
-      const trackJson = await getTrackJson(trackIdStr)
 
       // Skip if duplicate download reason
       if (
@@ -487,13 +489,13 @@ export const removeTrackDownload = async ({
   try {
     const trackIdStr = trackId.toString()
     const diskTrack = await getTrackJson(trackIdStr)
-    const downloadReasons = diskTrack.offline?.reasons_for_download ?? []
+    const downloadReasons = diskTrack?.offline?.reasons_for_download ?? []
     const remainingReasons = downloadReasons.filter((reason) =>
       downloadReason.collection_id === DOWNLOAD_REASON_FAVORITES
         ? !reason.is_from_favorites
         : !isEqual(reason, downloadReason)
     )
-    if (remainingReasons.length === 0) {
+    if (!diskTrack || remainingReasons.length === 0) {
       purgeDownloadedTrack(trackIdStr)
       store.dispatch(removeDownload(trackIdStr))
     } else {

--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import type {
   Collection,
   CollectionMetadata,
+  Nullable,
   Track,
   UserMetadata,
   UserTrackMetadata
@@ -170,7 +171,7 @@ export const listTracks = async (): Promise<string[]> => {
 
 export const getTrackJson = async (
   trackId: string
-): Promise<Track & UserTrackMetadata> => {
+): Promise<Nullable<Track & UserTrackMetadata>> => {
   try {
     const trackJson = await readFile(getLocalTrackJsonPath(trackId), 'utf8')
     return JSON.parse(trackJson)
@@ -178,7 +179,7 @@ export const getTrackJson = async (
     if (e instanceof SyntaxError) {
       purgeDownloadedTrack(trackId)
     }
-    return Promise.reject(e)
+    return null
   }
 }
 


### PR DESCRIPTION
### Description

Ensures queued tracks that should be deleted are properly removed from queue and it's status is updated in redux

Fixes two interesting bugs with track delete:
1. during delete flow, `const diskTrack = await getTrackJson(trackIdStr)` would throw an error because the track hasn't been picked up by worker, causing the dequeue + delete flow to short circuit, meaning the track job would stay in the queue.
2. After fixing 1, we still had issues where tracks wouldn't be dequeued because the `isEqual` check for parsed job data and requested dequeued data was different, since `favoriteCreatedAt` is included in the job, but not always for the requested data. This was fixed by updating the equality check to ignore `favoriteCreatedAt`
