### PR TITLE
[C-2164] add retry and requeue logic to download track jobs

### DIFF
--- a/packages/mobile/src/components/offline-downloads/CollectionDownloadStatusIndicator.tsx
+++ b/packages/mobile/src/components/offline-downloads/CollectionDownloadStatusIndicator.tsx
@@ -50,12 +50,19 @@ export const getCollectionDownloadStatus = (
     trackStatuses.every(
       (status) =>
         status === OfflineDownloadStatus.SUCCESS ||
-        status === OfflineDownloadStatus.ERROR
+        status === OfflineDownloadStatus.ERROR ||
+        status === OfflineDownloadStatus.ABANDONED
     )
   )
     return OfflineDownloadStatus.SUCCESS
 
-  if (trackStatuses.every((status) => status === OfflineDownloadStatus.ERROR))
+  if (
+    trackStatuses.every(
+      (status) =>
+        status === OfflineDownloadStatus.ERROR ||
+        status === OfflineDownloadStatus.ABANDONED
+    )
+  )
     return OfflineDownloadStatus.ERROR
 
   if (
@@ -63,7 +70,8 @@ export const getCollectionDownloadStatus = (
       (status) =>
         status === OfflineDownloadStatus.INIT ||
         status === OfflineDownloadStatus.SUCCESS ||
-        status === OfflineDownloadStatus.ERROR
+        status === OfflineDownloadStatus.ERROR ||
+        status === OfflineDownloadStatus.ABANDONED
     )
   )
     return OfflineDownloadStatus.LOADING

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/requestProccessNextJobSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/requestProccessNextJobSaga.ts
@@ -34,7 +34,7 @@ function* processNextJob() {
   if (type === 'collection') {
     yield* call(downloadCollectionWorker, id)
   } else if (type === 'track') {
-    yield* call(downloadTrackWorker, id)
+    yield* call(downloadTrackWorker, id, item.retryCount)
   } else if (type === 'collection-sync') {
     yield* call(syncCollectionWorker, id)
   } else if (type === 'play-count') {

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/requestProccessNextJobSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/requestProccessNextJobSaga.ts
@@ -34,7 +34,7 @@ function* processNextJob() {
   if (type === 'collection') {
     yield* call(downloadCollectionWorker, id)
   } else if (type === 'track') {
-    yield* call(downloadTrackWorker, id, item.retryCount)
+    yield* call(downloadTrackWorker, id, item.requeueCount)
   } else if (type === 'collection-sync') {
     yield* call(syncCollectionWorker, id)
   } else if (type === 'play-count') {

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -50,7 +50,7 @@ function* shouldAbortDownload(trackId: ID) {
   }
 }
 
-export function* downloadTrackWorker(trackId: ID, requeueCount: number) {
+export function* downloadTrackWorker(trackId: ID, requeueCount?: number) {
   const queueItem: OfflineJob = { type: 'track', id: trackId, requeueCount }
   track(
     make({ eventName: EventNames.OFFLINE_MODE_DOWNLOAD_START, ...queueItem })
@@ -82,7 +82,7 @@ export function* downloadTrackWorker(trackId: ID, requeueCount: number) {
         })
       )
       yield* call(removeDownloadedTrack, trackId)
-      if (requeueCount < MAX_REQUEUE_COUNT - 1) {
+      if ((requeueCount ?? 0) < MAX_REQUEUE_COUNT - 1) {
         yield* put(errorJob(queueItem))
       } else {
         yield* put(abandonJob(queueItem))

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -39,6 +39,8 @@ const { SET_UNREACHABLE } = reachabilityActions
 
 const { getUserId } = accountSelectors
 
+const MAX_RETRY_COUNT = 3
+
 function* shouldAbortDownload(trackId: ID) {
   while (true) {
     yield* take(removeOfflineItems.type)
@@ -47,8 +49,8 @@ function* shouldAbortDownload(trackId: ID) {
   }
 }
 
-export function* downloadTrackWorker(trackId: ID) {
-  const queueItem: OfflineJob = { type: 'track', id: trackId }
+export function* downloadTrackWorker(trackId: ID, retryCount: number) {
+  const queueItem: OfflineJob = { type: 'track', id: trackId, retryCount }
   track(
     make({ eventName: EventNames.OFFLINE_MODE_DOWNLOAD_START, ...queueItem })
   )
@@ -64,8 +66,8 @@ export function* downloadTrackWorker(trackId: ID) {
     yield* call(removeDownloadedTrack, trackId)
     yield* put(requestProcessNextJob())
   } else if (cancel) {
-    yield* put(cancelJob(queueItem))
     yield* call(removeDownloadedTrack, trackId)
+    yield* put(cancelJob(queueItem))
   } else if (jobResult === OfflineDownloadStatus.ERROR) {
     track(
       make({
@@ -73,8 +75,14 @@ export function* downloadTrackWorker(trackId: ID) {
         ...queueItem
       })
     )
-    yield* put(errorJob(queueItem))
     yield* call(removeDownloadedTrack, trackId)
+    if (retryCount < MAX_RETRY_COUNT - 1) {
+      console.log('OfflineQueue - failed job - retrying', trackId, retryCount)
+      yield* put(errorJob(queueItem))
+    } else {
+      console.log('OfflineQueue - failed job - abandoning', trackId, retryCount)
+      yield* put(abandonJob(queueItem))
+    }
     yield* put(requestProcessNextJob())
   } else if (jobResult === OfflineDownloadStatus.ABANDONED) {
     track(

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -73,10 +73,8 @@ export function* downloadTrackWorker(trackId: ID, requeueCount: number) {
       yield* put(cancelJob(queueItem))
       return
     } else if (jobResult === OfflineDownloadStatus.ERROR) {
-      if (retryCount < MAX_RETRY_COUNT - 1) {
-        console.log('OfflineQueue - looping failed job', trackId, retryCount)
-        continue
-      }
+      if (retryCount < MAX_RETRY_COUNT - 1) continue
+
       track(
         make({
           eventName: EventNames.OFFLINE_MODE_DOWNLOAD_FAILURE,
@@ -85,20 +83,8 @@ export function* downloadTrackWorker(trackId: ID, requeueCount: number) {
       )
       yield* call(removeDownloadedTrack, trackId)
       if (requeueCount < MAX_REQUEUE_COUNT - 1) {
-        console.log(
-          'OfflineQueue - failed job - requeueing',
-          trackId,
-          retryCount,
-          requeueCount
-        )
         yield* put(errorJob(queueItem))
       } else {
-        console.log(
-          'OfflineQueue - failed job - abandoning',
-          trackId,
-          retryCount,
-          requeueCount
-        )
         yield* put(abandonJob(queueItem))
       }
       yield* put(requestProcessNextJob())
@@ -150,7 +136,6 @@ function* downloadTrackAsync(
     return OfflineDownloadStatus.ABANDONED
   }
 
-  if (Math.random() < 0.75) return OfflineDownloadStatus.ERROR
   try {
     yield* all([
       call(downloadTrackCoverArt, track),

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/staleTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/staleTrackWorker.ts
@@ -66,7 +66,9 @@ export function* handleStaleTrack(trackId: ID) {
 
   if (moment(latestTrack.updated_at).isAfter(currentTrack.updated_at)) {
     yield* put(
-      redownloadOfflineItems({ items: [{ type: 'track', id: trackId }] })
+      redownloadOfflineItems({
+        items: [{ type: 'track', id: trackId }]
+      })
     )
   }
 

--- a/packages/mobile/src/store/offline-downloads/sagas/utils/retryOfflineJob.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/utils/retryOfflineJob.ts
@@ -1,0 +1,23 @@
+import { call, retry } from 'typed-redux-saga'
+
+import { OfflineDownloadStatus } from '../../slice'
+
+export function* retryOfflineJob<
+  Fn extends (...args: any[]) => Generator<any, OfflineDownloadStatus>
+>(maxTries: number, delayLength: number, fn: Fn, ...args: Parameters<Fn>) {
+  function* fnWrapped(...args: Parameters<Fn>) {
+    const returnValue = yield* call(fn, ...args)
+    if (returnValue === OfflineDownloadStatus.ERROR) {
+      throw new Error(returnValue)
+    }
+    return returnValue
+  }
+
+  try {
+    return yield* retry(maxTries, delayLength, fnWrapped, ...args)
+  } catch (e) {
+    if (e.message === OfflineDownloadStatus.ERROR)
+      return OfflineDownloadStatus.ERROR
+    throw e
+  }
+}

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -25,7 +25,7 @@ export type TrackOfflineMetadataPayload = {
 
 export type OfflineJob =
   | { type: 'collection'; id: CollectionId }
-  | { type: 'track'; id: ID; retryCount: number }
+  | { type: 'track'; id: ID; requeueCount: number }
   | { type: 'collection-sync'; id: CollectionId }
   | { type: 'play-count'; id: ID }
   | { type: 'stale-track'; id: ID }
@@ -186,7 +186,7 @@ const slice = createSlice({
             trackStatus[id] === OfflineDownloadStatus.ERROR
           ) {
             trackStatus[id] = OfflineDownloadStatus.INIT
-            offlineQueue.push({ type, id, retryCount: 0 })
+            offlineQueue.push({ type, id, requeueCount: 0 })
           }
         } else if (item.type === 'collection') {
           const { type, id, metadata } = item
@@ -323,7 +323,7 @@ const slice = createSlice({
         console.log('OfflineQueue - retrying job', action.payload)
         state.offlineQueue.push({
           ...action.payload,
-          retryCount: action.payload.retryCount + 1
+          requeueCount: action.payload.requeueCount + 1
         })
       } else if (type === 'stale-track') {
         // continue

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -25,7 +25,7 @@ export type TrackOfflineMetadataPayload = {
 
 export type OfflineJob =
   | { type: 'collection'; id: CollectionId }
-  | { type: 'track'; id: ID }
+  | { type: 'track'; id: ID; retryCount: number }
   | { type: 'collection-sync'; id: CollectionId }
   | { type: 'play-count'; id: ID }
   | { type: 'stale-track'; id: ID }
@@ -58,7 +58,11 @@ export type RequestRemoveFavoritedDownloadedCollectionAction = PayloadAction<{
 }>
 
 export type OfflineEntry =
-  | { type: 'track'; id: ID; metadata: OfflineTrackMetadata }
+  | {
+      type: 'track'
+      id: ID
+      metadata: OfflineTrackMetadata
+    }
   | {
       type: 'collection'
       id: CollectionId
@@ -182,7 +186,7 @@ const slice = createSlice({
             trackStatus[id] === OfflineDownloadStatus.ERROR
           ) {
             trackStatus[id] = OfflineDownloadStatus.INIT
-            offlineQueue.push({ type, id })
+            offlineQueue.push({ type, id, retryCount: 0 })
           }
         } else if (item.type === 'collection') {
           const { type, id, metadata } = item
@@ -315,6 +319,12 @@ const slice = createSlice({
         state.collectionStatus[id] = OfflineDownloadStatus.ERROR
       } else if (type === 'track') {
         state.trackStatus[id] = OfflineDownloadStatus.ERROR
+        // re-queue the track
+        console.log('OfflineQueue - retrying job', action.payload)
+        state.offlineQueue.push({
+          ...action.payload,
+          retryCount: action.payload.retryCount + 1
+        })
       } else if (type === 'stale-track') {
         // continue
       }

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -320,7 +320,6 @@ const slice = createSlice({
       } else if (type === 'track') {
         state.trackStatus[id] = OfflineDownloadStatus.ERROR
         // re-queue the track
-        console.log('OfflineQueue - retrying job', action.payload)
         state.offlineQueue.push({
           ...action.payload,
           requeueCount: action.payload.requeueCount + 1

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -25,7 +25,7 @@ export type TrackOfflineMetadataPayload = {
 
 export type OfflineJob =
   | { type: 'collection'; id: CollectionId }
-  | { type: 'track'; id: ID; requeueCount: number }
+  | { type: 'track'; id: ID; requeueCount?: number }
   | { type: 'collection-sync'; id: CollectionId }
   | { type: 'play-count'; id: ID }
   | { type: 'stale-track'; id: ID }
@@ -186,7 +186,7 @@ const slice = createSlice({
             trackStatus[id] === OfflineDownloadStatus.ERROR
           ) {
             trackStatus[id] = OfflineDownloadStatus.INIT
-            offlineQueue.push({ type, id, requeueCount: 0 })
+            offlineQueue.push({ type, id })
           }
         } else if (item.type === 'collection') {
           const { type, id, metadata } = item
@@ -322,7 +322,7 @@ const slice = createSlice({
         // re-queue the track
         state.offlineQueue.push({
           ...action.payload,
-          requeueCount: action.payload.requeueCount + 1
+          requeueCount: (action.payload.requeueCount ?? 0) + 1
         })
       } else if (type === 'stale-track') {
         // continue


### PR DESCRIPTION
### Description

1. DownloadTrackWorker retries the download up to 3 times internally before putting down the job
2. If the worker fails max times, re-enqueue the track to be tried again later
3. If the re-queue count hits 3, abandon the job

*Note:* The job is still abandoned immediately if the track is unavailable for download or the job is otherwise invalid.

### How Has This Been Tested?

Set `downloadTrackAsync` to fail 75% of the time. Tracks were succeeding at a high rate, and failed tracks would be processed again at the back of the queue. We successfully downloaded nearly all tracks even while the internal job was usually failing.

