### PR TITLE
[C-2123] Fix collection lineup when coming online

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -334,7 +334,7 @@ export const Lineup = ({
 
   useReachableEffect(
     useCallback(() => {
-      if (entries.length > 0 || status === Status.LOADING) return
+      if (status === Status.LOADING) return
       handleLoadMore(true)
       // using the latest creates infinite loop, and we only need the initial state
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -29,7 +29,7 @@ import { formatCount } from 'app/utils/format'
 import { CollectionHeader } from './CollectionHeader'
 import { useCollectionLineup } from './useCollectionLineup'
 const { getCollectionUid, getUserUid } = collectionPageSelectors
-const { resetCollection } = collectionPageActions
+const { fetchCollection, resetCollection } = collectionPageActions
 const { getPlaying, getUid, getCurrentTrack } = playerSelectors
 const { getIsReachable } = reachabilitySelectors
 
@@ -93,9 +93,14 @@ export const CollectionScreenDetailsTile = ({
   const userUid = useSelector(getUserUid)
 
   const fetchLineup = useCallback(() => {
-    dispatch(resetCollection(collectionUid, userUid))
+    dispatch(resetCollection(collectionId as number, collectionUid, userUid))
+
+    // Need to refetch the collection after resetting
+    // Will pull from cache if it exists
+    // TODO: fix this for smart collections
+    dispatch(fetchCollection(collectionId as number))
     dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined))
-  }, [dispatch, collectionUid, userUid])
+  }, [dispatch, collectionUid, userUid, collectionId])
 
   const { entries, status } = useCollectionLineup(collectionId, fetchLineup)
   const trackUids = useMemo(() => entries.map(({ uid }) => uid), [entries])

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -93,7 +93,7 @@ export const CollectionScreenDetailsTile = ({
   const userUid = useSelector(getUserUid)
 
   const fetchLineup = useCallback(() => {
-    dispatch(resetCollection(collectionId as number, collectionUid, userUid))
+    dispatch(resetCollection(collectionUid, userUid))
 
     // Need to refetch the collection after resetting
     // Will pull from cache if it exists

--- a/packages/web/src/common/store/pages/collection/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/collection/lineups/sagas.js
@@ -34,11 +34,11 @@ function* getCollectionTracks() {
     collection = yield call(waitForValue, getCollection)
   }
 
-  const track = collection.playlist_contents.track_ids
+  const tracks = collection.playlist_contents.track_ids
 
-  const trackIds = track.map((t) => t.track)
+  const trackIds = tracks.map((t) => t.track)
   // TODO: Conform all timestamps to be of the same format so we don't have to do any special work here.
-  const times = track.map((t) => t.metadata_time ?? t.time)
+  const times = tracks.map((t) => t.metadata_time ?? t.time)
 
   // Reconcile fetching this playlist with the queue.
   // Search the queue for its currently playing uids. If any are sourced
@@ -85,8 +85,8 @@ function* getCollectionTracks() {
         }
         if (uidForSource[id] && uidForSource[id].length > 0) {
           metadata.uid = uidForSource[id].shift()
-        } else if (track[i].uid) {
-          metadata.uid = track[i].uid
+        } else if (tracks[i].uid) {
+          metadata.uid = tracks[i].uid
         }
         return metadata
       })


### PR DESCRIPTION
### Description

Simple fix but I tried a lot of different things to get to this place lol. There still seems to be some race case that is resulting in the lineup being empty occasionally, but it was happening so infrequently that it was difficult to pin down

I think ideally we wouldn't be resetting the collection. This is important now because the getCollectionTracks saga waits for the collection to exist, and without the reset it uses the previous collection. https://github.com/AudiusProject/audius-client/blob/main/packages/web/src/common/store/pages/collection/lineups/sagas.js#L34 But if we just defer the fetchLineupMetadatas until after the collection has been fetched, we wouldn't need to reset

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

