### PR TITLE
[PAY-1020] Refresh collectibles when adding/removing wallets

### DIFF
--- a/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
+++ b/packages/web/src/common/store/pages/token-dashboard/removeWalletSaga.ts
@@ -9,10 +9,14 @@ import {
   tokenDashboardPageActions,
   walletActions
 } from '@audius/common'
-import { call, put, select, takeLatest } from 'typed-redux-saga'
+import { call, fork, put, select, takeLatest } from 'typed-redux-saga'
 
 import { requestConfirmation } from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
+import {
+  fetchOpenSeaAssets,
+  fetchSolanaCollectibles
+} from 'common/store/profile/sagas'
 import { waitForWrite } from 'utils/sagaHelpers'
 
 import { getAccountMetadataCID } from './getAccountMetadataCID'
@@ -112,6 +116,9 @@ function* removeWallet(action: ConfirmRemoveWalletAction) {
         }
       ])
     )
+
+    yield* fork(fetchSolanaCollectibles, updatedMetadata)
+    yield* fork(fetchOpenSeaAssets, updatedMetadata)
   }
 
   function* onError() {

--- a/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
+++ b/packages/web/src/store/token-dashboard/connectNewWalletSaga.ts
@@ -1,11 +1,15 @@
 import { getContext, Name, tokenDashboardPageActions } from '@audius/common'
 import * as Sentry from '@sentry/browser'
-import { put, takeEvery } from 'typed-redux-saga'
+import { fork, put, takeEvery } from 'typed-redux-saga'
 
 import { addWalletToUser } from 'common/store/pages/token-dashboard/addWalletToUser'
 import { associateNewWallet } from 'common/store/pages/token-dashboard/associateNewWallet'
 import { checkIsNewWallet } from 'common/store/pages/token-dashboard/checkIsNewWallet'
 import { getWalletInfo } from 'common/store/pages/token-dashboard/getWalletInfo'
+import {
+  fetchOpenSeaAssets,
+  fetchSolanaCollectibles
+} from 'common/store/profile/sagas'
 
 import { disconnectWallet } from './disconnectWallet'
 import { establishWalletConnection } from './establishWalletConnection'
@@ -70,6 +74,9 @@ function* handleConnectNewWallet() {
     const disconnect = () => disconnectWallet(connection)
 
     yield* addWalletToUser(updatedUserMetadata, disconnect)
+
+    yield* fork(fetchSolanaCollectibles, updatedUserMetadata)
+    yield* fork(fetchOpenSeaAssets, updatedUserMetadata)
   } catch (e) {
     // Very likely we hit error path here i.e. user closes the web3 popup. Log it and restart
     const err = `Caught error during handleConnectNewWallet:  ${e}, resetting to initial state`


### PR DESCRIPTION
### Description

Refresh collectibles state when the user adds or removes a wallet, so that they can gate on the newly added wallet's collectibles or access tracks gated by the newly added wallet's collectibles, as well as so they can't gate on collectibles no longer linked.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

