### PR TITLE
Don't download on save if all favorites toggle off

### DIFF
--- a/packages/mobile/src/store/offline-downloads/sagas/watchSaveTrackSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/watchSaveTrackSaga.ts
@@ -1,9 +1,10 @@
 import { tracksSocialActions } from '@audius/common'
 import moment from 'moment'
-import { put, takeEvery } from 'typed-redux-saga'
+import { put, takeEvery, select } from 'typed-redux-saga'
 
 import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
 
+import { getIsCollectionMarkedForDownload } from '../selectors'
 import { addOfflineItems } from '../slice'
 
 export function* watchSaveTrackSaga() {
@@ -14,6 +15,11 @@ function* downloadSavedTrack(
   action: ReturnType<typeof tracksSocialActions.saveTrack>
 ) {
   const { trackId } = action
+  const isAllFavoritesDownloadOn = yield* select(
+    getIsCollectionMarkedForDownload(DOWNLOAD_REASON_FAVORITES)
+  )
+
+  if (!isAllFavoritesDownloadOn) return
   yield* put(
     addOfflineItems({
       items: [


### PR DESCRIPTION
We were downloading tracks on save even if the favorites download toggle was not on.

