### PR TITLE
Fix onPressRail animation error

### DIFF
--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -163,7 +163,7 @@ export const Slider = memo((props: SliderProps) => {
       Animated.timing(translationAnim, {
         duration: 100,
         toValue: newPosition,
-        useNativeDriver: true
+        useNativeDriver: false
       }).start()
       handlePressHandleIn()
       onPressIn()


### PR DESCRIPTION
### Description

Fixes issue where pressing the slider rail throws error, this is due to us changing the animation type for `useNativeDriver: false`
