### PR TITLE
Decode artist pick IDs and fix artist pick reads from discovery

### DIFF
--- a/packages/common/src/models/User.ts
+++ b/packages/common/src/models/User.ts
@@ -10,8 +10,8 @@ import { Timestamped } from './Timestamped'
 
 export type UserMetadata = {
   album_count: number
-  artist_pick_track_id: number | null
-  bio: string | null
+  artist_pick_track_id: Nullable<number>
+  bio: Nullable<string>
   cover_photo: Nullable<CID>
   creator_node_endpoint: Nullable<string>
   current_user_followee_follow_count: number

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -38,6 +38,12 @@ export const makeUser = (
     return undefined
   }
 
+  // TODO remove conditional once all DN nodes are encoding the artist pick ID
+  let decoded_artist_pick_track_id = user.artist_pick_track_id
+  if (typeof user.artist_pick_track_id === 'string') {
+    decoded_artist_pick_track_id = decodeHashId(user.artist_pick_track_id)
+  }
+
   const balance = user.balance as StringWei
   const associated_wallets_balance =
     user.associated_wallets_balance as StringWei
@@ -58,6 +64,7 @@ export const makeUser = (
 
   const newUser = {
     ...user,
+    artist_pick_track_id: decoded_artist_pick_track_id,
     balance,
     associated_wallets_balance,
     album_count,
@@ -78,8 +85,7 @@ export const makeUser = (
     // Fields to prune
     id: undefined,
     cover_photo_legacy: undefined,
-    profile_picture_legacy: undefined,
-    artist_pick_track_id: null
+    profile_picture_legacy: undefined
   }
 
   delete newUser.id

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -39,9 +39,11 @@ export const makeUser = (
   }
 
   // TODO remove conditional once all DN nodes are encoding the artist pick ID
-  let decoded_artist_pick_track_id = user.artist_pick_track_id
+  let decoded_artist_pick_track_id: number | null
   if (typeof user.artist_pick_track_id === 'string') {
     decoded_artist_pick_track_id = decodeHashId(user.artist_pick_track_id)
+  } else {
+    decoded_artist_pick_track_id = user.artist_pick_track_id
   }
 
   const balance = user.balance as StringWei

--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -38,7 +38,7 @@ export const makeUser = (
     return undefined
   }
 
-  // TODO remove conditional once all DN nodes are encoding the artist pick ID
+  // TODO remove conditional once all DNs are encoding the artist pick ID
   let decoded_artist_pick_track_id: number | null
   if (typeof user.artist_pick_track_id === 'string') {
     decoded_artist_pick_track_id = decodeHashId(user.artist_pick_track_id)

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -23,7 +23,8 @@ export type OpaqueID = string
 
 export type APIUser = {
   album_count: number
-  artist_pick_track_id: Nullable<number>
+  // TODO remove number type once all DN nodes are encoding the artist pick ID
+  artist_pick_track_id: Nullable<number | OpaqueID>
   blocknumber: number
   balance: string
   associated_wallets_balance: string

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -23,7 +23,7 @@ export type OpaqueID = string
 
 export type APIUser = {
   album_count: number
-  // TODO remove number type once all DN nodes are encoding the artist pick ID
+  // TODO remove number type once all DNs are encoding the artist pick ID
   artist_pick_track_id: Nullable<number | OpaqueID>
   blocknumber: number
   balance: string


### PR DESCRIPTION
### Description
Noticed I didn't encode artist pick track IDs in the user API response... added in discovery in https://github.com/AudiusProject/audius-protocol/pull/4725; these are the accompanying client changes. Will remove the conditional and 'number' type when all discovery nodes have updated.

Also noticed reading artist pick from discovery wasn't working when viewing other people's profiles. This was because we had added a line manually pruning the artist pick field when fetching and caching the user's metadata sometime between now and when I initially added the flag in. Does not affect viewing one's own profile because that info is fetched and cached in getAccount in AudiusBackend.ts.

Going to hotfix this change onto the 1.5.9 release so that we can turn on reads then delete the legacy identity path for artist pick in the next client release.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested reads and writes with and without the backend changes encoding the IDs.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

