### PR TITLE
[C-1974] Add batch remove downloads

### DIFF
--- a/packages/mobile/src/components/drawers/RemoveDownloadedFavoritesDrawer.tsx
+++ b/packages/mobile/src/components/drawers/RemoveDownloadedFavoritesDrawer.tsx
@@ -1,4 +1,8 @@
-import { removeAllDownloadedFavorites } from 'app/services/offline-downloader'
+import { useCallback } from 'react'
+
+import { useDispatch } from 'react-redux'
+
+import { removeAllDownloadedFavorites } from 'app/store/offline-downloads/slice'
 
 import { ConfirmationDrawer } from './ConfirmationDrawer'
 
@@ -12,11 +16,17 @@ const messages = {
 const drawerName = 'RemoveDownloadedFavorites'
 
 export const RemoveDownloadedFavoritesDrawer = () => {
+  const dispatch = useDispatch()
+
+  const handleConfirm = useCallback(() => {
+    dispatch(removeAllDownloadedFavorites())
+  }, [dispatch])
+
   return (
     <ConfirmationDrawer
       drawerName={drawerName}
       messages={messages}
-      onConfirm={removeAllDownloadedFavorites}
+      onConfirm={handleConfirm}
     />
   )
 }

--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -8,8 +8,7 @@ import {
   batchInitDownload,
   errorCollectionDownload,
   errorDownload,
-  removeCollectionDownload,
-  removeDownload
+  removeCollectionDownload
 } from 'app/store/offline-downloads/slice'
 
 import type { CollectionForDownload, TrackForDownload } from './types'

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -13,8 +13,7 @@ import {
   cacheTracksSelectors,
   SquareSizes,
   encodeHashId,
-  accountSelectors,
-  reachabilitySelectors
+  accountSelectors
 } from '@audius/common'
 import { uniq, isEqual } from 'lodash'
 import RNFetchBlob from 'rn-fetch-blob'
@@ -25,8 +24,7 @@ import { getAccountCollections } from 'app/screens/favorites-screen/selectors'
 import { store } from 'app/store'
 import {
   getOfflineCollections,
-  getOfflineFavoritedCollections,
-  getOfflineTracks
+  getOfflineFavoritedCollections
 } from 'app/store/offline-downloads/selectors'
 import {
   actions as offlineDownloadsActions,
@@ -71,7 +69,6 @@ const {
 } = RNFetchBlob
 const { getUserId } = accountSelectors
 const { getTrack } = cacheTracksSelectors
-const { getIsReachable } = reachabilitySelectors
 export const DOWNLOAD_REASON_FAVORITES = 'favorites'
 
 export const downloadAllFavorites = async () => {
@@ -358,81 +355,6 @@ const shouldAbortDownload = (trackForDownload: TrackForDownload) => {
   if (collection_id === DOWNLOAD_REASON_FAVORITES && isSaved === false) {
     return true
   }
-}
-
-export const removeAllDownloadedFavorites = async () => {
-  const state = store.getState()
-  const currentUserId = getUserId(state)
-  const isReachable = getIsReachable(state)
-  if (!currentUserId) return
-  const downloadedCollections = getOfflineCollections(state)
-  const favoritedDownloadedCollections = getOfflineFavoritedCollections(state)
-  const offlineTracks = getOfflineTracks(state)
-
-  const downloadedFavoritedTracks = Object.values(offlineTracks)
-    .filter((track) => !!track.offline?.favorite_created_at)
-    .map((track) => ({
-      trackId: track.track_id,
-      favoriteCreatedAt: track.offline?.favorite_created_at
-    }))
-
-  purgeDownloadedCollection(DOWNLOAD_REASON_FAVORITES)
-
-  const allFavoritedTracks = isReachable
-    ? [
-        ...(await fetchAllFavoritedTracks(currentUserId)),
-        ...downloadedFavoritedTracks
-      ]
-    : downloadedFavoritedTracks
-  const tracksForDownload: TrackForDownload[] = allFavoritedTracks.map(
-    ({ trackId, favoriteCreatedAt }) => ({
-      trackId,
-      downloadReason: {
-        is_from_favorites: true,
-        collection_id: DOWNLOAD_REASON_FAVORITES,
-        favorite_created_at: favoriteCreatedAt
-      }
-    })
-  )
-
-  // remove collections if they're not also downloaded separately
-  Object.entries(favoritedDownloadedCollections).forEach(
-    ([collectionId, isDownloaded]) => {
-      // Find any tracks from downloaded collections and mark them
-      // to be removed.
-      tracksForDownload.push(
-        ...Object.values(offlineTracks)
-          .filter((track) =>
-            track.offline?.reasons_for_download.some(
-              (reason) =>
-                reason.collection_id === collectionId &&
-                reason.is_from_favorites
-            )
-          )
-          .map((track) => ({
-            trackId: track.track_id,
-            downloadReason: {
-              is_from_favorites: true,
-              collection_id: collectionId
-            }
-          }))
-      )
-
-      if (!isDownloaded) return
-      if (downloadedCollections[collectionId]) {
-        store.dispatch(
-          offlineDownloadsActions.removeCollectionDownload({
-            collectionId,
-            isFavoritesDownload: true
-          })
-        )
-      } else {
-        purgeDownloadedCollection(collectionId)
-      }
-    }
-  )
-
-  batchRemoveTrackDownload(tracksForDownload)
 }
 
 export const removeDownloadedCollectionFromFavorites = async (

--- a/packages/mobile/src/services/offline-downloader/types.ts
+++ b/packages/mobile/src/services/offline-downloader/types.ts
@@ -1,7 +1,9 @@
 import type { DownloadReason } from '@audius/common'
 
+import type { CollectionId } from 'app/store/offline-downloads/slice'
+
 export type CollectionForDownload = {
-  collectionId: number
+  collectionId: CollectionId
   isFavoritesDownload?: boolean
 }
 

--- a/packages/mobile/src/services/offline-downloader/types.ts
+++ b/packages/mobile/src/services/offline-downloader/types.ts
@@ -1,9 +1,7 @@
-import type { DownloadReason } from '@audius/common'
-
-import type { CollectionId } from 'app/store/offline-downloads/slice'
+import type { DownloadReason, ID } from '@audius/common'
 
 export type CollectionForDownload = {
-  collectionId: CollectionId
+  collectionId: ID
   isFavoritesDownload?: boolean
 }
 

--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -43,6 +43,10 @@ import {
   setPlayCounterWorker
 } from 'app/services/offline-downloader/workers'
 
+import { watchRemoveAllDownloadedFavorites } from './sagas/removeAllDownloadedFavoritesSaga'
+import { watchRemoveCollectionDownloads } from './sagas/removeCollectionDownloadsSaga'
+import { watchRemoveTrackDownloads } from './sagas/removeTrackDownloadsSaga'
+import { watchUpdateTrackDownloadReasons } from './sagas/updateTrackDownloadReasonsSaga'
 import {
   getIsCollectionMarkedForDownload,
   getOfflineCollections,
@@ -262,7 +266,11 @@ const sagas = () => {
     watchSetReachable,
     watchSetUnreachable,
     startSync,
-    watchAddTrackToPlaylist
+    watchAddTrackToPlaylist,
+    watchRemoveAllDownloadedFavorites,
+    watchRemoveTrackDownloads,
+    watchUpdateTrackDownloadReasons,
+    watchRemoveCollectionDownloads
   ]
 }
 

--- a/packages/mobile/src/store/offline-downloads/sagas/removeAllDownloadedFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/removeAllDownloadedFavoritesSaga.ts
@@ -7,6 +7,7 @@ import type {
   TrackForDownload
 } from 'app/services/offline-downloader'
 import {
+  DOWNLOAD_REASON_FAVORITES,
   cancelQueuedCollectionDownloads,
   cancelQueuedDownloads
 } from 'app/services/offline-downloader'
@@ -80,13 +81,15 @@ function* removeFavoritedCollections() {
   )
   const offlineFavoritedCollectionIds = Object.keys(offlineFavoritedCollections)
 
-  const collectionsToRemove: CollectionId[] = ['favorites']
+  const collectionsToRemove: CollectionId[] = [DOWNLOAD_REASON_FAVORITES]
   const collectionsToUpdate: CollectionReasonsToUpdate[] = []
   const collectionsToDequeue: CollectionForDownload[] =
-    offlineFavoritedCollectionIds.map((collectionId) => ({
-      collectionId,
-      isFavoritesDownload: true
-    }))
+    offlineFavoritedCollectionIds
+      .filter((collectionId) => collectionId !== DOWNLOAD_REASON_FAVORITES)
+      .map((collectionId) => ({
+        collectionId: parseInt(collectionId, 10),
+        isFavoritesDownload: true
+      }))
 
   offlineFavoritedCollectionIds.forEach((favoritedCollectionId) => {
     const offlineCollectionStatus = offlineCollections[favoritedCollectionId]

--- a/packages/mobile/src/store/offline-downloads/sagas/removeAllDownloadedFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/removeAllDownloadedFavoritesSaga.ts
@@ -1,0 +1,127 @@
+import type { ID } from '@audius/common'
+import { takeEvery, select, put } from 'typed-redux-saga'
+
+import {
+  getOfflineCollections,
+  getOfflineFavoritedCollections,
+  getOfflineTracks
+} from '../selectors'
+import type {
+  CollectionId,
+  CollectionReasonsToUpdate,
+  TrackReasonsToUpdate
+} from '../slice'
+import {
+  OfflineDownloadStatus,
+  updateCollectionDownloadReasons,
+  removeCollectionDownloads,
+  updateTrackDownloadReasons,
+  removeTrackDownloads,
+  removeAllDownloadedFavorites
+} from '../slice'
+
+/*
+ * Saga initiated when user has requested to un-download their favorites.
+ * This includes the "favorites" collection and all collections that were
+ * not explicitly downloaded by the user previously.
+ */
+export function* watchRemoveAllDownloadedFavorites() {
+  yield* takeEvery(
+    removeAllDownloadedFavorites.type,
+    removeAllDownloadedFavoritesWorker
+  )
+}
+
+function* removeAllDownloadedFavoritesWorker() {
+  yield* removeAllFavoritesTracks()
+  yield* removeAllFavoritesCollections()
+}
+
+function* removeAllFavoritesTracks() {
+  const offlineTracks = yield* select(getOfflineTracks)
+  const offlineTrackList = Object.keys(offlineTracks).map(
+    (offlineTrackId) => offlineTracks[offlineTrackId]
+  )
+
+  const tracksToRemove: ID[] = []
+  const reasonsToUpdate: TrackReasonsToUpdate[] = []
+
+  // TODO: double check if "favorites" collection is in here
+  const offlineFavoritedCollections = yield* select(
+    getOfflineFavoritedCollections
+  )
+  const favoritedCollectionIds = new Set([
+    'favorites',
+    ...Object.keys(offlineFavoritedCollections)
+  ])
+
+  offlineTrackList.forEach((offlineTrack) => {
+    const { track_id, offline } = offlineTrack
+    if (!offline) return
+
+    const { reasons_for_download } = offline
+
+    const remainingReasons = reasons_for_download.filter((reason) => {
+      const { is_from_favorites, collection_id } = reason
+      return !(
+        is_from_favorites &&
+        collection_id &&
+        favoritedCollectionIds.has(collection_id)
+      )
+    })
+
+    if (remainingReasons.length === 0) {
+      tracksToRemove.push(track_id)
+    } else {
+      reasonsToUpdate.push({
+        trackId: track_id,
+        reasons_for_download: remainingReasons
+      })
+    }
+  })
+
+  if (tracksToRemove.length > 0) {
+    yield* put(removeTrackDownloads({ trackIds: tracksToRemove }))
+  }
+
+  if (reasonsToUpdate.length > 0) {
+    yield* put(updateTrackDownloadReasons({ reasons: reasonsToUpdate }))
+  }
+}
+
+function* removeAllFavoritesCollections() {
+  const offlineCollections = yield* select(getOfflineCollections)
+  const offlineFavoritedCollections = yield* select(
+    getOfflineFavoritedCollections
+  )
+
+  const collectionsToRemove: CollectionId[] = ['favorites']
+  const collectionsToUpdate: CollectionReasonsToUpdate[] = []
+
+  Object.keys(offlineFavoritedCollections).forEach((favoritedCollectionId) => {
+    const offlineCollectionStatus = offlineCollections[favoritedCollectionId]
+    const isAlsoOfflineCollection =
+      offlineCollectionStatus &&
+      offlineCollectionStatus !== OfflineDownloadStatus.INIT
+
+    if (isAlsoOfflineCollection) {
+      collectionsToUpdate.push({
+        collectionId: parseInt(favoritedCollectionId, 10),
+        isFavoritesDownload: false
+      })
+    } else {
+      collectionsToRemove.push(parseInt(favoritedCollectionId, 10))
+    }
+  })
+
+  if (collectionsToRemove.length > 0) {
+    yield* put(
+      removeCollectionDownloads({ collectionIds: collectionsToRemove })
+    )
+  }
+  if (collectionsToUpdate.length > 0) {
+    yield* put(
+      updateCollectionDownloadReasons({ reasons: collectionsToUpdate })
+    )
+  }
+}

--- a/packages/mobile/src/store/offline-downloads/sagas/removeAllDownloadedFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/removeAllDownloadedFavoritesSaga.ts
@@ -139,7 +139,7 @@ function* removeFavoritedTracks() {
       reasons_for_download,
       (reason) => {
         const { is_from_favorites, collection_id } = reason
-        return !(
+        return (
           is_from_favorites &&
           collection_id &&
           favoritedCollectionIds.has(collection_id)

--- a/packages/mobile/src/store/offline-downloads/sagas/removeCollectionDownloadsSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/removeCollectionDownloadsSaga.ts
@@ -1,0 +1,23 @@
+import RNFetchBlob from 'rn-fetch-blob'
+import { takeEvery, call } from 'typed-redux-saga'
+
+import { getLocalCollectionDir } from 'app/services/offline-downloader'
+
+import type { RemoveCollectionDownloadsAction } from '../slice'
+import { removeCollectionDownloads } from '../slice'
+
+export function* watchRemoveCollectionDownloads() {
+  yield* takeEvery(removeCollectionDownloads.type, removeCollectionsFromDisk)
+}
+
+function* removeCollectionsFromDisk(action: RemoveCollectionDownloadsAction) {
+  const { collectionIds } = action.payload
+  for (const collectionId of collectionIds) {
+    const collectionDirectory = yield* call(
+      getLocalCollectionDir,
+      collectionId.toString()
+    )
+
+    yield* call(RNFetchBlob.fs.unlink, collectionDirectory)
+  }
+}

--- a/packages/mobile/src/store/offline-downloads/sagas/removeTrackDownloadsSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/removeTrackDownloadsSaga.ts
@@ -1,0 +1,19 @@
+import RNFetchBlob from 'rn-fetch-blob'
+import { takeEvery, call } from 'typed-redux-saga'
+
+import { getLocalTrackDir } from 'app/services/offline-downloader'
+
+import type { RemoveTrackDownloadsAction } from '../slice'
+import { removeTrackDownloads } from '../slice'
+
+function* removeTracksFromDisk(action: RemoveTrackDownloadsAction) {
+  const { trackIds } = action.payload
+  for (const trackId of trackIds) {
+    const trackDirectory = yield* call(getLocalTrackDir, trackId.toString())
+    yield* call(RNFetchBlob.fs.unlink, trackDirectory)
+  }
+}
+
+export function* watchRemoveTrackDownloads() {
+  yield* takeEvery(removeTrackDownloads.type, removeTracksFromDisk)
+}

--- a/packages/mobile/src/store/offline-downloads/sagas/updateTrackDownloadReasonsSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/updateTrackDownloadReasonsSaga.ts
@@ -1,0 +1,47 @@
+import type { Nullable, Track } from '@audius/common'
+import RNFetchBlob from 'rn-fetch-blob'
+import { takeEvery, fork, call } from 'typed-redux-saga'
+
+import { getLocalTrackJsonPath } from 'app/services/offline-downloader'
+
+import type {
+  TrackReasonsToUpdate,
+  UpdateTrackDownloadReasonsAction
+} from '../slice'
+import { updateTrackDownloadReasons } from '../slice'
+
+export function* watchUpdateTrackDownloadReasons() {
+  yield* takeEvery(updateTrackDownloadReasons.type, saveDownloadReasonsToDisk)
+}
+
+function* saveDownloadReasonsToDisk(action: UpdateTrackDownloadReasonsAction) {
+  const { reasons } = action.payload
+  for (const reason of reasons) {
+    yield* fork(saveDownloadReasonToDisk, reason)
+  }
+}
+
+function* saveDownloadReasonToDisk(reason: TrackReasonsToUpdate) {
+  const { trackId, reasons_for_download } = reason
+  const trackPath = yield* call(getLocalTrackJsonPath, trackId.toString())
+  const trackMetadata: Nullable<Track> = yield* call(
+    RNFetchBlob.fs.readFile,
+    trackPath,
+    'utf8'
+  )
+  if (!trackMetadata) return
+
+  const newTrackMetadata = {
+    ...trackMetadata,
+    offline: {
+      ...trackMetadata.offline,
+      reasons_for_download
+    }
+  }
+
+  yield* call(
+    RNFetchBlob.fs.writeFile,
+    trackPath,
+    JSON.stringify(newTrackMetadata)
+  )
+}


### PR DESCRIPTION
### Description

Adds batch remove downloads flow
Interested to see what yall think regarding the architecture. In this case, remove-downloads-button dispatches an action, and that action runs a saga which then batch updates the redux store, which triggers more sagas to save to disk. With this architecture we have a potentially simpler data flow.


TODO: need to fit in the queue cancel. would like to talk about that a bit to make sure we are cancelling the correct jobs
