### PR TITLE
[C-1897] Add updated format for long durations on lineup tiles for web and mobile

### DIFF
--- a/packages/common/src/utils/timeUtil.ts
+++ b/packages/common/src/utils/timeUtil.ts
@@ -14,10 +14,19 @@ export const formatSeconds = (seconds: number): string => {
 
 export const formatSecondsAsText = (seconds: number): string => {
   const d = moment.duration(seconds, 'seconds')
-  if (seconds > 60 * 60) {
+  if (seconds > SECONDS_PER_HOUR) {
     return `${d.hours()}h ${d.minutes()}m`
   }
   return `${d.minutes()}m ${d.seconds()}s`
+}
+
+export const formatLineupTileDuration = (
+  seconds: number,
+  isPodcast = false
+) => {
+  if (!isPodcast && seconds < SECONDS_PER_HOUR) return formatSeconds(seconds)
+  const d = moment.duration(seconds, 'seconds')
+  return `${d.hours()}hr ${d.minutes()}m`
 }
 
 export const formatDate = (date: MomentInput, format?: string): string => {

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import {
   accountSelectors,
+  Genre,
   premiumContentActions,
   usePremiumContentAccess
 } from '@audius/common'
@@ -111,6 +112,7 @@ export const LineupTile = ({
           isUnlisted={isUnlisted}
           premiumConditions={premiumConditions}
           isArtistPick={isArtistPick}
+          isPodcast={isTrack ? item.genre === Genre.PODCASTS : false}
           showArtistPick={showArtistPick}
         />
         <LineupTileMetadata

--- a/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
@@ -1,5 +1,5 @@
 import type { PremiumConditions, Nullable } from '@audius/common'
-import { formatSeconds } from '@audius/common'
+import { formatLineupTileDuration } from '@audius/common'
 import type { ViewStyle } from 'react-native'
 import { StyleSheet, View } from 'react-native'
 import type { SvgProps } from 'react-native-svg'
@@ -79,6 +79,10 @@ type Props = {
    */
   isArtistPick?: boolean
   /**
+   * Whether or not the track is a podcast
+   */
+  isPodcast?: boolean
+  /**
    * Whether or not the track is unlisted (hidden)
    */
   isUnlisted?: boolean
@@ -95,6 +99,7 @@ type Props = {
 export const LineupTileTopRight = ({
   duration,
   isArtistPick,
+  isPodcast,
   isUnlisted,
   showArtistPick,
   premiumConditions
@@ -138,7 +143,7 @@ export const LineupTileTopRight = ({
         />
       )}
       <Text style={trackTileStyles.statText}>
-        {duration && formatSeconds(duration)}
+        {duration ? formatLineupTileDuration(duration, isPodcast) : null}
       </Text>
     </View>
   )

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -22,7 +22,8 @@ import {
   playerSelectors,
   usePremiumContentAccess,
   premiumContentActions,
-  FeatureFlags
+  FeatureFlags,
+  Genre
 } from '@audius/common'
 import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
@@ -128,6 +129,7 @@ const ConnectedTrackTile = memo(
       premium_conditions: premiumConditions,
       track_id: trackId,
       title,
+      genre,
       permalink,
       repost_count,
       save_count,
@@ -404,6 +406,7 @@ const ConnectedTrackTile = memo(
           artwork={artwork}
           rightActions={rightActions}
           title={title}
+          genre={genre as Genre}
           userName={userName}
           duration={duration}
           stats={stats}

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -3,8 +3,9 @@ import { memo, MouseEvent, useCallback } from 'react'
 import {
   formatCount,
   pluralize,
-  formatSeconds,
-  FeatureFlags
+  FeatureFlags,
+  formatLineupTileDuration,
+  Genre
 } from '@audius/common'
 import { IconCrown, IconHidden } from '@audius/stems'
 import cn from 'classnames'
@@ -82,6 +83,7 @@ const TrackTile = memo(
     rightActions,
     header,
     title,
+    genre,
     userName,
     duration,
     stats,
@@ -248,7 +250,9 @@ const TrackTile = memo(
                 </div>
               )}
               {!isLoading && duration && (
-                <div className={styles.duration}>{formatSeconds(duration)}</div>
+                <div className={styles.duration}>
+                  {formatLineupTileDuration(duration, genre === Genre.PODCASTS)}
+                </div>
               )}
             </div>
             <div className={styles.bottomRight}>

--- a/packages/web/src/components/track/helpers.ts
+++ b/packages/web/src/components/track/helpers.ts
@@ -1,4 +1,4 @@
-import { Collection, FieldVisibility, Track, User } from '@audius/common'
+import { Collection, FieldVisibility, Genre, Track, User } from '@audius/common'
 
 const defaultFieldVisibility: FieldVisibility = {
   genre: true,
@@ -20,6 +20,7 @@ export const getTrackWithFallback = (track: Track | null) => {
       followee_saves: [],
       duration: 0,
       save_count: 0,
+      genre: Genre.ALL,
       field_visibility: defaultFieldVisibility,
       has_current_user_reposted: false,
       has_current_user_saved: false,

--- a/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackTile.tsx
@@ -20,7 +20,8 @@ import {
   favoritesUserListActions,
   playerSelectors,
   usePremiumContentAccess,
-  FeatureFlags
+  FeatureFlags,
+  Genre
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -94,6 +95,7 @@ const ConnectedTrackTile = memo(
       premium_conditions: premiumConditions,
       track_id,
       title,
+      genre,
       permalink,
       repost_count,
       save_count,
@@ -208,6 +210,7 @@ const ConnectedTrackTile = memo(
         hasLoaded={hasLoaded}
         ordered={ordered}
         title={title}
+        genre={genre as Genre}
         repostCount={repost_count}
         saveCount={save_count}
         followeeReposts={followee_reposts}

--- a/packages/web/src/components/track/mobile/PlaylistTile.tsx
+++ b/packages/web/src/components/track/mobile/PlaylistTile.tsx
@@ -5,7 +5,7 @@ import {
   ID,
   LineupTrack,
   formatCount,
-  formatSeconds
+  formatLineupTileDuration
 } from '@audius/common'
 import cn from 'classnames'
 import { range } from 'lodash'
@@ -153,7 +153,7 @@ const PlaylistTile = (props: PlaylistTileProps & ExtraProps) => {
     <div className={styles.container}>
       <div className={styles.mainContent} onClick={props.togglePlay}>
         <div className={cn(styles.duration, styles.statText, fadeIn)}>
-          {formatSeconds(props.duration)}
+          {formatLineupTileDuration(props.duration)}
         </div>
         <div className={styles.metadata}>
           <TrackTileArt

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -3,12 +3,13 @@ import { useCallback, useState, useEffect, MouseEvent } from 'react'
 import {
   ID,
   formatCount,
-  formatSeconds,
   PremiumConditions,
   Nullable,
   premiumContentSelectors,
   premiumContentActions,
-  FeatureFlags
+  FeatureFlags,
+  formatLineupTileDuration,
+  Genre
 } from '@audius/common'
 import { IconCrown, IconHidden, IconTrending } from '@audius/stems'
 import cn from 'classnames'
@@ -126,7 +127,9 @@ const TrackTile = (props: TrackTileProps & ExtraProps) => {
     isTrending,
     showRankIcon,
     permalink,
-    artistHandle
+    artistHandle,
+    duration,
+    genre
   } = props
   const { isEnabled: isPremiumContentEnabled } = useFlag(
     FeatureFlags.PREMIUM_CONTENT_ENABLED
@@ -245,7 +248,9 @@ const TrackTile = (props: TrackTileProps & ExtraProps) => {
             </div>
           )}
           <div className={cn(styles.duration, fadeIn)}>
-            {props.duration && formatSeconds(props.duration)}
+            {duration
+              ? formatLineupTileDuration(duration, genre === Genre.PODCASTS)
+              : null}
           </div>
         </div>
         <div className={styles.metadata}>

--- a/packages/web/src/components/track/types.ts
+++ b/packages/web/src/components/track/types.ts
@@ -11,7 +11,8 @@ import {
   LineupTrack,
   Remix,
   PremiumConditions,
-  Nullable
+  Nullable,
+  Genre
 } from '@audius/common'
 
 export enum TrackTileSize {
@@ -47,6 +48,7 @@ export type TileProps = {
 
 export type TrackTileProps = TileProps & {
   title: string
+  genre: Genre
   showArtistPick?: boolean
   showListens?: boolean
   disableActions?: boolean
@@ -155,6 +157,9 @@ export type DesktopTrackTileProps = {
 
   /** The beneath the header is the title, for the track's name */
   title: ReactNode
+
+  /** For updating the duration format based on if the track is a podcast */
+  genre?: Genre
 
   /** The beneath the title is the username, for the track's creator */
   userName: ReactNode


### PR DESCRIPTION
### Description
Updating the format of the durations for long tracks and podcasts on the lineup tiles

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

