### PR TITLE
[C-2209] Improve collection-screen perf

### DIFF
--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -48,7 +48,7 @@ const selectTrackCount = (state: AppState) => {
   return getCollectionTracksLineup(state).total
 }
 
-const selectLineupLoading = (state: AppState) => {
+const selectIsLineupLoading = (state: AppState) => {
   return getCollectionTracksLineup(state).status === Status.LOADING
 }
 
@@ -138,7 +138,7 @@ export const CollectionScreenDetailsTile = ({
   const trackUids = useSelector(selectTrackUids)
   const collectionTrackCount = useSelector(selectTrackCount)
   const trackCount = trackCountProp ?? collectionTrackCount
-  const lineupLoading = useSelector(selectLineupLoading)
+  const isLineupLoading = useSelector(selectIsLineupLoading)
   const collectionDuration = useSelector(selectCollectionDuration)
   const playingUid = useSelector(getUid)
   const isQueued = useSelector(selectIsQueued)
@@ -148,23 +148,23 @@ export const CollectionScreenDetailsTile = ({
   const firstTrack = useSelector(selectFirstTrack)
 
   const details = useMemo(() => {
-    if (!lineupLoading && trackCount === 0) return []
+    if (!isLineupLoading && trackCount === 0) return []
     return [
       {
         label: 'Tracks',
-        value: lineupLoading
+        value: isLineupLoading
           ? messages.detailsPlaceholder
           : formatCount(trackCount)
       },
       {
         label: 'Duration',
-        value: lineupLoading
+        value: isLineupLoading
           ? messages.detailsPlaceholder
           : formatSecondsAsText(collectionDuration)
       },
       ...extraDetails
     ].filter(({ isHidden, value }) => !isHidden && !!value)
-  }, [lineupLoading, trackCount, collectionDuration, extraDetails])
+  }, [isLineupLoading, trackCount, collectionDuration, extraDetails])
 
   const handlePressPlay = useCallback(() => {
     if (isPlaying && isQueued) {
@@ -205,9 +205,9 @@ export const CollectionScreenDetailsTile = ({
       <TrackList
         hideArt
         showDivider
-        showSkeleton={lineupLoading}
+        showSkeleton={isLineupLoading}
         togglePlay={handlePressTrackListItemPlay}
-        uids={lineupLoading ? Array(Math.min(5, trackCount ?? 0)) : trackUids}
+        uids={isLineupLoading ? Array(Math.min(5, trackCount ?? 0)) : trackUids}
         ListHeaderComponent={
           trackCount > 0 ? <View style={styles.trackListDivider} /> : undefined
         }
@@ -216,7 +216,7 @@ export const CollectionScreenDetailsTile = ({
     )
   }, [
     handlePressTrackListItemPlay,
-    lineupLoading,
+    isLineupLoading,
     styles,
     trackUids,
     trackCount

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -2,6 +2,8 @@ import { useCallback, useMemo } from 'react'
 
 import type { ID, Maybe, SmartCollectionVariant, UID } from '@audius/common'
 import {
+  removeNullable,
+  collectionPageSelectors,
   collectionPageActions,
   playerSelectors,
   Status,
@@ -13,6 +15,7 @@ import {
 } from '@audius/common'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
+import { createSelector } from 'reselect'
 
 import { Text } from 'app/components/core'
 import { DetailsTile } from 'app/components/details-tile'
@@ -22,6 +25,7 @@ import type {
 } from 'app/components/details-tile/types'
 import { TrackList } from 'app/components/track-list'
 import { make, track } from 'app/services/analytics'
+import type { AppState } from 'app/store'
 import { makeStyles } from 'app/styles'
 import { formatCount } from 'app/utils/format'
 
@@ -30,6 +34,44 @@ import { useCollectionLineup } from './useCollectionLineup'
 const { resetAndFetchCollectionTracks } = collectionPageActions
 const { getPlaying, getUid, getCurrentTrack } = playerSelectors
 const { getIsReachable } = reachabilitySelectors
+const { getCollectionTracksLineup } = collectionPageSelectors
+
+const selectTrackUids = createSelector(
+  (state: AppState) => getCollectionTracksLineup(state).entries,
+  (entries) => entries.map(({ uid }) => uid)
+)
+
+const selectFirstTrack = (state: AppState) =>
+  getCollectionTracksLineup(state).entries[0]
+
+const selectTrackCount = (state: AppState) => {
+  return getCollectionTracksLineup(state).total
+}
+
+const selectLineupLoading = (state: AppState) => {
+  return getCollectionTracksLineup(state).status === Status.LOADING
+}
+
+const selectCollectionDuration = createSelector(
+  (state: AppState) => getCollectionTracksLineup(state).entries,
+  (state: AppState) => state.tracks.entries,
+  (entries, tracks) => {
+    return entries
+      .map((entry) => tracks[entry.id]?.metadata.duration)
+      .filter(removeNullable)
+      .reduce((totalDuration, trackDuration) => {
+        return totalDuration + trackDuration
+      }, 0)
+  }
+)
+
+const selectIsQueued = createSelector(
+  selectTrackUids,
+  getUid,
+  (trackUids, playingUid) => {
+    return trackUids.some((trackUid) => playingUid === trackUid)
+  }
+)
 
 const messages = {
   empty: 'This playlist is empty.',
@@ -79,7 +121,7 @@ export const CollectionScreenDetailsTile = ({
   isPrivate,
   isPublishing,
   renderImage,
-  trackCount,
+  trackCount: trackCountProp,
   ...detailsTileProps
 }: CollectionScreenDetailsTileProps) => {
   const styles = useStyles()
@@ -91,55 +133,51 @@ export const CollectionScreenDetailsTile = ({
     dispatch(resetAndFetchCollectionTracks(collectionId))
   }, [dispatch, collectionId])
 
-  const { entries, status } = useCollectionLineup(collectionId, fetchLineup)
-  const trackUids = useMemo(() => entries.map(({ uid }) => uid), [entries])
+  useCollectionLineup(collectionId, fetchLineup)
 
-  const tracksLoading = status === Status.LOADING
-  const numTracks = entries.length
-
-  const duration = entries?.reduce(
-    (duration, entry) => duration + entry.duration,
-    0
-  )
+  const trackUids = useSelector(selectTrackUids)
+  const collectionTrackCount = useSelector(selectTrackCount)
+  const trackCount = trackCountProp ?? collectionTrackCount
+  const lineupLoading = useSelector(selectLineupLoading)
+  const collectionDuration = useSelector(selectCollectionDuration)
+  const playingUid = useSelector(getUid)
+  const isQueued = useSelector(selectIsQueued)
+  const isPlaying = useSelector(getPlaying)
+  const playingTrack = useSelector(getCurrentTrack)
+  const playingTrackId = playingTrack?.track_id
+  const firstTrack = useSelector(selectFirstTrack)
 
   const details = useMemo(() => {
-    if (!tracksLoading && numTracks === 0) return []
+    if (!lineupLoading && trackCount === 0) return []
     return [
       {
         label: 'Tracks',
-        value: tracksLoading
+        value: lineupLoading
           ? messages.detailsPlaceholder
-          : formatCount(numTracks)
+          : formatCount(trackCount)
       },
       {
         label: 'Duration',
-        value: tracksLoading
+        value: lineupLoading
           ? messages.detailsPlaceholder
-          : formatSecondsAsText(duration)
+          : formatSecondsAsText(collectionDuration)
       },
       ...extraDetails
     ].filter(({ isHidden, value }) => !isHidden && !!value)
-  }, [tracksLoading, numTracks, duration, extraDetails])
-
-  const isPlaying = useSelector(getPlaying)
-  const playingUid = useSelector(getUid)
-  const playingTrack = useSelector(getCurrentTrack)
-  const trackId = playingTrack?.track_id
-
-  const isQueued = entries.some((entry) => playingUid === entry.uid)
+  }, [lineupLoading, trackCount, collectionDuration, extraDetails])
 
   const handlePressPlay = useCallback(() => {
     if (isPlaying && isQueued) {
       dispatch(tracksActions.pause())
-      recordPlay(trackId, false)
+      recordPlay(playingTrackId, false)
     } else if (!isPlaying && isQueued) {
       dispatch(tracksActions.play())
-      recordPlay(trackId)
-    } else if (entries.length > 0) {
-      dispatch(tracksActions.play(entries[0].uid))
-      recordPlay(entries[0].track_id)
+      recordPlay(playingTrackId)
+    } else if (trackCount > 0) {
+      dispatch(tracksActions.play(firstTrack.uid))
+      recordPlay(firstTrack.id)
     }
-  }, [dispatch, isPlaying, trackId, entries, isQueued])
+  }, [dispatch, isPlaying, playingTrackId, isQueued, trackCount, firstTrack])
 
   const handlePressTrackListItemPlay = useCallback(
     (uid: UID, id: ID) => {
@@ -162,34 +200,27 @@ export const CollectionScreenDetailsTile = ({
     [collectionId]
   )
 
-  const renderTrackList = () => {
-    if (tracksLoading)
-      return (
-        <>
-          <View style={styles.trackListDivider} />
-          <TrackList
-            hideArt
-            showDivider
-            showSkeleton
-            uids={Array(Math.min(10, trackCount ?? 0))}
-          />
-        </>
-      )
-
-    return entries.length === 0 ? (
-      <Text style={styles.empty}>{messages.empty}</Text>
-    ) : (
-      <>
-        <View style={styles.trackListDivider} />
-        <TrackList
-          hideArt
-          showDivider
-          togglePlay={handlePressTrackListItemPlay}
-          uids={trackUids}
-        />
-      </>
+  const renderTrackList = useCallback(() => {
+    return (
+      <TrackList
+        hideArt
+        showDivider
+        showSkeleton={lineupLoading}
+        togglePlay={handlePressTrackListItemPlay}
+        uids={lineupLoading ? Array(Math.min(5, trackCount ?? 0)) : trackUids}
+        ListHeaderComponent={
+          trackCount > 0 ? <View style={styles.trackListDivider} /> : undefined
+        }
+        ListEmptyComponent={<Text style={styles.empty}>{messages.empty}</Text>}
+      />
     )
-  }
+  }, [
+    handlePressTrackListItemPlay,
+    lineupLoading,
+    styles,
+    trackUids,
+    trackCount
+  ])
 
   return (
     <DetailsTile

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -30,7 +30,7 @@ import { makeStyles } from 'app/styles'
 import { formatCount } from 'app/utils/format'
 
 import { CollectionHeader } from './CollectionHeader'
-import { useCollectionLineup } from './useCollectionLineup'
+import { useFetchCollectionLineup } from './useFetchCollectionLineup'
 const { resetAndFetchCollectionTracks } = collectionPageActions
 const { getPlaying, getUid, getCurrentTrack } = playerSelectors
 const { getIsReachable } = reachabilitySelectors
@@ -133,7 +133,7 @@ export const CollectionScreenDetailsTile = ({
     dispatch(resetAndFetchCollectionTracks(collectionId))
   }, [dispatch, collectionId])
 
-  useCollectionLineup(collectionId, fetchLineup)
+  useFetchCollectionLineup(collectionId, fetchLineup)
 
   const trackUids = useSelector(selectTrackUids)
   const collectionTrackCount = useSelector(selectTrackCount)

--- a/packages/mobile/src/screens/collection-screen/useFetchCollectionLineup.ts
+++ b/packages/mobile/src/screens/collection-screen/useFetchCollectionLineup.ts
@@ -4,16 +4,13 @@ import type { SmartCollectionVariant } from '@audius/common'
 import {
   Uid,
   areSetsEqual,
-  useProxySelector,
   Kind,
   makeUid,
   cacheActions,
   cacheCollectionsSelectors,
   collectionPageLineupActions,
   collectionPageSelectors,
-  queueSelectors,
-  lineupSelectors,
-  reachabilitySelectors
+  queueSelectors
 } from '@audius/common'
 import moment from 'moment'
 import { useDispatch, useSelector } from 'react-redux'
@@ -24,17 +21,13 @@ import { getOfflineTrackIds } from 'app/store/offline-downloads/selectors'
 
 const { getCollection } = cacheCollectionsSelectors
 const { getCollectionTracksLineup } = collectionPageSelectors
-const { makeGetTableMetadatas } = lineupSelectors
 const { getPositions } = queueSelectors
-const { getIsReachable } = reachabilitySelectors
-
-const getTracksLineup = makeGetTableMetadatas(getCollectionTracksLineup)
 
 /**
  * Returns a collection lineup, supports boths online and offline
  * @param collectionId the numeric collection id
  */
-export const useCollectionLineup = (
+export const useFetchCollectionLineup = (
   collectionId: number | SmartCollectionVariant | null,
   fetchLineup: () => void
 ) => {
@@ -44,7 +37,6 @@ export const useCollectionLineup = (
     (state) => new Set(getOfflineTrackIds(state) || []),
     areSetsEqual
   )
-  const isReachable = useSelector(getIsReachable)
   const collection = useSelector((state) => {
     return getCollection(state, { id: collectionId as number })
   })
@@ -80,8 +72,6 @@ export const useCollectionLineup = (
     },
     {}
   ) as Record<number, string[]>
-
-  const lineup = useProxySelector(getTracksLineup, [isReachable])
 
   const fetchLineupOffline = useCallback(() => {
     if (isOfflineModeEnabled && collectionId && collection) {
@@ -141,6 +131,4 @@ export const useCollectionLineup = (
 
   // Fetch the lineup based on reachability
   useReachabilityEffect(fetchLineup, fetchLineupOffline)
-
-  return lineup
 }


### PR DESCRIPTION
### Description

Improves collection-screen perf by improving data selectors and refactoring rendered track-list. The main issue was `getLineupTableMetadatas` selects every track by uid, resulting in a very slow select for lineup when the cache is large. Now we limit the selections to just what is needed.

