### PR TITLE
Read subscribers from bulk endpoint

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2834,9 +2834,7 @@ export const audiusBackend = ({
         const encodedUserId = encodeHashId(userId)
         const bulkResp: { user_id: string; subscriber_ids: string[] }[] =
           await audiusLibs.User.bulkGetUserSubscribers([encodedUserId])
-        const encodedSubscriberIds = bulkResp.find(
-          (user) => user.user_id === encodedUserId
-        )!.subscriber_ids
+        const encodedSubscriberIds = bulkResp[0].subscriber_ids
         const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
         return subscriberIds.includes(account.user_id)
       } catch (e) {

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -70,7 +70,6 @@ import {
   decodeHashId,
   Timer
 } from '../../utils'
-import { APIUser } from '../audius-api-client/types'
 
 import { MonitoringCallbacks } from './types'
 
@@ -2832,12 +2831,13 @@ export const audiusBackend = ({
     if (isreadSubscribersFromDiscoveryEnabled) {
       // Read subscribers from discovery
       try {
-        const subscribers: APIUser[] = await audiusLibs.User.getUserSubscribers(
-          encodeHashId(userId)
-        )
-        const subscriberIds = subscribers.map((subscriber) =>
-          decodeHashId(subscriber.id)
-        )
+        const encodedUserId = encodeHashId(userId)
+        const bulkResp: { user_id: string; subscriber_ids: string[] }[] =
+          await audiusLibs.User.bulkGetUserSubscribers([encodedUserId])
+        const encodedSubscriberIds = bulkResp.find(
+          (user) => user.user_id === encodedUserId
+        )!.subscriber_ids
+        const subscriberIds = encodedSubscriberIds.map((id) => decodeHashId(id))
         return subscriberIds.includes(account.user_id)
       } catch (e) {
         console.error(getErrorMessage(e))


### PR DESCRIPTION
### Description
Bulk endpoint retrieves only subscriber ids (no other user info) and has no pagination limits. The current path using /user/id/subscribers is buggy because of the pagination defaults.

Need this code change to be in before turning on the `read_subscriptions_from_discovery` flag. After the flag is on, can deploy these PRs https://github.com/AudiusProject/audius-client/pull/3005 and https://github.com/AudiusProject/audius-protocol/pull/4909 removing the legacy identity subscriptions path.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

