### PR TITLE
[C-1984] Don't use nativeDriver for slider and tracking bar anims

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/TrackingBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/TrackingBar.tsx
@@ -59,7 +59,10 @@ export const TrackingBar = (props: TrackingBarProps) => {
     currentAnimation.current = Animated.timing(translateXAnimation.current, {
       toValue: 1,
       duration: timeRemaining * 1000,
-      useNativeDriver: true
+      // Can't use native driver because this animation is potentially hours long,
+      // and would have to be serialized into an array to be passed to the native layer.
+      // The array exceeds the number of properties allowed in hermes
+      useNativeDriver: false
     })
 
     currentAnimation.current.start()

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -138,7 +138,10 @@ export const Slider = memo((props: SliderProps) => {
       currentAnimation.current = Animated.timing(translationAnim, {
         toValue: railWidth,
         duration: timeRemaining,
-        useNativeDriver: true
+        // Can't use native driver because this animation is potentially hours long,
+        // and would have to be serialized into an array to be passed to the native layer.
+        // The array exceeds the number of properties allowed in hermes
+        useNativeDriver: false
       })
       currentAnimation.current.start()
     },


### PR DESCRIPTION
### Description
![image](https://user-images.githubusercontent.com/19916043/217685055-a1fa0fd4-f957-41f8-8dac-625432ff3121.png)

* Don't use nativeDriver for slider and tracking bar anims
  Both were crashing but only the error for tracking bar was logged because the app crashed afterwards
  The serialized animations for an hour long track have over 300k properties and hermes has an upper bound
  https://reactnative.dev/docs/animations#using-the-native-driver

### Dragons

Slightly less performant, but I checked and there was not a significant difference in cpu usage or app responsiveness

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

