### PR TITLE
[C-2067] Add 'play-count' queue

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -306,7 +306,6 @@ export const Audio = () => {
       if (isReachable) {
         dispatch(recordListen(trackId))
       } else if (isOfflineModeEnabled) {
-        // TODO fix offline play counts
         dispatch(
           addOfflineItems({ items: [{ type: 'play-count', id: trackId }] })
         )

--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -49,7 +49,10 @@ import {
   getOfflineTrackStatus,
   getIsCollectionMarkedForDownload
 } from 'app/store/offline-downloads/selectors'
-import { OfflineDownloadStatus } from 'app/store/offline-downloads/slice'
+import {
+  addOfflineItems,
+  OfflineDownloadStatus
+} from 'app/store/offline-downloads/slice'
 
 const { getUsers } = cacheUsersSelectors
 const { getTracks } = cacheTracksSelectors
@@ -304,7 +307,9 @@ export const Audio = () => {
         dispatch(recordListen(trackId))
       } else if (isOfflineModeEnabled) {
         // TODO fix offline play counts
-        // queue.addJob<PlayCountWorkerPayload>(PLAY_COUNTER_WORKER, { trackId })
+        dispatch(
+          addOfflineItems({ items: [{ type: 'play-count', id: trackId }] })
+        )
       }
     }, RECORD_LISTEN_SECONDS)
 

--- a/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/playCounterWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/playCounterWorker.ts
@@ -1,0 +1,13 @@
+import type { ID } from '@audius/common'
+import { tracksSocialActions } from '@audius/common'
+import { put } from 'typed-redux-saga'
+
+import { completePlayCount, requestDownloadQueuedItem } from '../../slice'
+
+const { recordListen } = tracksSocialActions
+
+export function* playCounterWorker(trackId: ID) {
+  yield* put(recordListen(trackId))
+  yield* put(completePlayCount())
+  yield* put(requestDownloadQueuedItem())
+}

--- a/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/requestDownloadQueuedItemSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/requestDownloadQueuedItemSaga.ts
@@ -9,6 +9,7 @@ import {
 
 import { downloadCollectionWorker } from './downloadCollectionWorker'
 import { downloadTrackWorker } from './downloadTrackWorker'
+import { playCounterWorker } from './playCounterWorker'
 import { syncCollectionWorker } from './syncCollectionWorker'
 
 export function* requestDownloadQueuedItemSaga() {
@@ -35,5 +36,7 @@ function* downloadQueuedItem() {
     yield* call(downloadTrackWorker, id)
   } else if (type === 'collection-sync') {
     yield* call(syncCollectionWorker, id)
+  } else if (type === 'play-count') {
+    yield* call(playCounterWorker, id)
   }
 }

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -28,6 +28,7 @@ export type DownloadQueueItem =
   | { type: 'collection'; id: CollectionId }
   | { type: 'track'; id: ID }
   | { type: 'collection-sync'; id: CollectionId }
+  | { type: 'play-count'; id: ID }
 
 export type OfflineDownloadsState = {
   trackStatus: {
@@ -67,6 +68,7 @@ export type OfflineItem =
       type: 'collection-sync'
       id: CollectionId
     }
+  | { type: 'play-count'; id: ID }
 
 export type RedownloadOfflineItemsAction = PayloadAction<{
   items: DownloadQueueItem[]
@@ -197,6 +199,8 @@ const slice = createSlice({
             collectionSyncStatus[id] = CollectionSyncStatus.INIT
             downloadQueue.push({ type: 'collection-sync', id })
           }
+        } else if (item.type === 'play-count') {
+          downloadQueue.push(item)
         }
       }
     },
@@ -299,6 +303,9 @@ const slice = createSlice({
       state.collectionSyncStatus[id] = CollectionSyncStatus.ERROR
       state.downloadQueue.shift()
     },
+    completePlayCount: (state) => {
+      state.downloadQueue.shift()
+    },
     updateQueueStatus: (state, action: UpdateQueueStatusAction) => {
       state.queueStatus = action.payload.queueStatus
     },
@@ -351,6 +358,7 @@ export const {
   completeCollectionSync,
   cancelCollectionSync,
   errorCollectionSync,
+  completePlayCount,
   updateQueueStatus,
   requestDownloadAllFavorites,
   requestDownloadCollection,


### PR DESCRIPTION
### Description

Add play-count type to offline queue.
This was removed in the queue refactor.

### Dragons

1. Do we need error handling? Is best-effort good enough?
2. Is the same queue state logic sufficient for this? Process while online, stop while offline.

### How Has This Been Tested?

- [ ] TODO - untested