### PR TITLE
Abort jobs on clearOfflineDownloads

### DIFF
--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadCollectionWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadCollectionWorker.ts
@@ -59,19 +59,19 @@ export function* downloadCollectionWorker(collectionId: CollectionId) {
   )
   yield* put(startJob(queueItem))
 
-  const { jobResult, cancel, abort, abortJob } = yield* race({
+  const { jobResult, cancel, abortDownload, abortJob } = yield* race({
     jobResult: retryOfflineJob(
       MAX_RETRY_COUNT,
       1000,
       downloadCollectionAsync,
       collectionId
     ),
-    abort: call(shouldAbortDownload, collectionId),
+    abortDownload: call(shouldAbortDownload, collectionId),
     abortJob: call(shouldAbortJob),
     cancel: call(shouldCancelJob)
   })
 
-  if (abort || abortJob) {
+  if (abortDownload || abortJob) {
     yield* call(removeDownloadedCollection, collectionId)
     yield* put(requestProcessNextJob())
   } else if (cancel) {

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/staleTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/staleTrackWorker.ts
@@ -25,14 +25,14 @@ const { getTrack } = cacheTracksSelectors
 
 export function* staleTrackWorker(trackId: ID) {
   yield* put(startJob({ type: 'stale-track', id: trackId }))
-  const { jobResult, abort, abortJob, cancel } = yield* race({
+  const { jobResult, abortStaleTrack, abortJob, cancel } = yield* race({
     jobResult: call(handleStaleTrack, trackId),
-    abort: call(shouldAbortStaleTrack, trackId),
+    abortStaleTrack: call(shouldAbortStaleTrack, trackId),
     abortJob: call(shouldAbortJob),
     cancel: call(shouldCancelJob)
   })
 
-  if (abort || abortJob) {
+  if (abortStaleTrack || abortJob) {
     yield* put(requestProcessNextJob())
   } else if (cancel) {
     // continue

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/staleTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/staleTrackWorker.ts
@@ -18,19 +18,21 @@ import {
   startJob
 } from 'app/store/offline-downloads/slice'
 
+import { shouldAbortJob } from '../../utils/shouldAbortJob'
 import { shouldCancelJob } from '../../utils/shouldCancelJob'
 const { getUserId } = accountSelectors
 const { getTrack } = cacheTracksSelectors
 
 export function* staleTrackWorker(trackId: ID) {
   yield* put(startJob({ type: 'stale-track', id: trackId }))
-  const { jobResult, abort, cancel } = yield* race({
+  const { jobResult, abort, abortJob, cancel } = yield* race({
     jobResult: call(handleStaleTrack, trackId),
-    abort: call(shouldAbortJob, trackId),
+    abort: call(shouldAbortStaleTrack, trackId),
+    abortJob: call(shouldAbortJob),
     cancel: call(shouldCancelJob)
   })
 
-  if (abort) {
+  if (abort || abortJob) {
     yield* put(requestProcessNextJob())
   } else if (cancel) {
     // continue
@@ -74,7 +76,7 @@ export function* handleStaleTrack(trackId: ID) {
   return OfflineDownloadStatus.SUCCESS
 }
 
-function* shouldAbortJob(trackId: ID) {
+function* shouldAbortStaleTrack(trackId: ID) {
   while (true) {
     yield* take(removeOfflineItems.type)
     const trackStatus = yield* select(getTrackOfflineDownloadStatus(trackId))

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/syncCollectionWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/syncCollectionWorker.ts
@@ -51,14 +51,14 @@ function* shouldAbortSync(collectionId: CollectionId) {
 export function* syncCollectionWorker(collectionId: CollectionId) {
   yield* put(startCollectionSync({ id: collectionId }))
 
-  const { jobResult, abort, abortJob, cancel } = yield* race({
+  const { jobResult, abortSync, abortJob, cancel } = yield* race({
     jobResult: call(syncCollectionAsync, collectionId),
-    abort: call(shouldAbortSync, collectionId),
+    abortSync: call(shouldAbortSync, collectionId),
     abortJob: call(shouldAbortJob),
     cancel: call(shouldCancelJob)
   })
 
-  if (abort || abortJob) {
+  if (abortSync || abortJob) {
     yield* put(requestProcessNextJob())
   } else if (cancel) {
     yield* put(cancelCollectionSync({ id: collectionId }))

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/syncCollectionWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/syncCollectionWorker.ts
@@ -30,6 +30,7 @@ import {
   removeOfflineItems,
   startCollectionSync
 } from '../../../slice'
+import { shouldAbortJob } from '../../utils/shouldAbortJob'
 import { shouldCancelJob } from '../../utils/shouldCancelJob'
 
 const { getUserId } = accountSelectors
@@ -50,13 +51,14 @@ function* shouldAbortSync(collectionId: CollectionId) {
 export function* syncCollectionWorker(collectionId: CollectionId) {
   yield* put(startCollectionSync({ id: collectionId }))
 
-  const { jobResult, abort, cancel } = yield* race({
+  const { jobResult, abort, abortJob, cancel } = yield* race({
     jobResult: call(syncCollectionAsync, collectionId),
     abort: call(shouldAbortSync, collectionId),
+    abortJob: call(shouldAbortJob),
     cancel: call(shouldCancelJob)
   })
 
-  if (abort) {
+  if (abort || abortJob) {
     yield* put(requestProcessNextJob())
   } else if (cancel) {
     yield* put(cancelCollectionSync({ id: collectionId }))

--- a/packages/mobile/src/store/offline-downloads/sagas/utils/shouldAbortJob.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/utils/shouldAbortJob.ts
@@ -1,0 +1,8 @@
+import { take } from 'typed-redux-saga'
+
+import { clearOfflineDownloads } from '../../slice'
+
+export function* shouldAbortJob() {
+  yield* take([clearOfflineDownloads])
+  return true
+}


### PR DESCRIPTION
### Description

Fix issue where a job could sneak through after removing all downloads on logout or using the new settings button.

### Dragons

Careful not to break existing job flows and accidentally cancel stuff.