### PR TITLE
[PAY-893] UserBadge in chat screen header

### DIFF
--- a/packages/mobile/src/components/core/Screen/Screen.tsx
+++ b/packages/mobile/src/components/core/Screen/Screen.tsx
@@ -48,7 +48,7 @@ export type ScreenProps = {
   title?: Nullable<ReactNode>
   icon?: ComponentType<SvgProps>
   IconProps?: SvgProps
-  headerTitle?: ReactNode
+  headerTitle?: Nullable<(() => ReactNode) | string>
   style?: StyleProp<ViewStyle>
   // url used for screen view analytics
   url?: string

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -5,9 +5,7 @@ import {
   chatSelectors,
   encodeUrlName,
   Status,
-  hasTail,
-  accountSelectors,
-  cacheUsersSelectors
+  hasTail
 } from '@audius/common'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
@@ -25,10 +23,7 @@ import { ChatMessageListItem } from './ChatMessageListItem'
 
 const { getChatMessages, getOtherChatUsers, getChatMessagesStatus } =
   chatSelectors
-
-const { getUsers } = cacheUsersSelectors
 const { fetchMoreMessages } = chatActions
-const { getUserId } = accountSelectors
 
 const messages = {
   title: 'Messages',

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -5,7 +5,9 @@ import {
   chatSelectors,
   encodeUrlName,
   Status,
-  hasTail
+  hasTail,
+  accountSelectors,
+  cacheUsersSelectors
 } from '@audius/common'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
@@ -13,6 +15,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import IconSend from 'app/assets/images/iconSend.svg'
 import { TextInput, Screen, FlatList, ScreenContent } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
+import { ProfilePicture } from 'app/components/user'
+import { UserBadges } from 'app/components/user-badges'
 import { useRoute } from 'app/hooks/useRoute'
 import { makeStyles } from 'app/styles'
 import { useThemePalette } from 'app/utils/theme'
@@ -21,7 +25,10 @@ import { ChatMessageListItem } from './ChatMessageListItem'
 
 const { getChatMessages, getOtherChatUsers, getChatMessagesStatus } =
   chatSelectors
+
+const { getUsers } = cacheUsersSelectors
 const { fetchMoreMessages } = chatActions
+const { getUserId } = accountSelectors
 
 const messages = {
   title: 'Messages',
@@ -70,36 +77,62 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     width: spacing(5),
     height: spacing(5),
     fill: palette.primary
+  },
+  userBadgeTitle: {
+    fontSize: typography.fontSize.medium,
+    fontWeight: '800',
+    color: palette.neutral
+  },
+  profilePicture: {
+    width: spacing(6),
+    height: spacing(6),
+    marginRight: spacing(2)
   }
 }))
 
 export const ChatScreen = () => {
   const styles = useStyles()
+  const palette = useThemePalette()
   const dispatch = useDispatch()
 
-  const [iconOpacity, setIconOpacity] = useState(0.5)
-  const [text, setText] = useState('')
   const { params } = useRoute<'Chat'>()
   const { chatId } = params
   const url = `/chat/${encodeUrlName(chatId)}`
+  const [iconOpacity, setIconOpacity] = useState(0.5)
+  const [text, setText] = useState('')
+
   const chatMessages = useSelector((state) =>
     getChatMessages(state, chatId ?? '')
   )
   const status = useSelector((state) =>
     getChatMessagesStatus(state, chatId ?? '')
   )
-  const palette = useThemePalette()
 
   useEffect(() => {
     dispatch(fetchMoreMessages({ chatId }))
   }, [dispatch, chatId])
 
-  const otherUser = useSelector((state) => getOtherChatUsers(state, chatId))
+  const [otherUser] = useSelector((state) => getOtherChatUsers(state, chatId))
 
   return (
     <Screen
       url={url}
-      title={otherUser[0] ? otherUser[0].handle : messages.title}
+      headerTitle={
+        otherUser
+          ? () => (
+              <>
+                <ProfilePicture
+                  profile={otherUser}
+                  style={styles.profilePicture}
+                />
+                <UserBadges
+                  user={otherUser}
+                  nameStyle={styles.userBadgeTitle}
+                />
+              </>
+            )
+          : messages.title
+      }
     >
       <ScreenContent>
         <View style={styles.rootContainer}>


### PR DESCRIPTION
### Description
Took me a while to find out that I could pass a component into the Screen via `headerTitle` prop instead of `title`.
![Screenshot_1676492871](https://user-images.githubusercontent.com/3893871/219146813-be9658a1-ac6c-4855-8147-a86632ab22fa.png)


### Dragons

### How Has This Been Tested?

Android emulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

