### PR TITLE
[C-2079] Fix mobile sign up analytics

### DIFF
--- a/packages/mobile/src/screens/signon/SignOnScreen.tsx
+++ b/packages/mobile/src/screens/signon/SignOnScreen.tsx
@@ -1,17 +1,4 @@
-import { useEffect } from 'react'
-
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
-import {
-  getAccountReady,
-  getEmailField,
-  getHandleField
-} from 'common/store/pages/signon/selectors'
-import type { EditableField } from 'common/store/pages/signon/types'
-import { useDispatch, useSelector } from 'react-redux'
-
-import { remindUserToTurnOnNotifications } from 'app/components/notification-reminder/NotificationReminder'
-import { track, make } from 'app/services/analytics'
-import { EventNames } from 'app/types/analytics'
 
 import CreatePassword from './CreatePassword'
 import FirstFollows from './FirstFollows'
@@ -56,35 +43,6 @@ const screenOptions = {
 }
 
 export const SignOnScreen = () => {
-  const dispatch = useDispatch()
-
-  const accountReady = useSelector(getAccountReady)
-
-  const emailField: EditableField = useSelector(getEmailField)
-  const handleField: EditableField = useSelector(getHandleField)
-
-  useEffect(() => {
-    if (accountReady) {
-      // Record both CREATE_ACCOUNT_COMPLETE_CREATING and
-      // CREATE_ACCOUNT_FINISH events
-      track(
-        make({
-          eventName: EventNames.CREATE_ACCOUNT_COMPLETE_CREATING,
-          emailAddress: emailField.value,
-          handle: handleField.value
-        })
-      )
-      track(
-        make({
-          eventName: EventNames.CREATE_ACCOUNT_FINISH,
-          emailAddress: emailField.value,
-          handle: handleField.value
-        })
-      )
-      remindUserToTurnOnNotifications(dispatch)
-    }
-  }, [accountReady, dispatch, emailField.value, handleField.value])
-
   return (
     <Stack.Navigator
       initialRouteName='SignOn'

--- a/packages/mobile/src/store/sagas.ts
+++ b/packages/mobile/src/store/sagas.ts
@@ -65,6 +65,7 @@ import offlineDownloadSagas from './offline-downloads/sagas'
 import rateCtaSagas from './rate-cta/sagas'
 import settingsSagas from './settings/sagas'
 import signOutSagas from './sign-out/sagas'
+import signUpSagas from './sign-up/sagas'
 import themeSagas from './theme/sagas'
 import walletsSagas from './wallet-connect/sagas'
 
@@ -95,6 +96,9 @@ export default function* rootSaga() {
     // Sign in / Sign out
     ...signOnSagas(),
     ...signOutSagas(),
+
+    // Sign up
+    ...signUpSagas(),
 
     // Tipping
     ...tippingSagas(),

--- a/packages/mobile/src/store/sign-up/sagas.ts
+++ b/packages/mobile/src/store/sign-up/sagas.ts
@@ -1,0 +1,7 @@
+import { watchSignUpSucceeded } from './sagas/watchSignUpSucceededSaga'
+
+const sagas = () => {
+  return [watchSignUpSucceeded]
+}
+
+export default sagas

--- a/packages/mobile/src/store/sign-up/sagas/watchSignUpSucceededSaga.ts
+++ b/packages/mobile/src/store/sign-up/sagas/watchSignUpSucceededSaga.ts
@@ -1,0 +1,38 @@
+import { make } from 'common/store/analytics/actions'
+import { SIGN_UP_SUCCEEDED } from 'common/store/pages/signon/actions'
+import {
+  getEmailField,
+  getHandleField
+} from 'common/store/pages/signon/selectors'
+import { takeEvery, put, select } from 'typed-redux-saga'
+
+import { remindUserToTurnOnNotifications } from 'app/components/notification-reminder/NotificationReminder'
+import { EventNames } from 'app/types/analytics'
+
+export function* watchSignUpSucceeded() {
+  yield* takeEvery(SIGN_UP_SUCCEEDED, handleSignUpSucceeded)
+}
+
+function* handleSignUpSucceeded() {
+  const emailField = yield* select(getEmailField)
+  const handleField = yield* select(getHandleField)
+
+  // Record both CREATE_ACCOUNT_COMPLETE_CREATING and
+  // CREATE_ACCOUNT_FINISH events
+
+  yield put(
+    make(EventNames.CREATE_ACCOUNT_COMPLETE_CREATING, {
+      emailAddress: emailField.value,
+      handle: handleField.value
+    })
+  )
+
+  yield put(
+    make(EventNames.CREATE_ACCOUNT_FINISH, {
+      emailAddress: emailField.value,
+      handle: handleField.value
+    })
+  )
+
+  remindUserToTurnOnNotifications(put)
+}


### PR DESCRIPTION
### Description

The way we were firing sign up complete analytics in a useEffect in the SignOnScreen did not always trigger because the screen was removed as soon as an account existed (in RootScreen) 

This pr moves the analytics and notification reminder into a mobile specific saga that watches SIGN_UP_SUCCEEDED. We've followed this pattern for other mobile specific sagas but open to thoughts/comments. Also @dylanjeffers I followed the pattern you did for offline mode sagas

Edit: I think sign up needs an audit / some love in general

### Dragons

Specifically did not make any changes that affect web. This should be fairly safe

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

