### PR TITLE
Fix mobile web track screen special access spacing

### DIFF
--- a/packages/web/src/components/track/TrackBannerIcon.module.css
+++ b/packages/web/src/components/track/TrackBannerIcon.module.css
@@ -4,7 +4,6 @@
   left: 0;
   z-index: 10;
   width: 80px;
-  height: 80px;
   pointer-events: none;
 }
 


### PR DESCRIPTION
### Description
Fix spacing issue for mobile web special access track screens.

### Dragons

### How Has This Been Tested?
Local mobile web against stage. Confirmed normal (non-special access) track tiles look the same, as well as non-mobile wb.


<img width="393" alt="Screenshot 2023-03-07 at 5 16 51 PM copy" src="https://user-images.githubusercontent.com/3893871/223566237-574f72a7-61cc-44e0-b06d-f5aabc130111.png">


What it looked like before:
<img width="392" alt="Screenshot 2023-03-07 at 5 26 18 PM copy" src="https://user-images.githubusercontent.com/3893871/223568315-d6bb1396-a8e7-4ee0-a7bd-2f9ff9543d7d.png">


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

