### PR TITLE
[C-1941] Refresh queue when download toggle is flipped

### DIFF
--- a/packages/common/src/store/queue/selectors.ts
+++ b/packages/common/src/store/queue/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect'
 
 import { UID } from '../../models'
+import { Uid } from '../../utils/uid'
 import { cacheUsersSelectors, cacheTracksSelectors } from '../cache'
 import { playerSelectors } from '../player'
 import { CommonState } from '../reducers'
@@ -38,6 +39,11 @@ export const getId = (state: CommonState) =>
 export const getCollectible = (state: CommonState) => {
   if (!isQueueIndexValid(state)) return null
   return state.queue.order[state.queue.index].collectible ?? null
+}
+export const getCollectionId = (state: CommonState) => {
+  const uid = getUid(state)
+  if (!uid) return null
+  return Uid.getCollectionId(uid)
 }
 
 const getCurrentTrack = (state: CommonState) =>

--- a/packages/common/src/utils/uid.ts
+++ b/packages/common/src/utils/uid.ts
@@ -46,6 +46,14 @@ export class Uid {
     return kind.substring(componentName.length + 1)
   }
 
+  static makeCollectionSourceId = (source: string, collectionId: string) =>
+    `${source}:collection:${collectionId}`
+
+  static getCollectionId = (uid: string) => {
+    const source = this.getComponent(uid, 'source')
+    return source.split('collection:')[1] ?? null
+  }
+
   toString = () => {
     return `kind:${this.kind}-id:${this.id}${
       this.source ? `-source:${this.source}` : ''

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -16,7 +16,8 @@ import {
   Genre,
   tracksSocialActions,
   SquareSizes,
-  shallowCompare
+  shallowCompare,
+  savedPageTracksLineupActions
 } from '@audius/common'
 import { isEqual } from 'lodash'
 import queue from 'react-native-job-queue'
@@ -31,7 +32,7 @@ import TrackPlayer, {
   TrackType
 } from 'react-native-track-player'
 import { useDispatch, useSelector } from 'react-redux'
-import { useEffectOnce } from 'react-use'
+import { useEffectOnce, usePrevious } from 'react-use'
 
 import { DEFAULT_IMAGE_URL } from 'app/components/image/TrackImage'
 import { getImageSourceOptimistic } from 'app/hooks/useContentNodeImage'
@@ -41,18 +42,29 @@ import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { apiClient } from 'app/services/audius-api-client'
 import { audiusBackendInstance } from 'app/services/audius-backend-instance'
 import {
+  DOWNLOAD_REASON_FAVORITES,
   getLocalAudioPath,
   isAudioAvailableOffline
 } from 'app/services/offline-downloader'
 import type { PlayCountWorkerPayload } from 'app/services/offline-downloader/workers/playCounterWorker'
 import { PLAY_COUNTER_WORKER } from 'app/services/offline-downloader/workers/playCounterWorker'
-import { getOfflineTracks } from 'app/store/offline-downloads/selectors'
+import {
+  getOfflineTracks,
+  getIsCollectionMarkedForDownload
+} from 'app/store/offline-downloads/selectors'
 
 const { getUsers } = cacheUsersSelectors
 const { getTracks } = cacheTracksSelectors
 const { getPlaying, getSeek, getCurrentTrack, getCounter } = playerSelectors
 const { recordListen } = tracksSocialActions
-const { getIndex, getOrder, getRepeat, getShuffle } = queueSelectors
+const {
+  getIndex,
+  getOrder,
+  getSource,
+  getCollectionId,
+  getRepeat,
+  getShuffle
+} = queueSelectors
 const { getIsReachable } = reachabilitySelectors
 
 // TODO: These constants are the same in now playing drawer. Move them to shared location
@@ -123,6 +135,8 @@ export const Audio = () => {
   const queueIndex = useSelector(getIndex)
   const queueShuffle = useSelector(getShuffle)
   const queueOrder = useSelector(getOrder)
+  const queueSource = useSelector(getSource)
+  const collectionId = useSelector(getCollectionId)
   const queueTrackUids = queueOrder.map((trackData) => trackData.uid)
   const queueTrackIds = queueOrder.map((trackData) => trackData.id)
   const queueTrackMap = useSelector(
@@ -137,6 +151,19 @@ export const Audio = () => {
     (state) => getUsers(state, { ids: queueTrackOwnerIds }),
     shallowCompare
   )
+
+  const isCollectionMarkedForDownload = useSelector(
+    getIsCollectionMarkedForDownload(
+      queueSource === savedPageTracksLineupActions.prefix
+        ? DOWNLOAD_REASON_FAVORITES
+        : collectionId?.toString()
+    )
+  )
+  const wasCollectionMarkedForDownload = usePrevious(
+    isCollectionMarkedForDownload
+  )
+  const didOfflineToggleChange =
+    isCollectionMarkedForDownload !== wasCollectionMarkedForDownload
 
   // A map from trackId to offline availability
   const offlineAvailabilityByTrackId = useSelector((state) => {
@@ -330,7 +357,12 @@ export const Audio = () => {
 
   const handleQueueChange = useCallback(async () => {
     const refUids = queueListRef.current
-    if (queueIndex === -1 || isEqual(refUids, queueTrackUids)) return
+    if (queueIndex === -1) {
+      return
+    }
+    if (isEqual(refUids, queueTrackUids) && !didOfflineToggleChange) {
+      return
+    }
 
     updatingQueueRef.current = true
     queueListRef.current = queueTrackUids
@@ -347,11 +379,14 @@ export const Audio = () => {
       newQueueTracks.map(async (track) => {
         const trackOwner = queueTrackOwnersMap[track.owner_id]
         const trackId = track.track_id.toString()
+        const isAudioAvailableOfflineToStream = await isAudioAvailableOffline(
+          trackId
+        )
         const offlineTrackAvailable =
           trackId &&
           isOfflineModeEnabled &&
           offlineAvailabilityByTrackId[trackId] &&
-          (await isAudioAvailableOffline(trackId))
+          isAudioAvailableOfflineToStream
 
         // Get Track url
         let url: string
@@ -425,7 +460,8 @@ export const Audio = () => {
     queueIndex,
     queueTrackOwnersMap,
     queueTrackUids,
-    queueTracks
+    queueTracks,
+    didOfflineToggleChange
   ])
 
   const handleQueueIdxChange = useCallback(async () => {

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -136,7 +136,7 @@ export const Audio = () => {
   const queueShuffle = useSelector(getShuffle)
   const queueOrder = useSelector(getOrder)
   const queueSource = useSelector(getSource)
-  const collectionId = useSelector(getCollectionId)
+  const queueCollectionId = useSelector(getCollectionId)
   const queueTrackUids = queueOrder.map((trackData) => trackData.uid)
   const queueTrackIds = queueOrder.map((trackData) => trackData.id)
   const queueTrackMap = useSelector(
@@ -156,7 +156,7 @@ export const Audio = () => {
     getIsCollectionMarkedForDownload(
       queueSource === savedPageTracksLineupActions.prefix
         ? DOWNLOAD_REASON_FAVORITES
-        : collectionId?.toString()
+        : queueCollectionId?.toString()
     )
   )
   const wasCollectionMarkedForDownload = usePrevious(
@@ -391,7 +391,7 @@ export const Audio = () => {
         // Get Track url
         let url: string
         let isM3u8 = false
-        if (offlineTrackAvailable) {
+        if (offlineTrackAvailable && isCollectionMarkedForDownload) {
           const audioFilePath = getLocalAudioPath(trackId)
           url = `file://${audioFilePath}`
         } else if (isStreamMp3Enabled && isReachable) {
@@ -461,7 +461,8 @@ export const Audio = () => {
     queueTrackOwnersMap,
     queueTrackUids,
     queueTracks,
-    didOfflineToggleChange
+    didOfflineToggleChange,
+    isCollectionMarkedForDownload
   ])
 
   const handleQueueIdxChange = useCallback(async () => {

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -394,7 +394,7 @@ function* reset(
           const trackUid = new Uid(
             Kind.TRACKS,
             trackId,
-            makeCollectionSourceId(source, collection.playlist_id),
+            Uid.makeCollectionSourceId(source, collection.playlist_id),
             idx
           )
           return { UID: trackUid.toString() }

--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -36,8 +36,6 @@ const { getUsers } = cacheUsersSelectors
 const { getTrack, getTracks } = cacheTracksSelectors
 const { getCollection } = cacheCollectionsSelectors
 
-const makeCollectionSourceId = (source, playlistId) =>
-  `${source}:collection:${playlistId}`
 const getEntryId = (entry) => `${entry.kind}:${entry.id}`
 
 const flatten = (list) =>
@@ -231,7 +229,7 @@ function* fetchLineupMetadatasAsync(
             const uid = new Uid(
               Kind.TRACKS,
               id,
-              makeCollectionSourceId(source, metadata.playlist_id),
+              Uid.makeCollectionSourceId(source, metadata.playlist_id),
               idx
             )
             return { id, uid: uid.toString() }


### PR DESCRIPTION
### Description

This was kinda tricky!
Architecturally, it's simple, refresh the queue stuff when the toggle is flipped to fix the bug -- this is because we use UIDs to check whether the queue should change. We need to keep the UIDs the same to allow playback to work when reachability state changes.

There was no exposure to the collection that is playing from the queue, so I had to add that, and then do some changes within Audio.tsx to respect toggles to the switch contextually based on what you're listening to.

Could be more elegant, but I think not terrible given the way this comes together.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Scrubber too fast on short song I played, but I promise both played during this repro!

https://user-images.githubusercontent.com/2731362/216489719-28d91a26-91d7-4f6b-9bb6-b6add1d03d19.mp4



### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

