### PR TITLE
[C-2042] Fix empty collection on deep link

### DIFF
--- a/packages/common/src/store/pages/collection/actions.ts
+++ b/packages/common/src/store/pages/collection/actions.ts
@@ -5,6 +5,8 @@ export const FETCH_COLLECTION = 'FETCH_COLLECTION'
 export const FETCH_COLLECTION_SUCCEEDED = 'FETCH_COLLECTION_SUCCEEDED'
 export const FETCH_COLLECTION_FAILED = 'FETCH_COLLECTION_FAILED'
 export const RESET_COLLECTION = 'RESET_COLLECTION'
+export const RESET_AND_FETCH_COLLECTION_TRACKS =
+  'RESET_AND_FETCH_COLLECTION_TRACKS'
 export const SET_SMART_COLLECTION = 'SET_SMART_COLLECTION'
 export const SET_COLLECTION_PERMALINK = 'SET_COLLECTION_PERMALINK'
 
@@ -42,6 +44,13 @@ export const resetCollection = (
   type: RESET_COLLECTION,
   collectionUid,
   userUid
+})
+
+export const resetAndFetchCollectionTracks = (
+  collectionId: Nullable<ID | SmartCollectionVariant>
+) => ({
+  type: RESET_AND_FETCH_COLLECTION_TRACKS,
+  collectionId
 })
 
 export const setSmartCollection = (

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -27,7 +27,7 @@ import { formatCount } from 'app/utils/format'
 
 import { CollectionHeader } from './CollectionHeader'
 import { useCollectionLineup } from './useCollectionLineup'
-const { resetAndFetchCollection } = collectionPageActions
+const { resetAndFetchCollectionTracks } = collectionPageActions
 const { getPlaying, getUid, getCurrentTrack } = playerSelectors
 const { getIsReachable } = reachabilitySelectors
 
@@ -88,7 +88,7 @@ export const CollectionScreenDetailsTile = ({
   const isReachable = useSelector(getIsReachable)
 
   const fetchLineup = useCallback(() => {
-    dispatch(resetAndFetchCollection(collectionId))
+    dispatch(resetAndFetchCollectionTracks(collectionId))
   }, [dispatch, collectionId])
 
   const { entries, status } = useCollectionLineup(collectionId, fetchLineup)

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -9,7 +9,6 @@ import {
   PlaybackSource,
   formatSecondsAsText,
   collectionPageLineupActions as tracksActions,
-  collectionPageSelectors,
   reachabilitySelectors
 } from '@audius/common'
 import { View } from 'react-native'
@@ -28,8 +27,7 @@ import { formatCount } from 'app/utils/format'
 
 import { CollectionHeader } from './CollectionHeader'
 import { useCollectionLineup } from './useCollectionLineup'
-const { getCollectionUid, getUserUid } = collectionPageSelectors
-const { fetchCollection, resetCollection } = collectionPageActions
+const { resetAndFetchCollection } = collectionPageActions
 const { getPlaying, getUid, getCurrentTrack } = playerSelectors
 const { getIsReachable } = reachabilitySelectors
 
@@ -89,20 +87,9 @@ export const CollectionScreenDetailsTile = ({
 
   const isReachable = useSelector(getIsReachable)
 
-  const collectionUid = useSelector(getCollectionUid)
-  const userUid = useSelector(getUserUid)
-
   const fetchLineup = useCallback(() => {
-    dispatch(resetCollection(collectionUid, userUid))
-
-    // Need to refetch the collection after resetting
-    // Will pull from cache if it exists
-    // TODO: fix this for smart collections
-    if (typeof collectionId === 'number') {
-      dispatch(fetchCollection(collectionId))
-    }
-    dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined))
-  }, [dispatch, collectionUid, userUid, collectionId])
+    dispatch(resetAndFetchCollection(collectionId))
+  }, [dispatch, collectionId])
 
   const { entries, status } = useCollectionLineup(collectionId, fetchLineup)
   const trackUids = useMemo(() => entries.map(({ uid }) => uid), [entries])


### PR DESCRIPTION
### Description

* Fix empty collection lineup upon deep linking due not waiting for the reset action to complete before triggering the fetch
* Sequence reset and fetch actions by putting into a new saga

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

