### PR TITLE
[C-2205] Wait for user to follow in sign up

### DIFF
--- a/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
+++ b/packages/mobile/src/components/notification-reminder/NotificationReminder.tsx
@@ -1,20 +1,19 @@
 import { useCallback } from 'react'
 
-import { accountSelectors } from '@audius/common'
+import { getHasCompletedAccount } from 'common/store/pages/signon/selectors'
 import { checkNotifications, RESULTS } from 'react-native-permissions'
 import { useDispatch, useSelector } from 'react-redux'
 import type { Dispatch } from 'redux'
 
 import useSessionCount from 'app/hooks/useSessionCount'
 import { setVisibility } from 'app/store/drawers/slice'
-const getHasAccount = accountSelectors.getHasAccount
 
 const FIRST_REMINDER_SESSION = 10
 const REMINDER_FREQUENCY = 10
 
 export const NotificationReminder = () => {
-  const hasAccount = useSelector(getHasAccount)
-  if (hasAccount) {
+  const hasCompletedAccount = useSelector(getHasCompletedAccount)
+  if (hasCompletedAccount) {
     return <NotificationReminderInternal />
   }
   return null

--- a/packages/mobile/src/components/rate-cta-drawer/RateCtaReminder.tsx
+++ b/packages/mobile/src/components/rate-cta-drawer/RateCtaReminder.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from 'react'
 
-import { accountSelectors, FeatureFlags } from '@audius/common'
+import { FeatureFlags } from '@audius/common'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { getHasCompletedAccount } from 'common/store/pages/signon/selectors'
 import { useDispatch, useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
@@ -10,13 +11,11 @@ import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import useSessionCount from 'app/hooks/useSessionCount'
 import { requestReview } from 'app/store/rate-cta/slice'
 
-const getHasAccount = accountSelectors.getHasAccount
-
 const FIRST_REMINDER_SESSION = 3
 const REMINDER_FREQUENCY = 5
 
 export const RateCtaReminder = () => {
-  const hasAccount = useSelector(getHasAccount)
+  const hasCompletedAccount = useSelector(getHasCompletedAccount)
   const { isEnabled: isRateCtaEnabled } = useFeatureFlag(
     FeatureFlags.RATE_CTA_ENABLED
   )
@@ -25,7 +24,10 @@ export const RateCtaReminder = () => {
     AsyncStorage.getItem(RATE_CTA_STORAGE_KEY)
   )
 
-  return isRateCtaEnabled && !loading && !userRateResponse && hasAccount ? (
+  return isRateCtaEnabled &&
+    !loading &&
+    !userRateResponse &&
+    hasCompletedAccount ? (
     <RateCtaReminderInternal />
   ) : null
 }

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -3,11 +3,7 @@ import { useEffect, useState } from 'react'
 import { accountSelectors, Status } from '@audius/common'
 import type { NavigatorScreenParams } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
-import {
-  getStartedSignUpProcess,
-  getFinishedSignUpProcess
-} from 'common/store/pages/signon/selectors'
-import { Pages } from 'common/store/pages/signon/types'
+import { getHasCompletedAccount } from 'common/store/pages/signon/selectors'
 import { Platform } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -23,7 +19,7 @@ import { AppDrawerScreen } from '../app-drawer-screen'
 
 import { ThemedStatusBar } from './StatusBar'
 
-const { getAccountStatus, getHasAccount } = accountSelectors
+const { getAccountStatus } = accountSelectors
 
 const IS_IOS = Platform.OS === 'ios'
 
@@ -35,16 +31,6 @@ export type RootScreenParamList = {
 
 const Stack = createNativeStackNavigator()
 
-const useShowHomeStack = () => {
-  const hasAccount = useSelector(getHasAccount)
-  const startedSignUpProcess = useSelector(getStartedSignUpProcess)
-  const finishedSignUpProcess = useSelector(getFinishedSignUpProcess)
-
-  // Show HomeStack if user has an account and
-  // they have finished the sign up process if they started
-  return hasAccount && (!startedSignUpProcess || finishedSignUpProcess)
-}
-
 /**
  * The top level navigator. Switches between sign on screens and main tab navigator
  * based on if the user is authed
@@ -52,7 +38,7 @@ const useShowHomeStack = () => {
 export const RootScreen = () => {
   const dispatch = useDispatch()
   const accountStatus = useSelector(getAccountStatus)
-  const showHomeStack = useShowHomeStack()
+  const showHomeStack = useSelector(getHasCompletedAccount)
   const { updateRequired } = useUpdateRequired()
   const [isLoaded, setIsLoaded] = useState(false)
 

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -3,6 +3,11 @@ import { useEffect, useState } from 'react'
 import { accountSelectors, Status } from '@audius/common'
 import type { NavigatorScreenParams } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
+import {
+  getStartedSignUpProcess,
+  getFinishedSignUpProcess
+} from 'common/store/pages/signon/selectors'
+import { Pages } from 'common/store/pages/signon/types'
 import { Platform } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -30,6 +35,16 @@ export type RootScreenParamList = {
 
 const Stack = createNativeStackNavigator()
 
+const useShowHomeStack = () => {
+  const hasAccount = useSelector(getHasAccount)
+  const startedSignUpProcess = useSelector(getStartedSignUpProcess)
+  const finishedSignUpProcess = useSelector(getFinishedSignUpProcess)
+
+  // Show HomeStack if user has an account and
+  // they have finished the sign up process if they started
+  return hasAccount && (!startedSignUpProcess || finishedSignUpProcess)
+}
+
 /**
  * The top level navigator. Switches between sign on screens and main tab navigator
  * based on if the user is authed
@@ -37,7 +52,7 @@ const Stack = createNativeStackNavigator()
 export const RootScreen = () => {
   const dispatch = useDispatch()
   const accountStatus = useSelector(getAccountStatus)
-  const hasAccount = useSelector(getHasAccount)
+  const showHomeStack = useShowHomeStack()
   const { updateRequired } = useUpdateRequired()
   const [isLoaded, setIsLoaded] = useState(false)
 
@@ -69,7 +84,7 @@ export const RootScreen = () => {
         >
           {updateRequired ? (
             <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
-          ) : hasAccount ? (
+          ) : showHomeStack ? (
             <Stack.Screen name='HomeStack' component={AppDrawerScreen} />
           ) : (
             <Stack.Screen name='SignOnStack' component={SignOnScreen} />

--- a/packages/mobile/src/screens/signon/FirstFollows.tsx
+++ b/packages/mobile/src/screens/signon/FirstFollows.tsx
@@ -37,6 +37,7 @@ const FirstFollows = (props: FirstFollowsProps) => {
   const { selectedUserIds: followedArtistIds } = followArtists
 
   const handleArtistsSelected = () => {
+    dispatch(signOnActions.finishSignUp())
     dispatch(signOnActions.followArtists(followArtists.selectedUserIds))
 
     track(

--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -646,6 +646,7 @@ const SignOn = ({ navigation }: SignOnProps) => {
                     email,
                     () => {
                       // On available email, move to create password
+                      dispatch(signOnActions.startSignUp())
                       navigation.push('CreatePassword')
                       setIsWorking(false)
                     },

--- a/packages/web/src/common/store/pages/signon/actions.ts
+++ b/packages/web/src/common/store/pages/signon/actions.ts
@@ -35,6 +35,8 @@ export const SIGN_IN_SUCCEEDED = 'SIGN_ON/SIGN_IN_SUCCEEDED'
 export const SIGN_IN_FAILED = 'SIGN_ON/SIGN_IN_FAILED'
 
 export const SIGN_UP = 'SIGN_ON/SIGN_UP'
+export const START_SIGN_UP = 'SIGN_ON/START_SIGN_UP'
+export const FINISH_SIGN_UP = 'SIGN_ON/FINISH_SIGN_UP'
 export const SIGN_UP_SUCCEEDED = 'SIGN_ON/SIGN_UP_SUCCEEDED'
 export const SIGN_UP_SUCCEEDED_WITH_ID = 'SIGN_ON/SIGN_UP_SUCCEEDED_WITH_ID'
 export const SIGN_UP_FAILED = 'SIGN_ON/SIGN_UP_FAILED'
@@ -166,6 +168,20 @@ export function validateHandleFailed(error: string) {
  */
 export function signUp() {
   return { type: SIGN_UP }
+}
+
+/**
+ * When the user starts the sign up flow
+ */
+export function startSignUp() {
+  return { type: START_SIGN_UP }
+}
+
+/**
+ * When the user finishes the sign up flow
+ */
+export function finishSignUp() {
+  return { type: FINISH_SIGN_UP }
 }
 
 export const signUpSucceeded = () => ({ type: SIGN_UP_SUCCEEDED })

--- a/packages/web/src/common/store/pages/signon/reducer.js
+++ b/packages/web/src/common/store/pages/signon/reducer.js
@@ -23,6 +23,8 @@ import {
   GO_TO_PAGE,
   SET_STATUS,
   SIGN_UP,
+  START_SIGN_UP,
+  FINISH_SIGN_UP,
   SIGN_UP_SUCCEEDED,
   SIGN_UP_FAILED,
   SIGN_IN,
@@ -67,7 +69,8 @@ const initialState = {
   status: 'editing', // 'editing', 'loading', 'success', or 'failure'
   toastText: null,
   page: Pages.EMAIL,
-  startedSignOnProcess: false,
+  startedSignUpProcess: false,
+  finishedSignUpProcess: false,
   followArtists: {
     selectedCategory: FollowArtistsCategory.FEATURED,
     categories: {},
@@ -313,8 +316,19 @@ const actionsMap = {
   [SIGN_UP](state, action) {
     return {
       ...state,
-      startedSignOnProcess: true,
       status: 'loading'
+    }
+  },
+  [START_SIGN_UP](state, action) {
+    return {
+      ...state,
+      startedSignUpProcess: true
+    }
+  },
+  [FINISH_SIGN_UP](state, action) {
+    return {
+      ...state,
+      finishedSignUpProcess: true
     }
   },
   [SIGN_UP_SUCCEEDED](state, action) {

--- a/packages/web/src/common/store/pages/signon/selectors.js
+++ b/packages/web/src/common/store/pages/signon/selectors.js
@@ -18,8 +18,10 @@ export const getToastText = (state) => state.signOn.toastText
 export const getRouteOnCompletion = (state) => state.signOn.routeOnCompletion
 export const getRouteOnExit = (state) => state.signOn.routeOnExit
 export const getAccountReady = (state) => state.signOn.accountReady
-export const getStartedSignOnProcess = (state) =>
-  state.signOn.startedSignOnProcess
+export const getStartedSignUpProcess = (state) =>
+  state.signOn.startedSignUpProcess
+export const getFinishedSignUpProcess = (state) =>
+  state.signOn.finishedSignUpProcess
 export const getReferrer = (state) => state.signOn.referrer
 
 export const getFollowArtists = (state) => state.signOn.followArtists

--- a/packages/web/src/common/store/pages/signon/selectors.js
+++ b/packages/web/src/common/store/pages/signon/selectors.js
@@ -1,5 +1,6 @@
-import { cacheUsersSelectors } from '@audius/common'
+import { accountSelectors, cacheUsersSelectors } from '@audius/common'
 import { createSelector } from 'reselect'
+const { getHasAccount } = accountSelectors
 const { getUsers } = cacheUsersSelectors
 
 // Sign On selectors
@@ -32,6 +33,16 @@ export const getSuggestedFollowIds = (state) => {
   const { selectedCategory, categories } = state.signOn.followArtists
   return categories[selectedCategory] || []
 }
+
+export const getHasCompletedAccount = createSelector(
+  [getHasAccount, getStartedSignUpProcess, getFinishedSignUpProcess],
+  (hasAccount, startedSignUpProcess, finishedSignUpProcess) => {
+    // If a user has started the sign up flow,
+    // only return true if they finish the flow
+    // (including selecting followees)
+    return hasAccount && (!startedSignUpProcess || finishedSignUpProcess)
+  }
+)
 
 /**
  * Each lineup that invokes this selector should pass its own selector as an argument, e.g.


### PR DESCRIPTION
### Description

We were rendering `HomeStack` as soon as `hasAccount` was true, meaning that if the account finished creating while the user was still on the screen to pick first follows it would automatically switch to the feed screen
* Add a couple new actions to track sign up progress on mobile (`startedSignOnProcess` was not used)
* Add a selector `getHasCompletedAccount` to designate that the user has an account and they have completed the sign up flow
* Ensure the Rate and Notification drawers don't get shown until the user has a completed account

### Dragons

Sign up changes! Dangerous

### How Has This Been Tested?

Tested:
* Sign up flow with user taking long time to follower accounts
* Sign up flow with user quickly following accounts
* Sign in

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

