### PR TITLE
[C-2551] Fix macos ci step

### DIFF
--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -95,6 +95,8 @@ web-distribute:
     - run:
         name: distribute
         command: |
+          nvm install 14.20.1
+          nvm use 14.20.1
           cd packages/web
           npm run dist:<< parameters.build-type >>
 


### PR DESCRIPTION
### Description

Patch package was failing during the macos ci step

```
> patch-package

lerna ERR! lifecycle "postinstall" errored in "audius-mobile-client", exiting 1

Exited with code exit status 1
```

This happened when running `install-dmg-license`. It failed because, although the initial deps and been installed with node 14 and cached, this second install was run on a macos box now defaulting to node 16. This introduced additional changes to the package.json of a couple packages which we were trying to patch

Making this pr as a quick fix, but also thinking we should standardize the version of node across all our jobs. Right now we are mostly using 14.18

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

