### PR TITLE
Fix audio tx modal where metadata is null

### DIFF
--- a/packages/common/src/store/ui/transaction-details/types.ts
+++ b/packages/common/src/store/ui/transaction-details/types.ts
@@ -1,6 +1,7 @@
 import { Action } from '@reduxjs/toolkit'
 
 import { StringAudio, Status } from '../../../models'
+import { Nullable } from '../../../utils/typeUtils'
 
 export enum TransactionType {
   PURCHASE = 'PURCHASE',
@@ -46,7 +47,7 @@ export type TransactionDetails =
       date: string
       change: StringAudio
       balance: StringAudio
-      metadata?: InAppAudioPurchaseMetadata
+      metadata?: Nullable<InAppAudioPurchaseMetadata>
     }
   | {
       signature: string

--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -6,7 +6,8 @@ import {
   formatDate,
   StringAudio,
   transactionDetailsActions,
-  getContext
+  getContext,
+  Nullable
 } from '@audius/common'
 import type { InAppAudioPurchaseMetadata } from '@audius/common'
 import { AudiusLibs, full } from '@audius/sdk'
@@ -157,7 +158,7 @@ function* fetchTransactionMetadata() {
       }
       yield* call(waitForLibsInit)
       const libs: AudiusLibs = yield* call(audiusBackendInstance.getAudiusLibs)
-      const response: InAppAudioPurchaseMetadata = yield* call(
+      const response = yield* call(
         [
           libs.identityService!,
           libs.identityService!.getUserBankTransactionMetadata
@@ -169,9 +170,7 @@ function* fetchTransactionMetadata() {
           transactionId: txDetails.signature,
           transactionDetails: {
             ...txDetails,
-            // If metadata does not exist on identity, mark as null to indicate
-            // that fetch was attempted but failed.
-            metadata: response ?? null
+            metadata: response as Nullable<InAppAudioPurchaseMetadata>
           }
         })
       )

--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -153,19 +153,21 @@ function* fetchTransactionMetadata() {
       const { txDetails } = action.payload
       yield* call(waitForLibsInit)
       const libs: AudiusLibs = yield* call(audiusBackendInstance.getAudiusLibs)
-      const response = yield* call(
+      const response = (yield* call(
         [
           libs.identityService!,
           libs.identityService!.getUserBankTransactionMetadata
         ],
         txDetails.signature
-      )
+      )) as any[]
       yield put(
         fetchTransactionDetailsSucceeded({
           transactionId: txDetails.signature,
           transactionDetails: {
             ...txDetails,
-            metadata: (response as any[])[0].metadata
+            // If metadata does not exist on identity, mark as null to indicate
+            // that fetch was attempted but failed.
+            metadata: response.length === 0 ? null : response[0].metadata
           }
         })
       )

--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -167,7 +167,7 @@ function* fetchTransactionMetadata() {
             ...txDetails,
             // If metadata does not exist on identity, mark as null to indicate
             // that fetch was attempted but failed.
-            metadata: response.length === 0 ? null : response[0].metadata
+            metadata: response[0]?.metadata ?? null
           }
         })
       )

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -98,14 +98,12 @@ const dateAndMetadataBlocks = (transactionDetails: TransactionDetails) => {
   switch (transactionDetails.transactionType) {
     case TransactionType.PURCHASE: {
       // Rare case: metadata will be null if failed to fetch from identity.
-      if (transactionDetails.metadata === null) {
+      if (!transactionDetails.metadata) {
         return
       }
       return (
         <>
-          <TransactionPurchaseMetadata
-            metadata={transactionDetails.metadata!}
-          />
+          <TransactionPurchaseMetadata metadata={transactionDetails.metadata} />
           <Block header={messages.date}>{transactionDetails.date}</Block>
         </>
       )

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -97,10 +97,6 @@ const UserDetails = ({ userId }: UserDetailsProps) => {
 const dateAndMetadataBlocks = (transactionDetails: TransactionDetails) => {
   switch (transactionDetails.transactionType) {
     case TransactionType.PURCHASE: {
-      // Rare case: metadata will be null if failed to fetch from identity.
-      if (!transactionDetails.metadata) {
-        return
-      }
       return (
         <>
           <TransactionPurchaseMetadata metadata={transactionDetails.metadata} />

--- a/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionDetailsContent.tsx
@@ -97,6 +97,10 @@ const UserDetails = ({ userId }: UserDetailsProps) => {
 const dateAndMetadataBlocks = (transactionDetails: TransactionDetails) => {
   switch (transactionDetails.transactionType) {
     case TransactionType.PURCHASE: {
+      // Rare case: metadata will be null if failed to fetch from identity.
+      if (transactionDetails.metadata === null) {
+        return
+      }
       return (
         <>
           <TransactionPurchaseMetadata

--- a/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
@@ -1,4 +1,8 @@
-import { InAppAudioPurchaseMetadata, formatNumberString } from '@audius/common'
+import {
+  InAppAudioPurchaseMetadata,
+  formatNumberString,
+  Nullable
+} from '@audius/common'
 
 import { ReactComponent as IconExternalLink } from 'assets/img/iconExternalLink.svg'
 import {
@@ -23,7 +27,7 @@ const messages = {
 export const TransactionPurchaseMetadata = ({
   metadata
 }: {
-  metadata?: InAppAudioPurchaseMetadata
+  metadata?: Nullable<InAppAudioPurchaseMetadata>
 }) => {
   return (
     <BlockContainer>

--- a/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
+++ b/packages/web/src/components/transaction-details-modal/components/TransactionPurchaseMetadata.tsx
@@ -23,14 +23,14 @@ const messages = {
 export const TransactionPurchaseMetadata = ({
   metadata
 }: {
-  metadata: InAppAudioPurchaseMetadata
+  metadata?: InAppAudioPurchaseMetadata
 }) => {
   return (
     <BlockContainer>
       <Block header={messages.cost}>
         <IconUSD />
         <span className={styles.amount}>
-          {metadata.usd
+          {metadata?.usd
             ? formatNumberString(metadata.usd, {
                 minDecimals: 2,
                 maxDecimals: 2
@@ -41,7 +41,7 @@ export const TransactionPurchaseMetadata = ({
       </Block>
       <Block
         header={
-          metadata.purchaseTransactionId ? (
+          metadata?.purchaseTransactionId ? (
             <a
               className={styles.link}
               href={`https://explorer.solana.com/tx/${metadata.purchaseTransactionId}`}
@@ -58,7 +58,7 @@ export const TransactionPurchaseMetadata = ({
       >
         <IconSOL />
         <span className={styles.amount}>
-          {metadata.sol
+          {metadata?.sol
             ? formatNumberString(metadata.sol, { maxDecimals: 2 })
             : '?'}
         </span>
@@ -66,7 +66,7 @@ export const TransactionPurchaseMetadata = ({
       </Block>
       <Block
         header={
-          metadata.swapTransactionId ? (
+          metadata?.swapTransactionId ? (
             <a
               className={styles.link}
               href={`https://explorer.solana.com/tx/${metadata.swapTransactionId}`}
@@ -83,7 +83,7 @@ export const TransactionPurchaseMetadata = ({
       >
         <IconAUDIO />
         <span className={styles.amount}>
-          {metadata.audio
+          {metadata?.audio
             ? formatNumberString(metadata.audio, { maxDecimals: 2 })
             : '?'}
         </span>


### PR DESCRIPTION
### Description
In some rare cases, the tx metadata doesn't exist on identity (usually due to bugs). This fixes client so that it doesn't crash when this occurs.

### Dragons
Fallout from this fix: the modal will start at 580px then suddenly shrink when this case occurs. I think this is ok to ignore though as this is a rare case.

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web client.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

