### PR TITLE
Fix track permalink share route

### DIFF
--- a/packages/mobile/src/utils/routes.tsx
+++ b/packages/mobile/src/utils/routes.tsx
@@ -10,7 +10,7 @@ export const getTrackRoute = (
   track: { permalink: string },
   fullUrl = false
 ) => {
-  const route = `/${encodeUrlName(track.permalink)}`
+  const route = track.permalink
   return fullUrl ? `${AUDIUS_URL}${route}` : route
 }
 


### PR DESCRIPTION
### Description

Fixes track permalink share route once again, not realizing encodeUriName strips out the / needed for artist/track. This general uri encoding issues still exists, but reverting for the mobile release.
