### PR TITLE
Fix artist pick reads from discovery

### DIFF
--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -79,7 +79,6 @@ export const makeUser = (
     id: undefined,
     cover_photo_legacy: undefined,
     profile_picture_legacy: undefined,
-    artist_pick_track_id: null
   }
 
   delete newUser.id


### PR DESCRIPTION
### Description
Noticed reading artist pick from discovery wasn't working when viewing other people's profiles. This was because we had added this line manually pruning the artist pick field when fetching and caching the user's metadata sometime between now and when I initially added the flag in. Does not affect viewing one's own profile because that info is fetched and cached in `getAccount` in `AudiusBackend.ts`.

Going to hotfix this change onto the 1.5.9 release so that we can turn on reads then delete the legacy identity path for artist pick in the next client release.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

