### PR TITLE
Rename is_repost_of_repost and move repost metadata logic

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1174,7 +1174,7 @@ export const audiusBackend = ({
 
   async function repostTrack(
     trackId: ID,
-    metadata?: { is_repost_repost: boolean }
+    metadata?: { is_repost_of_repost: boolean }
   ) {
     try {
       return await audiusLibs.EntityManager.repostTrack(
@@ -1198,7 +1198,7 @@ export const audiusBackend = ({
 
   async function repostCollection(
     playlistId: ID,
-    metadata?: { is_repost_repost: boolean }
+    metadata?: { is_repost_of_repost: boolean }
   ) {
     try {
       return audiusLibs.EntityManager.repostPlaylist(

--- a/packages/common/src/store/social/collections/actions.ts
+++ b/packages/common/src/store/social/collections/actions.ts
@@ -26,10 +26,11 @@ export const SHARE_AUDIO_NFT_PLAYLIST = 'SOCIAL/SHARE_AUDIO_NFT_PLAYLIST'
 
 export const repostCollection = createCustomAction(
   REPOST_COLLECTION,
-  (collectionId: ID, source: RepostSource, metadata?: any) => ({
+  (collectionId: ID, source: RepostSource, isFeed = false, metadata?: any) => ({
     collectionId,
     metadata,
-    source
+    source,
+    isFeed
   })
 )
 

--- a/packages/common/src/store/social/tracks/actions.ts
+++ b/packages/common/src/store/social/tracks/actions.ts
@@ -32,7 +32,7 @@ export const repostTrack = createCustomAction(
   (
     trackId: ID,
     source: RepostSource,
-    metadata?: { is_repost_repost: boolean }
+    metadata?: { is_repost_of_repost: boolean }
   ) => ({
     trackId,
     source,

--- a/packages/common/src/store/social/tracks/actions.ts
+++ b/packages/common/src/store/social/tracks/actions.ts
@@ -29,14 +29,10 @@ export const SHARE_TRACK = 'SOCIAL/SHARE_TRACK'
 
 export const repostTrack = createCustomAction(
   REPOST_TRACK,
-  (
-    trackId: ID,
-    source: RepostSource,
-    metadata?: { is_repost_of_repost: boolean }
-  ) => ({
+  (trackId: ID, source: RepostSource, isFeed = false) => ({
     trackId,
     source,
-    metadata
+    isFeed
   })
 )
 

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -103,7 +103,7 @@ export function* confirmRepostCollection(
   ownerId: ID,
   collectionId: ID,
   user: User,
-  metadata: { is_repost_repost: boolean }
+  metadata: { is_repost_of_repost: boolean }
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -78,12 +78,19 @@ export function* repostCollectionAsync(
   })
   yield* put(event)
 
+  const repostMetadata = action.isFeed
+    ? // If we're on the feed, and someone i follow has
+      // reposted the content i am reposting,
+      // is_repost_of_repost is true
+      { is_repost_of_repost: collection.followee_reposts.length !== 0 }
+    : { is_repost_of_repost: false }
+
   yield* call(
     confirmRepostCollection,
     collection.playlist_owner_id,
     action.collectionId,
     user,
-    action.metadata
+    repostMetadata
   )
 
   yield* put(

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -65,10 +65,16 @@ export function* repostTrackAsync(
   })
   yield* put(event)
 
-  yield* call(confirmRepostTrack, action.trackId, user, action.metadata)
-
   const track = yield* select(getTrack, { id: action.trackId })
   if (!track) return
+
+  const repostMetadata = action.isFeed
+    ? // If we're on the feed, and someone i follow has
+      // reposted the content i am reposting,
+      // is_repost_of_repost is true
+      { is_repost_of_repost: track.followee_reposts.length !== 0 }
+    : { is_repost_of_repost: false }
+  yield* call(confirmRepostTrack, action.trackId, user, repostMetadata)
 
   const eagerlyUpdatedMetadata: Partial<Track> = {
     has_current_user_reposted: true,

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -67,8 +67,8 @@ export function* repostTrackAsync(
 
   yield* call(confirmRepostTrack, action.trackId, user, action.metadata)
 
-  const tracks = yield* select(getTracks, { ids: [action.trackId] })
-  const track = tracks[action.trackId]
+  const track = yield* select(getTrack, { id: action.trackId })
+  if (!track) return
 
   const eagerlyUpdatedMetadata: Partial<Track> = {
     has_current_user_reposted: true,
@@ -141,7 +141,7 @@ export function* repostTrackAsync(
 export function* confirmRepostTrack(
   trackId: ID,
   user: User,
-  metadata?: { is_repost_repost: boolean }
+  metadata?: { is_repost_of_repost: boolean }
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -387,28 +387,13 @@ const ConnectedPlaylistTile = memo(
       }
     }, [saveCollection, unsaveCollection, id, isFavorited])
 
-    const onRepostMetadata = useMemo(() => {
-      return isFeed
-        ? // If we're on the feed, and someone i follow has
-          // reposted the content i am reposting,
-          // is_repost_of_repost is true
-          { is_repost_of_repost: followeeReposts.length !== 0 }
-        : { is_repost_of_repost: false }
-    }, [followeeReposts, isFeed])
-
     const onClickRepost = useCallback(() => {
       if (isReposted) {
         undoRepostCollection(id)
       } else {
-        repostCollection(id, onRepostMetadata)
+        repostCollection(id, isFeed)
       }
-    }, [
-      repostCollection,
-      undoRepostCollection,
-      id,
-      isReposted,
-      onRepostMetadata
-    ])
+    }, [repostCollection, undoRepostCollection, id, isReposted, isFeed])
 
     const onClickShare = useCallback(() => {
       shareCollection(id)
@@ -585,8 +570,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
           source: ShareSource.TILE
         })
       ),
-    repostCollection: (id: ID, metadata: { is_repost_of_repost: boolean }) =>
-      dispatch(repostCollection(id, RepostSource.TILE, metadata)),
+    repostCollection: (id: ID, isFeed: boolean) =>
+      dispatch(repostCollection(id, RepostSource.TILE, isFeed)),
     undoRepostCollection: (id: ID) =>
       dispatch(undoRepostCollection(id, RepostSource.TILE)),
     saveCollection: (id: ID) =>

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -391,9 +391,9 @@ const ConnectedPlaylistTile = memo(
       return isFeed
         ? // If we're on the feed, and someone i follow has
           // reposted the content i am reposting,
-          // is_repost_repost is true
-          { is_repost_repost: followeeReposts.length !== 0 }
-        : { is_repost_repost: false }
+          // is_repost_of_repost is true
+          { is_repost_of_repost: followeeReposts.length !== 0 }
+        : { is_repost_of_repost: false }
     }, [followeeReposts, isFeed])
 
     const onClickRepost = useCallback(() => {
@@ -585,7 +585,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
           source: ShareSource.TILE
         })
       ),
-    repostCollection: (id: ID, metadata: { is_repost_repost: boolean }) =>
+    repostCollection: (id: ID, metadata: { is_repost_of_repost: boolean }) =>
       dispatch(repostCollection(id, RepostSource.TILE, metadata)),
     undoRepostCollection: (id: ID) =>
       dispatch(undoRepostCollection(id, RepostSource.TILE)),

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -313,9 +313,9 @@ const ConnectedTrackTile = memo(
       return isFeed
         ? // If we're on the feed, and someone i follow has
           // reposted the content i am reposting,
-          // is_repost_repost is true
-          { is_repost_repost: followee_reposts.length !== 0 }
-        : { is_repost_repost: false }
+          // is_repost_of_repost is true
+          { is_repost_of_repost: followee_reposts.length !== 0 }
+        : { is_repost_of_repost: false }
     }, [followee_reposts, isFeed])
 
     const onClickRepost = useCallback(() => {
@@ -435,7 +435,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
           source: ShareSource.TILE
         })
       ),
-    repostTrack: (trackId: ID, metadata: { is_repost_repost: boolean }) =>
+    repostTrack: (trackId: ID, metadata: { is_repost_of_repost: boolean }) =>
       dispatch(repostTrack(trackId, RepostSource.TILE, metadata)),
     undoRepostTrack: (trackId: ID) =>
       dispatch(undoRepostTrack(trackId, RepostSource.TILE)),

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -1,7 +1,6 @@
 import {
   memo,
   useState,
-  useMemo,
   useCallback,
   useEffect,
   MouseEvent,

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -309,22 +309,13 @@ const ConnectedTrackTile = memo(
       }
     }, [saveTrack, unsaveTrack, trackId, isFavorited])
 
-    const onRepostMetadata = useMemo(() => {
-      return isFeed
-        ? // If we're on the feed, and someone i follow has
-          // reposted the content i am reposting,
-          // is_repost_of_repost is true
-          { is_repost_of_repost: followee_reposts.length !== 0 }
-        : { is_repost_of_repost: false }
-    }, [followee_reposts, isFeed])
-
     const onClickRepost = useCallback(() => {
       if (isReposted) {
         undoRepostTrack(trackId)
       } else {
-        repostTrack(trackId, onRepostMetadata)
+        repostTrack(trackId, isFeed)
       }
-    }, [repostTrack, undoRepostTrack, trackId, isReposted, onRepostMetadata])
+    }, [repostTrack, undoRepostTrack, trackId, isReposted, isFeed])
 
     const onClickShare = useCallback(() => {
       shareTrack(trackId)
@@ -435,8 +426,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
           source: ShareSource.TILE
         })
       ),
-    repostTrack: (trackId: ID, metadata: { is_repost_of_repost: boolean }) =>
-      dispatch(repostTrack(trackId, RepostSource.TILE, metadata)),
+    repostTrack: (trackId: ID, isFeed: boolean) =>
+      dispatch(repostTrack(trackId, RepostSource.TILE, isFeed)),
     undoRepostTrack: (trackId: ID) =>
       dispatch(undoRepostTrack(trackId, RepostSource.TILE)),
     saveTrack: (trackId: ID) =>

--- a/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -112,22 +112,13 @@ const ConnectedPlaylistTile = memo(
       }
     }, [collection, unsaveCollection, saveCollection])
 
-    const onRepostMetadata = useMemo(() => {
-      return isFeed
-        ? // If we're on the feed, and someone i follow has
-          // reposted the content i am reposting,
-          // is_repost_of_repost is true
-          { is_repost_of_repost: collection.followee_reposts.length !== 0 }
-        : { is_repost_of_repost: false }
-    }, [collection.followee_reposts, isFeed])
-
     const toggleRepost = useCallback(() => {
       if (collection.has_current_user_reposted) {
         unrepostCollection(collection.playlist_id)
       } else {
-        repostCollection(collection.playlist_id, onRepostMetadata)
+        repostCollection(collection.playlist_id, isFeed)
       }
-    }, [collection, unrepostCollection, repostCollection, onRepostMetadata])
+    }, [collection, unrepostCollection, repostCollection, isFeed])
 
     const getRoute = useCallback(() => {
       return collection.is_album
@@ -337,10 +328,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(saveCollection(collectionId, FavoriteSource.TILE)),
     unsaveCollection: (collectionId: ID) =>
       dispatch(unsaveCollection(collectionId, FavoriteSource.TILE)),
-    repostCollection: (
-      collectionId: ID,
-      metadata: { is_repost_of_repost: boolean }
-    ) => dispatch(repostCollection(collectionId, RepostSource.TILE, metadata)),
+    repostCollection: (collectionId: ID, isFeed: boolean) =>
+      dispatch(repostCollection(collectionId, RepostSource.TILE, isFeed)),
     unrepostCollection: (collectionId: ID) =>
       dispatch(undoRepostCollection(collectionId, RepostSource.TILE)),
     clickOverflow: (collectionId: ID, overflowActions: OverflowAction[]) =>

--- a/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -116,9 +116,9 @@ const ConnectedPlaylistTile = memo(
       return isFeed
         ? // If we're on the feed, and someone i follow has
           // reposted the content i am reposting,
-          // is_repost_repost is true
-          { is_repost_repost: collection.followee_reposts.length !== 0 }
-        : { is_repost_repost: false }
+          // is_repost_of_repost is true
+          { is_repost_of_repost: collection.followee_reposts.length !== 0 }
+        : { is_repost_of_repost: false }
     }, [collection.followee_reposts, isFeed])
 
     const toggleRepost = useCallback(() => {
@@ -339,7 +339,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(unsaveCollection(collectionId, FavoriteSource.TILE)),
     repostCollection: (
       collectionId: ID,
-      metadata: { is_repost_repost: boolean }
+      metadata: { is_repost_of_repost: boolean }
     ) => dispatch(repostCollection(collectionId, RepostSource.TILE, metadata)),
     unrepostCollection: (collectionId: ID) =>
       dispatch(undoRepostCollection(collectionId, RepostSource.TILE)),

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -119,9 +119,9 @@ const ConnectedTrackTile = memo(
     const onRepostMetadata = isFeed
       ? // If we're on the feed, and someone i follow has
         // reposted the content i am reposting,
-        // we have a repost of a repost. is_repost_repost is true
-        { is_repost_repost: followee_reposts.length !== 0 }
-      : { is_repost_repost: false }
+        // we have a repost of a repost. is_repost_of_repost is true
+        { is_repost_of_repost: followee_reposts.length !== 0 }
+      : { is_repost_of_repost: false }
 
     const toggleRepost = (trackId: ID) => {
       if (has_current_user_reposted) {
@@ -268,7 +268,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(saveTrack(trackId, FavoriteSource.TILE)),
     unsaveTrack: (trackId: ID) =>
       dispatch(unsaveTrack(trackId, FavoriteSource.TILE)),
-    repostTrack: (trackId: ID, metadata: { is_repost_repost: boolean }) =>
+    repostTrack: (trackId: ID, metadata: { is_repost_of_repost: boolean }) =>
       dispatch(repostTrack(trackId, RepostSource.TILE, metadata)),
     unrepostTrack: (trackId: ID) =>
       dispatch(undoRepostTrack(trackId, RepostSource.TILE)),

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -116,18 +116,11 @@ const ConnectedTrackTile = memo(
       }
     }
 
-    const onRepostMetadata = isFeed
-      ? // If we're on the feed, and someone i follow has
-        // reposted the content i am reposting,
-        // we have a repost of a repost. is_repost_of_repost is true
-        { is_repost_of_repost: followee_reposts.length !== 0 }
-      : { is_repost_of_repost: false }
-
     const toggleRepost = (trackId: ID) => {
       if (has_current_user_reposted) {
         unrepostTrack(trackId)
       } else {
-        repostTrack(trackId, onRepostMetadata)
+        repostTrack(trackId, isFeed)
       }
     }
 
@@ -268,8 +261,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(saveTrack(trackId, FavoriteSource.TILE)),
     unsaveTrack: (trackId: ID) =>
       dispatch(unsaveTrack(trackId, FavoriteSource.TILE)),
-    repostTrack: (trackId: ID, metadata: { is_repost_of_repost: boolean }) =>
-      dispatch(repostTrack(trackId, RepostSource.TILE, metadata)),
+    repostTrack: (trackId: ID, isFeed: boolean) =>
+      dispatch(repostTrack(trackId, RepostSource.TILE, isFeed)),
     unrepostTrack: (trackId: ID) =>
       dispatch(undoRepostTrack(trackId, RepostSource.TILE)),
     clickOverflow: (trackId: ID, overflowActions: OverflowAction[]) =>


### PR DESCRIPTION
### Description
two things:
1. rename is_repost_repost metadata to is_repost_of_repost in the client
2. move repost metadata logic from the web/mobile playlist/track tile components into track and playlist social sagas. this DRYs up the code to generate the logic

### How Has This Been Tested?

Tested locally pointing client against stage. Reposting from feed vs trending and confirming the metadata sent to audius backend is expected.