### PR TITLE
Fix button visibilities and other small misc gated related items

### DIFF
--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -29,7 +29,8 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.MAX_AUDIO_PURCHASE_AMOUNT]: 999,
   [IntKeys.BUY_AUDIO_WALLET_POLL_DELAY_MS]: 1000,
   [IntKeys.BUY_AUDIO_WALLET_POLL_MAX_RETRIES]: 120,
-  [IntKeys.BUY_AUDIO_SLIPPAGE]: 3
+  [IntKeys.BUY_AUDIO_SLIPPAGE]: 3,
+  [IntKeys.GATED_TRACK_POLL_INTERVAL_MS]: 1000
 }
 
 export const remoteConfigStringDefaults: {

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -142,7 +142,12 @@ export enum IntKeys {
   /**
    * The allowed slippage percentage/padding percentage for the BuyAudio Modal
    */
-  BUY_AUDIO_SLIPPAGE = 'BUY_AUDIO_SLIPPAGE'
+  BUY_AUDIO_SLIPPAGE = 'BUY_AUDIO_SLIPPAGE',
+
+  /**
+   * The interval in milliseconds between polls for gated tracks to check for access
+   */
+  GATED_TRACK_POLL_INTERVAL_MS = 'GATED_TRACK_POLL_INTERVAL_MS'
 }
 
 export enum BooleanKeys {

--- a/packages/common/src/services/solana-client/SolanaClient.ts
+++ b/packages/common/src/services/solana-client/SolanaClient.ts
@@ -183,7 +183,7 @@ export class SolanaClient {
         imageUrl
       }
     } catch (e) {
-      console.warn(`Could not get nft metadata for mint address ${mintAddress}`)
+      console.warn(`Could not get nft metadata for mint address ${mintAddress}, Error: ${(e as Error).message}`)
       return null
     }
   }

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -31,6 +31,7 @@ import type { TileProps } from '../core'
 import type { ImageProps } from '../image/FastImage'
 
 import { LineupTile } from './LineupTile'
+import { useIsPremiumContentEnabled } from 'app/hooks/useIsPremiumContentEnabled'
 
 const { getUid } = playerSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
