### PR TITLE
[C-2194] Disabled the repost and favorite buttons in the NowPlayingDrawer for track owner

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/FavoriteButton.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/FavoriteButton.tsx
@@ -7,28 +7,30 @@ import { AnimatedButton } from 'app/components/core'
 import { colorize } from 'app/utils/colorizeLottie'
 import { useThemeColors } from 'app/utils/theme'
 
-type FavoriteButtonProps = Omit<AnimatedButtonProps, 'iconJSON'>
+type FavoriteButtonProps = Omit<AnimatedButtonProps, 'iconJSON'> & {
+  isOwner?: boolean
+}
 
 export const FavoriteButton = (props: FavoriteButtonProps) => {
-  const { iconIndex } = props
-  const { neutral, primary } = useThemeColors()
+  const { iconIndex, isOwner = false } = props
+  const { neutralLight6, neutral, primary } = useThemeColors()
 
   const iconJSON = useMemo(() => {
     const ColorizedFavoriteOnIcon = colorize(IconFavoriteOnLight, {
       // icon_Favorites Outlines 2.Group 1.Fill 1
-      'layers.0.shapes.0.it.1.c.k.0.s': neutral,
+      'layers.0.shapes.0.it.1.c.k.0.s': isOwner ? neutralLight6 : neutral,
       // icon_Favorites Outlines 2.Group 1.Fill 1
-      'layers.0.shapes.0.it.1.c.k.1.s': primary
+      'layers.0.shapes.0.it.1.c.k.1.s': isOwner ? neutralLight6 : primary
     })
 
     const ColorizedFavoriteOffIcon = colorize(IconFavoriteOffLight, {
       // icon_Favorites Outlines 2.Group 1.Fill 1
-      'layers.0.shapes.0.it.1.c.k.0.s': primary,
+      'layers.0.shapes.0.it.1.c.k.0.s': isOwner ? neutralLight6 : primary,
       // icon_Favorites Outlines 2.Group 1.Fill 1
-      'layers.0.shapes.0.it.1.c.k.1.s': neutral
+      'layers.0.shapes.0.it.1.c.k.1.s': isOwner ? neutralLight6 : neutral
     })
     return [ColorizedFavoriteOnIcon, ColorizedFavoriteOffIcon]
-  }, [neutral, primary])
+  }, [isOwner, neutral, neutralLight6, primary])
 
   return (
     <AnimatedButton {...props} haptics={iconIndex === 0} iconJSON={iconJSON} />

--- a/packages/mobile/src/components/now-playing-drawer/RepostButton.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/RepostButton.tsx
@@ -1,41 +1,47 @@
+import { useMemo } from 'react'
+
 import IconRepostOffLight from 'app/assets/animations/iconRepostOffLight.json'
 import IconRepostOnLight from 'app/assets/animations/iconRepostOnLight.json'
 import type { AnimatedButtonProps } from 'app/components/core'
 import { AnimatedButton } from 'app/components/core'
-import { makeAnimations } from 'app/styles'
 import { colorize } from 'app/utils/colorizeLottie'
+import { useThemeColors } from 'app/utils/theme'
 
-const useAnimations = makeAnimations(({ palette }) => {
-  const { neutral, primary } = palette
-
-  const ColorizedRepostOnIcon = colorize(IconRepostOnLight, {
-    // iconRepost Outlines Comp 1.iconRepost Outlines.Group 1.Fill 1
-    'assets.0.layers.0.shapes.0.it.3.c.k.0.s': neutral,
-    // iconRepost Outlines Comp 1.iconRepost Outlines.Group 1.Fill 1
-    'assets.0.layers.0.shapes.0.it.3.c.k.1.s': primary
-  })
-
-  const ColorizedRepostOffIcon = colorize(IconRepostOffLight, {
-    // iconRepost Outlines Comp 2.iconRepost Outlines.Group 1.Fill 1
-    'assets.0.layers.0.shapes.0.it.3.c.k.0.s': primary,
-    // iconRepost Outlines Comp 2.iconRepost Outlines.Group 1.Fill 1
-    'assets.0.layers.0.shapes.0.it.3.c.k.1.s': neutral
-  })
-
-  return [ColorizedRepostOnIcon, ColorizedRepostOffIcon]
-})
-
-type RepostButtonProps = Omit<AnimatedButtonProps, 'iconJSON'>
+type RepostButtonProps = Omit<AnimatedButtonProps, 'iconJSON'> & {
+  isOwner: boolean
+}
 
 export const RepostButton = (props: RepostButtonProps) => {
-  const { iconIndex } = props
-  const animations = useAnimations()
+  const { iconIndex, isOwner = false } = props
+  const { neutralLight6, neutral, primary } = useThemeColors()
+
+  const iconJSON = useMemo(() => {
+    const ColorizedRepostOnIcon = colorize(IconRepostOnLight, {
+      // iconRepost Outlines Comp 1.iconRepost Outlines.Group 1.Fill 1
+      'assets.0.layers.0.shapes.0.it.3.c.k.0.s': isOwner
+        ? neutralLight6
+        : neutral,
+      // iconRepost Outlines Comp 1.iconRepost Outlines.Group 1.Fill 1
+      'assets.0.layers.0.shapes.0.it.3.c.k.1.s': isOwner
+        ? neutralLight6
+        : primary
+    })
+
+    const ColorizedRepostOffIcon = colorize(IconRepostOffLight, {
+      // iconRepost Outlines Comp 2.iconRepost Outlines.Group 1.Fill 1
+      'assets.0.layers.0.shapes.0.it.3.c.k.0.s': isOwner
+        ? neutralLight6
+        : primary,
+      // iconRepost Outlines Comp 2.iconRepost Outlines.Group 1.Fill 1
+      'assets.0.layers.0.shapes.0.it.3.c.k.1.s': isOwner
+        ? neutralLight6
+        : neutral
+    })
+
+    return [ColorizedRepostOnIcon, ColorizedRepostOffIcon]
+  }, [isOwner, neutral, neutralLight6, primary])
 
   return (
-    <AnimatedButton
-      {...props}
-      haptics={iconIndex === 0}
-      iconJSON={animations}
-    />
+    <AnimatedButton {...props} haptics={iconIndex === 0} iconJSON={iconJSON} />
   )
 }


### PR DESCRIPTION
### Description
* Disabled the repost and favorite buttons in the NowPlayingDrawer for the track owner
  * Display a toast as well
* Add queue removal logic for TrackPlayer to prevent the track reset bug

### Dragons

Did some testing, but there may we some weird edge cases with the new TrackPlayer queue removal logic

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

