### PR TITLE
[C-2141] Fix missing lineup when coming back online

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionHeader.tsx
@@ -160,6 +160,8 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
     [playlist_id, downloadSwitchValue]
   )
 
+  const isReachable = useSelector(getIsReachable)
+
   const showDownloadSwitchAndIndicator =
     collection.has_current_user_saved ||
     collection.playlist_owner_id === currentUserId
@@ -214,7 +216,7 @@ const OfflineCollectionHeader = (props: OfflineCollectionHeaderProps) => {
           weight='demiBold'
           fontSize='small'
         >
-          {downloadStatus === OfflineDownloadStatus.LOADING
+          {downloadStatus === OfflineDownloadStatus.LOADING && isReachable
             ? messages.downloading
             : headerText}
         </Text>


### PR DESCRIPTION
### Description

Fixes missing lineup when coming back online
This improves general cancellation flow for fetchLineupMetadatas saga

Also fixes issue where collection header text says "downloading" when partially downloaded and offline