### PR TITLE
[C-2101] Improve initial download ui performance

### DIFF
--- a/packages/mobile/src/components/drawers/RemoveDownloadedFavoritesDrawer.tsx
+++ b/packages/mobile/src/components/drawers/RemoveDownloadedFavoritesDrawer.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { useDispatch } from 'react-redux'
 
-import { removeAllDownloadedFavorites } from 'app/store/offline-downloads/slice'
+import { requestRemoveAllDownloadedFavorites } from 'app/store/offline-downloads/slice'
 
 import { ConfirmationDrawer } from './ConfirmationDrawer'
 
@@ -19,7 +19,7 @@ export const RemoveDownloadedFavoritesDrawer = () => {
   const dispatch = useDispatch()
 
   const handleConfirm = useCallback(() => {
-    dispatch(removeAllDownloadedFavorites())
+    dispatch(requestRemoveAllDownloadedFavorites())
   }, [dispatch])
 
   return (

--- a/packages/mobile/src/hooks/useReachabilityEffect.ts
+++ b/packages/mobile/src/hooks/useReachabilityEffect.ts
@@ -23,7 +23,6 @@ export const useReachabilityEffect = (
   const handleReachabilityStateChange = useCallback(
     (nextReachabilityState: boolean) => {
       if (nextReachabilityState && !prevReachability && onBecomeReachable) {
-        console.info('Become reachable')
         onBecomeReachable()
       }
       if (
@@ -31,7 +30,6 @@ export const useReachabilityEffect = (
         (prevReachability || prevReachability === undefined) &&
         onBecomeUnreachable
       ) {
-        console.info('Become unreachable')
         onBecomeUnreachable()
       }
     },

--- a/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
@@ -149,13 +149,14 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
   const downloadStatus = useProxySelector(
     (state) => {
       const status = getCollectionDownloadStatus(state, playlist_id)
-      return isMarkedForDownload ? status : OfflineDownloadStatus.INACTIVE
+      return status ?? OfflineDownloadStatus.INACTIVE
     },
-    [isMarkedForDownload, playlist_id]
+    [playlist_id]
   )
 
   const [downloadSwitchValue, setDownloadSwitchValue] =
     useState(isMarkedForDownload)
+
   const removeDrawerVisibility = useSelector(
     getVisibility('RemoveDownloadedCollection')
   )

--- a/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
+++ b/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
@@ -1,99 +1,46 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useLayoutEffect, useState } from 'react'
 
 import { reachabilitySelectors } from '@audius/common'
-import { View } from 'react-native'
+import type { SwitchProps } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Switch } from 'app/components/core'
-import { DownloadStatusIndicator } from 'app/components/offline-downloads/DownloadStatusIndicator'
-import { useDebouncedCallback } from 'app/hooks/useDebouncedCallback'
-import { useProxySelector } from 'app/hooks/useProxySelector'
 import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
-import { getVisibility } from 'app/store/drawers/selectors'
 import { setVisibility } from 'app/store/drawers/slice'
-import { getOfflineTrackStatus } from 'app/store/offline-downloads/selectors'
-import {
-  OfflineDownloadStatus,
-  requestDownloadAllFavorites
-} from 'app/store/offline-downloads/slice'
-import { makeStyles } from 'app/styles'
+import { getCollectionDownloadStatus } from 'app/store/offline-downloads/selectors'
+import { requestDownloadAllFavorites } from 'app/store/offline-downloads/slice'
+
 const { getIsReachable } = reachabilitySelectors
 
-const useStyles = makeStyles(({ spacing }) => ({
-  root: {
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  downloadStatusIndicator: {
-    marginRight: spacing(1)
-  }
-}))
+type DownloadFavoritesSwitchProps = SwitchProps
 
-export const DownloadFavoritesSwitch = () => {
-  const styles = useStyles()
+export const DownloadFavoritesSwitch = (
+  props: DownloadFavoritesSwitchProps
+) => {
+  const { onValueChange } = props
   const dispatch = useDispatch()
-  const isReachable = useSelector(getIsReachable)
 
-  const isMarkedForDownload = useProxySelector((state) => {
-    const { collectionStatus } = state.offlineDownloads
-    return !!collectionStatus[DOWNLOAD_REASON_FAVORITES]
-  }, [])
-
-  const isDownloaded = useProxySelector((state) => {
-    const downloadStatus = getOfflineTrackStatus(state)
-    const tracksToDownload = Object.keys(downloadStatus)
-    if (tracksToDownload.length === 0) return false
-
-    const hasRemainingDownloads = tracksToDownload.some(
-      (trackId) =>
-        downloadStatus[trackId] === OfflineDownloadStatus.LOADING ||
-        downloadStatus[trackId] === OfflineDownloadStatus.INIT
+  const isSwitchDisabled = useSelector((state) => {
+    const isReachable = getIsReachable(state)
+    const isMarkedForDownload = getCollectionDownloadStatus(
+      state,
+      DOWNLOAD_REASON_FAVORITES
     )
+    return Boolean(!isReachable && isMarkedForDownload)
+  })
 
-    if (hasRemainingDownloads) return false
-
-    // Since downloadStatus can take a while to populate, use favorited
-    // tracks lineup as a backup
-    const favoritedTracks = state.pages.savedPage.tracks.entries
-    return favoritedTracks.every(({ id }) => {
-      return (
-        downloadStatus[id] === OfflineDownloadStatus.SUCCESS ||
-        downloadStatus[id] === OfflineDownloadStatus.ERROR ||
-        downloadStatus[id] === OfflineDownloadStatus.ABANDONED
-      )
-    })
-  }, [])
-
-  const getDownloadStatus = () => {
-    if (!isMarkedForDownload) {
-      return OfflineDownloadStatus.INACTIVE
-    }
-    if (isDownloaded) {
-      return OfflineDownloadStatus.SUCCESS
-    }
-    return OfflineDownloadStatus.LOADING
-  }
-
-  const downloadStatus = getDownloadStatus()
-  const [switchValue, setSwitchValue] = useState(isMarkedForDownload)
-  const removeDrawerVisibility = useSelector(
-    getVisibility('RemoveDownloadedFavorites')
+  const isMarkedForDownload = useSelector((state) =>
+    Boolean(getCollectionDownloadStatus(state, DOWNLOAD_REASON_FAVORITES))
   )
 
-  useEffect(() => {
-    if (
-      removeDrawerVisibility !== true &&
-      isMarkedForDownload !== switchValue
-    ) {
-      setSwitchValue(isMarkedForDownload)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isMarkedForDownload, removeDrawerVisibility])
+  const [value, setValue] = useState(isMarkedForDownload)
 
-  const handleToggleDownload = useCallback(
-    (isDownloadEnabled: boolean) => {
-      if (isDownloadEnabled) {
+  const handleValueChange = useCallback(
+    (newValue: boolean) => {
+      if (newValue) {
         dispatch(requestDownloadAllFavorites())
+        setValue(true)
+        onValueChange?.(true)
       } else {
         dispatch(
           setVisibility({
@@ -103,30 +50,24 @@ export const DownloadFavoritesSwitch = () => {
         )
       }
     },
-    [dispatch]
+    [dispatch, onValueChange]
   )
 
-  const debouncedHandleToggleDownload = useDebouncedCallback(
-    handleToggleDownload,
-    800
-  )
-
-  const handleSwitchValueChange = (isEnabled: boolean) => {
-    setSwitchValue(isEnabled)
-    debouncedHandleToggleDownload(isEnabled)
-  }
+  // When user confirms removal, turn switch off
+  useLayoutEffect(() => {
+    if (!isMarkedForDownload) {
+      setValue(false)
+      onValueChange?.(false)
+    }
+  }, [isMarkedForDownload, onValueChange])
 
   return (
-    <View style={styles.root}>
-      <DownloadStatusIndicator
-        status={downloadStatus}
-        style={styles.downloadStatusIndicator}
-      />
+    <>
       <Switch
-        value={switchValue}
-        onValueChange={handleSwitchValueChange}
-        disabled={!isReachable && !isMarkedForDownload}
+        value={value}
+        onValueChange={handleValueChange}
+        disabled={isSwitchDisabled}
       />
-    </View>
+    </>
   )
 }

--- a/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
+++ b/packages/mobile/src/screens/favorites-screen/DownloadFavoritesSwitch.tsx
@@ -17,7 +17,7 @@ type DownloadFavoritesSwitchProps = SwitchProps
 export const DownloadFavoritesSwitch = (
   props: DownloadFavoritesSwitchProps
 ) => {
-  const { onValueChange } = props
+  const { onValueChange, ...other } = props
   const dispatch = useDispatch()
 
   const isSwitchDisabled = useSelector((state) => {
@@ -67,6 +67,7 @@ export const DownloadFavoritesSwitch = (
         value={value}
         onValueChange={handleValueChange}
         disabled={isSwitchDisabled}
+        {...other}
       />
     </>
   )

--- a/packages/mobile/src/screens/favorites-screen/FavoritesDownloadSection.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesDownloadSection.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+
+import { View } from 'react-native'
+
+import { makeStyles } from 'app/styles'
+
+import { DownloadFavoritesSwitch } from './DownloadFavoritesSwitch'
+import { DownloadProgress } from './DownloadProgress'
+import { FavoritesDownloadStatusIndicator } from './FavoritesDownloadStatusIndicator'
+
+const useStyles = makeStyles(() => ({
+  root: { flexDirection: 'row', alignItems: 'center' }
+}))
+
+export const FavoritesDownloadSection = () => {
+  const styles = useStyles()
+
+  const [switchValue, setSwitchValue] = useState(false)
+
+  return (
+    <View style={styles.root}>
+      <DownloadProgress />
+      <FavoritesDownloadStatusIndicator switchValue={switchValue} />
+      <DownloadFavoritesSwitch onValueChange={setSwitchValue} />
+    </View>
+  )
+}

--- a/packages/mobile/src/screens/favorites-screen/FavoritesDownloadStatusIndicator.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesDownloadStatusIndicator.tsx
@@ -1,0 +1,58 @@
+import { DownloadStatusIndicator } from 'app/components/offline-downloads'
+import { useProxySelector } from 'app/hooks/useProxySelector'
+import { DOWNLOAD_REASON_FAVORITES } from 'app/services/offline-downloader'
+import type { AppState } from 'app/store'
+import { getOfflineTrackStatus } from 'app/store/offline-downloads/selectors'
+import { OfflineDownloadStatus } from 'app/store/offline-downloads/slice'
+import { makeStyles } from 'app/styles'
+
+const useStyles = makeStyles(({ spacing }) => ({
+  root: {
+    marginRight: spacing(1)
+  }
+}))
+
+const getFavoritesDownloadStatus = (state: AppState) => {
+  const { collectionStatus } = state.offlineDownloads
+  const favoritedCollectionStatus = collectionStatus[DOWNLOAD_REASON_FAVORITES]
+
+  if (!favoritedCollectionStatus) {
+    return OfflineDownloadStatus.INACTIVE
+  }
+
+  if (favoritedCollectionStatus === OfflineDownloadStatus.INIT) {
+    return OfflineDownloadStatus.LOADING
+  }
+
+  const downloadStatus = getOfflineTrackStatus(state)
+  const tracksToDownload = Object.keys(downloadStatus)
+
+  const hasRemainingDownloads = tracksToDownload?.some(
+    (trackId) =>
+      downloadStatus[trackId] === OfflineDownloadStatus.LOADING ||
+      downloadStatus[trackId] === OfflineDownloadStatus.INIT
+  )
+
+  if (hasRemainingDownloads) return OfflineDownloadStatus.LOADING
+
+  return OfflineDownloadStatus.SUCCESS
+}
+
+type FavoritesDownloadStatusIndicatorProps = {
+  switchValue: boolean
+}
+
+export const FavoritesDownloadStatusIndicator = (
+  props: FavoritesDownloadStatusIndicatorProps
+) => {
+  const { switchValue } = props
+  const styles = useStyles()
+  const downloadStatus = useProxySelector(getFavoritesDownloadStatus, [])
+
+  return (
+    <DownloadStatusIndicator
+      status={switchValue ? OfflineDownloadStatus.LOADING : downloadStatus}
+      style={styles.root}
+    />
+  )
+}

--- a/packages/mobile/src/screens/favorites-screen/FavoritesDownloadStatusIndicator.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesDownloadStatusIndicator.tsx
@@ -51,7 +51,11 @@ export const FavoritesDownloadStatusIndicator = (
 
   return (
     <DownloadStatusIndicator
-      status={switchValue ? OfflineDownloadStatus.LOADING : downloadStatus}
+      status={
+        switchValue && downloadStatus === OfflineDownloadStatus.INACTIVE
+          ? OfflineDownloadStatus.LOADING
+          : downloadStatus
+      }
       style={styles.root}
     />
   )

--- a/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
+++ b/packages/mobile/src/screens/favorites-screen/FavoritesScreen.tsx
@@ -1,5 +1,4 @@
 import { accountActions } from '@audius/common'
-import { View } from 'react-native'
 import { useDispatch } from 'react-redux'
 import { useEffectOnce } from 'react-use'
 
@@ -16,8 +15,7 @@ import {
 } from 'app/hooks/useIsOfflineModeEnabled'
 
 import { AlbumsTab } from './AlbumsTab'
-import { DownloadFavoritesSwitch } from './DownloadFavoritesSwitch'
-import { DownloadProgress } from './DownloadProgress'
+import { FavoritesDownloadSection } from './FavoritesDownloadSection'
 import { PlaylistsTab } from './PlaylistsTab'
 import { TracksTab } from './TracksTab'
 const { fetchSavedPlaylists, fetchSavedAlbums } = accountActions
@@ -63,12 +61,7 @@ export const FavoritesScreen = () => {
         icon={IconFavorite}
         styles={{ icon: { marginLeft: 3 } }}
       >
-        {isOfflineModeEnabled ? (
-          <View style={{ flexDirection: 'row' }}>
-            <DownloadProgress />
-            <DownloadFavoritesSwitch />
-          </View>
-        ) : null}
+        {isOfflineModeEnabled ? <FavoritesDownloadSection /> : null}
       </ScreenHeader>
       <ScreenContent isOfflineCapable={isOfflineModeEnabled}>
         {<TopTabNavigator screens={favoritesScreens} />}

--- a/packages/mobile/src/store/offline-downloads/sagas/requestRemoveAllDownloadedFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/requestRemoveAllDownloadedFavoritesSaga.ts
@@ -7,7 +7,10 @@ import {
   getOfflineTrackMetadata
 } from '../selectors'
 import type { OfflineItem } from '../slice'
-import { removeOfflineItems, removeAllDownloadedFavorites } from '../slice'
+import {
+  removeOfflineItems,
+  requestRemoveAllDownloadedFavorites
+} from '../slice'
 
 /*
  * Saga initiated when user has requested to un-download their favorites.
@@ -16,7 +19,7 @@ import { removeOfflineItems, removeAllDownloadedFavorites } from '../slice'
  */
 export function* requestRemoveAllDownloadedFavoritesSaga() {
   yield* takeEvery(
-    removeAllDownloadedFavorites.type,
+    requestRemoveAllDownloadedFavorites.type,
     removeAllDownloadedFavoritesWorker
   )
 }

--- a/packages/mobile/src/store/offline-downloads/selectors.ts
+++ b/packages/mobile/src/store/offline-downloads/selectors.ts
@@ -23,6 +23,11 @@ export const getCollectionSyncStatus = (
   collectionId: CollectionId
 ) => state.offlineDownloads.collectionSyncStatus[collectionId]
 
+export const getCollectionDownloadStatus = (
+  state: AppState,
+  collectionId: CollectionId
+) => state.offlineDownloads.collectionStatus[collectionId]
+
 // TODO: This should verify that the status is correct
 export const getIsCollectionMarkedForDownload =
   (collectionId?: string | ID) => (state: AppState) =>

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -232,10 +232,16 @@ const slice = createSlice({
 
           if (!offlineTrackMetadata[id]) {
             delete trackStatus[id]
-            const queueIndex = downloadQueue.findIndex(
+            const trackIndex = downloadQueue.findIndex(
               (queueItem) => queueItem.type === type && queueItem.id === id
             )
-            if (queueIndex !== -1) downloadQueue.splice(queueIndex, 1)
+            if (trackIndex !== -1) downloadQueue.splice(trackIndex, 1)
+
+            const staleTrackIndex = downloadQueue.findIndex(
+              (queueItem) =>
+                queueItem.type === 'stale-track' && queueItem.id === id
+            )
+            if (staleTrackIndex !== -1) downloadQueue.splice(staleTrackIndex, 1)
           }
         } else if (item.type === 'collection') {
           const { id, metadata } = item

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -235,24 +235,28 @@ const slice = createSlice({
             const queueIndex = downloadQueue.findIndex(
               (queueItem) => queueItem.type === type && queueItem.id === id
             )
-            if (queueIndex !== -1) {
-              downloadQueue.splice(queueIndex, 1)
-            }
+            if (queueIndex !== -1) downloadQueue.splice(queueIndex, 1)
           }
         } else if (item.type === 'collection') {
-          const { type, id, metadata } = item
+          const { id, metadata } = item
           removeOfflineCollection(offlineCollectionMetadata, id, metadata)
 
           if (!offlineCollectionMetadata[id]) {
             delete collectionStatus[id]
             delete collectionSyncStatus[id]
 
-            state.downloadQueue = downloadQueue.filter(
+            const collectionIndex = downloadQueue.findIndex(
               (queueItem) =>
-                (queueItem.type === type ||
-                  queueItem.type === 'collection-sync') &&
-                queueItem.id === id
+                queueItem.type === 'collection' && queueItem.id === id
             )
+            if (collectionIndex !== -1) downloadQueue.splice(collectionIndex, 1)
+
+            const collectionSyncIndex = downloadQueue.findIndex(
+              (queueItem) =>
+                queueItem.type === 'collection-sync' && queueItem.id === id
+            )
+            if (collectionSyncIndex !== -1)
+              downloadQueue.splice(collectionSyncIndex, 1)
           }
         }
       }
@@ -347,12 +351,12 @@ const slice = createSlice({
     },
     // Lifecycle actions that trigger complex saga flows
     requestDownloadAllFavorites: () => {},
+    requestRemoveAllDownloadedFavorites: () => {},
     requestDownloadCollection: (_state, _action: CollectionAction) => {},
     requestDownloadFavoritedCollection: (
       _state,
       _action: CollectionAction
     ) => {},
-    removeAllDownloadedFavorites: () => {},
     requestRemoveDownloadedCollection: (
       _state,
       _action: RequestRemoveDownloadedCollectionAction
@@ -384,7 +388,7 @@ export const {
   requestDownloadAllFavorites,
   requestDownloadCollection,
   requestDownloadFavoritedCollection,
-  removeAllDownloadedFavorites,
+  requestRemoveAllDownloadedFavorites,
   requestRemoveDownloadedCollection,
   requestRemoveFavoritedDownloadedCollection,
   requestDownloadQueuedItem


### PR DESCRIPTION
### Description

Majorly improves initial download ui performance by ensuring download loading status starts right when user presses toggle.

- improves favorite download components and control flow
- fixes bug with download removal reducer

Will address the performance of collection header ui separately, but will use same techniques
