### PR TITLE
[PLAT-702] Add repost-of-repost notification

### DIFF
--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -39,6 +39,7 @@ export enum NotificationType {
   Follow = 'Follow',
   Favorite = 'Favorite',
   Repost = 'Repost',
+  RepostOfRepost = 'RepostOfRepost',
   Milestone = 'Milestone',
   RemixCreate = 'RemixCreate',
   RemixCosign = 'RemixCosign',
@@ -157,6 +158,36 @@ export type RepostNotification = BaseNotification & {
 }
 
 export type RepostPushNotification = {
+  blocknumber: number
+  entityId: ID
+  initiator: ID
+  timestamp: string
+  type:
+    | PushNotificationType.RepostAlbum
+    | PushNotificationType.RepostPlaylist
+    | PushNotificationType.RepostTrack
+  actions: [
+    {
+      blocknumber: number
+      actionEntityId: ID
+      actionEntityType: Entity.User
+    }
+  ]
+  metadata: {
+    entity_owner_id: ID
+    entity_type: Entity.Album | Entity.Playlist | Entity.Track
+    entity_id: ID
+  }
+}
+
+export type RepostOfRepostNotification = BaseNotification & {
+  type: NotificationType.RepostOfRepost
+  entityId: ID
+  userIds: ID[]
+  entityType: Entity.Playlist | Entity.Album | Entity.Track
+}
+
+export type RepostOfRepostPushNotification = {
   blocknumber: number
   entityId: ID
   initiator: ID
@@ -519,6 +550,7 @@ export type Notification =
   | UserSubscriptionNotification
   | FollowNotification
   | RepostNotification
+  | RepostOfRepostNotification
   | FavoriteNotification
   | MilestoneNotification
   | RemixCreateNotification

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -63,6 +63,9 @@ export enum PushNotificationType {
   RepostTrack = 'RepostTrack',
   RepostPlaylist = 'RepostPlaylist',
   RepostAlbum = 'RepostAlbum',
+  RepostOfRepostTrack = 'RepostOfRepostTrack',
+  RepostOfRepostPlaylist = 'RepostOfRepostPlaylist',
+  RepostOfRepostAlbum = 'RepostOfRepostAlbum',
   MilestoneListen = 'MilestoneListen',
   MilestoneRepost = 'MilestoneRepost',
   MilestoneFavorite = 'MilestoneFavorite',
@@ -193,9 +196,9 @@ export type RepostOfRepostPushNotification = {
   initiator: ID
   timestamp: string
   type:
-    | PushNotificationType.RepostAlbum
-    | PushNotificationType.RepostPlaylist
-    | PushNotificationType.RepostTrack
+    | PushNotificationType.RepostOfRepostAlbum
+    | PushNotificationType.RepostOfRepostPlaylist
+    | PushNotificationType.RepostOfRepostTrack
   actions: [
     {
       blocknumber: number

--- a/packages/mobile/src/hooks/useNotificationNavigation.ts
+++ b/packages/mobile/src/hooks/useNotificationNavigation.ts
@@ -212,6 +212,9 @@ export const useNotificationNavigation = () => {
       [PushNotificationType.RepostAlbum]: socialActionHandler,
       [PushNotificationType.RepostPlaylist]: socialActionHandler,
       [PushNotificationType.RepostTrack]: socialActionHandler,
+      [PushNotificationType.RepostOfRepostAlbum]: socialActionHandler,
+      [PushNotificationType.RepostOfRepostPlaylist]: socialActionHandler,
+      [PushNotificationType.RepostOfRepostTrack]: socialActionHandler,
       [NotificationType.Repost]: socialActionHandler,
       [NotificationType.RepostOfRepost]: socialActionHandler,
       [NotificationType.SupporterDethroned]: (

--- a/packages/mobile/src/hooks/useNotificationNavigation.ts
+++ b/packages/mobile/src/hooks/useNotificationNavigation.ts
@@ -21,6 +21,8 @@ import type {
   RemixCreateNotification,
   RemixCreatePushNotification,
   RepostNotification,
+  RepostOfRepostNotification,
+  RepostOfRepostPushNotification,
   RepostPushNotification,
   SupporterDethronedNotification,
   SupporterRankUpNotification,
@@ -68,6 +70,8 @@ export const useNotificationNavigation = () => {
         | FollowPushNotification
         | RepostNotification
         | RepostPushNotification
+        | RepostOfRepostNotification
+        | RepostOfRepostPushNotification
         | FavoriteNotification
         | FavoritePushNotification
     ) => {
@@ -209,6 +213,7 @@ export const useNotificationNavigation = () => {
       [PushNotificationType.RepostPlaylist]: socialActionHandler,
       [PushNotificationType.RepostTrack]: socialActionHandler,
       [NotificationType.Repost]: socialActionHandler,
+      [NotificationType.RepostOfRepost]: socialActionHandler,
       [NotificationType.SupporterDethroned]: (
         notification: SupporterDethronedNotification
       ) => {

--- a/packages/mobile/src/screens/notifications-screen/NotificationListItem.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationListItem.tsx
@@ -22,6 +22,7 @@ import {
   AddTrackToPlaylistNotification,
   SupporterDethronedNotification
 } from './Notifications'
+import { RepostOfRepostNotification } from './Notifications/RepostOfRepostNotification'
 
 type NotificationListItemProps = {
   notification: Notification
@@ -48,6 +49,8 @@ export const NotificationListItem = (props: NotificationListItemProps) => {
         return <RemixCreateNotification notification={notification} />
       case NotificationType.Repost:
         return <RepostNotification notification={notification} />
+      case NotificationType.RepostOfRepost:
+        return <RepostOfRepostNotification notification={notification} />
       case NotificationType.TierChange:
         return <TierChangeNotification notification={notification} />
       case NotificationType.Reaction:

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RepostOfRepostNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RepostOfRepostNotification.tsx
@@ -1,0 +1,73 @@
+import { useCallback } from 'react'
+
+import type { RepostOfRepostNotification as RepostOfRepostNotificationType } from '@audius/common'
+import {
+  useProxySelector,
+  formatCount,
+  notificationsSelectors
+} from '@audius/common'
+
+import IconRepost from 'app/assets/images/iconRepost.svg'
+import { useNotificationNavigation } from 'app/hooks/useNotificationNavigation'
+
+import {
+  NotificationHeader,
+  NotificationTile,
+  ProfilePictureList,
+  UserNameLink,
+  USER_LENGTH_LIMIT,
+  NotificationText,
+  EntityLink
+} from '../Notification'
+
+const { getNotificationEntity, getNotificationUsers } = notificationsSelectors
+
+const messages = {
+  others: (userCount: number) =>
+    ` and ${formatCount(userCount)} other${userCount > 1 ? 's' : ''}`,
+  reposted: ' reposted your repost of'
+}
+
+type RepostOfRepostNotificationProps = {
+  notification: RepostOfRepostNotificationType
+}
+
+export const RepostOfRepostNotification = (
+  props: RepostOfRepostNotificationProps
+) => {
+  const { notification } = props
+  const { userIds, entityType } = notification
+  const navigation = useNotificationNavigation()
+
+  const users = useProxySelector(
+    (state) => getNotificationUsers(state, notification, USER_LENGTH_LIMIT),
+    [notification]
+  )
+  const firstUser = users?.[0]
+  const otherUsersCount = userIds.length - 1
+
+  const entity = useProxySelector(
+    (state) => getNotificationEntity(state, notification),
+    [notification]
+  )
+
+  const handlePress = useCallback(() => {
+    navigation.navigate(notification)
+  }, [navigation, notification])
+
+  if (!users || !firstUser || !entity) return null
+
+  return (
+    <NotificationTile notification={notification} onPress={handlePress}>
+      <NotificationHeader icon={IconRepost}>
+        <ProfilePictureList users={users} />
+      </NotificationHeader>
+      <NotificationText>
+        <UserNameLink user={firstUser} />
+        {otherUsersCount > 0 ? messages.others(otherUsersCount) : null}
+        {messages.reposted} {entityType.toLowerCase()}{' '}
+        <EntityLink entity={entity} />
+      </NotificationText>
+    </NotificationTile>
+  )
+}

--- a/packages/web/src/components/notification/Notification/Notification.tsx
+++ b/packages/web/src/components/notification/Notification/Notification.tsx
@@ -17,6 +17,7 @@ import { MilestoneNotification } from './MilestoneNotification'
 import { RemixCosignNotification } from './RemixCosignNotification'
 import { RemixCreateNotification } from './RemixCreateNotification'
 import { RepostNotification } from './RepostNotification'
+import { RepostOfRepostNotification } from './RepostOfRepostNotification'
 import { SupporterDethronedNotification } from './SupporterDethronedNotification'
 import { TierChangeNotification } from './TierChangeNotification'
 import { TipReactionNotification } from './TipReactionNotification'
@@ -91,6 +92,9 @@ export const Notification = (props: NotificationProps) => {
       }
       case NotificationType.Repost: {
         return <RepostNotification notification={notification} />
+      }
+      case NotificationType.RepostOfRepost: {
+        return <RepostOfRepostNotification notification={notification} />
       }
       case NotificationType.TierChange: {
         return <TierChangeNotification notification={notification} />

--- a/packages/web/src/components/notification/Notification/RepostOfRepostNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RepostOfRepostNotification.tsx
@@ -1,0 +1,106 @@
+import { MouseEventHandler, useCallback } from 'react'
+
+import {
+  notificationsSelectors,
+  RepostOfRepostNotification as RepostOfRepostNotificationType
+} from '@audius/common'
+import { push } from 'connected-react-router'
+import { useDispatch } from 'react-redux'
+
+import {
+  setUsers as setUserListUsers,
+  setVisibility as openUserListModal
+} from 'store/application/ui/userListModal/slice'
+import { UserListType } from 'store/application/ui/userListModal/types'
+import { isMobile } from 'utils/clientUtil'
+import { useSelector } from 'utils/reducer'
+
+import { EntityLink, useGoToEntity } from './components/EntityLink'
+import { NotificationBody } from './components/NotificationBody'
+import { NotificationFooter } from './components/NotificationFooter'
+import { NotificationHeader } from './components/NotificationHeader'
+import { NotificationTile } from './components/NotificationTile'
+import { OthersLink } from './components/OthersLink'
+import { UserNameLink } from './components/UserNameLink'
+import { UserProfilePictureList } from './components/UserProfilePictureList'
+import { IconRepost } from './components/icons'
+import { entityToUserListEntity, USER_LENGTH_LIMIT } from './utils'
+const { getNotificationEntity, getNotificationUsers } = notificationsSelectors
+
+const messages = {
+  reposted: 'reposted your repost of'
+}
+
+type RepostOfRepostNotificationProps = {
+  notification: RepostOfRepostNotificationType
+}
+
+export const RepostOfRepostNotification = (
+  props: RepostOfRepostNotificationProps
+) => {
+  const { notification } = props
+  const { id, userIds, entityType, timeLabel, isViewed } = notification
+  const users = useSelector((state) =>
+    getNotificationUsers(state, notification, USER_LENGTH_LIMIT)
+  )
+  const firstUser = users?.[0]
+  const otherUsersCount = userIds.length - 1
+  const isMultiUser = userIds.length > 1
+
+  const entity = useSelector((state) =>
+    getNotificationEntity(state, notification)
+  )
+
+  const dispatch = useDispatch()
+
+  const handleGoToEntity = useGoToEntity(entity, entityType)
+
+  const handleClick: MouseEventHandler = useCallback(
+    (event) => {
+      if (isMultiUser) {
+        dispatch(
+          setUserListUsers({
+            userListType: UserListType.NOTIFICATION,
+            entityType: entityToUserListEntity[entityType],
+            id: id as unknown as number
+          })
+        )
+        if (isMobile()) {
+          dispatch(push(`notification/${id}/users`))
+        } else {
+          dispatch(openUserListModal(true))
+        }
+      } else {
+        handleGoToEntity(event)
+      }
+    },
+    [isMultiUser, dispatch, entityType, id, handleGoToEntity]
+  )
+
+  if (!users || !firstUser || !entity) return null
+
+  return (
+    <NotificationTile
+      notification={notification}
+      onClick={handleClick}
+      disableClosePanel={otherUsersCount > 0}
+    >
+      <NotificationHeader icon={<IconRepost />}>
+        <UserProfilePictureList
+          users={users}
+          totalUserCount={userIds.length}
+          stopPropagation
+        />
+      </NotificationHeader>
+      <NotificationBody>
+        <UserNameLink user={firstUser} notification={notification} />{' '}
+        {otherUsersCount > 0 ? (
+          <OthersLink othersCount={otherUsersCount} onClick={handleClick} />
+        ) : null}{' '}
+        {messages.reposted} {entityType.toLowerCase()}{' '}
+        <EntityLink entity={entity} entityType={entityType} />
+      </NotificationBody>
+      <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />
+    </NotificationTile>
+  )
+}


### PR DESCRIPTION
### Description

adds repost-of-repost notification ui for web/mobile

### Dragons

There is still a bit to figure out regarding `onClick` for the notif tiles. I think it's possible for us to render a user-list like we do with reposts etc... it would probably be more consistent. But for now, we simply just go to the content.

