### PR TITLE
Re-add chat features to profile screen

### DIFF
--- a/packages/common/src/store/ui/modals/slice.ts
+++ b/packages/common/src/store/ui/modals/slice.ts
@@ -37,7 +37,8 @@ const initialState: ModalsState = {
   CreateChat: false,
   InboxSettings: false,
   LockedContent: false,
-  PlaybackRate: false
+  PlaybackRate: false,
+  ProfileActions: false
 }
 
 const slice = createSlice({

--- a/packages/common/src/store/ui/modals/types.ts
+++ b/packages/common/src/store/ui/modals/types.ts
@@ -34,5 +34,6 @@ export type Modals =
   | 'InboxSettings'
   | 'LockedContent'
   | 'PlaybackRate'
+  | 'ProfileActions'
 
 export type ModalsState = { [modal in Modals]: boolean | 'closing' }

--- a/packages/mobile/src/app/Drawers.tsx
+++ b/packages/mobile/src/app/Drawers.tsx
@@ -98,7 +98,8 @@ const commonDrawersMap: { [Modal in Modals]?: ComponentType } = {
   AddToPlaylist: AddToPlaylistDrawer,
   AudioBreakdown: AudioBreakdownDrawer,
   DeletePlaylistConfirmation: DeletePlaylistConfirmationDrawer,
-  VipDiscord: VipDiscordDrawer
+  VipDiscord: VipDiscordDrawer,
+  ProfileActions: ProfileActionsDrawer
 }
 
 const nativeDrawersMap: { [DrawerName in Drawer]?: ComponentType } = {
@@ -115,7 +116,6 @@ const nativeDrawersMap: { [DrawerName in Drawer]?: ComponentType } = {
   UnfavoriteDownloadedCollection: UnfavoriteDownloadedCollectionDrawer,
   LockedContent: LockedContentDrawer,
   ChatActions: ChatActionsDrawer,
-  ProfileActions: ProfileActionsDrawer,
   BlockMessages: BlockMessagesDrawer
 }
 

--- a/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
+++ b/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
@@ -1,14 +1,17 @@
-import { ShareSource, shareModalUIActions } from '@audius/common'
-import { View } from 'react-native'
+import { useCallback, useMemo } from 'react'
+
+import {
+  ShareSource,
+  shareModalUIActions,
+  profilePageSelectors
+} from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { Text } from 'app/components/core'
-import { NativeDrawer } from 'app/components/drawer'
+import ActionDrawer from 'app/components/action-drawer'
 import type { AppState } from 'app/store'
-import { getData } from 'app/store/drawers/selectors'
 import { setVisibility } from 'app/store/drawers/slice'
-import { makeStyles } from 'app/styles'
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
+const { getProfileUserId } = profilePageSelectors
 
 const PROFILE_ACTIONS_MODAL_NAME = 'ProfileActions'
 
@@ -17,31 +20,11 @@ const messages = {
   blockMessages: 'Block Messages'
 }
 
-const useStyles = makeStyles(({ spacing, typography, palette }) => ({
-  drawer: {
-    marginVertical: spacing(7),
-    alignItems: 'center'
-  },
-  text: {
-    fontSize: 21,
-    lineHeight: spacing(6.5),
-    letterSpacing: 0.233333,
-    fontFamily: typography.fontByWeight.bold,
-    color: palette.secondary,
-    paddingVertical: spacing(3),
-    borderBottomWidth: 1,
-    borderBottomColor: palette.neutralLight9
-  }
-}))
-
 export const ProfileActionsDrawer = () => {
-  const styles = useStyles()
   const dispatch = useDispatch()
-  const { userId } = useSelector((state: AppState) =>
-    getData<'ProfileActions'>(state)
-  )
+  const userId = useSelector((state: AppState) => getProfileUserId(state))
 
-  const handleShareProfilePress = () => {
+  const handleShareProfilePress = useCallback(() => {
     dispatch(
       setVisibility({
         drawer: 'ProfileActions',
@@ -57,34 +40,33 @@ export const ProfileActionsDrawer = () => {
         })
       )
     }
-  }
+  }, [userId, dispatch])
 
-  const handleBlockMessagesPress = () => {
+  const handleBlockMessagesPress = useCallback(() => {
     dispatch(
       setVisibility({
         drawer: 'ProfileActions',
         visible: false
       })
     )
-    dispatch(
-      setVisibility({
-        drawer: 'BlockMessages',
-        visible: true,
-        data: { userId }
-      })
-    )
-  }
+    if (userId) {
+      dispatch(
+        setVisibility({
+          drawer: 'BlockMessages',
+          visible: true,
+          data: { userId }
+        })
+      )
+    }
+  }, [dispatch, userId])
 
-  return (
-    <NativeDrawer drawerName={PROFILE_ACTIONS_MODAL_NAME}>
-      <View style={styles.drawer}>
-        <Text style={styles.text} onPress={handleShareProfilePress}>
-          {messages.shareProfile}
-        </Text>
-        <Text style={styles.text} onPress={handleBlockMessagesPress}>
-          {messages.blockMessages}
-        </Text>
-      </View>
-    </NativeDrawer>
+  const rows = useMemo(
+    () => [
+      { text: messages.shareProfile, callback: handleShareProfilePress },
+      { text: messages.blockMessages, callback: handleBlockMessagesPress }
+    ],
+    [handleShareProfilePress, handleBlockMessagesPress]
   )
+
+  return <ActionDrawer modalName={PROFILE_ACTIONS_MODAL_NAME} rows={rows} />
 }

--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -116,7 +116,7 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
       <EditProfileButton style={styles.followButton} />
     ) : (
       <>
-        {isChatEnabled ? <MessageButton profile={profile} /> : null}
+        {isChatEnabled && !isOwner ? <MessageButton profile={profile} /> : null}
         {does_current_user_follow ? (
           <SubscribeButton profile={profile} />
         ) : null}

--- a/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileInfo.tsx
@@ -1,17 +1,20 @@
 import {
   accountSelectors,
   FollowSource,
-  reachabilitySelectors
+  reachabilitySelectors,
+  FeatureFlags
 } from '@audius/common'
 import { View, Text } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import { FollowButton, FollowsYouChip } from 'app/components/user'
 import UserBadges from 'app/components/user-badges'
+import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { useRoute } from 'app/hooks/useRoute'
 import { flexRowCentered, makeStyles } from 'app/styles'
 
 import { EditProfileButton } from './EditProfileButton'
+import { MessageButton } from './MessageButton'
 import { SubscribeButton } from './SubscribeButton'
 import { useSelectProfile } from './selectors'
 
@@ -89,6 +92,7 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
   const isReachable = useSelector(getIsReachable)
   const accountHandle = useSelector(getUserHandle)
   const styles = useStyles()
+  const { isEnabled: isChatEnabled } = useFeatureFlag(FeatureFlags.CHAT_ENABLED)
 
   const profile = useSelectProfile([
     'user_id',
@@ -112,6 +116,7 @@ export const ProfileInfo = (props: ProfileInfoProps) => {
       <EditProfileButton style={styles.followButton} />
     ) : (
       <>
+        {isChatEnabled ? <MessageButton profile={profile} /> : null}
         {does_current_user_follow ? (
           <SubscribeButton profile={profile} />
         ) : null}

--- a/packages/mobile/src/store/drawers/slice.ts
+++ b/packages/mobile/src/store/drawers/slice.ts
@@ -49,7 +49,7 @@ export type DrawerData = {
   }
   LockedContent: undefined
   ChatActions: { userId: number }
-  ProfileActions: { userId: number }
+  ProfileActions: undefined
   BlockMessages: { userId: number }
 }
 


### PR DESCRIPTION
### Description
Re-add message button and change profile top right icon to include path to block messages drawer. But feature flagged this time.

And also using ActionDrawer for ProfileActionsDrawer. Still need to convert ChatActionsDrawer as well.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios against both staging and prod.
Staging:
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-10 at 07 54 22](https://user-images.githubusercontent.com/3893871/224321530-4843dc24-636f-4f26-9598-df8e1353f7a2.png)
Prod:
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-09 at 22 39 30](https://user-images.githubusercontent.com/3893871/224321532-d0d664f8-eb71-4c12-91e8-7bb6ab71cc29.png)


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

