### PR TITLE
Add custom mandatory update UI for mandatory OTA updates C-2258

### DIFF
--- a/packages/mobile/src/app/useSyncCodepush.ts
+++ b/packages/mobile/src/app/useSyncCodepush.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react'
+
+import codePush from 'react-native-code-push'
+import { useEffectOnce } from 'react-use'
+
+import { useEnterForeground } from 'app/hooks/useAppState'
+
+export const useSyncCodepush = () => {
+  const [
+    isPendingMandatoryCodePushUpdate,
+    setIsPendingMandatoryCodePushUpdate
+  ] = useState(false)
+
+  const codePushSync = useCallback(() => {
+    codePush.sync(
+      {
+        installMode: codePush.InstallMode.ON_NEXT_RESTART,
+        mandatoryInstallMode: codePush.InstallMode.ON_NEXT_RESTART
+        // ^ We'll manually show the mandatory update UI and prompt the user to restart the app.
+      },
+      (newStatus) => {
+        console.log('New CodePush Status: ', newStatus)
+        codePush.getUpdateMetadata(codePush.UpdateState.PENDING).then((res) => {
+          if (res != null && res.isMandatory) {
+            setIsPendingMandatoryCodePushUpdate(true)
+          }
+        })
+      }
+    )
+  }, [])
+
+  useEffectOnce(() => {
+    codePushSync()
+  })
+
+  useEnterForeground(() => {
+    codePushSync()
+  })
+
+  return { isPendingMandatoryCodePushUpdate }
+}

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -16,6 +16,7 @@ import { UpdateRequiredScreen } from 'app/screens/update-required-screen/UpdateR
 import { enterBackground, enterForeground } from 'app/store/lifecycle/actions'
 
 import { AppDrawerScreen } from '../app-drawer-screen'
+import { RestartRequiredScreen } from '../update-required-screen/RestartRequiredScreen'
 
 import { ThemedStatusBar } from './StatusBar'
 
