### PR TITLE
Refactor albumPage routing to use collectionPage route

### DIFF
--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -363,7 +363,6 @@ export const makePlaylist = (
     track_count,
     total_play_count,
     playlist_contents: playlistContents,
-    permalink: 'response-adapter-permalink',
 
     // Fields to prune
     id: undefined,

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -26,7 +26,7 @@ import { adjustUserField } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
-import { albumPage, audioNftPlaylistPage, playlistPage } from 'utils/route'
+import { audioNftPlaylistPage, collectionPage } from 'utils/route'
 import { waitForWrite } from 'utils/sagaHelpers'
 
 import watchCollectionErrors from './errorSagas'
@@ -542,17 +542,12 @@ export function* watchShareCollection() {
       const user = yield* select(getUser, { id: collection.playlist_owner_id })
       if (!user) return
 
-      const link = collection.is_album
-        ? albumPage(
-            user.handle,
-            collection.playlist_name,
-            collection.playlist_id
-          )
-        : playlistPage(
-            user.handle,
-            collection.playlist_name,
-            collection.playlist_id
-          )
+      const link = collectionPage(
+        user.handle,
+        collection.is_album,
+        collection.playlist_name,
+        collection.playlist_id
+      )
 
       const share = yield* getContext('share')
       share(link, formatShareText(collection.playlist_name, user.name))

--- a/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
+++ b/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.tsx
@@ -22,7 +22,7 @@ import { ToastContext } from 'components/toast/ToastContext'
 import ToastLinkContent from 'components/toast/mobile/ToastLinkContent'
 import { useCollectionCoverArt } from 'hooks/useCollectionCoverArt'
 import { AppState } from 'store/types'
-import { playlistPage } from 'utils/route'
+import { collectionPage } from 'utils/route'
 import { getTempPlaylistId } from 'utils/tempPlaylistId'
 
 import styles from './AddToPlaylistModal.module.css'
@@ -74,7 +74,12 @@ const AddToPlaylistModal = () => {
         <ToastLinkContent
           text={messages.addedToast}
           linkText={messages.view}
-          link={playlistPage(account.handle, trackTitle, playlist.playlist_id)}
+          link={collectionPage(
+            account.handle,
+            playlist.is_album,
+            trackTitle,
+            playlist.playlist_id
+          )}
         />
       )
     }
@@ -96,7 +101,12 @@ const AddToPlaylistModal = () => {
         <ToastLinkContent
           text={messages.createdToast}
           linkText={messages.view}
-          link={playlistPage(account.handle, trackTitle, tempId)}
+          link={collectionPage(
+            account.handle,
+            false /* isAlbum */,
+            trackTitle,
+            tempId
+          )}
         />
       )
     }

--- a/packages/web/src/components/add-to-playlist/mobile/AddToPlaylist.tsx
+++ b/packages/web/src/components/add-to-playlist/mobile/AddToPlaylist.tsx
@@ -23,7 +23,7 @@ import { ToastContext } from 'components/toast/ToastContext'
 import useHasChangedRoute from 'hooks/useHasChangedRoute'
 import NewPlaylistButton from 'pages/saved-page/components/mobile/NewPlaylistButton'
 import { AppState } from 'store/types'
-import { playlistPage } from 'utils/route'
+import { collectionPage } from 'utils/route'
 import { getTempPlaylistId } from 'utils/tempPlaylistId'
 import { withNullGuard } from 'utils/withNullGuard'
 
