### PR TITLE
use DocumentDir for offline file storage

### DIFF
--- a/packages/mobile/src/services/offline-downloader/offline-storage.ts
+++ b/packages/mobile/src/services/offline-downloader/offline-storage.ts
@@ -18,7 +18,7 @@ const {
 
 export type OfflineCollection = Collection & { user: UserMetadata }
 
-export const downloadsRoot = path.join(dirs.CacheDir, 'downloads')
+export const downloadsRoot = path.join(dirs.DocumentDir, 'downloads')
 const IMAGE_FILENAME = '1000x1000.jpg'
 
 export const getPathFromRoot = (string: string) => {


### PR DESCRIPTION
### Description

Switch to the more correct storage location. Both of these are still app-specific scoped storage, not the user's Documents directory which would be visible in file explorer.

See [android file directory](https://developer.android.com/training/data-storage/app-specific#internal-access-files) vs the [cached section](https://developer.android.com/training/data-storage/app-specific#internal-create-cache)
also [iOS docs](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)

iOS

Old: `.../CoreSimulator/Devices/19703453-AAB0-4D7A-AF00-A2EDE7FC1F23/data/Containers/Data/Application/729EB3A9-0674-4FCD-8C30-D67CA4136F63/Library/Caches`
New: `.../CoreSimulator/Devices/19703453-AAB0-4D7A-AF00-A2EDE7FC1F23/data/Containers/Data/Application/729EB3A9-0674-4FCD-8C30-D67CA4136F63/Documents`

Android

Old: `.../CoreSimulator/Devices/19703453-AAB0-4D7A-AF00-A2EDE7FC1F23/data/Containers/Data/Application/729EB3A9-0674-4FCD-8C30-D67CA4136F63/Library/Caches`
New: `.../CoreSimulator/Devices/19703453-AAB0-4D7A-AF00-A2EDE7FC1F23/data/Containers/Data/Application/729EB3A9-0674-4FCD-8C30-D67CA4136F63/Documents`

### How Has This Been Tested?

iOS and Android simulators

- Download
- Offline playback
- File delete
- Verify files not visible in file explorer
