### PR TITLE
[C-1975] Fix safari stream mp3

### DIFF
--- a/packages/web/src/pages/visualizer/VisualizerProvider.tsx
+++ b/packages/web/src/pages/visualizer/VisualizerProvider.tsx
@@ -72,18 +72,20 @@ const Visualizer = ({
   const [showVisualizer, setShowVisualizer] = useState(false)
 
   useEffect(() => {
-    if (!(window as any).AudioContext) {
+    if (showVisualizer) {
       let browser
-      if ((window as any).webkitAudioContext) {
+      if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
         browser = 'Safari'
-      } else if (window.navigator.userAgent.indexOf('MSIE ') > 0) {
+      } else if (/MSIE/i.test(navigator.userAgent)) {
         browser = 'Internet Explorer'
-      } else {
+      } else if (!window?.AudioContext) {
         browser = 'your browser'
       }
-      setToastText(messages(browser).notSupported)
+      if (browser) {
+        setToastText(messages(browser).notSupported)
+      }
     }
-  }, [])
+  }, [showVisualizer])
 
   if (!webGLExists) {
     return null

--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -12,6 +12,8 @@ declare global {
   }
 }
 
+const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+
 const FADE_IN_EVENT = new Event('fade-in')
 const FADE_OUT_EVENT = new Event('fade-out')
 const VOLUME_CHANGE_BASE = 10
@@ -143,7 +145,7 @@ export class AudioPlayer {
 
   _initContext = () => {
     this.audio.addEventListener('canplay', () => {
-      if (!this.audioCtx) {
+      if (!this.audioCtx && !IS_SAFARI) {
         // Set up WebAudio API handles
         const AudioContext = window.AudioContext || window.webkitAudioContext
         try {


### PR DESCRIPTION
### Description

![image](https://user-images.githubusercontent.com/2731362/217467252-d5ded79e-0ecc-4142-a4d6-733b7e47ab8a.png)

* Skip AudioContext set up on safari
* Fix visualizer check -- AudioContext is now defined in safari. We can probably make the visualizer work, but I tried for a little and couldn't figure it out for now.

Should be able to re-enable feature flag if we cherry this into this week's release.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

* MacOS Safari
* MacOS Chrome
* MacOS Firefox
* MacOS Edge
* iOS Safari
* iOS Chrome
* Android Chrome

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

