### PR TITLE
Fix share track url

### DIFF
--- a/packages/mobile/src/utils/routes.tsx
+++ b/packages/mobile/src/utils/routes.tsx
@@ -10,7 +10,7 @@ export const getTrackRoute = (
   track: { permalink: string },
   fullUrl = false
 ) => {
-  const route = encodeUrlName(track.permalink)
+  const route = `/${encodeUrlName(track.permalink)}`
   return fullUrl ? `${AUDIUS_URL}${route}` : route
 }
 


### PR DESCRIPTION
### Description

Issue where `encodeUrlName` removed the / in the beginning of permalink, so adding that back in. Affects latest prod rc

