### PR TITLE
[C-2065] Only show collection download switch if favorited

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
@@ -42,8 +42,6 @@ const useStyles = makeStyles(({ spacing }) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginTop: spacing(1),
-    marginBottom: spacing(2),
     paddingHorizontal: spacing(2)
   },
   headerLeft: {
@@ -63,7 +61,9 @@ const useStyles = makeStyles(({ spacing }) => ({
     justifyContent: 'flex-end'
   },
   headerText: {
+    marginVertical: spacing(4),
     letterSpacing: 2,
+    lineHeight: 17,
     textAlign: 'center',
     textTransform: 'uppercase'
   },
@@ -207,10 +207,12 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
     <View style={styles.root}>
       <View style={styles.headerLeft} />
       <View style={styles.headerCenter}>
-        <DownloadStatusIndicator
-          status={downloadStatus}
-          style={styles.downloadStatusIndicator}
-        />
+        {collection.has_current_user_saved ? (
+          <DownloadStatusIndicator
+            status={downloadStatus}
+            style={styles.downloadStatusIndicator}
+          />
+        ) : null}
         <Text
           style={styles.headerText}
           color={getTextColor()}
@@ -223,13 +225,15 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
         </Text>
       </View>
       <View style={styles.headerRight}>
-        <Switch
-          value={downloadSwitchValue}
-          onValueChange={handleDownloadSwitchChange}
-          disabled={
-            isFavoritesToggleOn || (!isReachable && !isMarkedForDownload)
-          }
-        />
+        {collection.has_current_user_saved ? (
+          <Switch
+            value={downloadSwitchValue}
+            onValueChange={handleDownloadSwitchChange}
+            disabled={
+              isFavoritesToggleOn || (!isReachable && !isMarkedForDownload)
+            }
+          />
+        ) : null}
       </View>
     </View>
   )

--- a/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import type { Collection, SmartCollectionVariant } from '@audius/common'
 import {
+  accountSelectors,
   reachabilitySelectors,
   collectionPageSelectors,
   Variant
@@ -26,6 +27,7 @@ import {
 import { makeStyles } from 'app/styles'
 const { getCollection } = collectionPageSelectors
 const { getIsReachable } = reachabilitySelectors
+const { getUserId } = accountSelectors
 
 const messages = {
   album: 'Album',
@@ -61,7 +63,8 @@ const useStyles = makeStyles(({ spacing }) => ({
     justifyContent: 'flex-end'
   },
   headerText: {
-    marginVertical: spacing(4),
+    marginTop: spacing(4),
+    marginBottom: spacing(4),
     letterSpacing: 2,
     lineHeight: 17,
     textAlign: 'center',
@@ -133,6 +136,7 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
   const { playlist_id } = collection
   const dispatch = useDispatch()
   const isReachable = useSelector(getIsReachable)
+  const currentUserId = useSelector(getUserId)
 
   const isMarkedForDownload = useSelector(
     getIsCollectionMarkedForDownload(playlist_id)
@@ -155,6 +159,10 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
   const removeDrawerVisibility = useSelector(
     getVisibility('RemoveDownloadedCollection')
   )
+
+  const showDownloadSwitchAndIndicator =
+    collection.has_current_user_saved ||
+    collection.playlist_owner_id === currentUserId
 
   useEffect(() => {
     if (
@@ -207,7 +215,7 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
     <View style={styles.root}>
       <View style={styles.headerLeft} />
       <View style={styles.headerCenter}>
-        {collection.has_current_user_saved ? (
+        {showDownloadSwitchAndIndicator ? (
           <DownloadStatusIndicator
             status={downloadStatus}
             style={styles.downloadStatusIndicator}
@@ -225,7 +233,7 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
         </Text>
       </View>
       <View style={styles.headerRight}>
-        {collection.has_current_user_saved ? (
+        {showDownloadSwitchAndIndicator ? (
           <Switch
             value={downloadSwitchValue}
             onValueChange={handleDownloadSwitchChange}

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -101,7 +101,7 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   hiddenDetailsTileWrapper: {
     ...flexRowCentered(),
     justifyContent: 'center',
-    marginBottom: spacing(4)
+    marginVertical: spacing(4)
   },
 
   hiddenTrackLabel: {
@@ -120,12 +120,13 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
 
   headerContainer: {
     ...flexRowCentered(),
-    justifyContent: 'center',
-    marginTop: spacing(2),
-    marginBottom: spacing(3)
+    justifyContent: 'center'
   },
   headerText: {
+    marginTop: spacing(4),
+    marginBottom: spacing(4),
     letterSpacing: 2,
+    lineHeight: 17,
     textAlign: 'center',
     textTransform: 'uppercase'
   },


### PR DESCRIPTION
### Description

* Only show collection download switch + download status indicator when the collection is saved or the current user is the owner
* Update styling of collection header to prevent layout shift when favoriting collection. Also matches the designs more closely
* Update the styling of track header to match

<img src="https://user-images.githubusercontent.com/19916043/218156029-127c4685-73c7-47b5-9e89-f62b081d6bdf.png" width=30% height=30%>
<img src="https://user-images.githubusercontent.com/19916043/218156045-1426891e-5d7d-422b-b17d-a8707b94946e.png" width=30% height=30%>
<img src="https://user-images.githubusercontent.com/19916043/218156056-4d14d222-7032-4d97-936c-36d8407bcec2.png" width=30% height=30%>


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

