### PR TITLE
C-2022 C-1970 Fix for: When offline and not fully downloaded, queued jobs keep running and fail

### DIFF
--- a/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
+++ b/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
@@ -38,7 +38,6 @@ export const OfflineDownloader = () => {
 
   const isReachable = useSelector(getIsReachable)
 
-  // Move this logic to watch set (un)rechable sagas?:
   useEffect(() => {
     if (!initialized) return
     const isQueueRunning = queue.isRunning

--- a/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
+++ b/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { reachabilitySelectors } from '@audius/common'
 import queue from 'react-native-job-queue'
@@ -18,12 +18,21 @@ export const OfflineDownloader = () => {
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
   const [initialized, setInitialized] = useState(false)
 
+  const initialize = useCallback(async () => {
+    try {
+      await startDownloadWorker()
+    } catch (e) {
+      console.warn('Download worker failed to start', e)
+      return
+    }
+    setInitialized(true)
+  }, [])
+
   useEffect(() => {
     if (!initialized && isOfflineModeEnabled) {
-      setInitialized(true)
-      startDownloadWorker()
+      initialize()
     }
-  }, [initialized, isOfflineModeEnabled])
+  }, [initialize, initialized, isOfflineModeEnabled])
 
   useLoadOfflineData()
 

--- a/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
+++ b/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
@@ -40,11 +40,10 @@ export const OfflineDownloader = () => {
 
   useEffect(() => {
     if (!initialized) return
-    const isQueueRunning = queue.isRunning
 
-    if (isReachable && !isQueueRunning) {
+    if (isReachable) {
       queue.start()
-    } else if (!isReachable && isQueueRunning) {
+    } else if (!isReachable) {
       queue.stop()
     }
   }, [initialized, isReachable])

--- a/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
+++ b/packages/mobile/src/components/offline-downloads/OfflineDownloader.tsx
@@ -29,6 +29,7 @@ export const OfflineDownloader = () => {
 
   const isReachable = useSelector(getIsReachable)
 
+  // Move this logic to watch set (un)rechable sagas?:
   useEffect(() => {
     if (!initialized) return
     const isQueueRunning = queue.isRunning

--- a/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-download-queue.ts
@@ -12,6 +12,7 @@ import {
 } from 'app/store/offline-downloads/slice'
 
 import type { CollectionForDownload, TrackForDownload } from './types'
+import { startQueueIfOnline } from './workers'
 import type { CollectionDownloadWorkerPayload } from './workers/collectionDownloadWorker'
 import {
   collectionDownloadWorker,
@@ -144,8 +145,6 @@ export const startDownloadWorker = async () => {
     })
 
   store.dispatch(batchInitDownload(trackIdsInQueue))
-
-  queue.start()
 }
 
 export const cancelQueuedCollectionDownloads = async (
@@ -185,7 +184,7 @@ export const cancelQueuedCollectionDownloads = async (
       console.warn(e)
     }
   })
-  queue.start()
+  startQueueIfOnline()
 }
 
 export const cancelQueuedDownloads = async (
@@ -222,5 +221,5 @@ export const cancelQueuedDownloads = async (
       console.warn(e)
     }
   })
-  queue.start()
+  startQueueIfOnline()
 }

--- a/packages/mobile/src/services/offline-downloader/workers/collectionDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/collectionDownloadWorker.ts
@@ -9,6 +9,8 @@ import {
 } from '../offline-downloader'
 import type { CollectionForDownload } from '../types'
 
+import { startQueueIfOnline } from './utils'
+
 export const COLLECTION_DOWNLOAD_WORKER = 'collection_download_worker'
 export type CollectionDownloadWorkerPayload = CollectionForDownload
 
@@ -35,7 +37,7 @@ const onFailure = async (
       } catch (e) {
         console.warn(e)
       }
-      queue.start()
+      startQueueIfOnline()
       break
     }
     default:

--- a/packages/mobile/src/services/offline-downloader/workers/index.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/index.ts
@@ -1,2 +1,3 @@
 export * from './playCounterWorker'
 export * from './trackDownloadWorker'
+export * from './utils'

--- a/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
@@ -3,6 +3,8 @@ import queue, { Worker } from 'react-native-job-queue'
 
 import { store } from 'app/store'
 
+import { startQueueIfOnline } from './utils'
+
 const { recordListen } = tracksSocialActions
 
 export const PLAY_COUNTER_WORKER = 'play_counter_worker'
@@ -20,7 +22,7 @@ export const setPlayCounterWorker = async (
   queue.stop()
   queue.removeWorker(PLAY_COUNTER_WORKER)
   queue.addWorker(worker)
-  await queue.start()
+  await startQueueIfOnline()
 }
 
 export const playCounterWorker = new Worker(PLAY_COUNTER_WORKER, countPlay)

--- a/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
@@ -1,9 +1,7 @@
 import { tracksSocialActions } from '@audius/common'
-import queue, { Worker } from 'react-native-job-queue'
+import { Worker } from 'react-native-job-queue'
 
 import { store } from 'app/store'
-
-import { startQueueIfOnline } from './utils'
 
 const { recordListen } = tracksSocialActions
 
@@ -14,15 +12,6 @@ export type PlayCountWorkerPayload = { trackId: number }
 const countPlay = async (payload: PlayCountWorkerPayload) => {
   const { trackId } = payload
   store.dispatch(recordListen(trackId))
-}
-
-export const setPlayCounterWorker = async (
-  worker: Worker<PlayCountWorkerPayload>
-) => {
-  queue.stop()
-  queue.removeWorker(PLAY_COUNTER_WORKER)
-  queue.addWorker(worker)
-  await startQueueIfOnline()
 }
 
 export const playCounterWorker = new Worker(PLAY_COUNTER_WORKER, countPlay)

--- a/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/playCounterWorker.ts
@@ -26,10 +26,3 @@ export const setPlayCounterWorker = async (
 }
 
 export const playCounterWorker = new Worker(PLAY_COUNTER_WORKER, countPlay)
-export const blockedPlayCounterWorker = new Worker(
-  PLAY_COUNTER_WORKER,
-  countPlay,
-  {
-    concurrency: 0
-  }
-)

--- a/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
@@ -12,6 +12,8 @@ import {
 } from '../offline-downloader'
 import type { TrackForDownload } from '../types'
 
+import { startQueueIfOnline } from './utils'
+
 export const TRACK_DOWNLOAD_WORKER = 'track_download_worker'
 export type TrackDownloadWorkerPayload = TrackForDownload
 
@@ -38,12 +40,21 @@ const onFailure = async (
       } catch (e) {
         console.warn(e)
       }
-      queue.start()
+      startQueueIfOnline()
       break
     }
     default:
       break
   }
