### PR TITLE
[C-2038] Fix unresponsive reactions

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/TrackingBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/TrackingBar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 import { playerSelectors } from '@audius/common'
-import { Animated, Dimensions } from 'react-native'
+import { Animated, Dimensions, Easing } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import TrackPlayer from 'react-native-track-player'
 import { useSelector } from 'react-redux'
@@ -59,6 +59,7 @@ export const TrackingBar = (props: TrackingBarProps) => {
     currentAnimation.current = Animated.timing(translateXAnimation.current, {
       toValue: 1,
       duration: timeRemaining * 1000,
+      easing: Easing.linear,
       // Can't use native driver because this animation is potentially hours long,
       // and would have to be serialized into an array to be passed to the native layer.
       // The array exceeds the number of properties allowed in hermes

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react'
 
 import { useAppState } from '@react-native-community/hooks'
 import type { GestureResponderEvent } from 'react-native'
-import { View, Animated, PanResponder } from 'react-native'
+import { Easing, View, Animated, PanResponder } from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import TrackPlayer from 'react-native-track-player'
 import { useAsync, usePrevious } from 'react-use'
@@ -138,6 +138,7 @@ export const Slider = memo((props: SliderProps) => {
       currentAnimation.current = Animated.timing(translationAnim, {
         toValue: railWidth,
         duration: timeRemaining,
+        easing: Easing.linear,
         // Can't use native driver because this animation is potentially hours long,
         // and would have to be serialized into an array to be passed to the native layer.
         // The array exceeds the number of properties allowed in hermes

--- a/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
+import type { ReactionTypes } from '@audius/common'
 import type { AnimatedLottieViewProps } from 'lottie-react-native'
 import LottieView from 'lottie-react-native'
 import type { StyleProp, View, ViewProps, ViewStyle } from 'react-native'
@@ -19,17 +20,23 @@ const useStyles = makeStyles(({ spacing }) => ({
 
 export type ReactionStatus = 'interacting' | 'idle' | 'selected' | 'unselected'
 
+type OnMeasureConfig = { x: number; width: number; reactionType: ReactionTypes }
+
+export type OnMeasure = (config: OnMeasureConfig) => void
+
 export type ReactionProps = ViewProps & {
+  reactionType: ReactionTypes
   autoPlay?: boolean
   source: AnimatedLottieViewProps['source']
   style?: StyleProp<ViewStyle>
   status?: ReactionStatus
-  onMeasure?: (values: { x: number; width: number }) => void
+  onMeasure?: OnMeasure
   isVisible: boolean
 }
 
 export const Reaction = (props: ReactionProps) => {
   const {
+    reactionType,
     autoPlay = true,
     source,
     style,
@@ -58,11 +65,12 @@ export const Reaction = (props: ReactionProps) => {
   }, [status, autoPlay, isVisible])
 
   useEffect(() => {
-    ref.current?.measureInWindow((x, _, width) => {
-      onMeasure?.({ x, width })
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- onMeasure changes too much
-  }, [])
+    if (isVisible && onMeasure) {
+      ref.current?.measureInWindow((x, _, width) => {
+        onMeasure({ x, width, reactionType })
+      })
+    }
+  }, [isVisible, onMeasure, reactionType])
 
   useEffect(() => {
     if (previousStatus !== 'interacting' && status === 'interacting') {

--- a/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
@@ -8,6 +8,7 @@ import { View, PanResponder } from 'react-native'
 import { AppDrawerContext } from 'app/screens/app-drawer-screen'
 import { makeStyles } from 'app/styles'
 
+import type { OnMeasure } from './Reaction'
 import { reactionMap } from './reactions'
 
 const useStyles = makeStyles(() => ({
@@ -43,8 +44,9 @@ type Positions = { [k in ReactionTypes]: { x: number; width: number } }
  * each reaction one of the following statuses: idle/interacting/selected/unselected
  */
 export const ReactionList = (props: ReactionListProps) => {
-  const styles = useStyles()
   const { selectedReaction, onChange, isVisible } = props
+  console.log('isVisible??', isVisible)
+  const styles = useStyles()
   // The current reaction the user is interacting with.
   // Note this needs to be a ref since the guesture handler is also a ref
   const interactingReactionRef = useRef<ReactionTypes | null>(null)
@@ -103,6 +105,11 @@ export const ReactionList = (props: ReactionListProps) => {
     })
   )
 
+  const handleMeasure: OnMeasure = useCallback((config) => {
+    const { x, width, reactionType } = config
+    positions.current = { ...positions.current, [reactionType]: { x, width } }
+  }, [])
+
   return (
     <View>
       <View style={styles.root} {...panResponder.current.panHandlers}>
@@ -122,12 +129,7 @@ export const ReactionList = (props: ReactionListProps) => {
             <Reaction
               key={reactionType}
               status={status}
-              onMeasure={({ x, width }: { x: number; width: number }) => {
-                positions.current = {
-                  ...positions.current,
-                  [reactionType]: { x, width }
-                }
-              }}
+              onMeasure={handleMeasure}
               isVisible={isVisible}
             />
           )

--- a/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
@@ -45,7 +45,6 @@ type Positions = { [k in ReactionTypes]: { x: number; width: number } }
  */
 export const ReactionList = (props: ReactionListProps) => {
   const { selectedReaction, onChange, isVisible } = props
-  console.log('isVisible??', isVisible)
   const styles = useStyles()
   // The current reaction the user is interacting with.
   // Note this needs to be a ref since the guesture handler is also a ref

--- a/packages/mobile/src/screens/notifications-screen/Reaction/reactions.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/reactions.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react'
 
 import type { ReactionTypes } from '@audius/common'
+import type { SetOptional } from 'type-fest'
 
 import type { ReactionProps as BaseReactionProps } from './Reaction'
 import { Reaction } from './Reaction'
@@ -9,19 +10,22 @@ import fire from './fire.json'
 import party from './partying_face.json'
 import heart from './smiling_face_with_heart_eyes.json'
 
-export type ReactionProps = Omit<BaseReactionProps, 'source'>
+export type ReactionProps = SetOptional<
+  BaseReactionProps,
+  'source' | 'reactionType'
+>
 
 export const HeartReaction = (props: ReactionProps) => (
-  <Reaction {...props} source={heart} />
+  <Reaction {...props} reactionType='heart' source={heart} />
 )
 export const FireReaction = (props: ReactionProps) => (
-  <Reaction {...props} source={fire} />
+  <Reaction {...props} reactionType='fire' source={fire} />
 )
 export const PartyReaction = (props: ReactionProps) => (
-  <Reaction {...props} source={party} />
+  <Reaction {...props} reactionType='party' source={party} />
 )
 export const ExplodeReaction = (props: ReactionProps) => (
-  <Reaction {...props} source={explode} />
+  <Reaction {...props} reactionType='explode' source={explode} />
 )
 
 export const reactionMap: {


### PR DESCRIPTION
### Description

Fixes edge case where reactions that render deep in the notification list don't respond to reactions. This was due to `onMeasure`, the function that calculates the reaction width needed for press-hold + drag functionality, being called to early. Now we wait until the reaction-list is in view before measuring.

Also changes play-bar animations to Linear for release