### PR TITLE
Fix image loading issues w Share to X

### DIFF
--- a/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
+++ b/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
@@ -123,8 +123,7 @@ export const ShareDrawer = () => {
     handleShareToInstagramStory,
     handleShareToSnapchat,
     handleShareToTikTok: handleShareVideoToTiktok,
-    selectedPlatform,
-    shouldRenderShareToStorySticker
+    selectedPlatform
   } = useShareToStory({ content, viewShotRef })
 
   const handleCopyLink = useCallback(() => {
@@ -264,7 +263,7 @@ export const ShareDrawer = () => {
   return (
     <>
       {/* Redundant `content?.type === 'track'` needed to make TS happy */}
-      {content?.type === 'track' && shouldRenderShareToStorySticker ? (
+      {content?.type === 'track' ? (
         <ViewShot
           style={styles.viewShot}
           ref={viewShotRef}

--- a/packages/mobile/src/components/share-drawer/ShareToStorySticker.tsx
+++ b/packages/mobile/src/components/share-drawer/ShareToStorySticker.tsx
@@ -1,7 +1,7 @@
 import type { Track, User } from '@audius/common'
 import { SquareSizes } from '@audius/common'
 import type { StyleProp, ViewStyle } from 'react-native'
-import { Image, View } from 'react-native'
+import { View } from 'react-native'
 
 import AudiusLogo from 'app/assets/images/audiusLogoHorizontal.svg'
 import { Divider, Text } from 'app/components/core'
@@ -9,7 +9,7 @@ import UserBadges from 'app/components/user-badges'
 import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
-import { useTrackImage } from '../image/TrackImage'
+import { TrackImage } from '../image/TrackImage'
 
 const messages = {
   by: 'by',
@@ -83,23 +83,16 @@ export const ShareToStorySticker = ({
 }: ShareToStoryStickerProps) => {
   const styles = useStyles()
 
-  const trackImage = useTrackImage({
-    track,
-    user,
-    size: SquareSizes.SIZE_480_BY_480
-  })
   const { neutralLight2, staticNeutralLight8 } = useThemeColors()
   return (
     <View style={[styles.container, style]}>
       <View>
-        {trackImage ? (
-          <Image
-            style={styles.trackImage}
-            onLoad={onLoad}
-            source={trackImage.source}
-            onError={trackImage.handleError}
-          />
-        ) : null}
+        <TrackImage
+          size={SquareSizes.SIZE_480_BY_480}
+          style={styles.trackImage}
+          track={track}
+          onLoad={onLoad}
+        />
         <Text
           color='staticNeutral'
           allowFontScaling={false}

--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -124,8 +124,6 @@ export const useShareToStory = ({
   const { toast } = useToast()
   const dispatch = useDispatch()
   const cancelRef = useRef(false)
-  const [shouldRenderShareToStorySticker, setShouldRenderShareToStorySticker] =
-    useState(false)
   const [selectedPlatform, setSelectedPlatform] =
     useState<ShareToStoryPlatform | null>(null)
   const trackTitle =
@@ -295,9 +293,6 @@ export const useShareToStory = ({
 
         // Step 1: Render and take a screenshot of the sticker:
         // Note: We have to capture the sticker image first because it doesn't work if you get the dominant colors first (mysterious).
-        if (!shouldRenderShareToStorySticker) {
-          setShouldRenderShareToStorySticker(true)
-        }
         const encodedTrackId = encodeHashId(content.track.track_id)
         const streamMp3Url = apiClient.makeUrl(
           `/tracks/${encodedTrackId}/stream`
@@ -449,7 +444,6 @@ export const useShareToStory = ({
       content,
       toggleProgressDrawer,
       captureStickerImage,
-      shouldRenderShareToStorySticker,
       pasteToInstagramApp,
       pasteToSnapchatApp,
       handleError,
@@ -526,7 +520,6 @@ export const useShareToStory = ({
     handleShareToInstagramStory,
     handleShareToTikTok,
     selectedPlatform,
-    shouldRenderShareToStorySticker,
     cancelStory
   }
 }


### PR DESCRIPTION
### Description
For some reason, about half the tracks fail to "Share to X" on the first time because the "sticker" image (which is loaded and captured off screen) fails to load in time.

Not sure why or how this regression occurred. But the changes in this PR fix this ~90-95% of the time.
-Use TrackImage component directly in the sticker, which uses FastImage under the hood
-Load the sticker as soon as you open the drawer (instead of when you click "Share to X")

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