+}
+
+export const setTrackDownloadWorker = async (
+  worker: Worker<TrackDownloadWorkerPayload>
+) => {
+  queue.stop()
+  queue.removeWorker(TRACK_DOWNLOAD_WORKER)
+  queue.addWorker(worker)
+  await startQueueIfOnline()
 }
 
 const executor = (payload: TrackDownloadWorkerPayload) => {

--- a/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/trackDownloadWorker.ts
@@ -48,15 +48,6 @@ const onFailure = async (
   }
 }
 
-export const setTrackDownloadWorker = async (
-  worker: Worker<TrackDownloadWorkerPayload>
-) => {
-  queue.stop()
-  queue.removeWorker(TRACK_DOWNLOAD_WORKER)
-  queue.addWorker(worker)
-  await startQueueIfOnline()
-}
-
 const executor = (payload: TrackDownloadWorkerPayload) => {
   const promise: CancellablePromise<void> = downloadTrack(payload)
   promise.rn_job_queue_cancel = () => {

--- a/packages/mobile/src/services/offline-downloader/workers/utils.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/utils.ts
@@ -9,7 +9,6 @@ export const startQueueIfOnline = async () => {
   const state = store.getState()
   const reachable = getIsReachable(state)
   if (reachable) {
-    console.log('actually starting queue')
     return queue.start()
   }
 }

--- a/packages/mobile/src/services/offline-downloader/workers/utils.ts
+++ b/packages/mobile/src/services/offline-downloader/workers/utils.ts
@@ -1,0 +1,15 @@
+import { reachabilitySelectors } from '@audius/common'
+import queue from 'react-native-job-queue'
+
+import { store } from 'app/store'
+
+const getIsReachable = reachabilitySelectors.getIsReachable
+
+export const startQueueIfOnline = async () => {
+  const state = store.getState()
+  const reachable = getIsReachable(state)
+  if (reachable) {
+    console.log('actually starting queue')
+    return queue.start()
+  }
+}

--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -18,7 +18,6 @@ import {
 import { waitForBackendSetup } from 'audius-client/src/common/store/backend/sagas'
 import { waitForRead } from 'audius-client/src/utils/sagaHelpers'
 import {
-  all,
   takeLatest,
   call,
   select,

--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -12,7 +12,6 @@ import {
   collectionsSocialActions,
   accountSelectors,
   cacheCollectionsSelectors,
-  reachabilityActions,
   savedPageActions
 } from '@audius/common'
 import { waitForBackendSetup } from 'audius-client/src/common/store/backend/sagas'
@@ -39,11 +38,6 @@ import {
   batchDownloadCollection,
   batchRemoveTrackDownload
 } from 'app/services/offline-downloader'
-import {
-  blockedPlayCounterWorker,
-  playCounterWorker,
-  setPlayCounterWorker
-} from 'app/services/offline-downloader/workers'
 
 import { watchRemoveAllDownloadedFavorites } from './sagas/removeAllDownloadedFavoritesSaga'
 import { watchRemoveCollectionDownloads } from './sagas/removeCollectionDownloadsSaga'
@@ -63,7 +57,6 @@ import {
 } from './slice'
 const { fetchCollection, FETCH_COLLECTION_SUCCEEDED, FETCH_COLLECTION_FAILED } =
   collectionPageActions
-const { SET_REACHABLE, SET_UNREACHABLE } = reachabilityActions
 const { getUserId } = accountSelectors
 const { getCollections } = cacheCollectionsSelectors
 
@@ -215,24 +208,6 @@ export function* startSync() {
   }
 }
 
-export function* handleSetReachable() {
-  // Why do we do this?
-  yield* call(setPlayCounterWorker, playCounterWorker)
-}
-
-export function* watchSetReachable() {
-  yield* takeLatest(SET_REACHABLE, handleSetReachable)
-}
-
-export function* handleSetUnreachable() {
-  // Why do we do this?
-  yield* call(setPlayCounterWorker, blockedPlayCounterWorker)
-}
-
-export function* watchSetUnreachable() {
-  yield* takeLatest(SET_UNREACHABLE, handleSetUnreachable)
-}
-
 function* downloadNewPlaylistTrackIfNecessary({
   trackId,
   playlistId
@@ -297,8 +272,6 @@ const sagas = () => {
     watchUnsaveTrack,
     watchSaveCollection,
     watchClearOfflineDownloads,
-    watchSetReachable,
-    watchSetUnreachable,
     startSync,
     watchAddTrackToPlaylist,
     watchAddLocalSave,

--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -18,6 +18,7 @@ import {
 import { waitForBackendSetup } from 'audius-client/src/common/store/backend/sagas'
 import { waitForRead } from 'audius-client/src/utils/sagaHelpers'
 import {
+  all,
   takeLatest,
   call,
   select,
@@ -216,7 +217,7 @@ export function* startSync() {
 }
 
 export function* handleSetReachable() {
-  yield* call(setPlayCounterWorker, playCounterWorker)
+  // yield* call(setPlayCounterWorker, playCounterWorker)
 }
 
 export function* watchSetReachable() {
@@ -224,7 +225,7 @@ export function* watchSetReachable() {
 }
 
 export function* handleSetUnreachable() {
-  yield* call(setPlayCounterWorker, blockedPlayCounterWorker)
+  // yield* all([call(setPlayCounterWorker, blockedPlayCounterWorker), call(setDownloadCollectionWorker)
 }
 
 export function* watchSetUnreachable() {

--- a/packages/mobile/src/store/offline-downloads/sagas.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas.ts
@@ -217,7 +217,8 @@ export function* startSync() {
 }
 
 export function* handleSetReachable() {
-  // yield* call(setPlayCounterWorker, playCounterWorker)
+  // Why do we do this?
+  yield* call(setPlayCounterWorker, playCounterWorker)
 }
 
 export function* watchSetReachable() {
@@ -225,7 +226,8 @@ export function* watchSetReachable() {
 }
 
 export function* handleSetUnreachable() {
-  // yield* all([call(setPlayCounterWorker, blockedPlayCounterWorker), call(setDownloadCollectionWorker)
+  // Why do we do this?
+  yield* call(setPlayCounterWorker, blockedPlayCounterWorker)
 }
 
 export function* watchSetUnreachable() {


### PR DESCRIPTION
### Description
Before: If you went offline after starting a download, or starting the app offline while you still had tracks to download, the queued jobs would keep running and fail.

After: The queue is stopped if you're offline.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

