### PR TITLE
[C-2200] Fix profile tabs loading/empty states

### DIFF
--- a/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/AlbumsTab.tsx
@@ -15,6 +15,8 @@ import { useSelectProfile } from './selectors'
 const { getProfileAlbums, getCollectionsStatus } = profilePageSelectors
 const { fetchCollections } = profilePageActions
 
+const emptyAlbums = []
+
 export const AlbumsTab = () => {
   const { handle, album_count } = useSelectProfile(['handle', 'album_count'])
   const albums = useSelector((state) => getProfileAlbums(state, handle))
@@ -33,7 +35,7 @@ export const AlbumsTab = () => {
   return (
     <CollectionList
       listKey='profile-albums'
-      collection={albums}
+      collection={album_count > 0 ? albums : emptyAlbums}
       ListEmptyComponent={<EmptyProfileTile tab='albums' />}
       disableTopTabScroll
       showsVerticalScrollIndicator={false}

--- a/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/PlaylistsTab.tsx
@@ -15,6 +15,8 @@ import { useSelectProfile } from './selectors'
 const { getProfilePlaylists, getCollectionsStatus } = profilePageSelectors
 const { fetchCollections } = profilePageActions
 
+const emptyPlaylists = []
+
 export const PlaylistsTab = () => {
   const { handle, playlist_count } = useSelectProfile([
     'handle',
@@ -36,7 +38,7 @@ export const PlaylistsTab = () => {
   return (
     <CollectionList
       listKey='profile-playlists'
-      collection={playlists}
+      collection={playlist_count > 0 ? playlists : emptyPlaylists}
       ListEmptyComponent={<EmptyProfileTile tab='playlists' />}
       disableTopTabScroll
       showsVerticalScrollIndicator={false}

--- a/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileTabNavigator.tsx
@@ -89,7 +89,7 @@ export const ProfileTabNavigator = ({
     name: 'Reposts',
     Icon: IconRepost,
     component: RepostsTab,
-    initialParams,
+    initialParams: isArtist ? { ...initialParams, lazy: true } : initialParams,
     refreshing,
     onRefresh,
     scrollY: animatedValue

--- a/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/RepostsTab.tsx
@@ -5,15 +5,19 @@ import {
   profilePageFeedLineupActions as feedActions,
   useProxySelector
 } from '@audius/common'
+import { useRoute } from '@react-navigation/native'
 
 import { Lineup } from 'app/components/lineup'
 
 import { EmptyProfileTile } from './EmptyProfileTile'
+import type { ProfileTabRoutes } from './routes'
 import { useSelectProfile } from './selectors'
 
 const { getProfileFeedLineup } = profilePageSelectors
 
 export const RepostsTab = () => {
+  const { params } = useRoute<ProfileTabRoutes<'Reposts'>>()
+  const { lazy } = params
   const { handle, repost_count } = useSelectProfile(['handle', 'repost_count'])
   const handleLower = handle.toLowerCase()
 
@@ -31,12 +35,12 @@ export const RepostsTab = () => {
     <Lineup
       listKey='profile-reposts'
       selfLoad
-      lazy
+      lazy={lazy}
       actions={feedActions}
       lineup={lineup}
       limit={repost_count}
       disableTopTabScroll
-      ListEmptyComponent={<EmptyProfileTile tab='reposts' />}
+      LineupEmptyComponent={<EmptyProfileTile tab='reposts' />}
       showsVerticalScrollIndicator={false}
       extraFetchOptions={extraFetchOptions}
     />

--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -56,7 +56,7 @@ export const TracksTab = () => {
       limit={track_count}
       loadMore={loadMore}
       disableTopTabScroll
-      ListEmptyComponent={<EmptyProfileTile tab='tracks' />}
+      LineupEmptyComponent={<EmptyProfileTile tab='tracks' />}
       showsVerticalScrollIndicator={false}
     />
   )

--- a/packages/mobile/src/screens/profile-screen/routes.ts
+++ b/packages/mobile/src/screens/profile-screen/routes.ts
@@ -1,0 +1,11 @@
+import type { RouteProp } from '@react-navigation/native'
+
+type ProfileTabParamList = {
+  Reposts: { lazy: boolean }
+  Albums: {}
+  Playlists: {}
+  Collectibles: {}
+}
+
+export type ProfileTabRoutes<RouteName extends keyof ProfileTabParamList> =
+  RouteProp<ProfileTabParamList, RouteName>


### PR DESCRIPTION
### Description

Fixes a few issues with profile tab loading and empty states.
- Fixes case where album/playlist-count == 0 wasn't showing empty tile
- Fixes case where ListEmptyComponent was used instead of LineupEmptyComponent, resulting in empty lineups rendering nothing
- Fixes case where RepostsTab was always lazy, resulting in issues for non-artists. Fixed by passing `lazy: true` to reposts only for non-artists
