### PR TITLE
[C-2132] unlink is safe on ios but not android

### DIFF
--- a/packages/mobile/src/services/track-download.ts
+++ b/packages/mobile/src/services/track-download.ts
@@ -67,6 +67,8 @@ const download = async ({
 
     // On failure attempt to delete the file
     try {
+      const exists = await RNFetchBlob.fs.exists(filePath)
+      if (!exists) return
       await RNFetchBlob.fs.unlink(filePath)
     } catch {}
   }

--- a/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/workers/downloadCollectionWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/workers/downloadCollectionWorker.ts
@@ -181,5 +181,7 @@ async function writeCollectionMetadata(collection: UserCollectionMetadata) {
 
 async function removeDownloadedCollection(collectionId: CollectionId) {
   const collectionDir = getLocalCollectionDir(collectionId.toString())
+  const exists = await RNFetchBlob.fs.exists(collectionDir)
+  if (!exists) return
   return await RNFetchBlob.fs.unlink(collectionDir)
 }

--- a/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/downloadQueueSagas/workers/downloadTrackWorker.ts
@@ -195,5 +195,7 @@ async function writeTrackMetadata(track: UserTrackMetadata) {
 
 async function removeDownloadedTrack(trackId: ID) {
   const trackDirectory = getLocalTrackDir(trackId.toString())
+  const exists = await RNFetchBlob.fs.exists(trackDirectory)
+  if (!exists) return
   return await RNFetchBlob.fs.unlink(trackDirectory)
 }

--- a/packages/mobile/src/store/offline-downloads/sagas/watchRemoveOfflineItems.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/watchRemoveOfflineItems.ts
@@ -36,10 +36,16 @@ function* deleteItemsFromDisk(action: RemoveOfflineItemsAction) {
         getLocalCollectionDir,
         item.id.toString()
       )
-      yield* call(RNFetchBlob.fs.unlink, collectionDirectory)
+      const exists = yield* call(RNFetchBlob.fs.exists, collectionDirectory)
+      if (exists) {
+        yield* call(RNFetchBlob.fs.unlink, collectionDirectory)
+      }
     } else if (item.type === 'track' && !trackStatus[item.id]) {
       const trackDirectory = yield* call(getLocalTrackDir, item.id.toString())
-      yield* call(RNFetchBlob.fs.unlink, trackDirectory)
+      const exists = yield* call(RNFetchBlob.fs.exists, trackDirectory)
+      if (exists) {
+        yield* call(RNFetchBlob.fs.unlink, trackDirectory)
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

We were getting "error deleting file" from `RNFetchBlob.unlink` on Android.
Looks like iOS handles it silently and Android throws.

### Dragons

This fixes the crash, but it also looks like `unlink` does not actually delete the files from disk on android... we can follow up with a separate change for that.

