### PR TITLE
[PAY-972] Handle duplicate wallet connections properly

### DIFF
--- a/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.module.css
@@ -60,3 +60,11 @@
 :global(#bitski-dialog-container) {
   z-index: 1000000 !important;
 }
+
+.error {
+  text-align: center;
+  margin: 0px 0px 32px;
+  color: var(--accent-red);
+  font-size: var(--font-m);
+  font-weight: var(--font-medium);
+}

--- a/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.tsx
@@ -36,6 +36,8 @@ const ConnectWalletsBody = ({ className }: ConnectWalletsBodyProps) => {
     dispatch(connectNewWallet())
   }, [dispatch])
 
+  const { errorMessage } = useSelector(getAssociatedWallets)
+
   const {
     status,
     confirmingWallet,
@@ -75,6 +77,7 @@ const ConnectWalletsBody = ({ className }: ConnectWalletsBodyProps) => {
           hideCollectibles
         />
       )}
+      {errorMessage && <div className={styles.error}>{errorMessage}</div>}
     </div>
   )
 }

--- a/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.tsx
@@ -75,6 +75,7 @@ const ConnectWalletsBody = ({ className }: ConnectWalletsBodyProps) => {
           className={styles.walletsContainer}
           hasActions
           hideCollectibles
+          suppressError // suppress error because we show it below, and we don't always show the WalletsTable here
         />
       )}
       {errorMessage && <div className={styles.error}>{errorMessage}</div>}

--- a/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/ConnectWalletsBody.tsx
@@ -75,7 +75,6 @@ const ConnectWalletsBody = ({ className }: ConnectWalletsBodyProps) => {
           className={styles.walletsContainer}
           hasActions
           hideCollectibles
-          suppressError // suppress error because we show it below, and we don't always show the WalletsTable here
         />
       )}
       {errorMessage && <div className={styles.error}>{errorMessage}</div>}

--- a/packages/web/src/pages/audio-rewards-page/components/WalletsTable.module.css
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletsTable.module.css
@@ -102,14 +102,6 @@
   z-index: 1000000 !important;
 }
 
-.error {
-  text-align: center;
-  margin: 8px 0px 8px;
-  color: var(--accent-red);
-  font-size: var(--font-m);
-  font-weight: var(--font-medium);
-}
-
 .walletsHeader {
   display: inline-flex;
   justify-content: space-between;

--- a/packages/web/src/pages/audio-rewards-page/components/WalletsTable.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletsTable.tsx
@@ -139,19 +139,16 @@ type WalletsTableProps = {
   className?: string
   hasActions?: boolean
   hideCollectibles?: boolean
-  suppressError?: boolean
 }
 
 const WalletsTable = ({
   hasActions = false,
   className,
-  hideCollectibles,
-  suppressError
+  hideCollectibles
 }: WalletsTableProps) => {
   const {
     status,
     confirmingWallet,
-    errorMessage,
     connectedEthWallets: ethWallets,
     connectedSolWallets: solWallets
   } = useSelector(getAssociatedWallets)
@@ -253,9 +250,6 @@ const WalletsTable = ({
           isConfirmRemoving={false}
         />
       )}
-      {!suppressError && errorMessage ? (
-        <div className={styles.error}>{errorMessage}</div>
-      ) : null}
     </div>
   )
 }

--- a/packages/web/src/pages/audio-rewards-page/components/WalletsTable.tsx
+++ b/packages/web/src/pages/audio-rewards-page/components/WalletsTable.tsx
@@ -139,12 +139,14 @@ type WalletsTableProps = {
   className?: string
   hasActions?: boolean
   hideCollectibles?: boolean
+  suppressError?: boolean
 }
 
 const WalletsTable = ({
   hasActions = false,
   className,
-  hideCollectibles
+  hideCollectibles,
+  suppressError
 }: WalletsTableProps) => {
   const {
     status,
@@ -251,7 +253,9 @@ const WalletsTable = ({
           isConfirmRemoving={false}
         />
       )}
-      {errorMessage && <div className={styles.error}>{errorMessage}</div>}
+      {!suppressError && errorMessage ? (
+        <div className={styles.error}>{errorMessage}</div>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
### Description

We would only show the error if you'd previously connected a wallet, on the `WalletsTable`
Only shown here previously:
<img width="749" alt="Screen Shot 2023-02-28 at 3 34 14 PM" src="https://user-images.githubusercontent.com/6780028/221975144-eb7b9a1b-1870-4198-8c8e-d1a5c5e1913f.png">

Now also showing here:

<img width="763" alt="Screen Shot 2023-02-28 at 3 41 41 PM" src="https://user-images.githubusercontent.com/6780028/221975263-5315c670-abe3-4cfd-9be4-d8cc7b01dca8.png">


### Dragons

[] Need to make sure this works on mobile
[] Doublechecking that this text goes away when a wallet *is* successfully connected


*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

