### PR TITLE
Add client notifications from discovery

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2106,7 +2106,6 @@ export const audiusBackend = ({
   }
 
   function mapDiscoveryNotification(notification: DiscoveryNotification) {
-    console.log({ notification })
     if (notification.type === 'follow') {
       const userIds = notification.actions.map((action) => {
         const data = action.data

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -53,7 +53,11 @@ import {
 } from '../../services/remote-config'
 import {
   BrowserNotificationSetting,
-  PushNotificationSetting
+  DiscoveryNotification,
+  PushNotificationSetting,
+  NotificationType,
+  Entity,
+  Achievement
 } from '../../store'
 import { CIDCache } from '../../store/cache/CIDCache'
 import {
@@ -2084,6 +2088,303 @@ export const audiusBackend = ({
     }
   }
 
+  function getDiscoveryEntityType(type: string) {
+    if (type === 'track') {
+      return Entity.Track
+    }
+    return Entity.Playlist
+  }
+
+  function formatBaseNotification(notification: DiscoveryNotification) {
+    const timestamp = notification.actions[0].timestamp
+    return {
+      groupId: notification.group_id,
+      timestamp: new Date(timestamp * 1000).toString(),
+      isViewed: notification.seen_at == null,
+      id: `timestamp:${timestamp}:group_id:${notification.group_id}`
+    }
+  }
+
+  function mapDiscoveryNotification(notification: DiscoveryNotification) {
+    console.log({ notification })
+    if (notification.type === 'follow') {
+      const userIds = notification.actions.map((action) => {
+        const data = action.data
+        return decodeHashId(data.follower_user_id)
+      })
+      return {
+        type: NotificationType.Follow,
+        userIds,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'repost') {
+      let entityId
+      let entityType
+      const userIds = notification.actions.map((action) => {
+        const data = action.data
+        entityId = decodeHashId(data.repost_item_id)
+        entityType = getDiscoveryEntityType(data.type)
+        return decodeHashId(data.user_id)
+      })
+      return {
+        type: NotificationType.Repost,
+        userIds,
+        entityId,
+        entityType,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'save') {
+      let entityId
+      let entityType
+      const userIds = notification.actions.map((action) => {
+        const data = action.data
+        entityId = decodeHashId(data.save_item_id)
+        entityType = getDiscoveryEntityType(data.type)
+        return decodeHashId(data.user_id)
+      })
+      return {
+        type: NotificationType.Favorite,
+        userIds,
+        entityId,
+        entityType,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'tip_send') {
+      const data = notification.actions[0].data
+      const amount = data.amount
+      const receiverUserId = decodeHashId(data.receiver_user_id) as number
+      return {
+        type: NotificationType.TipSend,
+        entityId: receiverUserId,
+        entityType: Entity.User,
+        amount: amount!.toString(),
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'tip_receive') {
+      const data = notification.actions[0].data
+      const amount = data.amount
+      const senderUserId = decodeHashId(data.sender_user_id) as number
+      return {
+        type: NotificationType.TipReceive,
+        entityId: senderUserId,
+        amount: amount!.toString(),
+        entityType: Entity.User,
+        tipTxSignature: data.tip_tx_signature,
+        reactionValue: data.reaction_value,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'supporter_rank_up') {
+      const data = notification.actions[0].data
+      const senderUserId = decodeHashId(data.receiver_user_id)
+      return {
+        type: NotificationType.SupporterRankUp,
+        entityId: senderUserId,
+        rank: data.rank,
+        entityType: Entity.User,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'supporting_rank_up') {
+      const data = notification.actions[0].data
+      const receiverUserId = decodeHashId(data.receiver_user_id)
+      return {
+        type: NotificationType.SupportingRankUp,
+        entityId: receiverUserId,
+        rank: data.rank,
+        entityType: Entity.User,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'supporter_dethroned') {
+      const data = notification.actions[0].data
+      return {
+        type: NotificationType.SupporterDethroned,
+        entityType: Entity.User,
+        entityId: decodeHashId(data.sender_user_id),
+        supportedUserId: decodeHashId(data.receiver_user_id),
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'challenge_reward') {
+      const data = notification.actions[0].data
+      const challengeId = data.challenge_id
+      return {
+        type: NotificationType.ChallengeReward,
+        challengeId,
+        entityType: Entity.User,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'tier_change') {
+      const data = notification.actions[0].data
+      const tier = data.new_tier
+      const userId = decodeHashId(notification.actions[0].specifier)
+      return {
+        type: NotificationType.TierChange,
+        tier,
+        userId,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'create') {
+      let entityType
+      const entityIds = notification.actions.map((action) => {
+        const data = action.data
+        if ('playlist_id' in data) {
+          entityType = data.is_album ? Entity.Album : Entity.Playlist
+          return decodeHashId(data.playlist_id)
+        }
+        entityType = Entity.Track
+        return decodeHashId(data.track_id)
+      })
+      const userId = decodeHashId(notification.actions[0].specifier)
+      return {
+        type: NotificationType.UserSubscription,
+        userId,
+        entityIds,
+        entityType,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'remix') {
+      let childTrackId, parentTrackId, trackOwnerId
+      notification.actions.forEach((action) => {
+        const data = action.data
+        childTrackId = decodeHashId(data.track_id)
+        parentTrackId = decodeHashId(data.parent_track_id)
+        trackOwnerId = decodeHashId(data.track_owner_id)
+      })
+      return {
+        type: NotificationType.RemixCreate,
+        entityType: Entity.Track,
+        parentTrackId,
+        childTrackId,
+        userId: trackOwnerId,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'cosign') {
+      const data = notification.actions[0].data
+      const entityType = Entity.Track
+      const entityIds = [decodeHashId(data.parent_track_id)]
+      const childTrackId = decodeHashId(data.track_id)
+      const parentTrackUserId = decodeHashId(notification.actions[0].specifier)
+      const userId = decodeHashId(data.track_owner_id)
+
+      return {
+        type: NotificationType.RemixCosign,
+        userId,
+        entityType,
+        entityIds,
+        parentTrackUserId,
+        childTrackId,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'trending') {
+      const data = notification.actions[0].data
+
+      return {
+        type: NotificationType.TrendingTrack,
+        rank: data.rank,
+        genre: data.genre,
+        time: data.time_range,
+        entityType: Entity.Track,
+        entityId: decodeHashId(data.track_id),
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'milestone') {
+      const data = notification.actions[0].data
+      if ('track_id' in data) {
+        let achievement
+        if (data.type === 'track_repost_count') {
+          achievement = Achievement.Reposts
+        } else if (data.type === 'track_save_count') {
+          achievement = Achievement.Favorites
+        } else {
+          achievement = Achievement.Listens
+        }
+        return {
+          type: NotificationType.Milestone,
+          entityType: Entity.Track,
+          entityId: decodeHashId(data.track_id),
+          value: data.threshold,
+          achievement,
+          ...formatBaseNotification(notification)
+        }
+      } else if ('playlist_id' in data) {
+        let achievement
+        if (data.type === 'playlist_repost_count') {
+          achievement = Achievement.Reposts
+        } else {
+          achievement = Achievement.Favorites
+        }
+        return {
+          type: NotificationType.Milestone,
+          entityType: Entity.Playlist,
+          entityId: decodeHashId(data.playlist_id),
+          value: data.threshold,
+          achievement,
+          ...formatBaseNotification(notification)
+        }
+      } else if ('user_id' in data) {
+        return {
+          type: NotificationType.Milestone,
+          entityType: Entity.User,
+          entityId: decodeHashId(data.user_id),
+          achievement: Achievement.Followers,
+          value: data.threshold,
+          ...formatBaseNotification(notification)
+        }
+      }
+    } else if (notification.type === 'announcement') {
+      const data = notification.actions[0].data
+
+      return {
+        type: NotificationType.Announcement,
+        title: data.title,
+        shortDescription: data.short_description,
+        longDescription: data.long_description,
+        ...formatBaseNotification(notification)
+      }
+    } else if (notification.type === 'reaction') {
+      const data = notification.actions[0].data
+      return {
+        type: NotificationType.Reaction,
+        entityId: decodeHashId(data.receiver_user_id),
+        entityType: Entity.User,
+        reactionValue: data.reaction_value,
+        reactionType: data.reaction_type,
+        reactedToEntity: {
+          tx_signature: data.reacted_to,
+          amount: data.tip_amount,
+          tip_sender_id: decodeHashId(data.sender_user_id)
+        },
+        ...formatBaseNotification(notification)
+      }
+    }
+
+    return notification
+  }
+
+  async function getDiscoveryNotifications({
+    timestamp,
+    groupIdOffset,
+    limit
+  }: {
+    timestamp?: number | undefined
+    groupIdOffset?: string | undefined
+    limit?: number | undefined
+  }) {
+    await waitForLibsInit()
+    const account = audiusLibs.Account.getCurrentUser()
+    if (!account) return
+    const encodedUserId = encodeHashId(account.user_id)
+
+    const response = await audiusLibs.Notifications.getNotifications({
+      encodedUserId,
+      timestamp,
+      groupId: groupIdOffset,
+      limit
+    })
+
+    return {
+      notifications: response.notifications.map(mapDiscoveryNotification)
+    }
+  }
+
   async function getNotifications({
     limit,
     timeOffset,
@@ -2108,7 +2409,7 @@ export const audiusBackend = ({
         : ''
       // TODO: withRemix, withTrending, withRewards are always true and should be removed in a future release
       const notifications = await fetch(
-        `${identityServiceUrl}/notifications?${limitQuery}${timeOffsetQuery}${handleQuery}${withDethronedQuery}&withTips=true&withRewards=true&withRemix=true&withTrendingTrack=true`,
+        `${identityServiceUrl}/notifications?${limitQuery}${timeOffsetQuery}${handleQuery}${withDethronedQuery}}&withTips=true&withRewards=true&withRemix=true&withTrendingTrack=true`,
         {
           headers: {
             'Content-Type': 'application/json',
@@ -3197,6 +3498,7 @@ export const audiusBackend = ({
     getImageUrl,
     getLatestTxReceipt,
     getNotifications,
+    getDiscoveryNotifications,
     getPlaylists,
     getPushNotificationSettings,
     getRandomFeePayer,

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -42,6 +42,7 @@ export enum FeatureFlags {
   SHARE_VIDEO_TO_TIKTOK = 'share_video_to_tiktok_2',
   PODCAST_CONTROL_UPDATES_ENABLED = 'podcast_control_updates_enabled',
   LAZY_USERBANK_CREATION_ENABLED = 'lazy_userbank_creation_enabled'
+  DISCOVERY_NOTIFICATIONS = 'discovery_notifications'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -98,5 +99,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.ENTITY_MANAGER_VIEW_NOTIFICATIONS_ENABLED]: false,
   [FeatureFlags.SHARE_VIDEO_TO_TIKTOK]: false,
   [FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED]: false,
-  [FeatureFlags.LAZY_USERBANK_CREATION_ENABLED]: false
+  [FeatureFlags.LAZY_USERBANK_CREATION_ENABLED]: false,
+  [FeatureFlags.DISCOVERY_NOTIFICATIONS]: false
 }

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -41,7 +41,7 @@ export enum FeatureFlags {
   ENTITY_MANAGER_VIEW_NOTIFICATIONS_ENABLED = 'entity_manager_view_notifications_enabled',
   SHARE_VIDEO_TO_TIKTOK = 'share_video_to_tiktok_2',
   PODCAST_CONTROL_UPDATES_ENABLED = 'podcast_control_updates_enabled',
-  LAZY_USERBANK_CREATION_ENABLED = 'lazy_userbank_creation_enabled'
+  LAZY_USERBANK_CREATION_ENABLED = 'lazy_userbank_creation_enabled',
   DISCOVERY_NOTIFICATIONS = 'discovery_notifications'
 }
 

--- a/packages/common/src/store/notifications/selectors.ts
+++ b/packages/common/src/store/notifications/selectors.ts
@@ -86,8 +86,9 @@ export const getNotificationUser = (
   notification: Notification
 ) => {
   if (
-    notification.type === NotificationType.Milestone &&
-    notification.achievement === Achievement.Followers
+    notification.type === NotificationType.TierChange ||
+    (notification.type === NotificationType.Milestone &&
+      notification.achievement === Achievement.Followers)
   ) {
     return getAccountUser(state)
   } else if ('userId' in notification) {

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -104,7 +104,229 @@ export type BaseNotification = {
   isViewed: boolean
   timestamp: string
   timeLabel?: string
+  // group id is a part of the notifications v2 spec
+  groupId?: string
 }
+
+export type DiscoveryBaseNotification<T, P> = {
+  type: T
+  group_id: string
+  seen_at: number | null
+  actions: DiscoveryAction<P>[]
+}
+
+export type DiscoveryAction<T> = {
+  specifier: string
+  type: string
+  timestamp: number
+  data: T
+}
+
+export type DiscoveryAnnouncementNotificationAction = {
+  title: string
+  short_description: string
+  long_description?: string
+}
+export type DiscoveryFollowNotificationAction = {
+  follower_user_id: string
+  followee_user_id: string
+}
+export type DiscoverySaveNotificationAction = {
+  type: string
+  user_id: string
+  save_item_id: string
+}
+export type DiscoveryRepostNotificationAction = {
+  type: string
+  user_id: string
+  repost_item_id: string
+}
+export type DiscoveryTipSendNotificationAction = {
+  amount: string
+  sender_user_id: string
+  receiver_user_id: string
+  tip_tx_signature: string
+}
+export type DiscoveryTipReceiveNotificationAction = {
+  amount: string
+  sender_user_id: string
+  receiver_user_id: string
+  tip_tx_signature: string
+  reaction_value: number
+}
+
+export type DiscoveryMilestoneFollowNotificationAction = {
+  type: 'follow_count'
+  threshold: number
+  user_id: string
+}
+export type DiscoveryMilestoneTrackNotificationAction = {
+  type: 'track_repost_count' | 'track_save_count' | 'track_listen_count'
+  threshold: number
+  track_id: string
+}
+export type DiscoveryMilestonePlaylistNotificationAction = {
+  type: 'playlist_repost_count' | 'playlist_save_count'
+  threshold: number
+  playlist_id: string
+}
+export type DiscoveryRemixNotificationAction = {
+  parent_track_id: string
+  track_id: string
+  track_owner_id: string
+}
+export type DiscoveryCosignNotificationAction = {
+  parent_track_id: string
+  parent_track_owner_id: string
+  track_id: string
+  track_owner_id: string
+}
+export type DiscoverySupporterRankUpNotificationAction = {
+  rank: number
+  sender_user_id: string
+  receiver_user_id: string
+}
+export type DiscoverySupportingRankUpNotificationAction = {
+  rank: number
+  sender_user_id: string
+  receiver_user_id: string
+}
+
+export type DiscoverySupporterDethronedNotificationAction = {
+  sender_user_id: string
+  receiver_user_id: string
+  dethroned_user_id: string
+}
+
+export type DiscoveryReactionNotificationAction = {
+  reacted_to: string
+  reaction_type: 'tip'
+  sender_wallet: string
+  reaction_value: number
+  receiver_user_id: string
+  sender_user_id: string
+  tip_amount: string
+}
+
+export type DiscoveryChallengeRewardNotificationAction = {
+  amount: string
+  specifier: string
+  challenge_id: string
+}
+export type DiscoveryTierChangeNotificationAction = {
+  new_tier: string
+  new_tier_value: number
+  current_value: string
+}
+
+export type DiscoveryCreateTrackNotificationAction = {
+  track_id: string
+}
+export type DiscoveryCreatePlaylistNotificationAction = {
+  is_album: boolean
+  playlist_id: string
+}
+
+export type TrendingRange = 'week' | 'month' | 'year'
+
+export type DiscoveryTrendingNotificationAction = {
+  rank: number
+  genre: string
+  track_id: string
+  time_range: TrendingRange
+}
+
+export type DiscoveryAnnouncementNotification = DiscoveryBaseNotification<
+  'announcement',
+  DiscoveryAnnouncementNotificationAction
+>
+export type DiscoveryFollowNotification = DiscoveryBaseNotification<
+  'follow',
+  DiscoveryFollowNotificationAction
+>
+export type DiscoverySaveNotification = DiscoveryBaseNotification<
+  'save',
+  DiscoverySaveNotificationAction
+>
+export type DiscoveryRepostNotification = DiscoveryBaseNotification<
+  'repost',
+  DiscoveryRepostNotificationAction
+>
+export type DiscoveryTipSendNotification = DiscoveryBaseNotification<
+  'tip_send',
+  DiscoveryTipSendNotificationAction
+>
+export type DiscoveryTipReceiveNotification = DiscoveryBaseNotification<
+  'tip_receive',
+  DiscoveryTipReceiveNotificationAction
+>
+
+export type DiscoveryRemixNotification = DiscoveryBaseNotification<
+  'remix',
+  DiscoveryRemixNotificationAction
+>
+export type DiscoveryCosignNotification = DiscoveryBaseNotification<
+  'cosign',
+  DiscoveryCosignNotificationAction
+>
+export type DiscoverySupporterRankUpNotification = DiscoveryBaseNotification<
+  'supporter_rank_up',
+  DiscoverySupporterRankUpNotificationAction
+>
+export type DiscoverySupportingRankUpNotification = DiscoveryBaseNotification<
+  'supporting_rank_up',
+  DiscoverySupportingRankUpNotificationAction
+>
+export type DiscoverySupporterDethronedNotification = DiscoveryBaseNotification<
+  'supporter_dethroned',
+  DiscoverySupporterDethronedNotificationAction
+>
+export type DiscoveryReactionNotification = DiscoveryBaseNotification<
+  'reaction',
+  DiscoveryReactionNotificationAction
+>
+export type DiscoveryChallengeRewardNotification = DiscoveryBaseNotification<
+  'challenge_reward',
+  DiscoveryChallengeRewardNotificationAction
+>
+export type DiscoveryTierChangeNotification = DiscoveryBaseNotification<
+  'tier_change',
+  DiscoveryTierChangeNotificationAction
+>
+export type DiscoveryCreateNotification = DiscoveryBaseNotification<
+  'create',
+  | DiscoveryCreateTrackNotificationAction
+  | DiscoveryCreatePlaylistNotificationAction
+>
+export type DiscoveryTrendingNotification = DiscoveryBaseNotification<
+  'trending',
+  DiscoveryTrendingNotificationAction
+>
+export type DiscoveryMilestoneNotification = DiscoveryBaseNotification<
+  'milestone',
+  | DiscoveryMilestoneFollowNotificationAction
+  | DiscoveryMilestoneTrackNotificationAction
+  | DiscoveryMilestonePlaylistNotificationAction
+>
+
+export type DiscoveryNotification =
+  | DiscoveryAnnouncementNotification
+  | DiscoveryFollowNotification
+  | DiscoverySaveNotification
+  | DiscoveryRepostNotification
+  | DiscoveryTipSendNotification
+  | DiscoveryTipReceiveNotification
+  | DiscoveryRemixNotification
+  | DiscoveryCosignNotification
+  | DiscoveryMilestoneNotification
+  | DiscoverySupporterRankUpNotification
+  | DiscoverySupportingRankUpNotification
+  | DiscoverySupporterDethronedNotification
+  | DiscoveryReactionNotification
+  | DiscoveryChallengeRewardNotification
+  | DiscoveryTierChangeNotification
+  | DiscoveryCreateNotification
+  | DiscoveryTrendingNotification
 
 export type AnnouncementNotification = BaseNotification & {
   type: NotificationType.Announcement

--- a/packages/web/src/common/store/notifications/sagas.ts
+++ b/packages/web/src/common/store/notifications/sagas.ts
@@ -145,6 +145,11 @@ export function* fetchNotifications(action: FetchNotifications) {
         getFeatureEnabled,
         FeatureFlags.SUPPORTER_DETHRONED_ENABLED
       )) as boolean | null) ?? false
+    const useDiscoveryNotifications =
+      ((yield* call(
+        getFeatureEnabled,
+        FeatureFlags.DISCOVERY_NOTIFICATIONS
+      )) as boolean | null) ?? false
 
     const notificationsResponse: NotificationsResponse = yield* call(() =>
       audiusBackendInstance.getNotifications({
@@ -153,6 +158,22 @@ export function* fetchNotifications(action: FetchNotifications) {
         withDethroned
       })
     )
+
+    if (useDiscoveryNotifications && 'notifications' in notificationsResponse) {
+      const discoveryNotifications = yield* call(() => {
+        let timestamp
+        if (lastNotification) {
+          timestamp = Math.trunc(Date.parse(lastNotification?.timestamp) / 1000)
+        }
+        return audiusBackendInstance.getDiscoveryNotifications({
+          timestamp,
+          groupIdOffset: lastNotification?.groupId
+        })
+      })
+      notificationsResponse.notifications =
+        discoveryNotifications!.notifications
+    }
+
     if ('error' in notificationsResponse) {
       yield* put(
         notificationActions.fetchNotificationsFailed(
@@ -539,6 +560,12 @@ export function* getNotifications(isFirstFetch: boolean) {
           FeatureFlags.SUPPORTER_DETHRONED_ENABLED
         )) as boolean | null) ?? false
 
+      const notifications: any[] = yield* call(() =>
+        audiusBackendInstance.getDiscoveryNotifications({
+          // limit
+          // timeOffset,
+        })
+      )
       const notificationsResponse: NotificationsResponse | undefined =
         yield* call(() =>
           audiusBackendInstance.getNotifications({
@@ -547,6 +574,9 @@ export function* getNotifications(isFirstFetch: boolean) {
             withDethroned
           })
         )
+      if (notificationsResponse && 'notifications' in notificationsResponse) {
+        notificationsResponse.notifications = notifications
+      }
       if (
         !notificationsResponse ||
         ('error' in notificationsResponse &&

--- a/packages/web/src/common/store/notifications/sagas.ts
+++ b/packages/web/src/common/store/notifications/sagas.ts
@@ -559,13 +559,12 @@ export function* getNotifications(isFirstFetch: boolean) {
           getFeatureEnabled,
           FeatureFlags.SUPPORTER_DETHRONED_ENABLED
         )) as boolean | null) ?? false
+      const useDiscoveryNotifications =
+        ((yield* call(
+          getFeatureEnabled,
+          FeatureFlags.DISCOVERY_NOTIFICATIONS
+        )) as boolean | null) ?? false
 
-      const notifications: any[] = yield* call(() =>
-        audiusBackendInstance.getDiscoveryNotifications({
-          // limit
-          // timeOffset,
-        })
-      )
       const notificationsResponse: NotificationsResponse | undefined =
         yield* call(() =>
           audiusBackendInstance.getNotifications({
@@ -574,8 +573,17 @@ export function* getNotifications(isFirstFetch: boolean) {
             withDethroned
           })
         )
-      if (notificationsResponse && 'notifications' in notificationsResponse) {
-        notificationsResponse.notifications = notifications
+
+      if (
+        useDiscoveryNotifications &&
+        notificationsResponse &&
+        'notifications' in notificationsResponse
+      ) {
+        const discoveryNotifications = yield* call(() => {
+          return audiusBackendInstance.getDiscoveryNotifications({})
+        })
+        notificationsResponse.notifications =
+          discoveryNotifications!.notifications
       }
       if (
         !notificationsResponse ||

--- a/packages/web/src/common/store/notifications/sagas.ts
+++ b/packages/web/src/common/store/notifications/sagas.ts
@@ -160,16 +160,17 @@ export function* fetchNotifications(action: FetchNotifications) {
     )
 
     if (useDiscoveryNotifications && 'notifications' in notificationsResponse) {
-      const discoveryNotifications = yield* call(() => {
-        let timestamp
-        if (lastNotification) {
-          timestamp = Math.trunc(Date.parse(lastNotification?.timestamp) / 1000)
-        }
-        return audiusBackendInstance.getDiscoveryNotifications({
+      let timestamp: number | undefined
+      if (lastNotification) {
+        timestamp = Math.trunc(Date.parse(lastNotification?.timestamp) / 1000)
+      }
+      const discoveryNotifications = yield* call(
+        audiusBackendInstance.getDiscoveryNotifications,
+        {
           timestamp,
           groupIdOffset: lastNotification?.groupId
-        })
-      })
+        }
+      )
       notificationsResponse.notifications =
         discoveryNotifications!.notifications
     }
@@ -579,9 +580,10 @@ export function* getNotifications(isFirstFetch: boolean) {
         notificationsResponse &&
         'notifications' in notificationsResponse
       ) {
-        const discoveryNotifications = yield* call(() => {
-          return audiusBackendInstance.getDiscoveryNotifications({})
-        })
+        const discoveryNotifications = yield* call(
+          audiusBackendInstance.getDiscoveryNotifications,
+          {}
+        )
         notificationsResponse.notifications =
           discoveryNotifications!.notifications
       }

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -146,16 +146,14 @@ export const NotificationPanel = ({ anchorRef }: NotificationPanelProps) => {
                 getScrollParent={getScrollParent}
               >
                 <div className={styles.content}>
-                  {notifications
-                    .filter(({ isHidden }: any) => !isHidden)
-                    .map((notification: Notifications) => {
-                      return (
-                        <Notification
-                          key={notification.id}
-                          notification={notification}
-                        />
-                      )
-                    })}
+                  {notifications.map((notification: Notifications) => {
+                    return (
+                      <Notification
+                        key={notification.id}
+                        notification={notification}
+                      />
+                    )
+                  })}
                   {status === Status.LOADING ? (
                     <div className={styles.spinnerContainer} key={'loading'}>
                       <Lottie


### PR DESCRIPTION
### Description
Client Reads for notifications from discovery

### Dragons
Behind a feature flag, but changes how notifications are read.

### How Has This Been Tested?
Ran against a local discovery box pointed at a prod discovery database and validated that each of the notification types were rendered

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?
notifications panel on web 

### Feature Flags ###
Yes, new discovery notifications read feature flag
