### PR TITLE
[C-2207] Fix scrubber timestamp sync issues

### DIFF
--- a/packages/mobile/src/components/scrubber/Scrubber.tsx
+++ b/packages/mobile/src/components/scrubber/Scrubber.tsx
@@ -70,7 +70,12 @@ export const Scrubber = (props: ScrubberProps) => {
     setIsInteracting(true)
   }, [onPressIn])
 
-  const handlePressOut = useCallback(
+  const handlePressOut = useCallback(() => {
+    onPressOut()
+    setIsInteracting(false)
+  }, [onPressOut])
+
+  const handleNewPosition = useCallback(
     (percentComplete: number) => {
       const newPosition = percentComplete * duration
       if (duration) {
@@ -105,6 +110,7 @@ export const Scrubber = (props: ScrubberProps) => {
         isPlaying={isPlaying}
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
+        onNewPosition={handleNewPosition}
         onDrag={handleDrag}
         onDragRelease={handleDragRelease}
         duration={duration}

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -82,10 +82,11 @@ type SliderProps = {
    * Callback invoked when focus is gained on the scrubber
    */
   onPressIn: () => void
+  onPressOut: () => void
   /**
    * Callback invoked when focus is lost on the scrubber
    */
-  onPressOut: (percentComplete: number) => void
+  onNewPosition: (percentComplete: number) => void
   /**
    * Callback invoked when dragging on the scrubber. A drag
    * begins by grabbing the handle or pressing the rail
@@ -108,6 +109,7 @@ export const Slider = memo((props: SliderProps) => {
     duration,
     onPressIn,
     onPressOut,
+    onNewPosition,
     onDrag,
     onDragRelease
   } = props
@@ -195,24 +197,23 @@ export const Slider = memo((props: SliderProps) => {
     [isPlaying, duration, play]
   )
 
+  const handlePressOut = useCallback(() => {
+    handlePressHandleOut()
+    onPressOut()
+  }, [handlePressHandleOut, onPressOut])
+
   const onReleaseRail = useCallback(
     (e: GestureResponderEvent) => {
       const newPosition = e.nativeEvent.pageX - railPageX
       const percentComplete = newPosition / railWidth
-      onPressOut(percentComplete)
-      handlePressHandleOut()
+      onNewPosition(percentComplete)
+      handlePressOut()
       animateFromNowToEnd(percentComplete)
     },
-    [
-      onPressOut,
-      handlePressHandleOut,
-      railPageX,
-      railWidth,
-      animateFromNowToEnd
-    ]
+    [onNewPosition, handlePressOut, railPageX, railWidth, animateFromNowToEnd]
   )
 
-  const onPressHandle = useCallback(
+  const onPressInHandle = useCallback(
     (event: GestureResponderEvent) => {
       const newPosition = event.nativeEvent.pageX - railPageX
       setHandlePosition(newPosition)
@@ -225,10 +226,10 @@ export const Slider = memo((props: SliderProps) => {
 
   const onReleaseHandle = useCallback(
     (percentComplete: number) => {
-      onPressOut(percentComplete)
+      onNewPosition(percentComplete)
       animateFromNowToEnd(percentComplete)
     },
-    [onPressOut, animateFromNowToEnd]
+    [onNewPosition, animateFromNowToEnd]
   )
 
   const panResponder = useMemo(
@@ -380,8 +381,8 @@ export const Slider = memo((props: SliderProps) => {
         ]}
       >
         <Animated.View
-          onTouchStart={onPressHandle}
-          onTouchEnd={handlePressHandleOut}
+          onTouchStart={onPressInHandle}
+          onTouchEnd={handlePressOut}
           hitSlop={{ top: 16, bottom: 16, right: 16, left: 16 }}
           style={[styles.handle, { transform: [{ scale: handleScale }] }]}
         />

--- a/packages/mobile/src/components/scrubber/usePosition.ts
+++ b/packages/mobile/src/components/scrubber/usePosition.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef } from 'react'
 
 import { formatSeconds } from '@audius/common'
+import { useAppState } from '@react-native-community/hooks'
 import type { TextInput } from 'react-native'
+import TrackPlayer from 'react-native-track-player'
+import { useAsync } from 'react-use'
 
 export const usePosition = (
   mediaKey: string,
@@ -46,6 +49,16 @@ export const usePosition = (
       clearTimeout(currentTimeout)
     }
   }, [isPlaying, isInteracting, duration])
+
+  // Android pauses timeouts when in background, so we use app state
+  // to trigger a position coercion
+  const appState = useAppState()
+
+  useAsync(async () => {
+    if (appState === 'active') {
+      positionRef.current = await TrackPlayer.getPosition()
+    }
+  }, [appState])
 
   useEffect(() => {
     setPosition(0)


### PR DESCRIPTION
### Description

Fixes two issues with timestamp sync:
1. When touching the scrubber handle and not dragging, the timestamp does not continue, since "isInteracting" was not properly being set to false
2. When going to background on android, `setTimeouts` are paused, resulting in inconsistent timer.