### PR TITLE
Refactor lineup hooks

### DIFF
--- a/packages/mobile/src/hooks/useLoadOfflineTracks.ts
+++ b/packages/mobile/src/hooks/useLoadOfflineTracks.ts
@@ -1,30 +1,14 @@
-import { useCallback } from 'react'
-
 import type {
   CollectionMetadata,
   Track,
   UserMetadata,
-  UserTrackMetadata,
-  SmartCollectionVariant
+  UserTrackMetadata
 } from '@audius/common'
-import {
-  savedPageTracksLineupActions,
-  Kind,
-  makeUid,
-  cacheActions,
-  cacheCollectionsSelectors,
-  savedPageSelectors,
-  collectionPageLineupActions,
-  collectionPageSelectors
-} from '@audius/common'
-import { orderBy } from 'lodash'
-import moment from 'moment'
-import { useDispatch, useSelector } from 'react-redux'
+import { Kind, makeUid, cacheActions } from '@audius/common'
+import { useDispatch } from 'react-redux'
 import { useAsync } from 'react-use'
 
 import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
-import { store } from 'app/store'
-import { getOfflineTracks } from 'app/store/offline-downloads/selectors'
 import {
   completeCollectionDownload,
   doneLoadingFromDisk,
@@ -41,10 +25,6 @@ import {
 } from '../services/offline-downloader/offline-storage'
 
 import { useIsOfflineModeEnabled } from './useIsOfflineModeEnabled'
-import { useReachabilityEffect } from './useReachabilityEffect'
-const { getCollection } = cacheCollectionsSelectors
-const { getSavedTracksLineup } = savedPageSelectors
-const { getCollectionTracksLineup } = collectionPageSelectors
 
 // Load offline data into redux on app start
 export const useLoadOfflineData = () => {
@@ -140,143 +120,4 @@ export const useLoadOfflineData = () => {
     dispatch(loadTracks(lineupTracks))
     dispatch(doneLoadingFromDisk())
   }, [isOfflineModeEnabled])
-}
-
-/**
- * Load a collection lineup, either online or offline
- * @param collectionId either the numeric collection id
- * TODO: Move this into the component layer
- */
-export const useOfflineCollectionLineup = (
-  collectionId: number | SmartCollectionVariant | null,
-  fetchOnlineContent: () => void
-) => {
-  const dispatch = useDispatch()
-  const isOfflineModeEnabled = useIsOfflineModeEnabled()
-  const offlineTracks = useSelector(getOfflineTracks)
-  const collection = useSelector((state) => {
-    return getCollection(state, { id: collectionId as number })
-  })
-  const collectionTracks = useSelector(getCollectionTracksLineup)
-  const collectionTrackUidMap = collectionTracks.entries.reduce(
-    (acc, track) => {
-      acc[track.id] = track.uid
-      return acc
-    },
-    {}
-  )
-
-  const fetchLocalContent = useCallback(() => {
-    if (isOfflineModeEnabled && collectionId && collection) {
-      const lineupTracks = Object.values(offlineTracks)
-        .filter((track) =>
-          track.offline?.reasons_for_download.some(
-            (reason) => reason.collection_id === collectionId.toString()
-          )
-        )
-        .map((track) => ({
-          id: track.track_id,
-          kind: Kind.TRACKS,
-          uid:
-            collectionTrackUidMap[track.track_id] ??
-            makeUid(Kind.TRACKS, track.track_id)
-        }))
-
-      const cacheTracks = lineupTracks.map((track) => ({
-        id: track.id,
-        uid: track.uid,
-        metadata: track
-      }))
-
-      store.dispatch(cacheActions.add(Kind.TRACKS, cacheTracks, false, true))
-
-      // Reorder lineup tracks according to the collection
-      // TODO: This may have issues for playlists with duplicate tracks
-      const sortedTracks = collection.playlist_contents.track_ids
-        .map(({ track: trackId, time }) => ({
-          ...lineupTracks.find((track) => trackId === track.id),
-          // Borrowed from common/store/pages/collection/linups/sagas.js
-          // An artifact of non-string legacy data
-          dateAdded: typeof time === 'string' ? moment(time) : moment.unix(time)
-        }))
-        .filter((track) => track.id)
-
-      dispatch(
-        collectionPageLineupActions.fetchLineupMetadatasSucceeded(
-          sortedTracks,
-          0,
-          sortedTracks.length,
-          0,
-          0
-        )
-      )
-    }
-  }, [
-    collectionTrackUidMap,
-    collection,
-    collectionId,
-    dispatch,
-    isOfflineModeEnabled,
-    offlineTracks
-  ])
-
-  useReachabilityEffect(fetchOnlineContent, fetchLocalContent)
-}
-
-/**
- * Load the favorites lineup, either online or offline
- * TODO: Move this into the component layer
- */
-export const useOfflineFavoritesLineup = (fetchOnlineContent: () => void) => {
-  const dispatch = useDispatch()
-  const isOfflineModeEnabled = useIsOfflineModeEnabled()
-  const offlineTracks = useSelector(getOfflineTracks)
-  const savedTracks = useSelector(getSavedTracksLineup)
-  const savedTracksUidMap = savedTracks.entries.reduce((acc, track) => {
-    acc[track.id] = track.uid
-    return acc
-  }, {})
-
-  const fetchLocalContent = useCallback(() => {
-    if (isOfflineModeEnabled) {
-      const lineupTracks = Object.values(offlineTracks)
-        .filter((track) =>
-          track.offline?.reasons_for_download.some(
-            (reason) => reason.collection_id === DOWNLOAD_REASON_FAVORITES
-          )
-        )
-        .map((track) => ({
-          uid:
-            savedTracksUidMap[track.track_id] ??
-            makeUid(Kind.TRACKS, track.track_id),
-          id: track.track_id,
-          dateSaved: track.offline?.favorite_created_at,
-          kind: Kind.TRACKS
-        }))
-
-      const cacheTracks = lineupTracks.map((track) => ({
-        id: track.id,
-        uid: track.uid,
-        metadata: track
-      }))
-
-      store.dispatch(cacheActions.add(Kind.TRACKS, cacheTracks, false, true))
-
-      // Reorder lineup tracks according to favorite time
-      const sortedTracks = orderBy(lineupTracks, (track) => track.dateSaved, [
-        'desc'
-      ])
-      dispatch(
-        savedPageTracksLineupActions.fetchLineupMetadatasSucceeded(
-          sortedTracks,
-          0,
-          sortedTracks.length,
-          0,
-          0
-        )
-      )
-    }
-  }, [dispatch, isOfflineModeEnabled, offlineTracks, savedTracksUidMap])
-
-  useReachabilityEffect(fetchOnlineContent, fetchLocalContent)
 }

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -86,6 +86,7 @@ export const CollectionScreenDetailsTile = ({
   isPrivate,
   isPublishing,
   renderImage,
+  trackCount,
   ...detailsTileProps
 }: CollectionScreenDetailsTileProps) => {
   const styles = useStyles()
@@ -194,7 +195,12 @@ export const CollectionScreenDetailsTile = ({
       return (
         <>
           <View style={styles.trackListDivider} />
-          <TrackList hideArt showDivider showSkeleton uids={Array(20)} />
+          <TrackList
+            hideArt
+            showDivider
+            showSkeleton
+            uids={Array(Math.min(10, trackCount ?? 0))}
+          />
         </>
       )
 

--- a/packages/mobile/src/screens/collection-screen/useCollectionLineup.ts
+++ b/packages/mobile/src/screens/collection-screen/useCollectionLineup.ts
@@ -1,0 +1,114 @@
+import { useCallback } from 'react'
+
+import type { SmartCollectionVariant } from '@audius/common'
+import {
+  useProxySelector,
+  Kind,
+  makeUid,
+  cacheActions,
+  cacheCollectionsSelectors,
+  collectionPageLineupActions,
+  collectionPageSelectors,
+  lineupSelectors,
+  reachabilitySelectors
+} from '@audius/common'
+import moment from 'moment'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
+import { useReachabilityEffect } from 'app/hooks/useReachabilityEffect'
+import { store } from 'app/store'
+import { getOfflineTracks } from 'app/store/offline-downloads/selectors'
+
+const { getCollection } = cacheCollectionsSelectors
+const { getCollectionTracksLineup } = collectionPageSelectors
+const { makeGetTableMetadatas } = lineupSelectors
+const { getIsReachable } = reachabilitySelectors
+
+const getTracksLineup = makeGetTableMetadatas(getCollectionTracksLineup)
+
+/**
+ * Returns a collection lineup, supports boths online and offline
+ * @param collectionId the numeric collection id
+ */
+export const useCollectionLineup = (
+  collectionId: number | SmartCollectionVariant | null,
+  fetchLineup: () => void
+) => {
+  const dispatch = useDispatch()
+  const isOfflineModeEnabled = useIsOfflineModeEnabled()
+  const offlineTracks = useSelector(getOfflineTracks)
+  const isReachable = useSelector(getIsReachable)
+  const collection = useSelector((state) => {
+    return getCollection(state, { id: collectionId as number })
+  })
+  const collectionTracks = useSelector(getCollectionTracksLineup)
+  const collectionTrackUidMap = collectionTracks.entries.reduce(
+    (acc, track) => {
+      acc[track.id] = track.uid
+      return acc
+    },
+    {}
+  )
+  // TODO: do we need proxy selector here
+  const lineup = useProxySelector(getTracksLineup, [isReachable])
+
+  const fetchLineupOffline = useCallback(() => {
+    if (isOfflineModeEnabled && collectionId && collection) {
+      const lineupTracks = Object.values(offlineTracks)
+        .filter((track) =>
+          track.offline?.reasons_for_download.some(
+            (reason) => reason.collection_id === collectionId.toString()
+          )
+        )
+        .map((track) => ({
+          id: track.track_id,
+          kind: Kind.TRACKS,
+          uid:
+            collectionTrackUidMap[track.track_id] ??
+            makeUid(Kind.TRACKS, track.track_id)
+        }))
+
+      const cacheTracks = lineupTracks.map((track) => ({
+        id: track.id,
+        uid: track.uid,
+        metadata: track
+      }))
+
+      store.dispatch(cacheActions.add(Kind.TRACKS, cacheTracks, false, true))
+
+      // Reorder lineup tracks according to the collection
+      // TODO: This may have issues for playlists with duplicate tracks
+      const sortedTracks = collection.playlist_contents.track_ids
+        .map(({ track: trackId, time }) => ({
+          ...lineupTracks.find((track) => trackId === track.id),
+          // Borrowed from common/store/pages/collection/linups/sagas.js
+          // An artifact of non-string legacy data
+          dateAdded: typeof time === 'string' ? moment(time) : moment.unix(time)
+        }))
+        .filter((track) => track.id)
+
+      dispatch(
+        collectionPageLineupActions.fetchLineupMetadatasSucceeded(
+          sortedTracks,
+          0,
+          sortedTracks.length,
+          0,
+          0
+        )
+      )
+    }
+  }, [
+    collectionTrackUidMap,
+    collection,
+    collectionId,
+    dispatch,
+    isOfflineModeEnabled,
+    offlineTracks
+  ])
+
+  // Fetch the lineup based on reachability
+  useReachabilityEffect(fetchLineup, fetchLineupOffline)
+
+  return lineup
+}

--- a/packages/mobile/src/screens/collection-screen/useCollectionLineup.ts
+++ b/packages/mobile/src/screens/collection-screen/useCollectionLineup.ts
@@ -50,7 +50,7 @@ export const useCollectionLineup = (
     },
     {}
   )
-  // TODO: do we need proxy selector here
+
   const lineup = useProxySelector(getTracksLineup, [isReachable])
 
   const fetchLineupOffline = useCallback(() => {

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -23,19 +23,18 @@ import { TrackList } from 'app/components/track-list'
 import type { TrackMetadata } from 'app/components/track-list/types'
 import { WithLoader } from 'app/components/with-loader/WithLoader'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
-import { useOfflineFavoritesLineup } from 'app/hooks/useLoadOfflineTracks'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 
 import { FilterInput } from './FilterInput'
 import { NoTracksPlaceholder } from './NoTracksPlaceholder'
 import { OfflineContentBanner } from './OfflineContentBanner'
+import { useFavoritesLineup } from './useFavoritesLineup'
 const { saveTrack, unsaveTrack } = tracksSocialActions
-const { fetchSaves, fetchMoreSaves } = savedPageActions
+const { fetchSavesAction, fetchMoreSaves } = savedPageActions
 const {
   getSaves,
   getLocalSaves,
-  getSavedTracksLineup,
   getSavedTracksStatus,
   getInitialFetchStatus,
   getIsFetchingMore
@@ -90,27 +89,25 @@ export const TracksTab = () => {
 
   const isLoading = savedTracksStatus !== Status.SUCCESS
 
-  const debouncedFetchSavesOnline = useMemo(() => {
+  const debouncedFetchSaves = useMemo(() => {
     return debounce((filterVal) => {
-      dispatch(fetchSaves(filterVal, '', '', 0, FETCH_LIMIT))
+      dispatch(fetchSavesAction(filterVal, '', '', 0, FETCH_LIMIT))
     }, 500)
   }, [dispatch])
 
-  const fetchSavesOnline = useCallback(() => {
-    debouncedFetchSavesOnline(filterValue)
-  }, [debouncedFetchSavesOnline, filterValue])
-
-  useOfflineFavoritesLineup(fetchSavesOnline)
+  const fetchSaves = useCallback(() => {
+    debouncedFetchSaves(filterValue)
+  }, [debouncedFetchSaves, filterValue])
 
   useEffect(() => {
+    // Need to fetch saves when the filterValue (by way of fetchSaves) changes
     if (isReachable) {
-      fetchSavesOnline()
+      fetchSaves()
     }
-  }, [isReachable, fetchSavesOnline])
+  }, [isReachable, fetchSaves])
 
-  const savedTrackUids: string[] = useSelector((state) => {
-    return getSavedTracksLineup(state).entries.map(({ uid }) => uid)
-  }, isEqual)
+  const { entries } = useFavoritesLineup(fetchSaves)
+  const trackUids = useMemo(() => entries.map(({ uid }) => uid), [entries])
 
   const filterTrack = (
     track: Nullable<Track>,
@@ -132,15 +129,15 @@ export const TracksTab = () => {
   }
 
   const allTracksFetched = useMemo(() => {
-    return savedTrackUids.length === saveCount && !filterValue
-  }, [savedTrackUids, saveCount, filterValue])
+    return trackUids.length === saveCount && !filterValue
+  }, [trackUids, saveCount, filterValue])
 
   const handleMoreFetchSaves = useCallback(() => {
     if (
       allTracksFetched ||
       isFetchingMore ||
       (isOfflineModeEnabled && !isReachable) ||
-      savedTrackUids.length < fetchPage * FETCH_LIMIT
+      trackUids.length < fetchPage * FETCH_LIMIT
     ) {
       return
     }
@@ -158,11 +155,11 @@ export const TracksTab = () => {
     isFetchingMore,
     isOfflineModeEnabled,
     isReachable,
-    savedTrackUids.length
+    trackUids.length
   ])
 
   const filteredTrackUids: string[] = useSelector((state) => {
-    return savedTrackUids.filter((uid) => {
+    return trackUids.filter((uid) => {
       const track = getTrack(state, { uid })
       const user = getUserFromTrack(state, { uid })
       return filterTrack(track, user)

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -31,7 +31,7 @@ import { NoTracksPlaceholder } from './NoTracksPlaceholder'
 import { OfflineContentBanner } from './OfflineContentBanner'
 import { useFavoritesLineup } from './useFavoritesLineup'
 const { saveTrack, unsaveTrack } = tracksSocialActions
-const { fetchSavesAction, fetchMoreSaves } = savedPageActions
+const { fetchSaves: fetchSavesAction, fetchMoreSaves } = savedPageActions
 const {
   getSaves,
   getLocalSaves,

--- a/packages/mobile/src/screens/favorites-screen/useFavoritesLineup.ts
+++ b/packages/mobile/src/screens/favorites-screen/useFavoritesLineup.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 
 import {
   savedPageTracksLineupActions,
@@ -7,7 +7,7 @@ import {
   cacheActions,
   savedPageSelectors
 } from '@audius/common'
-import { isEqual, debounce, orderBy } from 'lodash'
+import { orderBy } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
@@ -32,22 +32,6 @@ export const useFavoritesLineup = (fetchLineup: () => void) => {
     return acc
   }, {})
   const lineup = useSelector(getSavedTracksLineup)
-
-  const debouncedFetchSavesOnline = useMemo(() => {
-    return debounce((filterVal) => {
-      dispatch(fetchSaves(filterVal, '', '', 0, FETCH_LIMIT))
-    }, 500)
-  }, [dispatch])
-
-  const fetchSavesOnline = useCallback(() => {
-    debouncedFetchSavesOnline(filterValue)
-  }, [debouncedFetchSavesOnline, filterValue])
-
-  useEffect(() => {
-    if (isReachable) {
-      fetchSavesOnline()
-    }
-  }, [isReachable, fetchSavesOnline])
 
   const fetchLineupOffline = useCallback(() => {
     if (isOfflineModeEnabled) {

--- a/packages/mobile/src/screens/favorites-screen/useFavoritesLineup.ts
+++ b/packages/mobile/src/screens/favorites-screen/useFavoritesLineup.ts
@@ -1,0 +1,97 @@
+import { useCallback, useMemo } from 'react'
+
+import {
+  savedPageTracksLineupActions,
+  Kind,
+  makeUid,
+  cacheActions,
+  savedPageSelectors
+} from '@audius/common'
+import { isEqual, debounce, orderBy } from 'lodash'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
+import { useReachabilityEffect } from 'app/hooks/useReachabilityEffect'
+import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
+import { store } from 'app/store'
+import { getOfflineTracks } from 'app/store/offline-downloads/selectors'
+
+const { getSavedTracksLineup } = savedPageSelectors
+
+/**
+ * Returns a favorites lineup, supports boths online and offline
+ * @param fetchLineup the numeric collection id
+ */
+export const useFavoritesLineup = (fetchLineup: () => void) => {
+  const dispatch = useDispatch()
+  const isOfflineModeEnabled = useIsOfflineModeEnabled()
+  const offlineTracks = useSelector(getOfflineTracks)
+  const savedTracks = useSelector(getSavedTracksLineup)
+  const savedTracksUidMap = savedTracks.entries.reduce((acc, track) => {
+    acc[track.id] = track.uid
+    return acc
+  }, {})
+  const lineup = useSelector(getSavedTracksLineup)
+
+  const debouncedFetchSavesOnline = useMemo(() => {
+    return debounce((filterVal) => {
+      dispatch(fetchSaves(filterVal, '', '', 0, FETCH_LIMIT))
+    }, 500)
+  }, [dispatch])
+
+  const fetchSavesOnline = useCallback(() => {
+    debouncedFetchSavesOnline(filterValue)
+  }, [debouncedFetchSavesOnline, filterValue])
+
+  useEffect(() => {
+    if (isReachable) {
+      fetchSavesOnline()
+    }
+  }, [isReachable, fetchSavesOnline])
+
+  const fetchLineupOffline = useCallback(() => {
+    if (isOfflineModeEnabled) {
+      const lineupTracks = Object.values(offlineTracks)
+        .filter((track) =>
+          track.offline?.reasons_for_download.some(
+            (reason) => reason.collection_id === DOWNLOAD_REASON_FAVORITES
+          )
+        )
+        .map((track) => ({
+          uid:
+            savedTracksUidMap[track.track_id] ??
+            makeUid(Kind.TRACKS, track.track_id),
+          id: track.track_id,
+          dateSaved: track.offline?.favorite_created_at,
+          kind: Kind.TRACKS
+        }))
+
+      const cacheTracks = lineupTracks.map((track) => ({
+        id: track.id,
+        uid: track.uid,
+        metadata: track
+      }))
+
+      store.dispatch(cacheActions.add(Kind.TRACKS, cacheTracks, false, true))
+
+      // Reorder lineup tracks according to favorite time
+      const sortedTracks = orderBy(lineupTracks, (track) => track.dateSaved, [
+        'desc'
+      ])
+      dispatch(
+        savedPageTracksLineupActions.fetchLineupMetadatasSucceeded(
+          sortedTracks,
+          0,
+          sortedTracks.length,
+          0,
+          0
+        )
+      )
+    }
+  }, [dispatch, isOfflineModeEnabled, offlineTracks, savedTracksUidMap])
+
+  // Fetch the lineup based on reachability
+  useReachabilityEffect(fetchLineup, fetchLineupOffline)
+
+  return lineup
+}


### PR DESCRIPTION
### Description

* Refactor `useOfflineCollectionLineup` and `useOfflineFavoritesLineup` into `useCollectionLineup` and `useFavoritesLineup` at the component level
* Still passing in the function the fetch the data from remote because we need it in TracksTab to handle all the pagination
   Might make sense to push all the pagination and filter logic into `useFavoritesLineup` but wanted to keep this pr fairly small. @dylanjeffers what do you think about this?

### Dragons

relatively safe

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

