### PR TITLE
Remove upgradeToCreator

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1223,14 +1223,6 @@ export const audiusBackend = ({
     }
   }
 
-  /**
-   * Upgrades a user to a creator
-   * @param {string} newCreatorNodeEndpoint will follow the structure 'cn1,cn2,cn3'
-   */
-  async function upgradeToCreator(newCreatorNodeEndpoint: string) {
-    return audiusLibs.User.upgradeToCreator(userNodeUrl, newCreatorNodeEndpoint)
-  }
-
   // Uploads a single track
   // Returns { trackId, error, phase }
   async function uploadTrack(
@@ -3610,7 +3602,6 @@ export const audiusBackend = ({
     updateUserSubscription,
     subscribeToUser,
     unsubscribeFromUser,
-    upgradeToCreator,
     uploadImage,
     uploadTrack,
     uploadTrackToCreatorNode,

--- a/packages/common/src/store/upload/actions.ts
+++ b/packages/common/src/store/upload/actions.ts
@@ -24,7 +24,6 @@ export const TOGGLE_MULTI_TRACK_NOTIFICATION =
   'UPLOAD/TOGGLE_MULTI_TRACK_NOTIFICATION'
 
 // Errors
-export const UPGRADE_TO_CREATOR_ERROR = 'UPLOAD/ERROR/UPGRADE_TO_CREATOR'
 export const SINGLE_TRACK_UPLOAD_ERROR = 'UPLOAD/ERROR/SINGLE_TRACK_UPLOAD'
 export const SINGLE_TRACK_UPLOAD_TIMEOUT_ERROR =
   'UPLOAD/ERROR/SINGLE_TRACK_UPLOAD_TIMEOUT'
@@ -103,11 +102,6 @@ export const undoResetState = () => {
 export const toggleMultiTrackNotification = (open = false) => {
   return { type: TOGGLE_MULTI_TRACK_NOTIFICATION, open }
 }
-
-export const upgradeToCreatorError = (error: string) => ({
-  type: UPGRADE_TO_CREATOR_ERROR,
-  error
-})
 
 export const singleTrackUploadError = (
   error: string,

--- a/packages/web/src/common/store/cache/users/sagas.d.ts
+++ b/packages/web/src/common/store/cache/users/sagas.d.ts
@@ -11,8 +11,6 @@ export declare function* fetchUsers(
   forceRetrieveFromSource?: boolean
 ): { entries: Record<string, User> }
 
-export declare function* upgradeToCreator(): boolean
-
 export default function sagas(): (() => Generator<
   ForkEffect<never>,
   void,

--- a/packages/web/src/common/store/upload/errorSagas.ts
+++ b/packages/web/src/common/store/upload/errorSagas.ts
@@ -69,7 +69,6 @@ function* handleUploadError(action: UploadErrorActions) {
 export function* watchUploadErrors() {
   yield takeEvery(
     [
-      uploadActions.UPGRADE_TO_CREATOR_ERROR,
       uploadActions.SINGLE_TRACK_UPLOAD_ERROR,
       uploadActions.SINGLE_TRACK_UPLOAD_TIMEOUT_ERROR,
       uploadActions.MULTI_TRACK_UPLOAD_ERROR,


### PR DESCRIPTION
### Description
`upgradeToCreator()` has not existed in libs for a long time, so this PR removes the wallet connection logic that tries to call `upgradeToCreator()`

### Dragons
Most users should already have `metadata_multihash` and `creator_node_endpoint` (including new users - I tested that), and Entity Manager is handling them now (tagged Isaac for visibility), so this path was likely almost never called. [Sentry logs](https://audius.sentry.io/issues/3966211875/?project=1457231&query=is%3Aunresolved+upgradeToCreator&referrer=issue-stream&statsPeriod=14d) show one error in the past 14 days for this function (and the error was because the function doesn't exist in libs anyway so there's no point in trying to call it in client)

### How Has This Been Tested?
Created a new user, verified it has `metadata_multihash` and `creator_node_endpoint` at http://audius-protocol-discovery-provider-1:5000/v1/full/users/handle/<handle>, and successfully connected a wallet

### How will this change be monitored?
Monitor for `CONNECT_WALLET_ASSOCIATION_ERROR` errors

### Feature Flags ###
None