### PR TITLE
[C-2031] Fix confirmation drawer flashes

### DIFF
--- a/packages/mobile/src/components/drawer/NativeDrawer.tsx
+++ b/packages/mobile/src/components/drawer/NativeDrawer.tsx
@@ -19,12 +19,14 @@ type NativeDrawerProps = SetOptional<DrawerProps, 'isOpen' | 'onClose'> & {
 export const NativeDrawer = (props: NativeDrawerProps) => {
   const { drawerName, onClose: onCloseProp, ...other } = props
 
-  const { isOpen, onClose, onClosed } = useDrawer(drawerName)
+  const { isOpen, onClose, onClosed, visibleState } = useDrawer(drawerName)
 
   const handleClose = useCallback(() => {
     onCloseProp?.()
     onClose()
   }, [onCloseProp, onClose])
+
+  if (visibleState === false) return null
 
   return (
     <Drawer


### PR DESCRIPTION
### Description

Fixes issue where there is a one-frame flash of the confirmation drawer displaying after it's been closed. Added an additional `return null` gate deeper in the component hierarchy which seems to be fast enough for this edge case.