@@ -72,6 +73,7 @@ export const TrackTileComponent = ({
   user,
   ...lineupTileProps
 }: TrackTileProps) => {
+  const isPremiumContentEnabled = useIsPremiumContentEnabled()
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const isOnArtistsTracksTab = useNavigationState((state) => {
@@ -122,7 +124,7 @@ export const TrackTileComponent = ({
       return
     }
     const overflowActions = [
-      !isPremium ? OverflowAction.ADD_TO_PLAYLIST : null,
+      (!isPremiumContentEnabled || !isPremium) ? OverflowAction.ADD_TO_PLAYLIST : null,
       OverflowAction.VIEW_TRACK_PAGE,
       isOnArtistsTracksTab ? null : OverflowAction.VIEW_ARTIST_PAGE,
       isOwner ? OverflowAction.EDIT_TRACK : null,

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -25,13 +25,13 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { TrackImage } from 'app/components/image/TrackImage'
 import type { LineupItemProps } from 'app/components/lineup-tile/types'
+import { useIsPremiumContentEnabled } from 'app/hooks/useIsPremiumContentEnabled'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 import type { TileProps } from '../core'
 import type { ImageProps } from '../image/FastImage'
 
 import { LineupTile } from './LineupTile'
-import { useIsPremiumContentEnabled } from 'app/hooks/useIsPremiumContentEnabled'
 
 const { getUid } = playerSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
@@ -124,7 +124,9 @@ export const TrackTileComponent = ({
       return
     }
     const overflowActions = [
-      (!isPremiumContentEnabled || !isPremium) ? OverflowAction.ADD_TO_PLAYLIST : null,
+      !isPremiumContentEnabled || !isPremium
+        ? OverflowAction.ADD_TO_PLAYLIST
+        : null,
       OverflowAction.VIEW_TRACK_PAGE,
       isOnArtistsTracksTab ? null : OverflowAction.VIEW_ARTIST_PAGE,
       isOwner ? OverflowAction.EDIT_TRACK : null,
@@ -138,7 +140,14 @@ export const TrackTileComponent = ({
         overflowActions
       })
     )
-  }, [isPremium, track_id, dispatch, isOnArtistsTracksTab, isOwner])
+  }, [
+    isPremiumContentEnabled,
+    isPremium,
+    track_id,
+    dispatch,
+    isOnArtistsTracksTab,
+    isOwner
+  ])
 
   const handlePressShare = useCallback(() => {
     if (track_id === undefined) {

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -310,8 +310,9 @@ export const TrackScreenDetailsTile = ({
   }
 
   const handlePressOverflow = () => {
+    const addToPlaylistAction = (!isPremiumContentEnabled || !isPremium) ? OverflowAction.ADD_TO_PLAYLIST : null
     const overflowActions = [
-      OverflowAction.ADD_TO_PLAYLIST,
+      addToPlaylistAction,
       user.does_current_user_follow
         ? OverflowAction.UNFOLLOW_ARTIST
         : OverflowAction.FOLLOW_ARTIST,

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -24,7 +24,8 @@ import {
   RepostType,
   repostsUserListActions,
   favoritesUserListActions,
-  reachabilitySelectors
+  reachabilitySelectors,
+  usePremiumContentAccess
 } from '@audius/common'
 import { Image, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
@@ -162,7 +163,7 @@ export const TrackScreenDetailsTile = ({
   isLineupLoading
 }: TrackScreenDetailsTileProps) => {
   const isPremiumContentEnabled = useIsPremiumContentEnabled()
-
+  const { doesUserHaveAccess } = usePremiumContentAccess(track)
   const styles = useStyles()
   const navigation = useNavigation()
   const { accentOrange, accentBlue } = useThemeColors()
@@ -200,9 +201,9 @@ export const TrackScreenDetailsTile = ({
   } = track
 
   const isOwner = owner_id === currentUserId
-  const hideFavorite = is_unlisted || (isPremiumContentEnabled && isPremium)
+  const hideFavorite = is_unlisted || (isPremiumContentEnabled && !doesUserHaveAccess)
   const hideRepost =
-    is_unlisted || !isReachable || (isPremiumContentEnabled && isPremium)
+    is_unlisted || !isReachable || (isPremiumContentEnabled && !doesUserHaveAccess)
 
   const remixParentTrackId = remix_of?.tracks?.[0]?.parent_track_id
   const isRemix = !!remixParentTrackId

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -163,7 +163,7 @@ export const TrackScreenDetailsTile = ({
   isLineupLoading
 }: TrackScreenDetailsTileProps) => {
   const isPremiumContentEnabled = useIsPremiumContentEnabled()
-  const { doesUserHaveAccess } = usePremiumContentAccess(track)
+  const { doesUserHaveAccess } = usePremiumContentAccess(track as Track) // track is of type Track | SearchTrack but we only care about some of their common fields, maybe worth refactoring later
   const styles = useStyles()
   const navigation = useNavigation()
   const { accentOrange, accentBlue } = useThemeColors()

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -201,9 +201,12 @@ export const TrackScreenDetailsTile = ({
   } = track
 
   const isOwner = owner_id === currentUserId
-  const hideFavorite = is_unlisted || (isPremiumContentEnabled && !doesUserHaveAccess)
+  const hideFavorite =
+    is_unlisted || (isPremiumContentEnabled && !doesUserHaveAccess)
   const hideRepost =
-    is_unlisted || !isReachable || (isPremiumContentEnabled && !doesUserHaveAccess)
+    is_unlisted ||
+    !isReachable ||
+    (isPremiumContentEnabled && !doesUserHaveAccess)
 
   const remixParentTrackId = remix_of?.tracks?.[0]?.parent_track_id
   const isRemix = !!remixParentTrackId
@@ -310,7 +313,10 @@ export const TrackScreenDetailsTile = ({
   }
 
   const handlePressOverflow = () => {
-    const addToPlaylistAction = (!isPremiumContentEnabled || !isPremium) ? OverflowAction.ADD_TO_PLAYLIST : null
+    const addToPlaylistAction =
+      !isPremiumContentEnabled || !isPremium
+        ? OverflowAction.ADD_TO_PLAYLIST
+        : null
     const overflowActions = [
       addToPlaylistAction,
       user.does_current_user_follow

--- a/packages/web/src/components/track/GiantTrackTile.js
+++ b/packages/web/src/components/track/GiantTrackTile.js
@@ -373,7 +373,6 @@ class GiantTrackTile extends PureComponent {
     const isLoading = loading || artworkLoading
     const showPremiumCornerTag =
       !isLoading && premiumConditions && (isOwner || !doesUserHaveAccess)
-    // isPremiumContentEnabled && !isLoading && premiumConditions && (isOwner || !doesUserHaveAccess)
     const cornerTagIconType = showPremiumCornerTag
       ? isOwner
         ? premiumConditions.nft_collection

--- a/packages/web/src/components/track/GiantTrackTile.js
+++ b/packages/web/src/components/track/GiantTrackTile.js
@@ -404,7 +404,7 @@ class GiantTrackTile extends PureComponent {
         isArtistPick,
         includeEmbed: !isUnlisted,
         includeArtistPick: !isUnlisted,
-        includeAddToPlaylist: !isUnlisted,
+        includeAddToPlaylist: !isUnlisted && !isPremium,
         extraMenuItems: overflowMenuExtraItems
       }
     }

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -37,6 +37,7 @@ import Menu from 'components/menu/Menu'
 import { OwnProps as TrackMenuProps } from 'components/menu/TrackMenu'
 import { TrackArtwork } from 'components/track/desktop/Artwork'
 import UserBadges from 'components/user-badges/UserBadges'
+import { useFlag } from 'hooks/useRemoteConfig'
 import {
   setUsers,
   setVisibility
@@ -57,7 +58,6 @@ import styles from './ConnectedTrackTile.module.css'
 import TrackTile from './TrackTile'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
-import { useFlag } from 'hooks/useRemoteConfig'
 const { getUid, getPlaying, getBuffering } = playerSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { getTrack } = cacheTracksSelectors
@@ -117,7 +117,9 @@ const ConnectedTrackTile = memo(
     isFeed = false,
     showRankIcon
   }: ConnectedTrackTileProps) => {
-    const { isEnabled: isPremiumContentEnabled } = useFlag(FeatureFlags.PREMIUM_CONTENT_ENABLED)
+    const { isEnabled: isPremiumContentEnabled } = useFlag(
+      FeatureFlags.PREMIUM_CONTENT_ENABLED
+    )
     const trackWithFallback = getTrackWithFallback(track)
     const {
       is_delete,

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -21,7 +21,8 @@ import {
   shareModalUIActions,
   playerSelectors,
   usePremiumContentAccess,
-  premiumContentActions
+  premiumContentActions,
+  FeatureFlags
 } from '@audius/common'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
@@ -56,6 +57,7 @@ import styles from './ConnectedTrackTile.module.css'
 import TrackTile from './TrackTile'
 import Stats from './stats/Stats'
 import { Flavor } from './stats/StatsText'
+import { useFlag } from 'hooks/useRemoteConfig'
 const { getUid, getPlaying, getBuffering } = playerSelectors
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { getTrack } = cacheTracksSelectors
@@ -115,6 +117,7 @@ const ConnectedTrackTile = memo(
     isFeed = false,
     showRankIcon
   }: ConnectedTrackTileProps) => {
+    const { isEnabled: isPremiumContentEnabled } = useFlag(FeatureFlags.PREMIUM_CONTENT_ENABLED)
     const trackWithFallback = getTrackWithFallback(track)
     const {
       is_delete,
@@ -197,7 +200,7 @@ const ConnectedTrackTile = memo(
       const menu: Omit<TrackMenuProps, 'children'> = {
         extraMenuItems: [],
         handle,
-        includeAddToPlaylist: true,
+        includeAddToPlaylist: !isPremiumContentEnabled || !isPremium,
         includeArtistPick: handle === userHandle && !isUnlisted,
         includeEdit: handle === userHandle,
         includeEmbed: true,

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -180,7 +180,10 @@ const ConnectedTrackTile = memo(
             ? OverflowAction.UNFAVORITE
             : OverflowAction.FAVORITE
           : null
-      const addToPlaylistAction = (!isPremiumContentEnabled || !isPremium) ? OverflowAction.ADD_TO_PLAYLIST : null
+      const addToPlaylistAction =
+        !isPremiumContentEnabled || !isPremium
+          ? OverflowAction.ADD_TO_PLAYLIST
+          : null
       const overflowActions = [
         repostAction,
         favoriteAction,

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -180,10 +180,11 @@ const ConnectedTrackTile = memo(
             ? OverflowAction.UNFAVORITE
             : OverflowAction.FAVORITE
           : null
+      const addToPlaylistAction = (!isPremiumContentEnabled || !isPremium) ? OverflowAction.ADD_TO_PLAYLIST : null
       const overflowActions = [
         repostAction,
         favoriteAction,
-        OverflowAction.ADD_TO_PLAYLIST,
+        addToPlaylistAction,
         OverflowAction.VIEW_TRACK_PAGE,
         OverflowAction.VIEW_ARTIST_PAGE
       ].filter(Boolean) as OverflowAction[]

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -234,7 +234,9 @@ const TrackHeader = ({
         : isSaved
         ? OverflowAction.UNFAVORITE
         : OverflowAction.FAVORITE,
-      OverflowAction.ADD_TO_PLAYLIST,
+      (!isPremiumContentEnabled || !isPremium)
+        ? OverflowAction.ADD_TO_PLAYLIST
+        : null,
       isFollowing
         ? OverflowAction.UNFOLLOW_ARTIST
         : OverflowAction.FOLLOW_ARTIST,

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -234,7 +234,7 @@ const TrackHeader = ({
         : isSaved
         ? OverflowAction.UNFAVORITE
         : OverflowAction.FAVORITE,
-      (!isPremiumContentEnabled || !isPremium)
+      !isPremiumContentEnabled || !isPremium
         ? OverflowAction.ADD_TO_PLAYLIST
         : null,
       isFollowing


### PR DESCRIPTION
### Description

- Show repost/favorite button on unlocked mobile gated track screen
- Hide add to playlist overflow buttons for web, mobile web, and native mobile
- Show better warning message when failing to get nft metadata
- Remove forgotten comment
- Use remote config for gated track polling frequency

### Dragons

none

### How Has This Been Tested?

local dapp vs stage. tested on web, mobile web, and ios

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

existing

