### PR TITLE
Update lineup tile time util func to hide hour text when under 1 hour

### DIFF
--- a/packages/common/src/utils/timeUtil.ts
+++ b/packages/common/src/utils/timeUtil.ts
@@ -26,7 +26,8 @@ export const formatLineupTileDuration = (
 ) => {
   if (!isPodcast && seconds < SECONDS_PER_HOUR) return formatSeconds(seconds)
   const d = moment.duration(seconds, 'seconds')
-  return `${d.hours()}hr ${d.minutes()}m`
+  const hourText = d.hours() > 0 ? `${d.hours()}hr ` : ''
+  return `${hourText}${d.minutes()}m`
 }
 
 export const formatDate = (date: MomentInput, format?: string): string => {


### PR DESCRIPTION
### Description
Small update to hide the hour part of the duration text for podcasts under 1hr

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

