### PR TITLE
Fix fetchNotifications fallback

### DIFF
--- a/packages/web/src/common/store/notifications/fetchNotifications.ts
+++ b/packages/web/src/common/store/notifications/fetchNotifications.ts
@@ -96,7 +96,7 @@ export function* fetchNotifications(config: FetchNotificationsParams) {
       if (invalidNotifications.length !== 0) {
         const newLimit = limit - validNotifications.length
         const newTimestamp = moment(
-          validNotifications[validNotifications.length - 1].timestamp
+          validNotifications[validNotifications.length - 1]?.timestamp
         ).toISOString()
 
         const legacyNotificationsResponse = yield* call(


### PR DESCRIPTION
### Description

Fixes case where there may be no validNotifications, resulting in a runtime error. this kinda seems like a bug typescript should be able to catch, since we are indexing into an array. maybe we can check if there is a typescript option to prevent this in the future?