### PR TITLE
[C-2126] Fix empty collections on first session

### DIFF
--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -515,7 +515,6 @@ function* confirmUpdateProfile(userId, metadata) {
   yield waitForWrite()
   const apiClient = yield getContext('apiClient')
   const audiusBackendInstance = yield getContext('audiusBackendInstance')
-  const localStorage = yield getContext('localStorage')
   yield put(
     confirmerActions.requestConfirmation(
       makeKindId(Kind.USERS, userId),
@@ -551,8 +550,6 @@ function* confirmUpdateProfile(userId, metadata) {
         return users[0]
       },
       function* (confirmedUser) {
-        // Store the update in local storage so it is correct upon reload
-        yield call([localStorage, 'setAudiusAccountUser'], confirmedUser)
         // Update the cached user so it no longer contains image upload artifacts
         // and contains updated profile picture / cover photo sizes if any
         const newMetadata = {


### PR DESCRIPTION
### Description

Realized that we can probably remove the call to local-storage here, since it gets picked up whenever there is a cache/add/update to a user, it will merge that data with existing stuff, preserving the full account data.