@@ -106,7 +106,9 @@ const AddToPlaylist = g(
       createPlaylist(tempId, metadata, trackId!)
       addTrackToPlaylist(trackId!, tempId)
       toast(messages.createdToast)
-      goToRoute(playlistPage(account.handle, trackTitle, tempId))
+      goToRoute(
+        collectionPage(account.handle, false /* isAlbum */, trackTitle, tempId)
+      )
       close()
     }, [
       account,

--- a/packages/web/src/components/card/desktop/CollectionArtCard.tsx
+++ b/packages/web/src/components/card/desktop/CollectionArtCard.tsx
@@ -31,7 +31,7 @@ import {
   UserListEntityType
 } from 'store/application/ui/userListModal/types'
 import { AppState } from 'store/types'
-import { playlistPage, albumPage, profilePage } from 'utils/route'
+import { collectionPage, profilePage } from 'utils/route'
 import { withNullGuard } from 'utils/withNullGuard'
 
 import styles from './CollectionArtCard.module.css'
@@ -92,9 +92,7 @@ const CollectionArtCard = g(
 
     const goToCollection = useCallback(() => {
       if (isPerspectiveDisabled) return
-      const link = is_album
-        ? albumPage(handle, playlist_name, playlist_id)
-        : playlistPage(handle, playlist_name, playlist_id)
+      const link = collectionPage(handle, is_album, playlist_name, playlist_id)
       goToRoute(link)
     }, [
       is_album,

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -27,7 +27,7 @@ import {
 } from 'store/application/ui/editPlaylistModal/selectors'
 import { close } from 'store/application/ui/editPlaylistModal/slice'
 import { AppState } from 'store/types'
-import { FEED_PAGE, getPathname, playlistPage } from 'utils/route'
+import { FEED_PAGE, getPathname, collectionPage } from 'utils/route'
 import zIndex from 'utils/zIndex'
 
 import styles from './EditPlaylistModal.module.css'
@@ -86,7 +86,12 @@ const EditPlaylistModal = ({
     onClose()
     deletePlaylist(playlistId!)
     if (handle && title) {
-      const playlistRoute = playlistPage(handle, title, playlistId!)
+      const playlistRoute = collectionPage(
+        handle,
+        isAlbum || false,
+        title,
+        playlistId!
+      )
       // If on the playlist page, direct user to feed
       if (getPathname(location) === playlistRoute) goToRoute(FEED_PAGE)
     }

--- a/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
+++ b/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
@@ -33,7 +33,7 @@ import useHasChangedRoute from 'hooks/useHasChangedRoute'
 import UploadStub from 'pages/profile-page/components/mobile/UploadStub'
 import { AppState } from 'store/types'
 import { resizeImage } from 'utils/imageProcessingUtil'
-import { playlistPage } from 'utils/route'
+import { collectionPage } from 'utils/route'
 import { getTempPlaylistId } from 'utils/tempPlaylistId'
 import { withNullGuard } from 'utils/withNullGuard'
 
@@ -241,7 +241,12 @@ const EditPlaylistPage = g(
         toast(messages.toast)
         close()
         goToRoute(
-          playlistPage(account.handle, formFields.playlist_name, tempId)
+          collectionPage(
+            account.handle,
+            false /* isAlbum */,
+            formFields.playlist_name,
+            tempId
+          )
         )
       }
     }, [

--- a/packages/web/src/components/menu/CollectionMenu.tsx
+++ b/packages/web/src/components/menu/CollectionMenu.tsx
@@ -15,7 +15,7 @@ import { Dispatch } from 'redux'
 import * as embedModalActions from 'components/embed-modal/store/actions'
 import { open as openEditCollectionModal } from 'store/application/ui/editPlaylistModal/slice'
 import { AppState } from 'store/types'
-import { albumPage, playlistPage, profilePage } from 'utils/route'
+import { collectionPage, profilePage } from 'utils/route'
 const { getUser } = cacheUsersSelectors
 
 type PlaylistId = number
@@ -81,7 +81,6 @@ const CollectionMenu = (props: CollectionMenuProps) => {
       extraMenuItems
     } = props
 
-    const routePage = type === 'album' ? albumPage : playlistPage
     const shareMenuItem = {
       text: 'Share',
       onClick: () => {
@@ -114,9 +113,12 @@ const CollectionMenu = (props: CollectionMenuProps) => {
       onClick: () => goToRoute(profilePage(handle))
     }
 
+    const isAlbum = type === 'album'
+
     const playlistPageMenuItem = {
       text: `Visit ${typeName} Page`,
-      onClick: () => goToRoute(routePage(handle, playlistName, playlistId))
+      onClick: () =>
+        goToRoute(collectionPage(handle, isAlbum, playlistName, playlistId))
     }
 
     const editCollectionMenuItem = {

--- a/packages/web/src/components/nav/desktop/NavColumn.tsx
+++ b/packages/web/src/components/nav/desktop/NavColumn.tsx
@@ -69,7 +69,7 @@ import {
   FEED_PAGE,
   fullTrackPage,
   HISTORY_PAGE,
-  playlistPage,
+  collectionPage,
   profilePage,
   SAVED_PAGE,
   TRENDING_PAGE,
@@ -191,7 +191,14 @@ const NavColumn = ({
       createPlaylist(tempId, metadata)
       closeCreatePlaylistModal()
       if (account) {
-        goToRoute(playlistPage(account.handle, metadata.playlist_name, tempId))
+        goToRoute(
+          collectionPage(
+            account.handle,
+            kind === 'album',
+            metadata.playlist_name,
+            tempId
+          )
+        )
       }
     },
     [account, createPlaylist, closeCreatePlaylistModal, goToRoute]

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary.tsx
@@ -32,7 +32,7 @@ import { setFolderId as setEditFolderModalFolderId } from 'store/application/ui/
 import { open as openEditPlaylistModal } from 'store/application/ui/editPlaylistModal/slice'
 import { getIsDragging } from 'store/dragndrop/selectors'
 import { useSelector } from 'utils/reducer'
-import { audioNftPlaylistPage, getPathname, playlistPage } from 'utils/route'
+import { audioNftPlaylistPage, getPathname, collectionPage } from 'utils/route'
 
 import navColumnStyles from './NavColumn.module.css'
 import { PlaylistFolderNavItem } from './PlaylistFolderNavItem'
@@ -289,8 +289,8 @@ const PlaylistLibrary = ({
   const renderPlaylist = (playlistId: ID, level = 0) => {
     const playlist = playlists[playlistId]
     if (!account || !playlist) return null
-    const { id, name } = playlist
-    const url = playlistPage(playlist.user.handle, name, id)
+    const { id, name, is_album } = playlist
+    const url = collectionPage(playlist.user.handle, is_album, name, id)
     const addTrack = (trackId: ID) => dispatch(addTrackToPlaylist(trackId, id))
     const isOwner = playlist.user.handle === account.handle
     const hasUpdate = updatesSet.has(id)

--- a/packages/web/src/components/notification/Notification/utils.ts
+++ b/packages/web/src/components/notification/Notification/utils.ts
@@ -2,30 +2,26 @@ import { Entity, EntityType } from '@audius/common'
 
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { UserListEntityType } from 'store/application/ui/userListModal/types'
-import {
-  albumPage,
-  fullAlbumPage,
-  fullPlaylistPage,
-  fullTrackPage,
-  playlistPage
-} from 'utils/route'
+import { fullCollectionPage, fullTrackPage, collectionPage } from 'utils/route'
 
 export const getEntityLink = (entity: EntityType, fullRoute = false) => {
   if (!entity.user) return ''
   if ('track_id' in entity) {
     return fullRoute ? fullTrackPage(entity.permalink) : entity.permalink
   } else if (entity.user && entity.playlist_id && entity.is_album) {
-    const getRoute = fullRoute ? fullAlbumPage : albumPage
+    const getRoute = fullRoute ? fullCollectionPage : collectionPage
     return getRoute(
       entity.user.handle,
+      entity.is_album,
       entity.playlist_name,
       entity.playlist_id
     )
   }
   if (entity.user) {
-    const getRoute = fullRoute ? fullPlaylistPage : playlistPage
+    const getRoute = fullRoute ? fullCollectionPage : collectionPage
     return getRoute(
       entity.user.handle,
+      entity.is_album,
       entity.playlist_name,
       entity.playlist_id
     )

--- a/packages/web/src/components/search-bar/ConnectedSearchBar.js
+++ b/packages/web/src/components/search-bar/ConnectedSearchBar.js
@@ -21,7 +21,7 @@ import {
 } from 'common/store/search-bar/actions'
 import { getSearch } from 'common/store/search-bar/selectors'
 import Bar from 'components/search/SearchBar'
-import { albumPage, playlistPage, profilePage, getPathname } from 'utils/route'
+import { collectionPage, profilePage, getPathname } from 'utils/route'
 
 import styles from './ConnectedSearchBar.module.css'
 
@@ -102,7 +102,12 @@ class ConnectedSearchBar extends Component {
         (p) =>
           value ===
           (p.user
-            ? playlistPage(p.user.handle, p.playlist_name, p.playlist_id)
+            ? collectionPage(
+                p.user.handle,
+                p.is_album,
+                p.playlist_name,
+                p.playlist_id
+              )
             : '')
       )
       if (selectedPlaylist)
@@ -111,7 +116,13 @@ class ConnectedSearchBar extends Component {
         (a) =>
           value ===
           (a.user
-            ? albumPage(a.user.handle, a.playlist_name, a.playlist_id)
+            ? collectionPage(
+                a.user.handle,
+                a.is_album,
+                a.playlist_name,
+                a.playlist_id,
+                a.permalink
+              )
             : '')
       )
       if (selectedAlbum) return { kind: 'album', id: selectedAlbum.playlist_id }
@@ -178,8 +189,9 @@ class ConnectedSearchBar extends Component {
               primary: playlist.playlist_name,
               secondary: playlist.user ? playlist.user.name : '',
               key: playlist.user
-                ? playlistPage(
+                ? collectionPage(
                     playlist.user.handle,
+                    playlist.is_album,
                     playlist.playlist_name,
                     playlist.playlist_id
                   )
@@ -204,10 +216,12 @@ class ConnectedSearchBar extends Component {
           children: this.props.search.albums.map((album) => {
             return {
               key: album.user
-                ? albumPage(
+                ? collectionPage(
                     album.user.handle,
+                    album.is_album,
                     album.playlist_name,
-                    album.playlist_id
+                    album.playlist_id,
+                    album.permalink
                   )
                 : '',
               primary: album.playlist_name,

--- a/packages/web/src/components/search-bar/ConnectedSearchBar.js
+++ b/packages/web/src/components/search-bar/ConnectedSearchBar.js
@@ -120,8 +120,7 @@ class ConnectedSearchBar extends Component {
                 a.user.handle,
                 a.is_album,
                 a.playlist_name,
-                a.playlist_id,
-                a.permalink
+                a.playlist_id
               )
             : '')
       )
@@ -220,8 +219,7 @@ class ConnectedSearchBar extends Component {
                     album.user.handle,
                     album.is_album,
                     album.playlist_name,
-                    album.playlist_id,
-                    album.permalink
+                    album.playlist_id
                   )
                 : '',
               primary: album.playlist_name,

--- a/packages/web/src/components/share-modal/utils.ts
+++ b/packages/web/src/components/share-modal/utils.ts
@@ -1,8 +1,7 @@
 import { ShareToTwitter, ShareModalContent } from '@audius/common'
 
 import {
-  fullAlbumPage,
-  fullPlaylistPage,
+  fullCollectionPage,
   fullProfilePage,
   fullTrackPage,
   fullAudioNftPlaylistPage
@@ -41,21 +40,27 @@ export const getTwitterShareText = (
     }
     case 'album': {
       const {
-        album: { playlist_name, playlist_id },
+        album: { playlist_name, playlist_id, is_album, permalink },
         artist: { handle }
       } = content
       twitterText = messages.albumShareText(playlist_name, handle)
-      link = fullAlbumPage(handle, playlist_name, playlist_id)
+      link = fullCollectionPage(
+        handle,
+        is_album,
+        playlist_name,
+        playlist_id,
+        permalink
+      )
       analyticsEvent = { kind: 'album', id: playlist_id, url: link }
       break
     }
     case 'playlist': {
       const {
-        playlist: { playlist_name, playlist_id },
+        playlist: { playlist_name, playlist_id, is_album },
         creator: { handle }
       } = content
       twitterText = messages.playlistShareText(playlist_name, handle)
-      link = fullPlaylistPage(handle, playlist_name, playlist_id)
+      link = fullCollectionPage(handle, is_album, playlist_name, playlist_id)
       analyticsEvent = { kind: 'playlist', id: playlist_id, url: link }
       break
     }

--- a/packages/web/src/components/track-overflow-modal/ConnectedMobileOverflowModal.tsx
+++ b/packages/web/src/components/track-overflow-modal/ConnectedMobileOverflowModal.tsx
@@ -30,9 +30,8 @@ import { Dispatch } from 'redux'
 
 import { AppState } from 'store/types'
 import {
-  albumPage,
   collectibleDetailsPage,
-  playlistPage,
+  collectionPage,
   profilePage
 } from 'utils/route'
 
@@ -101,8 +100,7 @@ const ConnectedMobileOverflowModal = ({
   visitTrackPage,
   visitArtistPage,
   visitCollectiblePage,
-  visitPlaylistPage,
-  visitAlbumPage,
+  visitCollectionPage,
   unsubscribeUser,
   follow,
   unfollow,
@@ -175,12 +173,9 @@ const ConnectedMobileOverflowModal = ({
           onUnfavorite: () => unsaveCollection(id as ID),
           onShare: () => shareCollection(id as ID),
           onVisitArtistPage: () => visitArtistPage(handle),
-          onVisitCollectionPage: () =>
-            (isAlbum ? visitAlbumPage : visitPlaylistPage)(
-              id as ID,
-              handle,
-              title
-            ),
+          onVisitCollectionPage: () => {
+            return visitCollectionPage(id as ID, handle, title, isAlbum)
+          },
           onVisitCollectiblePage: () =>
             visitCollectiblePage(handle, id as string),
           onEditPlaylist: isAlbum ? () => {} : () => editPlaylist(id as ID),
@@ -380,13 +375,15 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
     visitCollectiblePage: (handle: string, id: string) => {
       dispatch(pushRoute(collectibleDetailsPage(handle, id)))
     },
-    visitPlaylistPage: (
+    visitCollectionPage: (
       playlistId: ID,
       handle: string,
-      playlistTitle: string
-    ) => dispatch(pushRoute(playlistPage(handle, playlistTitle, playlistId))),
-    visitAlbumPage: (albumId: ID, handle: string, albumTitle: string) =>
-      dispatch(pushRoute(albumPage(handle, albumTitle, albumId)))
+      playlistTitle: string,
+      isAlbum: boolean
+    ) =>
+      dispatch(
+        pushRoute(collectionPage(handle, isAlbum, playlistTitle, playlistId))
+      )
   }
 }
 

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -52,11 +52,9 @@ import {
 import { AppState } from 'store/types'
 import { isDescendantElementOf } from 'utils/domUtils'
 import {
-  albumPage,
-  fullAlbumPage,
-  fullPlaylistPage,
+  fullCollectionPage,
   fullTrackPage,
-  playlistPage,
+  collectionPage,
   profilePage
 } from 'utils/route'
 import { isDarkMode, isMatrix } from 'utils/theme/theme'
@@ -227,17 +225,11 @@ const ConnectedPlaylistTile = memo(
         record
       ]
     )
-    const href = isLoading
-      ? ''
-      : isAlbum
-      ? albumPage(handle, title, id)
-      : playlistPage(handle, title, id)
+    const href = isLoading ? '' : collectionPage(handle, isAlbum, title, id)
 
     const fullHref = isLoading
       ? ''
-      : isAlbum
-      ? fullAlbumPage(handle, title, id)
-      : fullPlaylistPage(handle, title, id)
+      : fullCollectionPage(handle, isAlbum, title, id)
 
     const onClickTitle = useCallback(
       (e: MouseEvent) => {

--- a/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -31,8 +31,7 @@ import { useRecord, make } from 'common/store/analytics/actions'
 import { PlaylistTileProps } from 'components/track/types'
 import { AppState } from 'store/types'
 import {
-  albumPage,
-  playlistPage,
+  collectionPage,
   profilePage,
   REPOSTING_USERS_ROUTE,
   FAVORITING_USERS_ROUTE
@@ -120,17 +119,12 @@ const ConnectedPlaylistTile = memo(
     }, [collection, unrepostCollection, repostCollection])
 
     const getRoute = useCallback(() => {
-      return collection.is_album
-        ? albumPage(
-            user.handle,
-            collection.playlist_name,
-            collection.playlist_id
-          )
-        : playlistPage(
-            user.handle,
-            collection.playlist_name,
-            collection.playlist_id
-          )
+      return collectionPage(
+        user.handle,
+        collection.is_album,
+        collection.playlist_name,
+        collection.playlist_id
+      )
     }, [collection, user])
 
     const goToCollectionPage = useCallback(

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -66,8 +66,7 @@ import {
   NOT_FOUND_PAGE,
   REPOSTING_USERS_ROUTE,
   FAVORITING_USERS_ROUTE,
-  playlistPage,
-  albumPage,
+  collectionPage,
   getPathname
 } from 'utils/route'
 import { parseCollectionRoute } from 'utils/route/collectionRouteParser'
@@ -280,10 +279,12 @@ class CollectionPage extends Component<
           user
         if (routeLacksCollectionInfo) {
           // Check if we are coming from a non-canonical route and replace route if necessary.
-          const newPath =
-            metadata.is_album && collectionId
-              ? albumPage(user!.handle, metadata.playlist_name, collectionId)
-              : playlistPage(user!.handle, metadata.playlist_name, collectionId)
+          const newPath = collectionPage(
+            user!.handle,
+            metadata.is_album,
+            metadata.playlist_name,
+            collectionId
+          )
           this.props.replaceRoute(newPath)
         } else {
           // Id matches or temp id matches

--- a/packages/web/src/pages/explore-page/components/desktop/CollectionsPage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/CollectionsPage.tsx
@@ -10,10 +10,8 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import Page from 'components/page/Page'
 import { useOrderedLoad } from 'hooks/useOrderedLoad'
 import {
-  playlistPage,
-  fullPlaylistPage,
-  albumPage,
-  fullAlbumPage,
+  collectionPage,
+  fullCollectionPage,
   BASE_URL,
   EXPLORE_PAGE,
   profilePage
@@ -92,19 +90,12 @@ const CollectionsPage = ({
         isReposted={playlist.has_current_user_reposted}
         isSaved={playlist.has_current_user_saved}
         cardCoverImageSizes={playlist._cover_art_sizes}
-        href={
-          playlist.is_album
-            ? fullAlbumPage(
-                playlist.user.handle,
-                playlist.playlist_name,
-                playlist.playlist_id
-              )
-            : fullPlaylistPage(
-                playlist.user.handle,
-                playlist.playlist_name,
-                playlist.playlist_id
-              )
-        }
+        href={fullCollectionPage(
+          playlist.user.handle,
+          playlist.is_album,
+          playlist.playlist_name,
+          playlist.playlist_id
+        )}
         reposts={playlist.repost_count}
         favorites={playlist.save_count}
         trackCount={playlist.playlist_contents.track_ids.length}
@@ -112,21 +103,14 @@ const CollectionsPage = ({
         onClickFavorites={() => onClickFavorites(playlist.playlist_id)}
         onClick={(e) => {
           e.preventDefault()
-          playlist.is_album
-            ? goToRoute(
-                albumPage(
-                  playlist.user.handle,
-                  playlist.playlist_name,
-                  playlist.playlist_id
-                )
-              )
-            : goToRoute(
-                playlistPage(
-                  playlist.user.handle,
-                  playlist.playlist_name,
-                  playlist.playlist_id
-                )
-              )
+          goToRoute(
+            collectionPage(
+              playlist.user.handle,
+              playlist.is_album,
+              playlist.playlist_name,
+              playlist.playlist_id
+            )
+          )
         }}
       />
     )

--- a/packages/web/src/pages/explore-page/components/mobile/CollectionsPage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/CollectionsPage.tsx
@@ -9,7 +9,7 @@ import CardLineup from 'components/lineup/CardLineup'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import MobilePageContainer from 'components/mobile-page-container/MobilePageContainer'
 import { useSubPageHeader } from 'components/nav/store/context'
-import { playlistPage, albumPage, BASE_URL, EXPLORE_PAGE } from 'utils/route'
+import { collectionPage, BASE_URL, EXPLORE_PAGE } from 'utils/route'
 
 import styles from './CollectionsPage.module.css'
 
@@ -51,21 +51,14 @@ const ExplorePage = ({
         onClickFavorites={() => onClickFavorites(playlist.playlist_id)}
         onClick={(e) => {
           e.preventDefault()
-          playlist.is_album
-            ? goToRoute(
-                albumPage(
-                  playlist.user.handle,
-                  playlist.playlist_name,
-                  playlist.playlist_id
-                )
-              )
-            : goToRoute(
-                playlistPage(
-                  playlist.user.handle,
-                  playlist.playlist_name,
-                  playlist.playlist_id
-                )
-              )
+          goToRoute(
+            collectionPage(
+              playlist.user.handle,
+              playlist.is_album,
+              playlist.playlist_name,
+              playlist.playlist_id
+            )
+          )
         }}
       />
     )

--- a/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
+++ b/packages/web/src/pages/explore-page/components/mobile/ExplorePage.tsx
@@ -43,8 +43,7 @@ import {
   ExploreMoodCollection
 } from 'pages/explore-page/collections'
 import {
-  playlistPage,
-  albumPage,
+  collectionPage,
   profilePage,
   BASE_URL,
   EXPLORE_PAGE
@@ -197,17 +196,12 @@ const ExplorePage = ({
     profileCards = []
   } else {
     playlistCards = playlists.map((playlist: UserCollection) => {
-      const href = playlist.is_album
-        ? albumPage(
-            playlist.user.handle,
-            playlist.playlist_name,
-            playlist.playlist_id
-          )
-        : playlistPage(
-            playlist.user.handle,
-            playlist.playlist_name,
-            playlist.playlist_id
-          )
+      const href = collectionPage(
+        playlist.user.handle,
+        playlist.is_album,
+        playlist.playlist_name,
+        playlist.playlist_id
+      )
 
       return (
         <Card

--- a/packages/web/src/pages/landing-page/components/FeaturedContent.tsx
+++ b/packages/web/src/pages/landing-page/components/FeaturedContent.tsx
@@ -15,7 +15,7 @@ import { handleClickRoute } from 'components/public-site/handleClickRoute'
 import useCardWeight from 'hooks/useCardWeight'
 import useHasViewed from 'hooks/useHasViewed'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
-import { playlistPage } from 'utils/route'
+import { collectionPage } from 'utils/route'
 
 import styles from './FeaturedContent.module.css'
 
@@ -197,8 +197,9 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                       p.user.creator_node_endpoint
                     )}
                     onClick={handleClickRoute(
-                      playlistPage(
+                      collectionPage(
                         p.user.handle,
+                        p.is_album,
                         p.playlist_name,
                         p.playlist_id
                       ),
@@ -251,8 +252,9 @@ const FeaturedContent = (props: FeaturedContentProps) => {
                       p.user.creator_node_endpoint
                     )}
                     onClick={handleClickRoute(
-                      playlistPage(
+                      collectionPage(
                         p.user.handle,
+                        p.is_album,
                         p.playlist_name,
                         p.playlist_id
                       ),

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -38,8 +38,7 @@ import useTabs, { useTabRecalculator } from 'hooks/useTabs/useTabs'
 import { MIN_COLLECTIBLES_TIER } from 'pages/profile-page/ProfilePageProvider'
 import EmptyTab from 'pages/profile-page/components/EmptyTab'
 import {
-  albumPage,
-  playlistPage,
+  collectionPage,
   profilePage,
   UPLOAD_PAGE,
   UPLOAD_ALBUM_PAGE,
@@ -280,7 +279,6 @@ const ProfilePage = ({
         imageSize={album._cover_art_sizes}
         isPlaylist={!album.is_album}
         primaryText={album.playlist_name}
-        // link={fullAlbumPage(profile.handle, album.playlist_name, album.playlist_id)}
         secondaryText={formatCardSecondaryText(
           album.save_count,
           album.playlist_contents.track_ids.length
@@ -288,11 +286,23 @@ const ProfilePage = ({
         cardCoverImageSizes={album._cover_art_sizes}
         isReposted={album.has_current_user_reposted}
         isSaved={album.has_current_user_saved}
-        href={albumPage(profile.handle, album.playlist_name, album.playlist_id)}
+        href={collectionPage(
+          profile.handle,
+          album.is_album,
+          album.playlist_name,
+          album.playlist_id,
+          album.permalink
+        )}
         onClick={(e: MouseEvent) => {
           e.preventDefault()
           goToRoute(
-            albumPage(profile.handle, album.playlist_name, album.playlist_id)
+            collectionPage(
+              profile.handle,
+              album.is_album,
+              album.playlist_name,
+              album.playlist_id,
+              album.permalink
+            )
           )
         }}
       />
@@ -330,16 +340,18 @@ const ProfilePage = ({
         cardCoverImageSizes={playlist._cover_art_sizes}
         isReposted={playlist.has_current_user_reposted}
         isSaved={playlist.has_current_user_saved}
-        href={playlistPage(
+        href={collectionPage(
           profile.handle,
+          playlist.is_album,
           playlist.playlist_name,
           playlist.playlist_id
         )}
         onClick={(e: MouseEvent) => {
           e.preventDefault()
           goToRoute(
-            playlistPage(
+            collectionPage(
               profile.handle,
+              playlist.is_album,
               playlist.playlist_name,
               playlist.playlist_id
             )
@@ -528,16 +540,18 @@ const ProfilePage = ({
         isReposted={playlist.has_current_user_reposted}
         isSaved={playlist.has_current_user_saved}
         cardCoverImageSizes={playlist._cover_art_sizes}
-        href={playlistPage(
+        href={collectionPage(
           profile.handle,
+          playlist.is_album,
           playlist.playlist_name,
           playlist.playlist_id
         )}
         onClick={(e: MouseEvent) => {
           e.preventDefault()
           goToRoute(
-            playlistPage(
+            collectionPage(
               profile.handle,
+              playlist.is_album,
               playlist.playlist_name,
               playlist.playlist_id
             )

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -290,8 +290,7 @@ const ProfilePage = ({
           profile.handle,
           album.is_album,
           album.playlist_name,
-          album.playlist_id,
-          album.permalink
+          album.playlist_id
         )}
         onClick={(e: MouseEvent) => {
           e.preventDefault()
@@ -300,8 +299,7 @@ const ProfilePage = ({
               profile.handle,
               album.is_album,
               album.playlist_name,
-              album.playlist_id,
-              album.permalink
+              album.playlist_id
             )
           )
         }}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -427,8 +427,7 @@ const ProfilePage = g(
               profile.handle,
               album.is_album,
               album.playlist_name,
-              album.playlist_id,
-              album.permalink
+              album.playlist_id
             )}
             onClick={(e: MouseEvent) => {
               e.preventDefault()
@@ -437,8 +436,7 @@ const ProfilePage = g(
                   profile.handle,
                   album.is_album,
                   album.playlist_name,
-                  album.playlist_id,
-                  album.permalink
+                  album.playlist_id
                 )
               )
             }}

--- a/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/ProfilePage.tsx
@@ -40,7 +40,7 @@ import TierExplainerDrawer from 'components/user-badges/TierExplainerDrawer'
 import useAsyncPoll from 'hooks/useAsyncPoll'
 import useTabs from 'hooks/useTabs/useTabs'
 import { MIN_COLLECTIBLES_TIER } from 'pages/profile-page/ProfilePageProvider'
-import { albumPage, playlistPage } from 'utils/route'
+import { collectionPage } from 'utils/route'
 import { getUserPageSEOFields } from 'utils/seo'
 import { withNullGuard } from 'utils/withNullGuard'
 
@@ -392,16 +392,18 @@ const ProfilePage = g(
             playlist.playlist_contents.track_ids.length,
             playlist.is_private
           )}
-          href={playlistPage(
+          href={collectionPage(
             profile.handle,
+            playlist.is_album,
             playlist.playlist_name,
             playlist.playlist_id
           )}
           onClick={(e: MouseEvent) => {
             e.preventDefault()
             goToRoute(
-              playlistPage(
+              collectionPage(
                 profile.handle,
+                playlist.is_album,
                 playlist.playlist_name,
                 playlist.playlist_id
               )
@@ -421,18 +423,22 @@ const ProfilePage = g(
               album.save_count,
               album.playlist_contents.track_ids.length
             )}
-            href={albumPage(
+            href={collectionPage(
               profile.handle,
+              album.is_album,
               album.playlist_name,
-              album.playlist_id
+              album.playlist_id,
+              album.permalink
             )}
             onClick={(e: MouseEvent) => {
               e.preventDefault()
               goToRoute(
-                albumPage(
+                collectionPage(
                   profile.handle,
+                  album.is_album,
                   album.playlist_name,
-                  album.playlist_id
+                  album.playlist_id,
+                  album.permalink
                 )
               )
             }}

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -29,7 +29,7 @@ import EmptyTable from 'components/tracks-table/EmptyTable'
 import { useOrderedLoad } from 'hooks/useOrderedLoad'
 import useTabs from 'hooks/useTabs/useTabs'
 import { MainContentContext } from 'pages/MainContentContext'
-import { albumPage } from 'utils/route'
+import { collectionPage } from 'utils/route'
 
 import styles from './SavedPage.module.css'
 
@@ -204,10 +204,12 @@ const SavedPage = ({
             cardCoverImageSizes={album._cover_art_sizes}
             onClick={() =>
               goToRoute(
-                albumPage(
+                collectionPage(
                   album.ownerHandle,
+                  album.is_album,
                   album.playlist_name,
-                  album.playlist_id
+                  album.playlist_id,
+                  album.permalink
                 )
               )
             }

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -208,8 +208,7 @@ const SavedPage = ({
                   album.ownerHandle,
                   album.is_album,
                   album.playlist_name,
-                  album.playlist_id,
-                  album.permalink
+                  album.playlist_id
                 )
               )
             }

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -30,7 +30,7 @@ import { useMainPageHeader } from 'components/nav/store/context'
 import TrackList from 'components/track/mobile/TrackList'
 import { TrackItemAction } from 'components/track/mobile/TrackListItem'
 import useTabs from 'hooks/useTabs/useTabs'
-import { albumPage, TRENDING_PAGE, playlistPage } from 'utils/route'
+import { TRENDING_PAGE, collectionPage } from 'utils/route'
 
 import NewPlaylistButton from './NewPlaylistButton'
 import styles from './SavedPage.module.css'
@@ -198,7 +198,13 @@ const AlbumCardLineup = ({
         )}
         onClick={() =>
           goToRoute(
-            albumPage(album.ownerHandle, album.playlist_name, album.playlist_id)
+            collectionPage(
+              album.ownerHandle,
+              album.is_album,
+              album.playlist_name,
+              album.playlist_id,
+              album.permalink
+            )
           )
         }
       />
@@ -286,8 +292,9 @@ const PlaylistCardLineup = ({
         )}
         onClick={() => {
           goToRoute(
-            playlistPage(
+            collectionPage(
               playlist.ownerHandle,
+              playlist.is_album,
               playlist.playlist_name,
               playlist.playlist_id
             )

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -202,8 +202,7 @@ const AlbumCardLineup = ({
               album.ownerHandle,
               album.is_album,
               album.playlist_name,
-              album.playlist_id,
-              album.permalink
+              album.playlist_id
             )
           )
         }

--- a/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
+++ b/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
@@ -245,8 +245,7 @@ class SearchPageContent extends Component {
             album.user.handle,
             album.is_album,
             album.playlist_name,
-            album.playlist_id,
-            album.permalink
+            album.playlist_id
           )
         )
         recordSearchResultClick({
@@ -273,8 +272,7 @@ class SearchPageContent extends Component {
             album.user.handle,
             album.is_album,
             album.playlist_name,
-            album.playlist_id,
-            album.permalink
+            album.playlist_id
           )}
           primaryText={album.playlist_name}
           firesOnClick={false}

--- a/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
+++ b/packages/web/src/pages/search-page/components/desktop/SearchPageContent.js
@@ -18,10 +18,8 @@ import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import Page from 'components/page/Page'
 import Toast from 'components/toast/Toast'
 import {
-  albumPage,
-  fullAlbumPage,
-  playlistPage,
-  fullPlaylistPage,
+  collectionPage,
+  fullCollectionPage,
   profilePage,
   fullSearchResultsPage,
   NOT_FOUND_PAGE
@@ -174,8 +172,9 @@ class SearchPageContent extends Component {
       const toastId = `playlist-${playlist.playlist_id}`
       const onClick = () => {
         goToRoute(
-          playlistPage(
+          collectionPage(
             playlist.user.handle,
+            playlist.is_album,
             playlist.playlist_name,
             playlist.playlist_id
           )
@@ -200,8 +199,9 @@ class SearchPageContent extends Component {
           fillParent={false}
           playlistId={playlist.playlist_id}
           isAlbum={playlist.is_album}
-          link={fullPlaylistPage(
+          link={fullCollectionPage(
             playlist.user.handle,
+            playlist.is_album,
             playlist.playlist_name,
             playlist.playlist_id
           )}
@@ -241,7 +241,13 @@ class SearchPageContent extends Component {
       const toastId = `album-${album.playlist_id}`
       const onClick = () => {
         goToRoute(
-          albumPage(album.user.handle, album.playlist_name, album.playlist_id)
+          collectionPage(
+            album.user.handle,
+            album.is_album,
+            album.playlist_name,
+            album.playlist_id,
+            album.permalink
+          )
         )
         recordSearchResultClick({
           term: searchText,
@@ -263,10 +269,12 @@ class SearchPageContent extends Component {
           fillParent={false}
           playlistId={album.playlist_id}
           isAlbum={album.is_album}
-          link={fullAlbumPage(
+          link={fullCollectionPage(
             album.user.handle,
+            album.is_album,
             album.playlist_name,
-            album.playlist_id
+            album.playlist_id,
+            album.permalink
           )}
           primaryText={album.playlist_name}
           firesOnClick={false}

--- a/packages/web/src/pages/search-page/components/mobile/SearchPageContent.tsx
+++ b/packages/web/src/pages/search-page/components/mobile/SearchPageContent.tsx
@@ -252,8 +252,7 @@ const CardSearchPage = ({
                 collection.user.handle,
                 isAlbum,
                 collection.playlist_name,
-                collection.playlist_id,
-                collection.permalink
+                collection.playlist_id
               ),
               primaryText: collection.playlist_name,
               secondaryText: collection.user.handle,

--- a/packages/web/src/pages/search-page/components/mobile/SearchPageContent.tsx
+++ b/packages/web/src/pages/search-page/components/mobile/SearchPageContent.tsx
@@ -36,8 +36,7 @@ import { getCategory } from 'pages/search-page/helpers'
 import { getLocationPathname } from 'store/routing/selectors'
 import { useSelector } from 'utils/reducer'
 import {
-  albumPage,
-  playlistPage,
+  collectionPage,
   profilePage,
   fullSearchResultsPage,
   SEARCH_PAGE
@@ -244,16 +243,17 @@ const CardSearchPage = ({
           }
           case CardType.ALBUM:
           case CardType.PLAYLIST: {
-            const routeFunc =
-              cardType === CardType.ALBUM ? albumPage : playlistPage
+            const isAlbum = cardType === CardType.ALBUM
             const collection = e as UserCollection
             return {
               userId: collection.playlist_owner_id,
               id: collection.playlist_id,
-              route: routeFunc(
+              route: collectionPage(
                 collection.user.handle,
+                isAlbum,
                 collection.playlist_name,
-                collection.playlist_id
+                collection.playlist_id,
+                collection.permalink
               ),
               primaryText: collection.playlist_name,
               secondaryText: collection.user.handle,

--- a/packages/web/src/pages/upload-page/UploadPage.js
+++ b/packages/web/src/pages/upload-page/UploadPage.js
@@ -19,7 +19,7 @@ import Header from 'components/header/desktop/Header'
 import Page from 'components/page/Page'
 import { dropdownRows as stemRows } from 'components/source-files-modal/SourceFilesModal'
 import { processFiles } from 'pages/upload-page/store/utils/processFiles'
-import { playlistPage, albumPage, profilePage } from 'utils/route'
+import { collectionPage, profilePage } from 'utils/route'
 
 import styles from './UploadPage.module.css'
 import EditPage from './components/EditPage'
@@ -304,17 +304,25 @@ class Upload extends Component {
         }
         case UploadType.PLAYLIST: {
           const playlistName = upload.metadata.playlist_name
-          route = playlistPage(
+          route = collectionPage(
             account.handle,
+            false,
             playlistName,
-            upload.completionId
+            upload.completionId,
+            ''
           )
           uploadType = 'playlist'
           break
         }
         case UploadType.ALBUM: {
           const albumName = upload.metadata.playlist_name
-          route = albumPage(account.handle, albumName, upload.completionId)
+          route = collectionPage(
+            account.handle,
+            true,
+            albumName,
+            upload.completionId,
+            ''
+          )
           uploadType = 'album'
           break
         }

--- a/packages/web/src/pages/upload-page/components/ShareBanner.tsx
+++ b/packages/web/src/pages/upload-page/components/ShareBanner.tsx
@@ -22,13 +22,11 @@ import { apiClient } from 'services/audius-api-client'
 import { audiusBackendInstance } from 'services/audius-backend/audius-backend-instance'
 import { copyLinkToClipboard } from 'utils/clipboardUtil'
 import {
-  fullAlbumPage,
-  fullPlaylistPage,
+  fullCollectionPage,
   fullProfilePage,
   fullTrackPage,
   profilePage,
-  albumPage,
-  playlistPage
+  collectionPage
 } from 'utils/route'
 import { openTwitterLink } from 'utils/tweet'
 
@@ -116,8 +114,14 @@ const getShareTextUrl = async (
       if (!metadata || !completionId) return { text: '', url: '' }
 
       const { playlist_name: title } = metadata
-      const getPage = fullUrl ? fullAlbumPage : albumPage
-      const url = getPage(user.handle, title, completionId)
+      const getPage = fullUrl ? fullCollectionPage : collectionPage
+      const url = getPage(
+        user.handle,
+        true /* isAlbum */,
+        title,
+        completionId,
+        ''
+      )
       return {
         text: `Check out my new album, ${title} on @AudiusProject #Audius`,
         url
@@ -128,8 +132,14 @@ const getShareTextUrl = async (
       if (!metadata || !completionId) return { text: '', url: '' }
 
       const { playlist_name: title } = metadata
-      const getPage = fullUrl ? fullPlaylistPage : playlistPage
-      const url = getPage(user.handle, title, completionId)
+      const getPage = fullUrl ? fullCollectionPage : collectionPage
+      const url = getPage(
+        user.handle,
+        false /* isAlbum */,
+        title,
+        completionId,
+        ''
+      )
       return {
         text: `Check out my new playlist, ${title} on @AudiusProject #Audius`,
         url

--- a/packages/web/src/utils/route.ts
+++ b/packages/web/src/utils/route.ts
@@ -92,6 +92,7 @@ export const SEARCH_PAGE = '/search/:query?'
 export const PLAYLIST_PAGE = '/:handle/playlist/:playlistName'
 export const PLAYLIST_BY_PERMALINK_PAGE = '/:handle/playlist/:slug'
 export const ALBUM_PAGE = '/:handle/album/:albumName'
+export const ALBUM_BY_PERMALINK_PAGE = '/:handle/album/:slug'
 export const TRACK_PAGE = '/:handle/:slug'
 export const TRACK_REMIXES_PAGE = '/:handle/:slug/remixes'
 export const PROFILE_PAGE = '/:handle'
@@ -275,8 +276,9 @@ export const fullAlbumPage = (handle: string, title: string, id: ID) => {
   return `${BASE_URL}${albumPage(handle, title, id)}`
 }
 
-export const playlistPage = (
+export const collectionPage = (
   handle: string,
+  isAlbum: boolean,
   playlistName?: string | null,
   playlistId?: ID | null,
   permalink?: string | null
@@ -285,22 +287,24 @@ export const playlistPage = (
   if (permalink) {
     return permalink
   } else if (playlistName && playlistId) {
-    return `/${encodeUrlName(handle)}/playlist/${encodeUrlName(
-      playlistName
-    )}-${playlistId}`
+    return `/${encodeUrlName(handle)}/${
+      isAlbum ? 'album' : 'playlist'
+    }/${encodeUrlName(playlistName)}-${playlistId}`
   } else {
     console.error('Missing required arguments to get PlaylistPage route.')
     return ''
   }
 }
-export const fullPlaylistPage = (
+export const fullCollectionPage = (
   handle: string,
+  isAlbum: boolean,
   playlistName?: string | null,
   playlistId?: ID | null,
   permalink?: string | null
 ) => {
-  return `${BASE_URL}${playlistPage(
+  return `${BASE_URL}${collectionPage(
     handle,
+    isAlbum,
     playlistName,
     playlistId,
     permalink

--- a/packages/web/src/utils/route/collectionRouteParser.ts
+++ b/packages/web/src/utils/route/collectionRouteParser.ts
@@ -43,26 +43,6 @@ export const parseCollectionRoute = (route: string): CollectionRouteParams => {
     return { collectionId, handle: null, collectionType: null, title: null }
   }
 
-  // const playlistByPermalinkMatch = matchPath<{
-  //   handle: string
-  //   slug: string
-  // }>(route, {
-  //   path: PLAYLIST_BY_PERMALINK_PAGE,
-  //   exact: true
-  // })
-  // if (playlistByPermalinkMatch) {
-  //   const { handle, slug } = playlistByPermalinkMatch.params
-  //   const permalink = `${handle}/playlist/${slug}`
-  //   console.log('matched to permalink route')
-  //   return {
-  //     title: null,
-  //     collectionId: null,
-  //     permalink,
-  //     handle: null,
-  //     collectionType: 'playlist'
-  //   }
-  // }
-
   const playlistPageMatch = matchPath<{
     handle: string
     playlistName: string

--- a/packages/web/src/utils/seo.ts
+++ b/packages/web/src/utils/seo.ts
@@ -2,12 +2,7 @@
  * SEO Utlity functions to generate titles and descriptions
  */
 
-import {
-  fullAlbumPage,
-  fullPlaylistPage,
-  fullProfilePage,
-  fullTrackPage
-} from './route'
+import { fullCollectionPage, fullProfilePage, fullTrackPage } from './route'
 
 export const createSeoDescription = (msg: string) => {
   return `${msg} | Stream tracks, albums, playlists on desktop and mobile`
@@ -125,9 +120,12 @@ export const getCollectionPageSEOFields = ({
   const pageDescription = createSeoDescription(
     `Listen to ${playlistName} by ${userName} on Audius`
   )
-  const canonicalUrl = isAlbum
-    ? fullAlbumPage(userHandle, playlistName, playlistId)
-    : fullPlaylistPage(userHandle, playlistName, playlistId)
+  const canonicalUrl = fullCollectionPage(
+    userHandle,
+    isAlbum || false,
+    playlistName,
+    playlistId
+  )
   const structuredData = {
     '@context': 'http://schema.googleapis.com/',
     '@type': 'MusicAlbum',


### PR DESCRIPTION
### Description
This combines the `albumPage` route and `playlistPage` route into one `collectionRoute` since their urls are pretty much the same. This will make it easier to update both album and playlist routes in the front end to accept a permalink 

### Dragons

There's a lot of widespread changes to the routing but behavior should be the same across the board.

### How Has This Been Tested?

Ran locally against stage. Tested loading albums from the search bar, loading playlists from feed, loading user collections, creating an album and playlist, exploring top albums, trending playlists, and playlists we love.


