### PR TITLE
[C-2130] Fix race cond in lineup init

### DIFF
--- a/packages/common/src/store/pages/collection/lineup/reducer.ts
+++ b/packages/common/src/store/pages/collection/lineup/reducer.ts
@@ -4,7 +4,7 @@ import { RESET_SUCCEEDED, stripPrefix } from 'store/lineup/actions'
 import { initialLineupState } from 'store/lineup/reducer'
 import { PREFIX } from 'store/pages/collection/lineup/actions'
 
-const initialState = {
+export const initialState = {
   ...initialLineupState,
   prefix: PREFIX
 }

--- a/packages/common/src/store/pages/collection/reducer.ts
+++ b/packages/common/src/store/pages/collection/reducer.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
-import tracksReducer from 'store/pages/collection/lineup/reducer'
+import tracksReducer, {
+  initialState as initialLineupState
+} from 'store/pages/collection/lineup/reducer'
 
 import { Status } from '../../../models/Status'
 import { asLineup } from '../../../store/lineup/reducer'
@@ -19,7 +21,8 @@ export const initialState = {
   collectionUid: null,
   userUid: null,
   status: null,
-  smartCollectionVariant: null
+  smartCollectionVariant: null,
+  tracks: initialLineupState
 }
 
 const actionsMap = {

--- a/packages/common/src/store/pages/feed/lineup/reducer.ts
+++ b/packages/common/src/store/pages/feed/lineup/reducer.ts
@@ -4,7 +4,7 @@ import { RESET_SUCCEEDED, stripPrefix } from 'store/lineup/actions'
 import { initialLineupState } from 'store/lineup/reducer'
 import { PREFIX } from 'store/pages/feed/lineup/actions'
 
-const initialState = {
+export const initialState = {
   ...initialLineupState,
   prefix: PREFIX,
   dedupe: true,

--- a/packages/common/src/store/pages/feed/reducer.ts
+++ b/packages/common/src/store/pages/feed/reducer.ts
@@ -6,13 +6,16 @@ import {
   SET_FEED_FILTER
 } from 'store/pages/feed/actions'
 import { PREFIX as FeedPrefix } from 'store/pages/feed/lineup/actions'
-import feedReducer from 'store/pages/feed/lineup/reducer'
+import feedReducer, {
+  initialState as feedLinupInitialState
+} from 'store/pages/feed/lineup/reducer'
 
 import { FeedFilter } from '../../../models'
 
 const initialState = {
   suggestedFollows: [],
-  feedFilter: FeedFilter.ALL
+  feedFilter: FeedFilter.ALL,
+  feed: feedLinupInitialState
 }
 
 const actionsMap = {
@@ -32,15 +35,7 @@ const actionsMap = {
 
 const feedLineupReducer = asLineup(FeedPrefix, feedReducer)
 
-const reducer = (state, action) => {
-  // On first run, create our initial state
-  if (!state) {
-    return {
-      ...initialState,
-      feed: feedLineupReducer(state, action)
-    }
-  }
-
+const reducer = (state = initialState, action) => {
   const feed = feedLineupReducer(state.feed, action)
   if (feed !== state.feed) return { ...state, feed }
 

--- a/packages/common/src/store/pages/history-page/lineups/tracks/reducer.ts
+++ b/packages/common/src/store/pages/history-page/lineups/tracks/reducer.ts
@@ -5,7 +5,7 @@ import { initialLineupState } from 'store/lineup/reducer'
 
 import { PREFIX } from './actions'
 
-const initialState = {
+export const initialState = {
   ...initialLineupState,
   prefix: PREFIX
 }

--- a/packages/common/src/store/pages/history-page/reducer.ts
+++ b/packages/common/src/store/pages/history-page/reducer.ts
@@ -3,9 +3,13 @@
 import { asLineup } from 'store/lineup/reducer'
 
 import { PREFIX as tracksPrefix } from './lineups/tracks/actions'
-import tracksReducer from './lineups/tracks/reducer'
+import tracksReducer, {
+  initialState as initialLineupState
+} from './lineups/tracks/reducer'
 
-const initialState = {}
+const initialState = {
+  tracks: initialLineupState
+}
 
 const actionsMap = {}
 

--- a/packages/common/src/store/pages/profile/reducer.ts
+++ b/packages/common/src/store/pages/profile/reducer.ts
@@ -2,8 +2,12 @@
 // TODO(nkang) - convert to TS
 
 import { asLineup } from 'store/lineup/reducer'
-import feedReducer from 'store/pages/profile/lineups/feed/reducer'
-import tracksReducer from 'store/pages/profile/lineups/tracks/reducer'
+import feedReducer, {
+  initialState as initialFeedLineupState
+} from 'store/pages/profile/lineups/feed/reducer'
+import tracksReducer, {
+  initialState as initialTracksLineupState
+} from 'store/pages/profile/lineups/tracks/reducer'
 import { FollowType, CollectionSortMode } from 'store/pages/profile/types'
 
 import { Status } from '../../../models'
@@ -48,7 +52,10 @@ const initialProfileState = {
 
   [FollowType.FOLLOWERS]: { status: Status.IDLE, userIds: [] },
   [FollowType.FOLLOWEES]: { status: Status.IDLE, userIds: [] },
-  [FollowType.FOLLOWEE_FOLLOWS]: { status: Status.IDLE, userIds: [] }
+  [FollowType.FOLLOWEE_FOLLOWS]: { status: Status.IDLE, userIds: [] },
+
+  feed: initialFeedLineupState,
+  tracks: initialTracksLineupState
 }
 
 const updateProfile = (state, action, data) => {

--- a/packages/common/src/store/pages/remixes/slice.ts
+++ b/packages/common/src/store/pages/remixes/slice.ts
@@ -6,16 +6,20 @@ import { asLineup } from 'store/lineup/reducer'
 import { ID } from '../../../models/Identifiers'
 
 import { PREFIX as remixesTracksPrefix } from './lineup/actions'
-import remixesTracksReducer from './lineup/reducer'
+import remixesTracksReducer, {
+  initialState as initialLineupState
+} from './lineup/reducer'
 
 type State = {
   trackId: ID | null
   count: number | null
+  tracks: typeof initialLineupState
 }
 
 const initialState: State = {
   trackId: null,
-  count: null
+  count: null,
+  tracks: initialLineupState
 }
 
 const slice = createSlice({

--- a/packages/common/src/store/pages/saved-page/lineups/tracks/reducer.ts
+++ b/packages/common/src/store/pages/saved-page/lineups/tracks/reducer.ts
@@ -4,7 +4,7 @@ import { RESET_SUCCEEDED, stripPrefix } from 'store/lineup/actions'
 import { initialLineupState } from 'store/lineup/reducer'
 import { PREFIX } from 'store/pages/saved-page/lineups/tracks/actions'
 
-const initialState = {
+export const initialState = {
   ...initialLineupState,
   prefix: PREFIX
 }

--- a/packages/common/src/store/pages/saved-page/reducer.ts
+++ b/packages/common/src/store/pages/saved-page/reducer.ts
@@ -13,7 +13,9 @@ import {
   REMOVE_LOCAL_SAVE,
   END_FETCHING
 } from 'store/pages/saved-page/actions'
-import tracksReducer from 'store/pages/saved-page/lineups/tracks/reducer'
+import tracksReducer, {
+  initialState as initialLineupState
+} from 'store/pages/saved-page/lineups/tracks/reducer'
 
 import { PREFIX as tracksPrefix } from './lineups/tracks/actions'
 
@@ -23,7 +25,8 @@ const initialState = {
   saves: [],
   initialFetch: false,
   hasReachedEnd: false,
-  fetchingMore: false
+  fetchingMore: false,
+  tracks: initialLineupState
 }
 
 const actionsMap = {

--- a/packages/common/src/store/pages/search-results/lineup/tracks/reducer.ts
+++ b/packages/common/src/store/pages/search-results/lineup/tracks/reducer.ts
@@ -4,7 +4,7 @@ import { PREFIX } from 'store/pages/search-results/lineup/tracks/actions'
 
 import { LineupState, Track } from '../../../../../models'
 
-const initialState: LineupState<Track> = {
+export const initialState: LineupState<Track> = {
   ...initialLineupState,
   prefix: PREFIX,
   containsDeleted: false

--- a/packages/common/src/store/pages/search-results/reducer.ts
+++ b/packages/common/src/store/pages/search-results/reducer.ts
@@ -14,7 +14,9 @@ import {
   FetchSearchPageTagsFailedAction
 } from 'store/pages/search-results/actions'
 import { PREFIX } from 'store/pages/search-results/lineup/tracks/actions'
-import tracksReducer from 'store/pages/search-results/lineup/tracks/reducer'
+import tracksReducer, {
+  initialState as initialLineupState
+} from 'store/pages/search-results/lineup/tracks/reducer'
 
 import { Status } from '../../../models'
 
@@ -71,21 +73,7 @@ const initialState: SearchPageState = {
   albumIds: undefined,
   playlistIds: undefined,
   artistIds: undefined,
-  tracks: {
-    entries: [],
-    order: {},
-    total: 0,
-    deleted: 0,
-    nullCount: 0,
-    status: Status.LOADING,
-    hasMore: true,
-    inView: false,
-    prefix: '',
-    page: 0,
-    isMetadataLoading: false,
-    maxEntries: null,
-    containsDeleted: false
-  }
+  tracks: initialLineupState
 }
 
 const actionsMap = {

--- a/packages/common/src/store/pages/track/lineup/reducer.ts
+++ b/packages/common/src/store/pages/track/lineup/reducer.ts
@@ -4,7 +4,7 @@ import { RESET_SUCCEEDED, stripPrefix } from 'store/lineup/actions'
 import { initialLineupState } from 'store/lineup/reducer'
 import { PREFIX } from 'store/pages/track/lineup/actions'
 
-const initialState = {
+export const initialState = {
   ...initialLineupState,
   prefix: PREFIX,
   maxEntries: 6

--- a/packages/common/src/store/pages/track/reducer.ts
+++ b/packages/common/src/store/pages/track/reducer.ts
@@ -1,7 +1,9 @@
 // @ts-nocheck
 // TODO(nkang) - convert to TS
 import { asLineup } from 'store/lineup/reducer'
-import tracksReducer from 'store/pages/track/lineup/reducer'
+import tracksReducer, {
+  initialState as initialLineupState
+} from 'store/pages/track/lineup/reducer'
 
 import {
   SET_TRACK_ID,
@@ -23,7 +25,8 @@ const initialState = {
     week: null,
     month: null,
     year: null
-  }
+  },
+  tracks: initialLineupState
 }
 
 const actionsMap = {

--- a/packages/common/src/store/pages/trending-playlists/slice.ts
+++ b/packages/common/src/store/pages/trending-playlists/slice.ts
@@ -3,9 +3,13 @@ import { combineReducers, createSlice } from '@reduxjs/toolkit'
 import { asLineup } from 'store/lineup/reducer'
 
 import { PREFIX } from './lineups/actions'
-import playlistsReducer from './lineups/reducer'
+import playlistsReducer, {
+  initialState as initialLineupState
+} from './lineups/reducer'
 
-const initialState = {}
+const initialState = {
+  trending: initialLineupState
+}
 
 const slice = createSlice({
   name: 'application/pages/trendingPlaylists',

--- a/packages/common/src/store/pages/trending-underground/lineup/reducer.ts
+++ b/packages/common/src/store/pages/trending-underground/lineup/reducer.ts
@@ -5,7 +5,7 @@ import { LineupState, Track } from '../../../../models'
 
 import { PREFIX } from './actions'
 
-const initialState: LineupState<Track> = {
+export const initialState: LineupState<Track> = {
   ...initialLineupState,
   prefix: PREFIX
 }

--- a/packages/common/src/store/pages/trending-underground/slice.ts
+++ b/packages/common/src/store/pages/trending-underground/slice.ts
@@ -3,9 +3,11 @@ import { combineReducers, createSlice } from '@reduxjs/toolkit'
 import { asLineup } from 'store/lineup/reducer'
 
 import { PREFIX } from './lineup/actions'
-import trendingReducer from './lineup/reducer'
+import trendingReducer, {
+  initialState as initialLineupState
+} from './lineup/reducer'
 
-const initialState = {}
+const initialState = { trending: initialLineupState }
 
 const slice = createSlice({
   name: 'application/pages/trendingUnderground',

--- a/packages/common/src/store/pages/trending/lineup/reducer.ts
+++ b/packages/common/src/store/pages/trending/lineup/reducer.ts
@@ -22,6 +22,12 @@ type ResetSucceededAction = {
   type: typeof RESET_SUCCEEDED
 }
 
+export const makeInitialState = (prefix: string) => ({
+  ...initialState,
+  entryIds: new Set() as Set<UID>,
+  prefix
+})
+
 const makeActionsMap = (initialState: TrendingLineupState) => {
   return {
     [RESET_SUCCEEDED](
@@ -35,11 +41,7 @@ const makeActionsMap = (initialState: TrendingLineupState) => {
 }
 
 const makeTrendingReducer = (prefix: string) => {
-  const newInitialState = {
-    ...initialState,
-    entryIds: new Set() as Set<UID>,
-    prefix
-  }
+  const newInitialState = makeInitialState(prefix)
   const newActionsMap = makeActionsMap(newInitialState)
 
   return (state = newInitialState, action: ResetSucceededAction) => {

--- a/packages/common/src/store/pages/trending/reducer.ts
+++ b/packages/common/src/store/pages/trending/reducer.ts
@@ -15,7 +15,12 @@ import { GENRES } from 'utils/genres'
 
 import { TimeRange } from '../../../models'
 
-import { trendingWeek, trendingMonth, trendingAllTime } from './lineup/reducer'
+import {
+  trendingWeek,
+  trendingMonth,
+  trendingAllTime,
+  makeInitialState
+} from './lineup/reducer'
 
 const urlParams = new URLSearchParams(window.location.search)
 const genre = urlParams.get('genre')
@@ -26,7 +31,10 @@ const initialState = {
     ? timeRange
     : TimeRange.WEEK,
   trendingGenre: Object.values(GENRES).includes(genre) ? genre : null,
-  lastFetchedTrendingGenre: null
+  lastFetchedTrendingGenre: null,
+  trendingWeek: makeInitialState(TRENDING_WEEK_PREFIX),
+  trendingMonth: makeInitialState(TRENDING_MONTH_PREFIX),
+  trendingAllTime: makeInitialState(TRENDING_ALL_TIME_PREFIX)
 }
 
 const actionsMap = {
@@ -57,17 +65,7 @@ const trendingAllTimeReducer = asLineup(
   trendingAllTime
 )
 
-const reducer = (state, action) => {
-  // On first run, create our initial state
-  if (!state) {
-    return {
-      ...initialState,
-      trendingWeek: trendingWeekReducer(state, action),
-      trendingMonth: trendingMonthReducer(state, action),
-      trendingAllTime: trendingAllTimeReducer(state, action)
-    }
-  }
-
+const reducer = (state = initialState, action) => {
   const trendingWeek = trendingWeekReducer(state.trendingWeek, action)
   if (trendingWeek !== state.trendingWeek) return { ...state, trendingWeek }
 

--- a/packages/web/src/pages/deleted-page/store/slice.ts
+++ b/packages/web/src/pages/deleted-page/store/slice.ts
@@ -3,12 +3,14 @@ import { createSlice } from '@reduxjs/toolkit'
 import { combineReducers } from 'redux'
 
 import { PREFIX as moreByPrefix } from './lineups/more-by/actions'
-import moreByTracksReducer from './lineups/more-by/reducer'
+import moreByTracksReducer, {
+  initialState as initialLineupState
+} from './lineups/more-by/reducer'
 const { asLineup } = lineupReducer
 
 type State = {}
 
-const initialState: State = {}
+const initialState: State = { moreBy: initialLineupState }
 
 const slice = createSlice({
   name: 'application/pages/remixes',


### PR DESCRIPTION
### Description

Rough bug. Turns out the way we initialize lineup reducers is bad.
Cannot read order of undefined comes from the fact that an action gets dispatched against feed when you repost *any* track https://github.com/AudiusProject/audius-client/blob/61d832b5e78ecfffd5f26c9bdcd96758ac5b61b1/packages/web/src/common/store/pages/profile/lineups/feed/sagas.js#L119 and that hits an `undefined` value for the feed lineup slice.

This removes the lazy init and normalizes a few things.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

This is a deep cut. Major lineup change (but should be for the better)

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally vs staging. Bug no longer reproable

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

