### PR TITLE
Fix useThrottledCallback trailing config

### DIFF
--- a/packages/mobile/src/hooks/useThrottledCallback.ts
+++ b/packages/mobile/src/hooks/useThrottledCallback.ts
@@ -8,6 +8,9 @@ export const useThrottledCallback = <T extends (...args: any) => any>(
   wait: number,
   deps: DependencyList
 ) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => throttle(callback, wait), [wait, ...deps])
+  return useMemo(
+    () => throttle(callback, wait, { trailing: false }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [wait, ...deps]
+  )
 }


### PR DESCRIPTION
### Description

Small fix to improve useThrottledCallback to ignore all calls in between the first one, and not call again after the wait if there is a pending call.

