### PR TITLE
[C-2228] Fix link position in Hyperlink

### DIFF
--- a/packages/mobile/src/components/core/Hyperlink.tsx
+++ b/packages/mobile/src/components/core/Hyperlink.tsx
@@ -63,19 +63,23 @@ export const Hyperlink = (props: HyperlinkProps) => {
   const [linkContainerLayout, setLinkContainerLayout] =
     useState<LayoutRectangle>()
 
-  /**
-   * Need to use `measureInWindow` instead of `onLayout` or `measure` because
-   * android doesn't return the correct layout for nested text elements
-   * */
   useEffect(() => {
-    Object.entries(links).forEach(([index]) => {
-      const linkRef = linkRefs[index]
+    let layouts = {}
+    const linkKeys = Object.keys(links)
+
+    // Measure the layout of each link
+    linkKeys.forEach((key) => {
+      const linkRef = linkRefs[key]
       if (linkRef) {
+        // Need to use `measureInWindow` instead of `onLayout` or `measure` because
+        // android doesn't return the correct layout for nested text elements
         linkRef.measureInWindow((x, y, width, height) => {
-          setLinkLayouts((linkLayouts) => ({
-            ...linkLayouts,
-            [index]: { x, y, width, height }
-          }))
+          layouts = { ...layouts, [key]: { x, y, width, height } }
+
+          // If all the links have been measured, update state
+          if (linkKeys.length === Object.keys(layouts).length) {
+            setLinkLayouts(layouts)
+          }
         })
       }
     })


### PR DESCRIPTION
### Description

* Fix positioning of links in Hyperlink component

This code is very hacky because we need to render the links in a separate stacking context to allow touches to pass through the bio text to scroll the header.

The problem was a race condition between the `linkRefs` ref being set and the useEffect that measures the positions of those elements. Was able to fix by not using a ref for `linkRefs` and tightening up the deps of `renderLink`. Also needed to iterate over `links` instead of `linkRefs` because `linkRefs` potentially exist before the layout of the element occurs, resulting in no position when we measure the element

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-01 at 16 22 11](https://user-images.githubusercontent.com/19916043/222278700-0ce47b5d-f201-4aad-87ec-ee289213bb0a.png)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

