### PR TITLE
[PAY-956] Catch wallet connect errors and reset modal state

### DIFF
--- a/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
+++ b/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
@@ -1,4 +1,5 @@
 import { tokenDashboardPageActions } from '@audius/common'
+import * as Sentry from '@sentry/browser'
 import { put, takeEvery } from 'typed-redux-saga'
 
 import { addWalletToUser } from 'common/store/pages/token-dashboard/addWalletToUser'
@@ -10,6 +11,7 @@ import { disconnectWallet } from './disconnectWallet'
 import { establishWalletConnection } from './establishWalletConnection'
 import { getWalletAddress } from './getWalletAddress'
 import { signMessage } from './signMessage'
+
 const { connectNewWallet } = tokenDashboardPageActions
 
 const { setIsConnectingWallet, setModalState, resetStatus } =
@@ -50,9 +52,9 @@ function* handleConnectNewWallet() {
     yield* addWalletToUser(updatedUserMetadata, disconnect)
   } catch (e) {
     // Very likely we hit error path here i.e. user closes the web3 popup. Log it and restart
-    console.error(
-      `Caught error during handleConnectNewWallet:  ${e}, resetting to initial state`
-    )
+    const err = `Caught error during handleConnectNewWallet:  ${e}, resetting to initial state`
+    console.warn(err)
+    Sentry.captureException(err)
     yield* put(
       setModalState({
         modalState: {

--- a/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
+++ b/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
@@ -12,40 +12,57 @@ import { getWalletAddress } from './getWalletAddress'
 import { signMessage } from './signMessage'
 const { connectNewWallet } = tokenDashboardPageActions
 
-const { setIsConnectingWallet } = tokenDashboardPageActions
+const { setIsConnectingWallet, setModalState, resetStatus } =
+  tokenDashboardPageActions
 
 function* handleConnectNewWallet() {
-  const connection = yield* establishWalletConnection()
-  if (!connection) return
+  try {
+    const connection = yield* establishWalletConnection()
+    if (!connection) return
 
-  const { chain } = connection
+    const { chain } = connection
 
-  const walletAddress = yield* getWalletAddress(connection)
-  if (!walletAddress) return
+    const walletAddress = yield* getWalletAddress(connection)
+    if (!walletAddress) return
 
-  const isNewWallet = yield* checkIsNewWallet(walletAddress, chain)
-  if (!isNewWallet) return
+    const isNewWallet = yield* checkIsNewWallet(walletAddress, chain)
+    if (!isNewWallet) return
 
-  const { balance, collectibleCount } = yield* getWalletInfo(
-    walletAddress,
-    chain
-  )
+    const { balance, collectibleCount } = yield* getWalletInfo(
+      walletAddress,
+      chain
+    )
 
-  yield* put(
-    setIsConnectingWallet({
-      wallet: walletAddress,
-      chain,
-      balance,
-      collectibleCount
-    })
-  )
+    yield* put(
+      setIsConnectingWallet({
+        wallet: walletAddress,
+        chain,
+        balance,
+        collectibleCount
+      })
+    )
 
-  const signature = yield* signMessage(connection)
-  const updatedUserMetadata = yield* associateNewWallet(signature)
+    const signature = yield* signMessage(connection)
+    const updatedUserMetadata = yield* associateNewWallet(signature)
 
-  const disconnect = () => disconnectWallet(connection)
+    const disconnect = () => disconnectWallet(connection)
 
-  yield* addWalletToUser(updatedUserMetadata, disconnect)
+    yield* addWalletToUser(updatedUserMetadata, disconnect)
+  } catch (e) {
+    // Very likely we hit error path here i.e. user closes the web3 popup. Log it and restart
+    console.error(
+      `Caught error during handleConnectNewWallet:  ${e}, resetting to initial state`
+    )
+    yield* put(
+      setModalState({
+        modalState: {
+          stage: 'CONNECT_WALLETS',
+          flowState: { stage: 'ADD_WALLET' }
+        }
+      })
+    )
+    yield* put(resetStatus())
+  }
 }
 
 export function* watchConnectNewWallet() {


### PR DESCRIPTION
### Description

Previously, if you try to connect with Phantom and then close the phantom popup, the app would crash! 

This fixes it by catching the errors and resetting the modal state. 

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

