### PR TITLE
[C-2056] Fix lineup scrolling

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -287,8 +287,8 @@ export const Lineup = ({
         (includeLineupStatus ? status !== Status.LOADING : true)
 
       if (shouldLoadMore || reset) {
-        const _offset = reset ? offset : 0
-        const _page = reset ? page : 0
+        const _offset = reset ? 0 : offset
+        const _page = reset ? 0 : page
         const itemLoadCount = itemCounts.initial + _page * itemCounts.loadMore
 
         if (!reset) {
@@ -506,6 +506,8 @@ export const Lineup = ({
   const pullToRefreshProps =
     pullToRefresh || refreshProp ? { onRefresh: refresh, refreshing } : {}
 
+  const handleEndReached = useCallback(() => handleLoadMore(), [handleLoadMore])
+
   return (
     <View style={styles.root}>
       <SectionList
@@ -518,7 +520,7 @@ export const Lineup = ({
           lineup.hasMore ? <View style={{ height: 16 }} /> : ListFooterComponent
         }
         ListEmptyComponent={LineupEmptyComponent}
-        onEndReached={handleLoadMore as () => void}
+        onEndReached={handleEndReached}
         onEndReachedThreshold={LOAD_MORE_THRESHOLD}
         sections={sections}
         stickySectionHeadersEnabled={false}


### PR DESCRIPTION
### Description

* `handleLoadMore` was being passed an object from `SectionList` `onEndReached`, so `reset` was always truthy. Also we had overridden the type
* The `_offset` and `_page` ternaries were backwards

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

