### PR TITLE
[C-2126] Fetch whole account for cache after confirmed update

### DIFF
--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -246,7 +246,7 @@ export function* fetchLocalAccountAsync() {
   }
 }
 
-function* cacheAccount(account) {
+export function* cacheAccount(account) {
   const localStorage = yield getContext('localStorage')
   const collections = account.playlists || []
 

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -32,6 +32,7 @@ import {
   takeEvery
 } from 'redux-saga/effects'
 
+import { cacheAccount } from 'common/store/account/sagas'
 import {
   fetchUsers,
   fetchUserByHandle,
@@ -552,7 +553,8 @@ function* confirmUpdateProfile(userId, metadata) {
       },
       function* (confirmedUser) {
         // Store the update in local storage so it is correct upon reload
-        yield call([localStorage, 'setAudiusAccountUser'], confirmedUser)
+        const account = yield call(audiusBackendInstance.getAccount)
+        yield call(cacheAccount, account)
         // Update the cached user so it no longer contains image upload artifacts
         // and contains updated profile picture / cover photo sizes if any
         const newMetadata = {

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -516,7 +516,6 @@ function* confirmUpdateProfile(userId, metadata) {
   yield waitForWrite()
   const apiClient = yield getContext('apiClient')
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  const localStorage = yield getContext('localStorage')
   yield put(
     confirmerActions.requestConfirmation(
       makeKindId(Kind.USERS, userId),


### PR DESCRIPTION
### Description

Cacheing the account after confirmer comes back with a confirmed update was not writing the full version of the account to local storage. Here we change to get the updated account from the api then use the same process as on sign in to update the cached account. This ensures parity in the shape of the data in local storage.

### Dragons

We're dispatching fetchAccountSucceeded an extra time here without fetchAccountRequested first. Should we add that in the confirmer side?

