### PR TITLE
[PAY-1020] Allow gated track in same session as wallet connect

### DIFF
--- a/packages/common/src/store/pages/profile/actions.ts
+++ b/packages/common/src/store/pages/profile/actions.ts
@@ -1,6 +1,6 @@
 import { Nullable } from 'utils'
 
-import { ID, User, UserMetadata } from '../../../models'
+import { Chain, ID, User, UserMetadata, WalletAddress } from '../../../models'
 
 import { CollectionSortMode, FollowType } from './types'
 
@@ -30,6 +30,9 @@ export const SET_NOTIFICATION_SUBSCRIPTION =
 export const FETCH_COLLECTIONS = 'PROFILE/FETCH_COLLECTIONS'
 export const FETCH_COLLECTIONS_SUCCEEDED = 'PROFILE/FETCH_COLLECTIONS_SUCCEEDED'
 export const FETCH_COLLECTIONS_FAILED = 'PROFILE/FETCH_COLLECTIONS_FAILED'
+
+export const REFRESH_WALLET_COLLECTIBLES = 'PROFILE/REFRESH_WALLET_COLLECTIBLES'
+export const REMOVE_WALLET_COLLECTIBLES = 'PROFILE/REMOVE_WALLET_COLLECTIBLES'
 
 // Either handle or userId is required
 // TODO: Move this to redux toolkit
@@ -175,5 +178,21 @@ export function fetchCollectionsFailed(handle: string) {
   return {
     type: FETCH_COLLECTIONS_FAILED,
     handle
+  }
+}
+
+export function refreshWalletCollectibles(chain: Chain, wallet: WalletAddress) {
+  return {
+    type: REFRESH_WALLET_COLLECTIBLES,
+    chain,
+    wallet
+  }
+}
+
+export function removeWalletCollectibles(chain: Chain, wallet: WalletAddress) {
+  return {
+    type: REMOVE_WALLET_COLLECTIBLES,
+    chain,
+    wallet
   }
 }

--- a/packages/common/src/store/pages/profile/reducer.ts
+++ b/packages/common/src/store/pages/profile/reducer.ts
@@ -29,7 +29,9 @@ import {
   SET_NOTIFICATION_SUBSCRIPTION,
   FETCH_COLLECTIONS,
   FETCH_COLLECTIONS_SUCCEEDED,
-  FETCH_COLLECTIONS_FAILED
+  FETCH_COLLECTIONS_FAILED,
+  REFRESH_WALLET_COLLECTIBLES,
+  REMOVE_WALLET_COLLECTIBLES
 } from './actions'
 import { PREFIX as feedPrefix } from './lineups/feed/actions'
 import { PREFIX as tracksPrefix } from './lineups/tracks/actions'
@@ -227,6 +229,12 @@ const actionsMap = {
   },
   [FETCH_COLLECTIONS_FAILED](state, action) {
     return updateProfile(state, action, { collectionStatus: Status.ERROR })
+  },
+  [REFRESH_WALLET_COLLECTIBLES](state, action) {
+    return state
+  },
+  [REMOVE_WALLET_COLLECTIBLES](state, action) {
+    return state
   }
 }
 

--- a/packages/mobile/src/screens/wallet-connect/useWalletStatusToasts.ts
+++ b/packages/mobile/src/screens/wallet-connect/useWalletStatusToasts.ts
@@ -7,7 +7,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useToast } from 'app/hooks/useToast'
-const { getError, getConfirmingWallet, getConfirmingWalletStatus, getRemoveWallet } =
+const { getError, getConfirmingWalletStatus, getRemoveWallet } =
   tokenDashboardPageSelectors
 const { resetStatus, resetRemovedStatus, updateWalletError } =
   tokenDashboardPageActions
