### PR TITLE
[C-2155 C-2127] Fix duplicate feed fetch

### DIFF
--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -338,7 +338,8 @@ export const Lineup = ({
     useCallback(() => {
       if (status === Status.LOADING || !inView) return
       handleLoadMore(true)
-    }, [status, inView, handleLoadMore])
+    }, [status, inView, handleLoadMore]),
+    false
   )
 
   // When scrolled past the end threshold of the lineup and the lineup is not loading,


### PR DESCRIPTION
### Description

Fixes issue where lineups double fetch on load. Other than improving perf, this could also help mitigate scrolling issues we were seeing in lineups due to out-of-order pagination.

The fix essentially is to add an option to reachability effect to not call on first render