@@ -31,15 +32,21 @@ export type RootScreenParamList = {
 
 const Stack = createNativeStackNavigator()
 
+type RootScreenProps = {
+  isPendingMandatoryCodePushUpdate?: boolean
+}
+
 /**
  * The top level navigator. Switches between sign on screens and main tab navigator
  * based on if the user is authed
  */
-export const RootScreen = () => {
+export const RootScreen = ({
+  isPendingMandatoryCodePushUpdate
+}: RootScreenProps) => {
   const dispatch = useDispatch()
   const accountStatus = useSelector(getAccountStatus)
   const showHomeStack = useSelector(getHasCompletedAccount)
-  const { updateRequired } = useUpdateRequired()
+  const { updateRequired: appUpdateRequired } = useUpdateRequired()
   const [isLoaded, setIsLoaded] = useState(false)
 
   useAppState(
@@ -68,8 +75,13 @@ export const RootScreen = () => {
         <Stack.Navigator
           screenOptions={{ gestureEnabled: false, headerShown: false }}
         >
-          {updateRequired ? (
-            <Stack.Screen name='UpdateStack' component={UpdateRequiredScreen} />
+          {appUpdateRequired || isPendingMandatoryCodePushUpdate ? (
+            <Stack.Screen
+              name='UpdateStack'
+              component={
+                appUpdateRequired ? UpdateRequiredScreen : RestartRequiredScreen
+              }
+            />
           ) : showHomeStack ? (
             <Stack.Screen name='HomeStack' component={AppDrawerScreen} />
           ) : (

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -12,11 +12,13 @@ import { useUpdateRequired } from 'app/hooks/useUpdateRequired'
 import type { AppScreenParamList } from 'app/screens/app-screen'
 import { SignOnScreen } from 'app/screens/signon'
 import { SplashScreen } from 'app/screens/splash-screen'
-import { UpdateRequiredScreen } from 'app/screens/update-required-screen/UpdateRequiredScreen'
+import {
+  UpdateRequiredScreen,
+  RestartRequiredScreen
+} from 'app/screens/update-required-screen'
 import { enterBackground, enterForeground } from 'app/store/lifecycle/actions'
 
 import { AppDrawerScreen } from '../app-drawer-screen'
-import { RestartRequiredScreen } from '../update-required-screen/RestartRequiredScreen'
 
 import { ThemedStatusBar } from './StatusBar'
 

--- a/packages/mobile/src/screens/update-required-screen/NewVersionPrompt.tsx
+++ b/packages/mobile/src/screens/update-required-screen/NewVersionPrompt.tsx
@@ -4,7 +4,7 @@ import IconDownload from 'app/assets/images/iconDownload.svg'
 import { Button, GradientText, Text } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 
-const useStyles = makeStyles(({ palette, spacing, typography }) => ({
+const useStyles = makeStyles(({ spacing }) => ({
   contentContainer: {
     paddingTop: spacing(32),
     paddingBottom: spacing(8),
@@ -25,15 +25,22 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   }
 }))
 
-type NewVersionPromptProps = {
+type BaseNewVersionPromptProps = {
   headerText: string
   contentText: string
   buttonText: string
-  /** Passing a `url` will make the CTA element a link */
-  url?: string
-  /** Passing an `onPress` callback will make the CTA element a Pressable */
-  onPress?: () => void
 }
+type NewVersionPromptProps = BaseNewVersionPromptProps &
+  (
+    | {
+        /** Passing a `url` will make the CTA element a link */
+        url: string
+      }
+    | {
+        /** Passing an `onPress` callback will make the CTA element a Pressable */
+        onPress: () => void
+      }
+  )
 
 export const NewVersionPrompt = ({
   headerText,

--- a/packages/mobile/src/screens/update-required-screen/NewVersionPrompt.tsx
+++ b/packages/mobile/src/screens/update-required-screen/NewVersionPrompt.tsx
@@ -1,0 +1,65 @@
+import { View } from 'react-native'
+
+import IconDownload from 'app/assets/images/iconDownload.svg'
+import { Button, GradientText, Text } from 'app/components/core'
+import { makeStyles } from 'app/styles'
+
+const useStyles = makeStyles(({ palette, spacing, typography }) => ({
+  contentContainer: {
+    paddingTop: spacing(32),
+    paddingBottom: spacing(8),
+    paddingHorizontal: spacing(6)
+  },
+  header: {
+    fontSize: 24,
+    lineHeight: 52,
+    textAlign: 'center',
+    textShadowOffset: { height: 2, width: 0 },
+    textShadowRadius: 4,
+    textShadowColor: 'rgba(162,47,235,0.2)'
+  },
+  text: {
+    textAlign: 'center',
+    marginBottom: spacing(8),
+    marginTop: spacing(6)
+  }
+}))
+
+type NewVersionPromptProps = {
+  headerText: string
+  contentText: string
+  buttonText: string
+  /** Passing a `url` will make the CTA element a link */
+  url?: string
+  /** Passing an `onPress` callback will make the CTA element a Pressable */
+  onPress?: () => void
+}
+
+export const NewVersionPrompt = ({
+  headerText,
+  contentText,
+  buttonText,
+  url,
+  onPress
+}: NewVersionPromptProps) => {
+  const styles = useStyles()
+
+  return (
+    <View style={styles.contentContainer}>
+      <GradientText accessibilityRole='header' style={styles.header}>
+        {headerText}
+      </GradientText>
+      <Text variant='h1' style={styles.text}>
+        {contentText}
+      </Text>
+      <Button
+        title={buttonText}
+        size='large'
+        icon={IconDownload}
+        iconPosition='left'
+        url={url}
+        onPress={onPress}
+      />
+    </View>
+  )
+}

--- a/packages/mobile/src/screens/update-required-screen/NewVersionPrompt.tsx
+++ b/packages/mobile/src/screens/update-required-screen/NewVersionPrompt.tsx
@@ -25,22 +25,15 @@ const useStyles = makeStyles(({ spacing }) => ({
   }
 }))
 
-type BaseNewVersionPromptProps = {
+type NewVersionPromptProps = {
   headerText: string
   contentText: string
   buttonText: string
+  /** Passing a `url` will make the CTA element a link */
+  url?: string
+  /** Passing an `onPress` callback will make the CTA element a Pressable */
+  onPress?: () => void
 }
-type NewVersionPromptProps = BaseNewVersionPromptProps &
-  (
-    | {
-        /** Passing a `url` will make the CTA element a link */
-        url: string
-      }
-    | {
-        /** Passing an `onPress` callback will make the CTA element a Pressable */
-        onPress: () => void
-      }
-  )
 
 export const NewVersionPrompt = ({
   headerText,

--- a/packages/mobile/src/screens/update-required-screen/RestartRequiredScreen.tsx
+++ b/packages/mobile/src/screens/update-required-screen/RestartRequiredScreen.tsx
@@ -3,9 +3,9 @@ import codePush from 'react-native-code-push'
 import { NewVersionPrompt } from './NewVersionPrompt'
 
 const messages = {
-  header: 'Please Restart ✨',
-  text: 'We need to apply some updates to your app.',
-  buttonText: 'Restart App'
+  header: 'Update Available ✨',
+  text: 'We need to apply some great new changes to the app.',
+  buttonText: 'Apply Updates'
 }
 
 export const RestartRequiredScreen = () => {

--- a/packages/mobile/src/screens/update-required-screen/RestartRequiredScreen.tsx
+++ b/packages/mobile/src/screens/update-required-screen/RestartRequiredScreen.tsx
@@ -1,0 +1,22 @@
+import codePush from 'react-native-code-push'
+
+import { NewVersionPrompt } from './NewVersionPrompt'
+
+const messages = {
+  header: 'Please Restart ✨',
+  text: 'We need to apply some updates to your app.',
+  buttonText: 'Restart App'
+}
+
+export const RestartRequiredScreen = () => {
+  return (
+    <NewVersionPrompt
+      headerText={messages.header}
+      contentText={messages.text}
+      buttonText={messages.buttonText}
+      onPress={() => {
+        codePush.restartApp()
+      }}
+    />
+  )
+}

--- a/packages/mobile/src/screens/update-required-screen/UpdateRequiredScreen.tsx
+++ b/packages/mobile/src/screens/update-required-screen/UpdateRequiredScreen.tsx
@@ -1,8 +1,6 @@
-import { Platform, View } from 'react-native'
+import { Platform } from 'react-native'
 
-import IconDownload from 'app/assets/images/iconDownload.svg'
-import { Button, GradientText, Text } from 'app/components/core'
-import { makeStyles } from 'app/styles'
+import { NewVersionPrompt } from './NewVersionPrompt'
 
 const ANDROID_PLAY_STORE_LINK =
   'https://play.google.com/store/apps/details?id=co.audius.app'
@@ -14,47 +12,16 @@ const messages = {
   buttonText: 'Update App'
 }
 
-const useStyles = makeStyles(({ palette, spacing, typography }) => ({
-  contentContainer: {
-    paddingTop: spacing(32),
-    paddingBottom: spacing(8),
-    paddingHorizontal: spacing(6)
-  },
-  header: {
-    fontSize: 24,
-    lineHeight: 52,
-    textAlign: 'center',
-    textShadowOffset: { height: 2, width: 0 },
-    textShadowRadius: 4,
-    textShadowColor: 'rgba(162,47,235,0.2)'
-  },
-  text: {
-    textAlign: 'center',
-    marginBottom: spacing(8),
-    marginTop: spacing(6)
-  }
-}))
-
 export const UpdateRequiredScreen = () => {
-  const styles = useStyles()
   const isAndroid = Platform.OS === 'android'
   const url = isAndroid ? ANDROID_PLAY_STORE_LINK : IOS_APP_STORE_LINK
 
   return (
-    <View style={styles.contentContainer}>
-      <GradientText accessibilityRole='header' style={styles.header}>
-        {messages.header}
-      </GradientText>
-      <Text variant='h1' style={styles.text}>
-        {messages.text}
-      </Text>
-      <Button
-        title={messages.buttonText}
-        size='large'
-        icon={IconDownload}
-        iconPosition='left'
-        url={url}
-      />
-    </View>
+    <NewVersionPrompt
+      headerText={messages.header}
+      contentText={messages.text}
+      buttonText={messages.buttonText}
+      url={url}
+    />
   )
 }

--- a/packages/mobile/src/screens/update-required-screen/index.ts
+++ b/packages/mobile/src/screens/update-required-screen/index.ts
@@ -1,0 +1,2 @@
+export { RestartRequiredScreen } from './RestartRequiredScreen'
+export { UpdateRequiredScreen } from './UpdateRequiredScreen'


### PR DESCRIPTION
### Description
Context: https://audius-internal.slack.com/archives/C0497Q799PU/p1677867259834309
Show a blocking "restart your app" CTA for mandatory OTA (Codepush) updates.

Copy awaiting approval from Product.
![IMG_9230](https://user-images.githubusercontent.com/36916764/224765145-837838b9-4bcc-4d63-9352-e639be445187.PNG)

https://user-images.githubusercontent.com/36916764/224765154-671ed0e9-161e-4cbe-8d79-1b1d03e66405.MP4


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested:
-Mandatory OTA update on Android
-Mandatory OTA update on iOS
-Optional OTA update on Android
-Optional OTA update on iOS
-OTA rollbacks (which are a subset of mandatory OTA updates)
-Mandatory full app release update on iOS

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

