### PR TITLE
Fix download progress numerator going down in the middle of downloading C-2037

### DIFF
--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -92,24 +92,45 @@ const slice = createSlice({
       { payload: trackIds }: PayloadAction<string[]>
     ) => {
       trackIds.forEach((trackId) => {
-        state.downloadStatus[trackId] = OfflineDownloadStatus.INIT
+        if (
+          !state.downloadStatus[trackId] ||
+          (state.downloadStatus[trackId] !== OfflineDownloadStatus.LOADING &&
+            state.downloadStatus[trackId] !== OfflineDownloadStatus.SUCCESS)
+        ) {
+          state.downloadStatus[trackId] = OfflineDownloadStatus.INIT
+        }
       })
     },
     // Actually starting the download
     startDownload: (state, { payload: trackId }: PayloadAction<string>) => {
-      state.downloadStatus[trackId] = OfflineDownloadStatus.LOADING
+      if (
+        !state.downloadStatus[trackId] ||
+        state.downloadStatus[trackId] !== OfflineDownloadStatus.SUCCESS
+      ) {
+        state.downloadStatus[trackId] = OfflineDownloadStatus.LOADING
+      }
     },
     completeDownload: (state, { payload: trackId }: PayloadAction<string>) => {
       state.downloadStatus[trackId] = OfflineDownloadStatus.SUCCESS
     },
     errorDownload: (state, { payload: trackId }: PayloadAction<string>) => {
-      state.downloadStatus[trackId] = OfflineDownloadStatus.ERROR
+      if (
+        !state.downloadStatus[trackId] ||
+        state.downloadStatus[trackId] !== OfflineDownloadStatus.SUCCESS
+      ) {
+        state.downloadStatus[trackId] = OfflineDownloadStatus.ERROR
+      }
     },
     removeDownload: (state, { payload: trackId }: PayloadAction<string>) => {
       delete state.downloadStatus[trackId]
     },
     abandonDownload: (state, { payload: trackId }: PayloadAction<string>) => {
-      state.downloadStatus[trackId] = OfflineDownloadStatus.ABANDONED
+      if (
+        !state.downloadStatus[trackId] ||
+        state.downloadStatus[trackId] !== OfflineDownloadStatus.SUCCESS
+      ) {
+        state.downloadStatus[trackId] = OfflineDownloadStatus.ABANDONED
+      }
     },
     batchInitCollectionDownload: (
       state,


### PR DESCRIPTION
### Description
Favorited tracks that had been downloaded would later be marked as INIT/LOADING if they were also in one of the favorited collections, causing the download progress numerator to decrease erroneously and a bunch of UI that rely on `downloadStatus` to be incorrect.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

