### PR TITLE
Send save_of_repost metadata on item save

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1806,9 +1806,15 @@ export const audiusBackend = ({
   }
 
   // Favoriting a track
-  async function saveTrack(trackId: ID) {
+  async function saveTrack(
+    trackId: ID,
+    metadata?: { is_save_of_repost: boolean }
+  ) {
     try {
-      return await audiusLibs.EntityManager.saveTrack(trackId)
+      return await audiusLibs.EntityManager.saveTrack(
+        trackId,
+        JSON.stringify(metadata)
+      )
     } catch (err) {
       console.log(getErrorMessage(err))
       throw err
@@ -1829,9 +1835,15 @@ export const audiusBackend = ({
   }
 
   // Favorite a playlist
-  async function saveCollection(playlistId: ID) {
+  async function saveCollection(
+    playlistId: ID,
+    metadata?: { is_save_of_repost: boolean }
+  ) {
     try {
-      return await audiusLibs.EntityManager.savePlaylist(playlistId)
+      return await audiusLibs.EntityManager.savePlaylist(
+        playlistId,
+        JSON.stringify(metadata)
+      )
     } catch (err) {
       console.log(getErrorMessage(err))
       throw err

--- a/packages/common/src/store/social/collections/actions.ts
+++ b/packages/common/src/store/social/collections/actions.ts
@@ -49,7 +49,11 @@ export const repostCollectionFailed = createCustomAction(
 
 export const saveCollection = createCustomAction(
   SAVE_COLLECTION,
-  (collectionId: ID, source: FavoriteSource) => ({ collectionId, source })
+  (collectionId: ID, source: FavoriteSource, isFeed = false) => ({
+    collectionId,
+    source,
+    isFeed
+  })
 )
 
 export const saveCollectionSucceeded = createCustomAction(

--- a/packages/common/src/store/social/tracks/actions.ts
+++ b/packages/common/src/store/social/tracks/actions.ts
@@ -52,7 +52,11 @@ export const trackRepostFailed = createCustomAction(
 
 export const saveTrack = createCustomAction(
   SAVE_TRACK,
-  (trackId: ID, source: FavoriteSource) => ({ trackId, source })
+  (trackId: ID, source: FavoriteSource, isFeed = false) => ({
+    trackId,
+    source,
+    isFeed
+  })
 )
 
 export const saveTrackSucceeded = createCustomAction(

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -334,10 +334,16 @@ export function* saveCollectionAsync(
   })
   yield* put(event)
 
+  const saveMetadata = action.isFeed
+    ? // If we're on the feed, and the content
+      // being saved is a repost
+      { is_save_of_repost: collection.followee_reposts.length !== 0 }
+    : { is_save_of_repost: false }
   yield* call(
     confirmSaveCollection,
     collection.playlist_owner_id,
-    action.collectionId
+    action.collectionId,
+    saveMetadata
   )
 
   if (!collection.is_album) {
@@ -379,7 +385,11 @@ export function* saveCollectionAsync(
   yield* put(socialActions.saveCollectionSucceeded(action.collectionId))
 }
 
-export function* confirmSaveCollection(ownerId: ID, collectionId: ID) {
+export function* confirmSaveCollection(
+  ownerId: ID,
+  collectionId: ID,
+  metadata?: { is_save_of_repost: boolean }
+) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(
     confirmerActions.requestConfirmation(
@@ -387,7 +397,8 @@ export function* confirmSaveCollection(ownerId: ID, collectionId: ID) {
       function* () {
         const { blockHash, blockNumber } = yield* call(
           audiusBackendInstance.saveCollection,
-          collectionId
+          collectionId,
+          metadata
         )
         const confirmed = yield* call(
           confirmTransaction,

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -342,7 +342,12 @@ export function* saveTrackAsync(
   })
   yield* put(event)
 
-  yield* call(confirmSaveTrack, action.trackId, user)
+  const saveMetadata = action.isFeed
+    ? // If we're on the feed, and the content
+      // being saved is a repost
+      { is_save_of_repost: track.followee_reposts.length !== 0 }
+    : { is_save_of_repost: false }
+  yield* call(confirmSaveTrack, action.trackId, user, saveMetadata)
 
   const eagerlyUpdatedMetadata: Partial<Track> = {
     has_current_user_saved: true,
@@ -404,7 +409,11 @@ export function* saveTrackAsync(
   }
 }
 
-export function* confirmSaveTrack(trackId: ID, user: User) {
+export function* confirmSaveTrack(
+  trackId: ID,
+  user: User,
+  metadata?: { is_save_of_repost: boolean }
+) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(
     confirmerActions.requestConfirmation(
@@ -412,7 +421,8 @@ export function* confirmSaveTrack(trackId: ID, user: User) {
       function* () {
         const { blockHash, blockNumber } = yield* call(
           audiusBackendInstance.saveTrack,
-          trackId
+          trackId,
+          metadata
         )
         const confirmed = yield* call(
           confirmTransaction,

--- a/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedPlaylistTile.tsx
@@ -383,9 +383,9 @@ const ConnectedPlaylistTile = memo(
       if (isFavorited) {
         unsaveCollection(id)
       } else {
-        saveCollection(id)
+        saveCollection(id, isFeed)
       }
-    }, [saveCollection, unsaveCollection, id, isFavorited])
+    }, [saveCollection, unsaveCollection, id, isFavorited, isFeed])
 
     const onRepostMetadata = useMemo(() => {
       return isFeed
@@ -589,8 +589,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(repostCollection(id, RepostSource.TILE, metadata)),
     undoRepostCollection: (id: ID) =>
       dispatch(undoRepostCollection(id, RepostSource.TILE)),
-    saveCollection: (id: ID) =>
-      dispatch(saveCollection(id, FavoriteSource.TILE)),
+    saveCollection: (id: ID, isFeed: boolean) =>
+      dispatch(saveCollection(id, FavoriteSource.TILE, isFeed)),
     unsaveCollection: (id: ID) =>
       dispatch(unsaveCollection(id, FavoriteSource.TILE)),
 

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -305,9 +305,9 @@ const ConnectedTrackTile = memo(
       if (isFavorited) {
         unsaveTrack(trackId)
       } else {
-        saveTrack(trackId)
+        saveTrack(trackId, isFeed)
       }
-    }, [saveTrack, unsaveTrack, trackId, isFavorited])
+    }, [isFavorited, unsaveTrack, trackId, saveTrack, isFeed])
 
     const onRepostMetadata = useMemo(() => {
       return isFeed
@@ -439,8 +439,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(repostTrack(trackId, RepostSource.TILE, metadata)),
     undoRepostTrack: (trackId: ID) =>
       dispatch(undoRepostTrack(trackId, RepostSource.TILE)),
-    saveTrack: (trackId: ID) =>
-      dispatch(saveTrack(trackId, FavoriteSource.TILE)),
+    saveTrack: (trackId: ID, isFeed: boolean) =>
+      dispatch(saveTrack(trackId, FavoriteSource.TILE, isFeed)),
     unsaveTrack: (trackId: ID) =>
       dispatch(unsaveTrack(trackId, FavoriteSource.TILE)),
 

--- a/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedPlaylistTile.tsx
@@ -108,9 +108,9 @@ const ConnectedPlaylistTile = memo(
       if (collection.has_current_user_saved) {
         unsaveCollection(collection.playlist_id)
       } else {
-        saveCollection(collection.playlist_id)
+        saveCollection(collection.playlist_id, isFeed)
       }
-    }, [collection, unsaveCollection, saveCollection])
+    }, [collection, unsaveCollection, saveCollection, isFeed])
 
     const onRepostMetadata = useMemo(() => {
       return isFeed
@@ -333,8 +333,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
           source: ShareSource.TILE
         })
       ),
-    saveCollection: (collectionId: ID) =>
-      dispatch(saveCollection(collectionId, FavoriteSource.TILE)),
+    saveCollection: (collectionId: ID, isFeed: boolean) =>
+      dispatch(saveCollection(collectionId, FavoriteSource.TILE, isFeed)),
     unsaveCollection: (collectionId: ID) =>
       dispatch(unsaveCollection(collectionId, FavoriteSource.TILE)),
     repostCollection: (

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -125,7 +125,7 @@ const ConnectedTrackTile = memo(
       if (has_current_user_saved) {
         unsaveTrack(trackId)
       } else {
-        saveTrack(trackId)
+        saveTrack(trackId, isFeed)
       }
     }
 
@@ -284,8 +284,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
           source: ShareSource.TILE
         })
       ),
-    saveTrack: (trackId: ID) =>
-      dispatch(saveTrack(trackId, FavoriteSource.TILE)),
+    saveTrack: (trackId: ID, isFeed: boolean) =>
+      dispatch(saveTrack(trackId, FavoriteSource.TILE, isFeed)),
     unsaveTrack: (trackId: ID) =>
       dispatch(unsaveTrack(trackId, FavoriteSource.TILE)),
     repostTrack: (trackId: ID, metadata: { is_repost_repost: boolean }) =>


### PR DESCRIPTION
### Description
This sends save of repost metadata to get processed by entity manager any time a track or collection gets reposted. Pretty much mimics what we've done for repost of a repost

### How Has This Been Tested?

Ran client locally against staging and printed metadata in audius backend endpoints to confirm the correct metadata is passed.