@@ -19,7 +19,6 @@ const messages = {
 
 export const useWalletStatusToasts = () => {
   const dispatch = useDispatch()
-  const confirmingWallet = useSelector(getConfirmingWallet)
   const confirmingWalletStatus = useSelector(getConfirmingWalletStatus)
   const { status: removeWalletStatus } = useSelector(getRemoveWallet)
   const errorMessage = useSelector(getError)
@@ -28,8 +27,6 @@ export const useWalletStatusToasts = () => {
 
   useEffect(() => {
     if (confirmingWalletStatus === 'Confirmed') {
-      // yes here
-      console.log('add',{confirmingWallet})
       toast({ content: messages.newWalletConnected, type: 'info' })
       dispatch(resetStatus())
     }
@@ -37,8 +34,6 @@ export const useWalletStatusToasts = () => {
 
   useEffect(() => {
     if (removeWalletStatus === 'Confirmed') {
-      // yes here
-      console.log('remove',{confirmingWallet})
       toast({ content: messages.walletRemoved, type: 'info' })
       dispatch(resetRemovedStatus())
     }

--- a/packages/mobile/src/screens/wallet-connect/useWalletStatusToasts.ts
+++ b/packages/mobile/src/screens/wallet-connect/useWalletStatusToasts.ts
@@ -7,7 +7,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux'
 
 import { useToast } from 'app/hooks/useToast'
-const { getError, getConfirmingWalletStatus, getRemoveWallet } =
+const { getError, getConfirmingWallet, getConfirmingWalletStatus, getRemoveWallet } =
   tokenDashboardPageSelectors
 const { resetStatus, resetRemovedStatus, updateWalletError } =
   tokenDashboardPageActions
@@ -19,6 +19,7 @@ const messages = {
 
 export const useWalletStatusToasts = () => {
   const dispatch = useDispatch()
+  const confirmingWallet = useSelector(getConfirmingWallet)
   const confirmingWalletStatus = useSelector(getConfirmingWalletStatus)
   const { status: removeWalletStatus } = useSelector(getRemoveWallet)
   const errorMessage = useSelector(getError)
@@ -27,6 +28,8 @@ export const useWalletStatusToasts = () => {
 
   useEffect(() => {
     if (confirmingWalletStatus === 'Confirmed') {
+      // yes here
+      console.log('add',{confirmingWallet})
       toast({ content: messages.newWalletConnected, type: 'info' })
       dispatch(resetStatus())
     }
@@ -34,6 +37,8 @@ export const useWalletStatusToasts = () => {
 
   useEffect(() => {
     if (removeWalletStatus === 'Confirmed') {
+      // yes here
+      console.log('remove',{confirmingWallet})
       toast({ content: messages.walletRemoved, type: 'info' })
       dispatch(resetRemovedStatus())
     }

--- a/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
@@ -6,6 +6,7 @@ import {
   getContext,
   Kind,
   newUserMetadata,
+  profilePageActions,
   tokenDashboardPageActions,
   walletActions
 } from '@audius/common'
@@ -26,6 +27,7 @@ const {
 } = tokenDashboardPageActions
 
 const { getBalance } = walletActions
+const { removeWalletCollectibles } = profilePageActions
 
 function* removeWallet(action: ConfirmRemoveWalletAction) {
   yield* waitForWrite()
@@ -100,6 +102,9 @@ function* removeWallet(action: ConfirmRemoveWalletAction) {
   }
 
   function* onSuccess() {
+    // Remove collectibles from removed wallet if any
+    yield* put(removeWalletCollectibles(removeChain, removeWallet))
+
     // Update the user's balance w/ the new wallet
     yield* put(getBalance())
     yield* put(removeWalletAction({ wallet: removeWallet, chain: removeChain }))

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -158,7 +158,7 @@ export function* fetchOpenSeaAssets(user) {
 // Also keep track of whether the user has unsupported
 // sol collections, which is the case if one of the following is true:
 // - there is a sol nft which has no verified collection metadata
-// - there a verified sol nft collection for which we could not fetch the metadata (this is an edge case e.g. we cannot fetch the metadata this collection mint address B3LDTPm6qoQmSEgar2FHUHLt6KEHEGu9eSGejoMMv5eb)
+// - there is a verified sol nft collection for which we could not fetch the metadata (this is an edge case e.g. we cannot fetch the metadata this collection mint address B3LDTPm6qoQmSEgar2FHUHLt6KEHEGu9eSGejoMMv5eb)
 function* computeValidSolanaCollections(solanaCollectibleList) {
   const solanaClient = yield getContext('solanaClient')
 

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -684,7 +684,7 @@ function* watchSetNotificationSubscription() {
   )
 }
 
-function* fetchWalletCollectibles(chain, wallet) {
+function* fetchWalletCollectiblesForChain(chain, wallet) {
   const collectiblesMap =
     chain === Chain.Eth
       ? yield call(fetchOpenSeaAssetsForWallets, [wallet])
@@ -701,7 +701,11 @@ function* refreshWalletCollectibles(action) {
   const { chain, wallet } = action
   const userId = account.user_id
 
-  const collectibles = yield call(fetchWalletCollectibles, chain, wallet)
+  const collectibles = yield call(
+    fetchWalletCollectiblesForChain,
+    chain,
+    wallet
+  )
   if (!collectibles.length) {
     console.log(
       `wallet ${wallet} has no ${
@@ -767,7 +771,7 @@ function* removeWalletCollectibles(action) {
   const { chain, wallet } = action
   const userId = account.user_id
 
-  const toRemove = yield call(fetchWalletCollectibles, chain, wallet)
+  const toRemove = yield call(fetchWalletCollectiblesForChain, chain, wallet)
   if (!toRemove.length) {
     console.log(
       `wallet ${wallet} has no ${

--- a/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
+++ b/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
@@ -1,4 +1,9 @@
-import { getContext, Name, tokenDashboardPageActions } from '@audius/common'
+import {
+  getContext,
+  Name,
+  profilePageActions,
+  tokenDashboardPageActions
+} from '@audius/common'
 import * as Sentry from '@sentry/browser'
 import { put, takeEvery } from 'typed-redux-saga'
 
@@ -16,6 +21,7 @@ const { connectNewWallet } = tokenDashboardPageActions
 
 const { setIsConnectingWallet, setModalState, resetStatus } =
   tokenDashboardPageActions
+const { refreshWalletCollectibles } = profilePageActions
 
 function* handleConnectNewWallet() {
   const analytics = yield* getContext('analytics')
@@ -58,6 +64,9 @@ function* handleConnectNewWallet() {
 
     const signature = yield* signMessage(connection)
     const updatedUserMetadata = yield* associateNewWallet(signature)
+
+    // Trigger collectibles fetch in case newly connected wallet has collectibles
+    yield* put(refreshWalletCollectibles(chain, walletAddress))
 
     analytics.track({
       eventName: Name.CONNECT_WALLET_NEW_WALLET_CONNECTED,


### PR DESCRIPTION
### Description

Currently, the collectibles state is not properly refreshed when a user connects or disconnects a wallet. This makes it so that they would need to refresh their session before uploading a collectible gated track right after connecting a wallet that has valid nft collections.
This PR fixes that.

This is only the fix for web.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local web app vs stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

