### PR TITLE
Improve download toggle, download progress and fetch

### DIFF
--- a/packages/mobile/src/components/offline-downloads/DownloadStatusIndicator.tsx
+++ b/packages/mobile/src/components/offline-downloads/DownloadStatusIndicator.tsx
@@ -83,6 +83,7 @@ export const DownloadStatusIndicator = (
           />
         )
       case OfflineDownloadStatus.ERROR:
+      case OfflineDownloadStatus.ABANDONED:
         return (
           <IconDownloadFailed
             fill={styles.iconDownloadFailed.fill}

--- a/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
+++ b/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
@@ -60,7 +60,8 @@ export const DownloadFavoritesSwitch = () => {
     return favoritedTracks.every(({ id }) => {
       return (
         downloadStatus[id] === OfflineDownloadStatus.SUCCESS ||
-        downloadStatus[id] === OfflineDownloadStatus.ERROR
+        downloadStatus[id] === OfflineDownloadStatus.ERROR ||
+        downloadStatus[id] === OfflineDownloadStatus.ABANDONED
       )
     })
   }, [])

--- a/packages/mobile/src/screens/favorites-screen/DownloadProgress.tsx
+++ b/packages/mobile/src/screens/favorites-screen/DownloadProgress.tsx
@@ -41,7 +41,8 @@ export const DownloadProgress = () => {
   const numDownloadsComplete = Object.values(downloadStatus).filter(
     (status) =>
       status === OfflineDownloadStatus.SUCCESS ||
-      status === OfflineDownloadStatus.ERROR
+      status === OfflineDownloadStatus.ERROR ||
+      status === OfflineDownloadStatus.ABANDONED
   ).length
   const numDownloadsSuccess = Object.values(downloadStatus).filter(
     (status) => status === OfflineDownloadStatus.SUCCESS

--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -353,9 +353,11 @@ export const downloadTrack = async (trackForDownload: TrackForDownload) => {
       return
     }
 
-    await downloadTrackCoverArt(trackFromApi)
+    await Promise.all([
+      downloadTrackCoverArt(trackFromApi),
+      tryDownloadTrackFromEachCreatorNode(trackFromApi)
+    ])
 
-    await tryDownloadTrackFromEachCreatorNode(trackFromApi)
     const now = Date.now()
     const trackToWrite: Track & UserTrackMetadata = {
       ...trackFromApi,

--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -206,7 +206,8 @@ export function* startSync() {
       syncCollectionsTracks,
       existingOfflineCollections,
       isFavoritesDownloadEnabled !== OfflineDownloadStatus.INACTIVE &&
-        isFavoritesDownloadEnabled !== OfflineDownloadStatus.ERROR
+        isFavoritesDownloadEnabled !== OfflineDownloadStatus.ERROR &&
+        isFavoritesDownloadEnabled !== OfflineDownloadStatus.ABANDONED
     )
     yield* call(syncStaleTracks)
   } catch (e) {

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -59,11 +59,19 @@ export type UpdateTrackDownloadReasonsAction = PayloadAction<{
 }>
 
 export enum OfflineDownloadStatus {
-  INACTIVE = 'INACTIVE', // download is not initiated,
-  INIT = 'INIT', // download is queued
-  LOADING = 'LOADING', // download is in progress
-  SUCCESS = 'SUCCESS', // download succeeded
-  ERROR = 'ERROR' // download errored
+  // download is not initiated
+  INACTIVE = 'INACTIVE',
+  // download is queued
+  INIT = 'INIT',
+  // download is in progress
+  LOADING = 'LOADING',
+  // download succeeded
+  SUCCESS = 'SUCCESS',
+  // download errored
+  ERROR = 'ERROR',
+  // download was abandoned (usually after error).
+  // downloads in the error state can be retried
+  ABANDONED = 'ABANDONED'
 }
 
 const initialState: OfflineDownloadsState = {
@@ -98,7 +106,11 @@ const slice = createSlice({
       state.downloadStatus[trackId] = OfflineDownloadStatus.ERROR
     },
     removeDownload: (state, { payload: trackId }: PayloadAction<string>) => {
-      delete state.downloadStatus[trackId]
+      if (state.downloadStatus[trackId] === OfflineDownloadStatus.ABANDONED) {
+        delete state.downloadStatus[trackId]
+      } else {
+        state.downloadStatus[trackId] = OfflineDownloadStatus.ABANDONED
+      }
     },
     batchInitCollectionDownload: (
       state,

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -106,11 +106,10 @@ const slice = createSlice({
       state.downloadStatus[trackId] = OfflineDownloadStatus.ERROR
     },
     removeDownload: (state, { payload: trackId }: PayloadAction<string>) => {
-      if (state.downloadStatus[trackId] === OfflineDownloadStatus.ABANDONED) {
-        delete state.downloadStatus[trackId]
-      } else {
-        state.downloadStatus[trackId] = OfflineDownloadStatus.ABANDONED
-      }
+      delete state.downloadStatus[trackId]
+    },
+    abandonDownload: (state, { payload: trackId }: PayloadAction<string>) => {
+      state.downloadStatus[trackId] = OfflineDownloadStatus.ABANDONED
     },
     batchInitCollectionDownload: (
       state,
@@ -249,6 +248,7 @@ export const {
   startDownload,
   completeDownload,
   errorDownload,
+  abandonDownload,
   removeDownload,
   batchInitCollectionDownload,
   startCollectionDownload,


### PR DESCRIPTION
### Description

Commits can be reviewed in isolation:
- [C-2026] Make it so we download all tracks from favorites + from collections within favorites in one fell swoop so download progress shows X/Y and Y is the complete number of tracks. Otherwise, you get Y in two parts
- [C-2028 & C-2027] Same fix: Add another state to consider downloads abandoned. Problem is that tracks that enter ERROR state get swept from the downloadTracks so your downloadprogress Y number goes down and the download spinner thinks you've never finished
- [C-2029] Quick little optimize to download art + track at same time.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Simulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

