### PR TITLE
[PAY-1019] Fix premium content tags overlap track title

### DIFF
--- a/packages/web/src/components/track/desktop/TrackTile.module.css
+++ b/packages/web/src/components/track/desktop/TrackTile.module.css
@@ -147,6 +147,10 @@
   height: 20px;
 }
 
+.withPremium {
+  margin-right: 188px;
+}
+
 .title {
   font-style: normal;
   font-weight: var(--font-bold);

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -197,6 +197,7 @@ const TrackTile = memo(
             <div
               className={cn(
                 styles.titleRow,
+                styles.title,
                 isPremium ? styles.withPremium : null
               )}
             >

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -194,7 +194,12 @@ const TrackTile = memo(
             <div className={cn(styles.headerRow)}>
               {!isLoading && header && <div>{header}</div>}
             </div>
-            <div className={styles.titleRow}>
+            <div
+              className={cn(
+                styles.titleRow,
+                isPremium ? styles.withPremium : null
+              )}
+            >
               {isLoading ? (
                 <Skeleton width='80%' className={styles.skeleton} />
               ) : (


### PR DESCRIPTION
### Description
Fixes UI bug where premium content tags were overlapping track tiles by truncating them earlier.
Bonus: Fixes style for ellipses.

https://www.figma.com/file/OBKeQ86g7vyzSnrn4ziLuz/NFT-Gated-Content?node-id=996-22293&t=QwvwSrYISQKCaZTq-0

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web.

<img width="733" alt="Screenshot 2023-03-07 at 7 05 47 PM copy" src="https://user-images.githubusercontent.com/3893871/223584167-19a53baa-c8af-4b91-aae3-99befc7d6748.png">

(Before ellipses style fix)
<img width="744" alt="Screenshot 2023-03-07 at 6 56 26 PM copy" src="https://user-images.githubusercontent.com/3893871/223582687-2f581edc-8d0c-4904-a245-e2e38fdeec95.png">

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

