### PR TITLE
Add redownload logic for rehydration and stale tracks

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-downloader.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-downloader.ts
@@ -117,7 +117,7 @@ export const tryDownloadTrackFromEachCreatorNode = async (
   }
 }
 
-/** Dowanload file at uri to destination unless there is already a file at that location or overwrite is true */
+/** Download file at uri to destination unless there is already a file at that location or overwrite is true */
 const downloadIfNotExists = async (
   uri: string,
   destination: string,

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -60,6 +60,10 @@ export type OfflineItem =
       metadata: OfflineCollectionMetadata
     }
 
+export type RedownloadOfflineItemsAction = PayloadAction<{
+  items: DownloadQueueItem[]
+}>
+
 export type AddOfflineItemsAction = PayloadAction<{
   items: OfflineItem[]
 }>
@@ -119,6 +123,21 @@ const slice = createSlice({
   name: 'offlineDownloads',
   initialState,
   reducers: {
+    redownloadOfflineItems: (state, action: RedownloadOfflineItemsAction) => {
+      const { trackStatus, collectionStatus, downloadQueue } = state
+      const { items } = action.payload
+
+      for (const item of items) {
+        const { type, id } = item
+
+        if (type === 'collection') {
+          collectionStatus[id] = OfflineDownloadStatus.INIT
+        } else if (type === 'track') {
+          trackStatus[id] = OfflineDownloadStatus.INIT
+        }
+        downloadQueue.push(item)
+      }
+    },
     addOfflineItems: (state, action: AddOfflineItemsAction) => {
       const { items } = action.payload
       const {
@@ -253,6 +272,7 @@ const slice = createSlice({
 
 export const {
   addOfflineItems,
+  redownloadOfflineItems,
   removeOfflineItems,
   doneLoadingFromDisk,
   clearOfflineDownloads,


### PR DESCRIPTION
### Description
Add redownload items saga and add logic to redownload missing items during rehydration and when tracks become stale

### Dragons

Lots of thoughts around when the last_verified_time should be updated and how to handle the isAvailableToPlay case for stale tracks

### How Has This Been Tested?

N/A

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

