### PR TITLE
[C-2015] Debounce the callbacks for the download toggles for favorites and collections

### DIFF
--- a/packages/mobile/src/hooks/useDebouncedCallback.ts
+++ b/packages/mobile/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,18 @@
+import { useCallback, useRef } from 'react'
+
+export const useDebouncedCallback = (func: Function, wait: number) => {
+  const timeout = useRef<NodeJS.Timeout | null>(null)
+
+  return useCallback(
+    (...args) => {
+      const later = () => {
+        if (timeout.current) clearTimeout(timeout.current)
+        func(...args)
+      }
+
+      if (timeout.current) clearTimeout(timeout.current)
+      timeout.current = setTimeout(later, wait)
+    },
+    [func, wait]
+  )
+}

--- a/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
@@ -9,13 +9,13 @@ import {
   collectionsSocialActions,
   Variant
 } from '@audius/common'
-import { debounce } from 'lodash'
 import { View } from 'react-native'
 import { useSelector, useDispatch } from 'react-redux'
 
 import { Switch, Text } from 'app/components/core'
 import { getCollectionDownloadStatus } from 'app/components/offline-downloads/CollectionDownloadStatusIndicator'
 import { DownloadStatusIndicator } from 'app/components/offline-downloads/DownloadStatusIndicator'
+import { useDebouncedCallback } from 'app/hooks/useDebouncedCallback'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
 import { useProxySelector } from 'app/hooks/useProxySelector'
 import {
@@ -152,9 +152,8 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
     [isMarkedForDownload, playlist_id]
   )
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleToggleDownload = useCallback(
-    debounce((isDownloadEnabled: boolean) => {
+    (isDownloadEnabled: boolean) => {
       if (isDownloadEnabled) {
         batchDownloadCollection([collection], false)
         const isOwner = currentUserId === collection.playlist_owner_id
@@ -175,8 +174,13 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
           })
         )
       }
-    }, 800),
+    },
     [collection, currentUserId, dispatch, playlist_id]
+  )
+
+  const debouncedHandleToggleDownload = useDebouncedCallback(
+    handleToggleDownload,
+    800
   )
 
   const getTextColor = () => {
@@ -210,7 +214,7 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
       <View style={styles.headerRight}>
         <Switch
           defaultValue={isMarkedForDownload}
-          onValueChange={handleToggleDownload}
+          onValueChange={debouncedHandleToggleDownload}
           disabled={
             isFavoritesToggleOn || (!isReachable && !isMarkedForDownload)
           }

--- a/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
@@ -9,6 +9,7 @@ import {
   collectionsSocialActions,
   Variant
 } from '@audius/common'
+import { debounce } from 'lodash'
 import { View } from 'react-native'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -151,8 +152,9 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
     [isMarkedForDownload, playlist_id]
   )
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleToggleDownload = useCallback(
-    (isDownloadEnabled: boolean) => {
+    debounce((isDownloadEnabled: boolean) => {
       if (isDownloadEnabled) {
         batchDownloadCollection([collection], false)
         const isOwner = currentUserId === collection.playlist_owner_id
@@ -173,7 +175,7 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
           })
         )
       }
-    },
+    }, 800),
     [collection, currentUserId, dispatch, playlist_id]
   )
 
@@ -207,7 +209,7 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
       </View>
       <View style={styles.headerRight}>
         <Switch
-          value={isMarkedForDownload}
+          defaultValue={isMarkedForDownload}
           onValueChange={handleToggleDownload}
           disabled={
             isFavoritesToggleOn || (!isReachable && !isMarkedForDownload)

--- a/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
+++ b/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from 'react'
 
 import { reachabilitySelectors } from '@audius/common'
-import { debounce } from 'lodash'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Switch } from 'app/components/core'
 import { DownloadStatusIndicator } from 'app/components/offline-downloads/DownloadStatusIndicator'
+import { useDebouncedCallback } from 'app/hooks/useDebouncedCallback'
 import { useProxySelector } from 'app/hooks/useProxySelector'
 import {
   downloadAllFavorites,
@@ -79,9 +79,8 @@ export const DownloadFavoritesSwitch = () => {
 
   const downloadStatus = getDownloadStatus()
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleToggleDownload = useCallback(
-    debounce((isDownloadEnabled: boolean) => {
+    (isDownloadEnabled: boolean) => {
       if (isDownloadEnabled) {
         downloadAllFavorites()
       } else {
@@ -92,8 +91,13 @@ export const DownloadFavoritesSwitch = () => {
           })
         )
       }
-    }, 800),
+    },
     [dispatch]
+  )
+
+  const debouncedHandleToggleDownload = useDebouncedCallback(
+    handleToggleDownload,
+    800
   )
 
   return (
@@ -104,7 +108,7 @@ export const DownloadFavoritesSwitch = () => {
       />
       <Switch
         defaultValue={isMarkedForDownload}
-        onValueChange={handleToggleDownload}
+        onValueChange={debouncedHandleToggleDownload}
         disabled={!isReachable && !isMarkedForDownload}
       />
     </View>

--- a/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
+++ b/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 
 import { reachabilitySelectors } from '@audius/common'
+import { debounce } from 'lodash'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -78,8 +79,9 @@ export const DownloadFavoritesSwitch = () => {
 
   const downloadStatus = getDownloadStatus()
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleToggleDownload = useCallback(
-    (isDownloadEnabled: boolean) => {
+    debounce((isDownloadEnabled: boolean) => {
       if (isDownloadEnabled) {
         downloadAllFavorites()
       } else {
@@ -90,7 +92,7 @@ export const DownloadFavoritesSwitch = () => {
           })
         )
       }
-    },
+    }, 800),
     [dispatch]
   )
 
@@ -101,7 +103,7 @@ export const DownloadFavoritesSwitch = () => {
         style={styles.downloadStatusIndicator}
       />
       <Switch
-        value={isMarkedForDownload}
+        defaultValue={isMarkedForDownload}
         onValueChange={handleToggleDownload}
         disabled={!isReachable && !isMarkedForDownload}
       />


### PR DESCRIPTION
### Description

Debounced the callback passed to the download switches for favorites and collections to try to prevent bad states when flipping the toggle rapidly.

Choose a slightly longer debounce time to handle slight lag when pressing the toggle, but willing to update the time to whatever we think makes sense here

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

