### PR TITLE
[C-2001] Remove queued downloads if deleted/unlisted/etc

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -158,7 +158,7 @@ export const cancelQueuedCollectionDownloads = async (
   )
   queue.stop()
   const jobs = await queue.getJobs()
-  jobs.forEach(async (rawJob) => {
+  jobs.forEach((rawJob) => {
     const { workerName, payload, id, active } = rawJob
     try {
       if (workerName === COLLECTION_DOWNLOAD_WORKER) {
@@ -197,7 +197,7 @@ export const cancelQueuedDownloads = async (
   )
   queue.stop()
   const jobs = await queue.getJobs()
-  jobs.forEach(async (rawJob) => {
+  jobs.forEach((rawJob) => {
     const { workerName, payload, id, active } = rawJob
     try {
       if (workerName === TRACK_DOWNLOAD_WORKER) {

--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -28,9 +28,9 @@ import {
   TRACK_DOWNLOAD_WORKER
 } from './workers/trackDownloadWorker'
 
-const isEqualCollectionPayload = isEqual
+export const isEqualCollectionPayload = isEqual
 
-const isEqualTrackPayload = (
+export const isEqualTrackPayload = (
   a: TrackDownloadWorkerPayload,
   b: TrackDownloadWorkerPayload
 ) => {
@@ -158,29 +158,29 @@ export const cancelQueuedCollectionDownloads = async (
   )
   queue.stop()
   const jobs = await queue.getJobs()
-  const jobsToCancel = jobs.filter(({ workerName, payload }) => {
+  jobs.forEach(async (rawJob) => {
+    const { workerName, payload, id, active } = rawJob
     try {
-      const parsedPayload: CollectionDownloadWorkerPayload = JSON.parse(payload)
-      return (
-        workerName === COLLECTION_DOWNLOAD_WORKER &&
-        (payloadsToCancelById[parsedPayload.collectionId] ?? []).some(
-          (payloadToCancel) =>
-            isEqualCollectionPayload(payloadToCancel, parsedPayload)
+      if (workerName === COLLECTION_DOWNLOAD_WORKER) {
+        const parsedPayload: CollectionDownloadWorkerPayload =
+          JSON.parse(payload)
+        const shouldCancel = (
+          payloadsToCancelById[parsedPayload.collectionId] ?? []
+        ).some((payloadToCancel) =>
+          isEqualCollectionPayload(payloadToCancel, parsedPayload)
         )
-      )
-    } catch (e) {
-      console.warn(e)
-      return false
-    }
-  })
-  jobsToCancel.forEach(async (rawJob) => {
-    try {
-      const parsedPayload: CollectionDownloadWorkerPayload = JSON.parse(
-        rawJob.payload
-      )
-      rawJob.active ? queue.cancelJob(rawJob.id) : queue.removeJob(rawJob)
 
-      store.dispatch(removeCollectionDownload(parsedPayload))
+        if (shouldCancel) {
+          if (active && id) {
+            // Still has attempts left
+            queue.cancelJob(id)
+          } else {
+            // No attempts left
+            queue.removeJob(rawJob)
+          }
+          store.dispatch(removeCollectionDownload(parsedPayload))
+        }
+      }
     } catch (e) {
       console.warn(e)
     }
@@ -197,29 +197,28 @@ export const cancelQueuedDownloads = async (
   )
   queue.stop()
   const jobs = await queue.getJobs()
-  const jobsToCancel = jobs.filter(({ workerName, payload }) => {
+  jobs.forEach(async (rawJob) => {
+    const { workerName, payload, id, active } = rawJob
     try {
-      const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(payload)
-      return (
-        workerName === TRACK_DOWNLOAD_WORKER &&
-        (payloadsToCancelById[parsedPayload.trackId] ?? []).some(
-          (payloadToCancel) =>
-            isEqualTrackPayload(payloadToCancel, parsedPayload)
+      if (workerName === TRACK_DOWNLOAD_WORKER) {
+        const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(payload)
+        const shouldCancel = (
+          payloadsToCancelById[parsedPayload.trackId] ?? []
+        ).some((payloadToCancel) =>
+          isEqualTrackPayload(payloadToCancel, parsedPayload)
         )
-      )
-    } catch (e) {
-      console.warn(e)
-      return false
-    }
-  })
-  jobsToCancel.forEach(async (rawJob) => {
-    try {
-      const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(
-        rawJob.payload
-      )
-      rawJob.active ? queue.cancelJob(rawJob.id) : queue.removeJob(rawJob)
 
-      store.dispatch(removeDownload(parsedPayload.trackId.toString()))
+        if (shouldCancel) {
+          if (active && id) {
+            // Still has attempts left
+            queue.cancelJob(id)
+          } else {
+            // No attempts left
+            queue.removeJob(rawJob)
+          }
+          store.dispatch(removeDownload(parsedPayload.trackId.toString()))
+        }
+      }
     } catch (e) {
       console.warn(e)
     }

--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -35,7 +35,7 @@ export const isEqualTrackPayload = (
   b: TrackDownloadWorkerPayload
 ) => {
   const { favoriteCreatedAt: ignoredAFavoriteCreatedAt, ...aPayload } = a
-  const { favoriteCreatedAt: ignoredBFavoriteCreatedAt, ...bPayload } = a
+  const { favoriteCreatedAt: ignoredBFavoriteCreatedAt, ...bPayload } = b
   return isEqual(aPayload, bPayload)
 }
 

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -364,7 +364,7 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
     const verified = await verifyTrack(trackIdStr, true)
     if (!verified) {
       throw failJob({
-        messsage: `DownloadQueueWorker - download verification failed ${trackIdStr}`,
+        message: `DownloadQueueWorker - download verification failed ${trackIdStr}`,
         error: DownloadTrackError.FAILED_TO_VERIFY
       })
     }

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -74,6 +74,21 @@ const { getTrack } = cacheTracksSelectors
 const { getIsReachable } = reachabilitySelectors
 export const DOWNLOAD_REASON_FAVORITES = 'favorites'
 
+export enum DownloadTrackError {
+  IS_DELETED = 'IS_DELETED',
+  IS_UNLISTED = 'IS_UNLISTED',
+  FAILED_TO_FETCH = 'FAILED_TO_FETCH',
+  FAILED_TO_VERIFY = 'FAILED_TO_VERIFY',
+  UNKNOWN = 'UNKNOWN'
+}
+
+export enum DownloadCollectionError {
+  IS_DELETED = 'IS_DELETED',
+  IS_PRIVATE = 'IS_PRIVATE',
+  FAILED_TO_FETCH = 'FAILED_TO_FETCH',
+  UNKNOWN = 'UNKNOWN'
+}
+
 export const downloadAllFavorites = async () => {
   const state = store.getState()
   const currentUserId = getUserId(state)
@@ -152,11 +167,18 @@ export const downloadCollection = async ({
   store.dispatch(startCollectionDownload({ collectionId, isFavoritesDownload }))
 
   // Throw this
-  const failJob = (message?: string) => {
+  const failJob = ({
+    message,
+    error
+  }: {
+    message?: string
+    error?: DownloadCollectionError
+  }) => {
     store.dispatch(
       errorCollectionDownload({ collectionId, isFavoritesDownload })
     )
-    return new Error(message)
+    console.warn(message)
+    return new Error(error)
   }
 
   const collectionFromApi = (
@@ -167,39 +189,53 @@ export const downloadCollection = async ({
   )[0]
 
   if (!collectionFromApi) {
-    throw failJob(
-      `collection to download not found on discovery - ${collectionFromApi}`
-    )
+    throw failJob({
+      message: `collection to download not found on discovery - ${collectionFromApi}`,
+      error: DownloadCollectionError.FAILED_TO_FETCH
+    })
   }
   const collection = collectionFromApi
 
   // Prevent download of unavailable collections
-  if (
-    collection.is_delete ||
-    // Not sure this is necessary
-    (collection.is_private && collection.playlist_owner_id !== currentUserId)
-  )
-    throw failJob(`collection to download is not available - ${collectionId}`)
-
-  await downloadCollectionCoverArt(collection)
-
-  const collectionToWrite: CollectionMetadata = {
-    ...collection,
-    offline: {
-      // TODO: This is broken! Need to add download reasons. We are only tracking the last known download reason.
-      isFavoritesDownload: !!isFavoritesDownload
-    }
+  if (collection.is_delete) {
+    throw failJob({
+      message: `collection to download is deleted - ${collectionId}`,
+      error: DownloadCollectionError.IS_DELETED
+    })
+  }
+  if (collection.is_private && collection.playlist_owner_id !== currentUserId) {
+    throw failJob({
+      message: `collection to download is private and user is not owner - ${collectionId} - ${currentUserId}`,
+      error: DownloadCollectionError.IS_PRIVATE
+    })
   }
 
-  await writeCollectionJson(
-    collectionId.toString(),
-    collectionToWrite,
-    collection.user
-  )
+  try {
+    await downloadCollectionCoverArt(collection)
 
-  store.dispatch(
-    completeCollectionDownload({ collectionId, isFavoritesDownload })
-  )
+    const collectionToWrite: CollectionMetadata = {
+      ...collection,
+      offline: {
+        // TODO: This is broken! Need to add download reasons. We are only tracking the last known download reason.
+        isFavoritesDownload: !!isFavoritesDownload
+      }
+    }
+
+    await writeCollectionJson(
+      collectionId.toString(),
+      collectionToWrite,
+      collection.user
+    )
+
+    store.dispatch(
+      completeCollectionDownload({ collectionId, isFavoritesDownload })
+    )
+  } catch (e) {
+    throw failJob({
+      message: e?.message ?? 'Unknown Error',
+      error: DownloadCollectionError.UNKNOWN
+    })
+  }
 }
 
 export const batchDownloadTrack = (tracksForDownload: TrackForDownload[]) => {
@@ -219,9 +255,16 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
   store.dispatch(startDownload(trackIdStr))
 
   // Throw this
-  const failJob = (message?: string) => {
+  const failJob = ({
+    message,
+    error
+  }: {
+    message?: string
+    error?: DownloadTrackError
+  }) => {
     store.dispatch(errorDownload(trackIdStr))
-    return new Error(message)
+    console.warn(message)
+    return new Error(error)
   }
 
   const state = store.getState()
@@ -234,13 +277,22 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
   })
 
   if (!trackFromApi) {
-    throw failJob(`track to download not found on discovery - ${trackIdStr}`)
+    throw failJob({
+      message: `track to download not found on discovery - ${trackIdStr}`,
+      error: DownloadTrackError.FAILED_TO_FETCH
+    })
   }
-  if (
-    trackFromApi?.is_delete ||
-    (trackFromApi?.is_unlisted && currentUserId !== trackFromApi.user.user_id)
-  ) {
-    throw failJob(`track to download is not available - ${trackIdStr}`)
+  if (trackFromApi.is_delete) {
+    throw failJob({
+      message: `track to download is deleted - ${trackIdStr}`,
+      error: DownloadTrackError.IS_DELETED
+    })
+  }
+  if (trackFromApi.is_unlisted && currentUserId !== trackFromApi.user.user_id) {
+    throw failJob({
+      message: `track to download is unlisted and user is not owner - ${trackIdStr} - ${currentUserId}`,
+      error: DownloadTrackError.IS_UNLISTED
+    })
   }
 
   try {
@@ -311,9 +363,10 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
 
     const verified = await verifyTrack(trackIdStr, true)
     if (!verified) {
-      throw failJob(
-        `DownloadQueueWorker - download verification failed ${trackIdStr}`
-      )
+      throw failJob({
+        messsage: `DownloadQueueWorker - download verification failed ${trackIdStr}`,
+        error: DownloadTrackError.FAILED_TO_VERIFY
+      })
     }
     store.dispatch(loadTrack(trackToWrite))
     store.dispatch(completeDownload(trackIdStr))
@@ -515,7 +568,8 @@ export const removeTrackDownload = async ({
     }
   } catch (e) {
     console.error(
-      `failed to remove track ${trackId} from collection ${downloadReason.collection_id}`
+      `failed to remove track ${trackId} from collection ${downloadReason.collection_id}`,
+      e
     )
   }
 }

--- a/packages/mobile/src/services/offline-downloader/workers/collectionDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/collectionDownloadWorker.ts
@@ -19,17 +19,23 @@ const onFailure = async (
   switch (error.message) {
     case DownloadCollectionError.IS_DELETED:
     case DownloadCollectionError.IS_PRIVATE: {
+      queue.stop()
       const jobs = await queue.getJobs()
-      jobs.forEach((rawJob) => {
-        if (rawJob.workerName === COLLECTION_DOWNLOAD_WORKER) {
-          const parsedPayload: CollectionDownloadWorkerPayload = JSON.parse(
-            rawJob.payload
-          )
-          if (isEqualCollectionPayload(payload, parsedPayload)) {
-            queue.removeJob(rawJob)
+      try {
+        jobs.forEach((rawJob) => {
+          if (rawJob.workerName === COLLECTION_DOWNLOAD_WORKER) {
+            const parsedPayload: CollectionDownloadWorkerPayload = JSON.parse(
+              rawJob.payload
+            )
+            if (isEqualCollectionPayload(payload, parsedPayload)) {
+              queue.removeJob(rawJob)
+            }
           }
-        }
-      })
+        })
+      } catch (e) {
+        console.warn(e)
+      }
+      queue.start()
       break
     }
     default:

--- a/packages/mobile/src/services/offline-downloader/workers/collectionDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/collectionDownloadWorker.ts
@@ -1,13 +1,41 @@
 import type { CancellablePromise } from 'react-native-job-queue'
-import { Worker } from 'react-native-job-queue'
+import queue, { Worker } from 'react-native-job-queue'
 
-import { downloadCollection } from '../offline-downloader'
+import { isEqualCollectionPayload } from 'app/services/offline-downloader/offline-download-queue'
+
+import {
+  downloadCollection,
+  DownloadCollectionError
+} from '../offline-downloader'
 import type { CollectionForDownload } from '../types'
 
 export const COLLECTION_DOWNLOAD_WORKER = 'collection_download_worker'
 export type CollectionDownloadWorkerPayload = CollectionForDownload
 
-const onFailure = ({ payload }: { payload: CollectionForDownload }) => {}
+const onFailure = async (
+  { payload }: { payload: CollectionForDownload },
+  error: Error
+) => {
+  switch (error.message) {
+    case DownloadCollectionError.IS_DELETED:
+    case DownloadCollectionError.IS_PRIVATE: {
+      const jobs = await queue.getJobs()
+      jobs.forEach((rawJob) => {
+        if (rawJob.workerName === COLLECTION_DOWNLOAD_WORKER) {
+          const parsedPayload: CollectionDownloadWorkerPayload = JSON.parse(
+            rawJob.payload
+          )
+          if (isEqualCollectionPayload(payload, parsedPayload)) {
+            queue.removeJob(rawJob)
+          }
+        }
+      })
+      break
+    }
+    default:
+      break
+  }
+}
 
 const executor = (payload: CollectionDownloadWorkerPayload) => {
   const promise: CancellablePromise<void> = downloadCollection(payload)

--- a/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
@@ -22,17 +22,23 @@ const onFailure = async (
   switch (error.message) {
     case DownloadTrackError.IS_DELETED:
     case DownloadTrackError.IS_UNLISTED: {
+      queue.stop()
       const jobs = await queue.getJobs()
-      jobs.forEach((rawJob) => {
-        if (rawJob.workerName === TRACK_DOWNLOAD_WORKER) {
-          const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(
-            rawJob.payload
-          )
-          if (isEqualTrackPayload(payload, parsedPayload)) {
-            queue.removeJob(rawJob)
+      try {
+        jobs.forEach((rawJob) => {
+          if (rawJob.workerName === TRACK_DOWNLOAD_WORKER) {
+            const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(
+              rawJob.payload
+            )
+            if (isEqualTrackPayload(payload, parsedPayload)) {
+              queue.removeJob(rawJob)
+            }
           }
-        }
-      })
+        })
+      } catch (e) {
+        console.warn(e)
+      }
+      queue.start()
       break
     }
     default:

--- a/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
@@ -1,17 +1,43 @@
 import type { CancellablePromise } from 'react-native-job-queue'
-import { Worker } from 'react-native-job-queue'
+import queue, { Worker } from 'react-native-job-queue'
 
+import { isEqualTrackPayload } from 'app/services/offline-downloader/offline-download-queue'
 import { store } from 'app/store'
 import { errorDownload } from 'app/store/offline-downloads/slice'
 
-import { batchRemoveTrackDownload, downloadTrack } from '../offline-downloader'
+import {
+  batchRemoveTrackDownload,
+  downloadTrack,
+  DownloadTrackError
+} from '../offline-downloader'
 import type { TrackForDownload } from '../types'
 
 export const TRACK_DOWNLOAD_WORKER = 'track_download_worker'
 export type TrackDownloadWorkerPayload = TrackForDownload
 
-const onFailure = ({ payload }: { payload: TrackForDownload }) => {
-  store.dispatch(errorDownload(payload.trackId.toString()))
+const onFailure = async (
+  { payload }: { payload: TrackForDownload },
+  error: Error
+) => {
+  switch (error.message) {
+    case DownloadTrackError.IS_DELETED:
+    case DownloadTrackError.IS_UNLISTED: {
+      const jobs = await queue.getJobs()
+      jobs.forEach((rawJob) => {
+        if (rawJob.workerName === TRACK_DOWNLOAD_WORKER) {
+          const parsedPayload: TrackDownloadWorkerPayload = JSON.parse(
+            rawJob.payload
+          )
+          if (isEqualTrackPayload(payload, parsedPayload)) {
+            queue.removeJob(rawJob)
+          }
+        }
+      })
+      break
+    }
+    default:
+      break
+  }
 }
 
 const executor = (payload: TrackDownloadWorkerPayload) => {


### PR DESCRIPTION
### Description

Removes queued downloads if the track/collection is deleted/unlisted. Currently deleted tracks in your favorites/collection cause a bottleneck as they wait to be retried 3 times only to find the same result.
Improves looping code in the existing cancelXDownloads methods

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Local simulator vs. staging with a bunch of deleted tracks

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

