### PR TITLE
[C-2136] Fix smart collection loading

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -98,7 +98,9 @@ export const CollectionScreenDetailsTile = ({
     // Need to refetch the collection after resetting
     // Will pull from cache if it exists
     // TODO: fix this for smart collections
-    dispatch(fetchCollection(collectionId as number))
+    if (typeof collectionId === 'number') {
+      dispatch(fetchCollection(collectionId))
+    }
     dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined))
   }, [dispatch, collectionUid, userUid, collectionId])
 


### PR DESCRIPTION
### Description

Small issue with the fix for collections not loading when coming online. The collection id is potentially a string (for smart collections) and calling fetch with that string breaks

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

