### PR TITLE
[C-2040] Improve duration counter accuracy/performance

### DIFF
--- a/packages/mobile/src/components/scrubber/PositionTimestamp.tsx
+++ b/packages/mobile/src/components/scrubber/PositionTimestamp.tsx
@@ -1,50 +1,35 @@
-import { useEffect } from 'react'
+import { forwardRef } from 'react'
 
-import type { Nullable } from '@audius/common'
-import { formatSeconds } from '@audius/common'
-import { useStreamPosition } from 'react-native-google-cast'
-import { useProgress } from 'react-native-track-player'
+import type { Text as TextInputProps } from 'react-native'
+import { TextInput, View } from 'react-native'
 
-import { Text } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 
-type PositionTimestampProps = {
-  dragSeconds: Nullable<string>
-  setDragSeconds: (seconds: Nullable<string>) => void
-}
+type PositionTimestampProps = Partial<TextInputProps>
 
-const useStyles = makeStyles(({ palette }) => ({
+const useStyles = makeStyles(({ palette, typography }) => ({
   timestamp: {
     width: 50,
     color: palette.neutral,
-    fontSize: 12,
+    fontSize: typography.fontSize.xs,
+    fontFamily: typography.fontByWeight.regular,
     flexShrink: 1,
     textAlign: 'right'
   }
 }))
 
-export const PositionTimestamp = (props: PositionTimestampProps) => {
-  const { dragSeconds, setDragSeconds } = props
-  const styles = useStyles()
-  const { position: trackPlayerPosition, duration: progressDuration } =
-    useProgress(1000)
-
-  const streamPosition = useStreamPosition(1000)
-
-  useEffect(() => {
-    setDragSeconds(null)
-  }, [progressDuration, streamPosition, setDragSeconds])
-
-  const position = streamPosition ?? trackPlayerPosition
-
-  return (
-    <Text
-      style={[styles.timestamp, { textAlign: 'right' }]}
-      fontSize='xs'
-      weight='regular'
-      numberOfLines={1}
-    >
-      {dragSeconds || formatSeconds(position)}
-    </Text>
-  )
-}
+export const PositionTimestamp = forwardRef<TextInput, PositionTimestampProps>(
+  (props, ref) => {
+    const styles = useStyles()
+    return (
+      <View pointerEvents='none'>
+        <TextInput
+          ref={ref}
+          style={styles.timestamp}
+          numberOfLines={1}
+          {...props}
+        />
+      </View>
+    )
+  }
+)

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -267,31 +267,6 @@ export const Slider = memo((props: SliderProps) => {
     ]
   )
 
-  // const panResponder2 = PanResponder.create({
-  //   onMoveShouldSetPanResponder: () => {
-  //     onDrag(handlePosition)
-  //     return true
-  //   },
-  //   onPanResponderMove: (e, gestureState) => {
-  //     const newPosition = Math.max(
-  //       0,
-  //       Math.min(gestureState.dx + handlePosition, railWidth)
-  //     )
-  //     attachToDx(translationAnim, newPosition)(e)
-  //     onDrag(newPosition / railWidth)
-  //   },
-  //   onPanResponderRelease: (e, gestureState) => {
-  //     const newPosition = Math.max(
-  //       0,
-  //       Math.min(gestureState.dx + handlePosition, railWidth)
-  //     )
-  //     attachToDx(translationAnim, newPosition)(e)
-  //     setHandlePosition(newPosition)
-  //     onReleaseHandle(newPosition / railWidth)
-  //     onDragRelease()
-  //   }
-  // })
-
   // When the media key changes, reset the scrubber
   useEffect(() => {
     translationAnim.setValue(0)

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -235,7 +235,6 @@ export const Slider = memo((props: SliderProps) => {
     () =>
       PanResponder.create({
         onMoveShouldSetPanResponder: () => {
-          onDrag(handlePosition)
           return true
         },
         onPanResponderMove: (e, gestureState) => {

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useAppState } from '@react-native-community/hooks'
 import type { GestureResponderEvent } from 'react-native'
@@ -92,6 +92,7 @@ type SliderProps = {
    * and then dragging.
    */
   onDrag: (percentComplete: number) => void
+  onDragRelease: () => void
 }
 
 /**
@@ -101,7 +102,15 @@ type SliderProps = {
  * re-renders of itself, despite having to update external timestamps on "drag."
  */
 export const Slider = memo((props: SliderProps) => {
-  const { mediaKey, isPlaying, duration, onPressIn, onPressOut, onDrag } = props
+  const {
+    mediaKey,
+    isPlaying,
+    duration,
+    onPressIn,
+    onPressOut,
+    onDrag,
+    onDragRelease
+  } = props
   const styles = useStyles()
   const { primaryLight2, primaryDark2 } = useThemeColors()
 
@@ -222,28 +231,66 @@ export const Slider = memo((props: SliderProps) => {
     [onPressOut, animateFromNowToEnd]
   )
 
-  const panResponder = PanResponder.create({
-    onMoveShouldSetPanResponder: () => {
-      return true
-    },
-    onPanResponderMove: (e, gestureState) => {
-      const newPosition = Math.max(
-        0,
-        Math.min(gestureState.dx + handlePosition, railWidth)
-      )
-      attachToDx(translationAnim, newPosition)(e)
-      onDrag(newPosition / railWidth)
-    },
-    onPanResponderRelease: (e, gestureState) => {
-      const newPosition = Math.max(
-        0,
-        Math.min(gestureState.dx + handlePosition, railWidth)
-      )
-      attachToDx(translationAnim, newPosition)(e)
-      setHandlePosition(newPosition)
-      onReleaseHandle(newPosition / railWidth)
-    }
-  })
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponder: () => {
+          onDrag(handlePosition)
+          return true
+        },
+        onPanResponderMove: (e, gestureState) => {
+          const newPosition = Math.max(
+            0,
+            Math.min(gestureState.dx + handlePosition, railWidth)
+          )
+          attachToDx(translationAnim, newPosition)(e)
+          onDrag(newPosition / railWidth)
+        },
+        onPanResponderRelease: (e, gestureState) => {
+          const newPosition = Math.max(
+            0,
+            Math.min(gestureState.dx + handlePosition, railWidth)
+          )
+          attachToDx(translationAnim, newPosition)(e)
+          setHandlePosition(newPosition)
+          onReleaseHandle(newPosition / railWidth)
+          onDragRelease()
+        }
+      }),
+    [
+      handlePosition,
+      onDrag,
+      onDragRelease,
+      onReleaseHandle,
+      railWidth,
+      translationAnim
+    ]
+  )
+
+  // const panResponder2 = PanResponder.create({
+  //   onMoveShouldSetPanResponder: () => {
+  //     onDrag(handlePosition)
+  //     return true
+  //   },
+  //   onPanResponderMove: (e, gestureState) => {
+  //     const newPosition = Math.max(
+  //       0,
+  //       Math.min(gestureState.dx + handlePosition, railWidth)
+  //     )
+  //     attachToDx(translationAnim, newPosition)(e)
+  //     onDrag(newPosition / railWidth)
+  //   },
+  //   onPanResponderRelease: (e, gestureState) => {
+  //     const newPosition = Math.max(
+  //       0,
+  //       Math.min(gestureState.dx + handlePosition, railWidth)
+  //     )
+  //     attachToDx(translationAnim, newPosition)(e)
+  //     setHandlePosition(newPosition)
+  //     onReleaseHandle(newPosition / railWidth)
+  //     onDragRelease()
+  //   }
+  // })
 
   // When the media key changes, reset the scrubber
   useEffect(() => {

--- a/packages/mobile/src/components/scrubber/usePosition.ts
+++ b/packages/mobile/src/components/scrubber/usePosition.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import { formatSeconds } from '@audius/common'
+import type { TextInput } from 'react-native'
+
+export const usePosition = (
+  mediaKey: string,
+  duration: number,
+  isPlaying: boolean,
+  isInteracting: boolean
+) => {
+  const positionRef = useRef(0)
+  const positionElementRef = useRef<TextInput>(null)
+
+  const setPosition = useCallback((position: number) => {
+    positionRef.current = position
+    positionElementRef.current?.setNativeProps({
+      text: formatSeconds(positionRef.current)
+    })
+  }, [])
+
+  useEffect(() => {
+    let outerTimeout: NodeJS.Timeout
+    let currentTimeout: NodeJS.Timeout
+
+    const updatePosition = () => {
+      const timeout = setTimeout(() => {
+        positionRef.current += 1
+
+        positionElementRef.current?.setNativeProps({
+          text: formatSeconds(positionRef.current)
+        })
+
+        if (positionRef.current <= duration) {
+          currentTimeout = updatePosition()
+        }
+      }, 1000)
+
+      return timeout
+    }
+
+    if (isPlaying && !isInteracting) {
+      outerTimeout = updatePosition()
+    }
+
+    return () => {
+      clearTimeout(outerTimeout)
+      clearTimeout(currentTimeout)
+    }
+  }, [isPlaying, isInteracting, duration])
+
+  useEffect(() => {
+    setPosition(0)
+  }, [mediaKey, setPosition])
+
+  return { ref: positionElementRef, setPosition }
+}

--- a/packages/mobile/src/components/scrubber/usePosition.ts
+++ b/packages/mobile/src/components/scrubber/usePosition.ts
@@ -20,7 +20,6 @@ export const usePosition = (
   }, [])
 
   useEffect(() => {
-    let outerTimeout: NodeJS.Timeout
     let currentTimeout: NodeJS.Timeout
 
     const updatePosition = () => {
@@ -40,11 +39,10 @@ export const usePosition = (
     }
 
     if (isPlaying && !isInteracting) {
-      outerTimeout = updatePosition()
+      currentTimeout = updatePosition()
     }
 
     return () => {
-      clearTimeout(outerTimeout)
       clearTimeout(currentTimeout)
     }
   }, [isPlaying, isInteracting, duration])

--- a/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
@@ -31,8 +31,6 @@ function* downloadAllFavorites() {
     limit: 10000
   })
 
-  console.log('favs?', allFavoritedTracks)
-
   if (!allFavoritedTracks) return
 
   for (const favoritedTrack of allFavoritedTracks) {


### PR DESCRIPTION
### Description

Adds interesting perf improvement to the position-timestamp on the now-playing drawer. 

By directly manipulating the text using `setNativeProps` we can avoid triggering a rerender every second as the track is playing, and can drastically improve perf when dragging scrubber, which was causing 40+ rerenders a second.

Also improves scrubber perf by memorizing the panHandlers