### PR TITLE
[C-2012] [C-1999] [C-1734] Fix collection image loading

### DIFF
--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -1,7 +1,5 @@
 import type { Collection, Nullable, SquareSizes, User } from '@audius/common'
 import { cacheUsersSelectors } from '@audius/common'
-import type { ImageProps } from 'react-native'
-import { Image } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import imageEmpty from 'app/assets/images/imageBlank2x.png'

--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -1,10 +1,13 @@
 import type { Collection, Nullable, SquareSizes, User } from '@audius/common'
 import { cacheUsersSelectors } from '@audius/common'
+import type { ImageProps } from 'react-native'
+import { Image } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import imageEmpty from 'app/assets/images/imageBlank2x.png'
 import { useContentNodeImage } from 'app/hooks/useContentNodeImage'
 import { useLocalCollectionImage } from 'app/hooks/useLocalImage'
+import { useThemeColors } from 'app/utils/theme'
 
 import type { FastImageProps } from './FastImage'
 import { FastImage } from './FastImage'
@@ -51,11 +54,24 @@ type CollectionImageProps = UseCollectionImageOptions & Partial<FastImageProps>
 
 export const CollectionImage = (props: CollectionImageProps) => {
   const { collection, size, user, style, ...other } = props
+
   const collectionImageSource = useCollectionImage({ collection, size, user })
+  const { neutralLight8 } = useThemeColors()
 
   if (!collectionImageSource) return null
 
-  const { source, handleError } = collectionImageSource
+  const { source, handleError, isFallbackImage } = collectionImageSource
+
+  if (isFallbackImage) {
+    return (
+      <FastImage
+        {...other}
+        style={[style, { backgroundColor: neutralLight8 }]}
+        source={source}
+        onError={handleError}
+      />
+    )
+  }
 
   return (
     <FastImage {...other} style={style} source={source} onError={handleError} />

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux'
 import imageEmpty from 'app/assets/images/imageBlank2x.png'
 import { useContentNodeImage } from 'app/hooks/useContentNodeImage'
 import { useLocalTrackImage } from 'app/hooks/useLocalImage'
+import { useThemeColors } from 'app/utils/theme'
 
 import type { FastImageProps } from './FastImage'
 import { FastImage } from './FastImage'
@@ -49,10 +50,22 @@ export const TrackImage = (props: TrackImageProps) => {
   const { track, size, user, style, ...other } = props
 
   const trackImageSource = useTrackImage({ track, size, user })
+  const { neutralLight8 } = useThemeColors()
 
   if (!trackImageSource) return null
 
-  const { source, handleError } = trackImageSource
+  const { source, handleError, isFallbackImage } = trackImageSource
+
+  if (isFallbackImage) {
+    return (
+      <FastImage
+        {...other}
+        style={[style, { backgroundColor: neutralLight8 }]}
+        source={source}
+        onError={handleError}
+      />
+    )
+  }
 
   return (
     <FastImage {...other} style={style} source={source} onError={handleError} />

--- a/packages/mobile/src/hooks/useContentNodeImage.ts
+++ b/packages/mobile/src/hooks/useContentNodeImage.ts
@@ -10,6 +10,7 @@ import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 export type ContentNodeImageSource = {
   source: ImageSourcePropType
   handleError: () => void
+  isFallbackImage: boolean
 }
 
 export const isImageUriSource = (
@@ -120,6 +121,7 @@ type UseContentNodeImageOptions = {
  * @returns {
  *  source: ImageSource
  *  onError: () => void
+ *  isFallbackImage: boolean
  * }
  */
 export const useContentNodeImage = ({
@@ -163,27 +165,25 @@ export const useContentNodeImage = ({
     }
   }, [imageSourceIndex, imageSources])
 
+  const showFallbackImage = useMemo(() => {
+    return !user || !cid || failedToLoad
+  }, [failedToLoad, user, cid])
+
   const source = useMemo(() => {
-    if (!user || !cid || failedToLoad) {
+    if (showFallbackImage) {
       return fallbackImageSource
     }
 
     return imageSources[imageSourceIndex]
-  }, [
-    imageSources,
-    imageSourceIndex,
-    fallbackImageSource,
-    failedToLoad,
-    user,
-    cid
-  ])
+  }, [showFallbackImage, imageSources, imageSourceIndex, fallbackImageSource])
 
   const result = useMemo(
     () => ({
       source,
-      handleError
+      handleError,
+      isFallbackImage: showFallbackImage
     }),
-    [source, handleError]
+    [source, handleError, showFallbackImage]
   )
 
   return result

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -1239,7 +1239,7 @@ function* watchFetchCoverArt() {
       inProgress.add(key)
 
       try {
-        let collection = yield select(getCollection, { id: collectionId })
+        const collection = yield select(getCollection, { id: collectionId })
         const user = yield select(getUser, { id: collection.playlist_owner_id })
         if (
           !collection ||
@@ -1260,14 +1260,18 @@ function* watchFetchCoverArt() {
           coverArtSize,
           gateways
         )
-        collection = yield select(getCollection, { id: collectionId })
-        collection._cover_art_sizes = {
-          ...collection._cover_art_sizes,
-          [coverArtSize || DefaultSizes.OVERRIDE]: url
-        }
         yield put(
           cacheActions.update(Kind.COLLECTIONS, [
-            { id: collectionId, metadata: collection }
+            {
+              id: collectionId,
+              metadata: {
+                ...collection,
+                _cover_art_sizes: {
+                  ...collection._cover_art_sizes,
+                  [coverArtSize || DefaultSizes.OVERRIDE]: url
+                }
+              }
+            }
           ])
         )
       } catch (e) {


### PR DESCRIPTION
### Description

* Add backgroundColor when displaying the fallback image for tracks and collections. It was invisible because it was white on white
* Fix loading of collection images on web profile and mobile favorites
  * In the saga responsible for fetching the collection images, we were mutating the collection returned from the selector. This meant that the selector at the profile page level (and others) were not running because the updated collection cache entries were equal to the ones already existing in the store
  * I believe this bug was revealed because we reduced redundant rerenders using better selector equality checks https://github.com/AudiusProject/audius-client/commit/82c465dd19980a8bce47730b06e0c4a50df40c0f

### Dragons

Are we mutating selected values anywhere else and putting them back in the cache??

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

