### PR TITLE
[C-2311] Fix notification timestamp logic

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -2112,6 +2112,16 @@
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "query-string": {
+          "version": "6.13.5",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
+          "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
         }
       }
     },
@@ -4088,6 +4098,11 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng=="
+    },
     "finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -5933,13 +5948,25 @@
       }
     },
     "query-string": {
-      "version": "6.13.5",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
-      "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz",
+      "integrity": "sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==",
       "requires": {
-        "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "dependencies": {
+        "decode-uri-component": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+          "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ=="
+        },
+        "split-on-first": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+          "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA=="
+        }
       }
     },
     "quick-lru": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -41,6 +41,7 @@
     "moment": "2.24.0",
     "numeral": "2.0.6",
     "proxy-memoize": "1.2.0",
+    "query-string": "8.1.0",
     "reselect": "4.0.0",
     "typed-redux-saga": "1.3.1",
     "typesafe-actions": "5.1.0"

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2117,7 +2117,7 @@ export const audiusBackend = ({
     const { timestamp, ...restNotification } = notification
     return {
       ...restNotification,
-      timestamp: Date.parse(timestamp) / 1000
+      timestamp: Math.round(Date.parse(timestamp) / 1000) // unix timestamp (sec)
     } as Notification
   }
 

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -13,6 +13,7 @@ import BN from 'bn.js'
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
+import queryString from 'query-string'
 
 import { Env } from 'services/env'
 
@@ -2103,7 +2104,7 @@ export const audiusBackend = ({
     const timestamp = notification.actions[0].timestamp
     return {
       groupId: notification.group_id,
-      timestamp: new Date(timestamp * 1000).toString(),
+      timestamp,
       isViewed: notification.seen_at == null,
       id: `timestamp:${timestamp}:group_id:${notification.group_id}`
     }
@@ -2412,6 +2413,7 @@ export const audiusBackend = ({
 
     type DiscoveryNotificationsResponse = {
       notifications: DiscoveryNotification[]
+      unread_count: number
     }
 
     const response: DiscoveryNotificationsResponse =
@@ -2423,9 +2425,12 @@ export const audiusBackend = ({
         validTypes
       })
 
+    const { unread_count, notifications } = response
+
     // TODO: update mapDiscoveryNotification to return Notification
     return {
-      notifications: response.notifications.map(
+      totalUnread: unread_count,
+      notifications: notifications.map(
         mapDiscoveryNotification
       ) as Notification[]
     }
@@ -2437,7 +2442,8 @@ export const audiusBackend = ({
     withDethroned
   }: {
     limit: number
-    timeOffset: string
+    // unix timestamp
+    timeOffset?: number
     withDethroned: boolean
   }) {
     await waitForLibsInit()
@@ -2448,27 +2454,35 @@ export const audiusBackend = ({
         error: new Error('User not signed in'),
         isRequestError: false
       }
+    const { handle } = account
     try {
       const { data, signature } = await signData()
-      const timeOffsetQuery = timeOffset
-        ? `&timeOffset=${encodeURI(timeOffset)}`
-        : ''
-      const limitQuery = `&limit=${limit}`
-      const handleQuery = `&handle=${account.handle}`
-      const withDethronedQuery = withDethroned
-        ? '&withSupporterDethroned=true'
-        : ''
+      const query = {
+        timeOffset: timeOffset
+          ? dayjs.unix(timeOffset).toISOString()
+          : undefined,
+        limit,
+        handle,
+        withSupporterDethroned: withDethroned,
+        withTips: true,
+        withRewards: true,
+        withRemix: true,
+        withTrendingTrack: true
+      }
+
+      const getNotificationsUrl = queryString.stringifyUrl({
+        url: `${identityServiceUrl}/notifications`,
+        query
+      })
+
       // TODO: withRemix, withTrending, withRewards are always true and should be removed in a future release
-      const notificationsResponse = await fetch(
-        `${identityServiceUrl}/notifications?${limitQuery}${timeOffsetQuery}${handleQuery}${withDethronedQuery}&withTips=true&withRewards=true&withRemix=true&withTrendingTrack=true`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            [AuthHeaders.Message]: data,
-            [AuthHeaders.Signature]: signature
-          }
+      const notificationsResponse = await fetch(getNotificationsUrl, {
+        headers: {
+          'Content-Type': 'application/json',
+          [AuthHeaders.Message]: data,
+          [AuthHeaders.Signature]: signature
         }
-      )
+      })
 
       if (notificationsResponse.status !== 200) {
         return {
@@ -2477,14 +2491,28 @@ export const audiusBackend = ({
           isRequestError: true
         }
       }
-      type Notifications = {
+      type NotificationsResult = {
         message: 'success'
-        notifications: Notification[]
+        notifications: (Omit<Notification, 'timestamp'> & {
+          timestamp: string
+        })[]
         totalUnread: number
         playlistUpdates: number[]
       }
-      const notifications: Notifications = await notificationsResponse.json()
-      return notifications
+      const notificationsResult: NotificationsResult =
+        await notificationsResponse.json()
+      const formattedNotifications = {
+        ...notificationsResult,
+        notifications: notificationsResult.notifications.map(
+          (notification) =>
+            ({
+              ...notification,
+              timestamp: Date.parse(notification.timestamp) / 1000
+            } as Notification)
+        )
+      }
+
+      return formattedNotifications
     } catch (e) {
       return {
         message: 'error',

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -59,7 +59,8 @@ import {
   NotificationType,
   Entity,
   Achievement,
-  Notification
+  Notification,
+  IdentityNotification
 } from '../../store'
 import { CIDCache } from '../../store/cache/CIDCache'
 import {
@@ -2110,6 +2111,16 @@ export const audiusBackend = ({
     }
   }
 
+  function mapIdentityNotification(
+    notification: IdentityNotification
+  ): Notification {
+    const { timestamp, ...restNotification } = notification
+    return {
+      ...restNotification,
+      timestamp: Date.parse(timestamp) / 1000
+    } as Notification
+  }
+
   function mapDiscoveryNotification(notification: DiscoveryNotification) {
     if (notification.type === 'follow') {
       const userIds = notification.actions.map((action) => {
@@ -2493,22 +2504,17 @@ export const audiusBackend = ({
       }
       type NotificationsResult = {
         message: 'success'
-        notifications: (Omit<Notification, 'timestamp'> & {
-          timestamp: string
-        })[]
+        notifications: IdentityNotification[]
         totalUnread: number
         playlistUpdates: number[]
       }
       const notificationsResult: NotificationsResult =
         await notificationsResponse.json()
+
       const formattedNotifications = {
         ...notificationsResult,
         notifications: notificationsResult.notifications.map(
-          (notification) =>
-            ({
-              ...notification,
-              timestamp: Date.parse(notification.timestamp) / 1000
-            } as Notification)
+          mapIdentityNotification
         )
       }
 

--- a/packages/common/src/services/remote-config/defaults.ts
+++ b/packages/common/src/services/remote-config/defaults.ts
@@ -31,7 +31,7 @@ export const remoteConfigIntDefaults: { [key in IntKeys]: number | null } = {
   [IntKeys.BUY_AUDIO_WALLET_POLL_MAX_RETRIES]: 120,
   [IntKeys.BUY_AUDIO_SLIPPAGE]: 3,
   [IntKeys.GATED_TRACK_POLL_INTERVAL_MS]: 1000,
-  [IntKeys.DISCOVERY_NOTIFICATIONS_GENESIS_TIMESTAMP]: 0
+  [IntKeys.DISCOVERY_NOTIFICATIONS_GENESIS_UNIX_TIMESTAMP]: 0
 }
 
 export const remoteConfigStringDefaults: {

--- a/packages/common/src/services/remote-config/types.ts
+++ b/packages/common/src/services/remote-config/types.ts
@@ -153,7 +153,7 @@ export enum IntKeys {
    * The start time for discovery notifications indexing, used to determine
    * when we should rollback to identity notifications
    */
-  DISCOVERY_NOTIFICATIONS_GENESIS_TIMESTAMP = 'DISCOVERY_NOTIFICATIONS_GENESIS_TIMESTAMP'
+  DISCOVERY_NOTIFICATIONS_GENESIS_UNIX_TIMESTAMP = 'DISCOVERY_NOTIFICATIONS_GENESIS_UNIX_TIMESTAMP'
 }
 
 export enum BooleanKeys {

--- a/packages/common/src/store/notifications/notificationsSlice.ts
+++ b/packages/common/src/store/notifications/notificationsSlice.ts
@@ -11,25 +11,6 @@ import {
   UpdateNotificationsAction
 } from './types'
 
-// export const notificationsAdapter = createEntityAdapter<Notification>({
-//   sortComparer: (a, b) => {
-//     const { timestamp: timestampA } = a
-//     const { timestamp: timestampB } = b
-//     const unixTimestampA =
-//       typeof timestampA === 'string' ? moment(timestampA).unix() : timestampA
-//     const unixTimestampB =
-//       typeof timestampB === 'string' ? moment(timestampB).unix() : timestampB
-
-//     console.log({ unixTimestampA, unixTimestampB })
-
-//     return unixTimestampA < unixTimestampB
-//       ? 1
-//       : unixTimestampA > unixTimestampB
-//       ? -1
-//       : 0
-//   }
-// })
-
 export const notificationsAdapter = createEntityAdapter<Notification>({
   sortComparer: (a, b) =>
     a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0

--- a/packages/common/src/store/notifications/notificationsSlice.ts
+++ b/packages/common/src/store/notifications/notificationsSlice.ts
@@ -11,6 +11,25 @@ import {
   UpdateNotificationsAction
 } from './types'
 
+// export const notificationsAdapter = createEntityAdapter<Notification>({
+//   sortComparer: (a, b) => {
+//     const { timestamp: timestampA } = a
+//     const { timestamp: timestampB } = b
+//     const unixTimestampA =
+//       typeof timestampA === 'string' ? moment(timestampA).unix() : timestampA
+//     const unixTimestampB =
+//       typeof timestampB === 'string' ? moment(timestampB).unix() : timestampB
+
+//     console.log({ unixTimestampA, unixTimestampB })
+
+//     return unixTimestampA < unixTimestampB
+//       ? 1
+//       : unixTimestampA > unixTimestampB
+//       ? -1
+//       : 0
+//   }
+// })
+
 export const notificationsAdapter = createEntityAdapter<Notification>({
   sortComparer: (a, b) =>
     a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -97,7 +97,7 @@ export type EntityType = TrackEntity | CollectionEntity
 export type BaseNotification = {
   id: string
   isViewed: boolean
-  timestamp: string
+  timestamp: number
   timeLabel?: string
   // group id is a part of the notifications v2 spec
   groupId?: string

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -835,6 +835,10 @@ export type Notification =
   | SupporterDethronedNotification
   | AddTrackToPlaylistNotification
 
+export type IdentityNotification = Omit<Notification, 'timestamp'> & {
+  timestamp: string
+}
+
 export interface NotificationState {
   modalNotificationId: string | undefined
   panelIsOpen: boolean

--- a/packages/web/src/common/store/notifications/checkForNewNotificationsSaga.ts
+++ b/packages/web/src/common/store/notifications/checkForNewNotificationsSaga.ts
@@ -5,7 +5,6 @@ import {
   NotificationType,
   walletActions
 } from '@audius/common'
-import moment from 'moment'
 import { call, put, select } from 'typed-redux-saga'
 
 import { NOTIFICATION_LIMIT_DEFAULT } from './constants'
@@ -64,11 +63,9 @@ export function* handleNewNotifications(notifications: Notification[]) {
 
 export function* checkForNewNotificationsSaga() {
   const limit = NOTIFICATION_LIMIT_DEFAULT
-  const timeOffset = moment().toISOString()
 
   const notificationsResponse = yield* call(fetchNotifications, {
-    limit,
-    timeOffset
+    limit
   })
 
   if ('error' in notificationsResponse) {

--- a/packages/web/src/common/store/notifications/fetchNotifications.ts
+++ b/packages/web/src/common/store/notifications/fetchNotifications.ts
@@ -19,7 +19,7 @@ type FetchNotificationsParams = {
 export function* fetchNotifications(config: FetchNotificationsParams) {
   const {
     limit,
-    timeOffset = Math.round(new Date().getTime() / 1000),
+    timeOffset = Math.round(new Date().getTime() / 1000), // current unix timestamp (sec)
     groupIdOffset
   } = config
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
@@ -49,14 +49,14 @@ export function* fetchNotifications(config: FetchNotificationsParams) {
     return notificationsResponse
   }
 
-  const discoveryNotificationsGenesisTimestamp = remoteConfig.getRemoteVar(
-    IntKeys.DISCOVERY_NOTIFICATIONS_GENESIS_TIMESTAMP
+  const discoveryNotificationsGenesisUnixTimestamp = remoteConfig.getRemoteVar(
+    IntKeys.DISCOVERY_NOTIFICATIONS_GENESIS_UNIX_TIMESTAMP
   )
 
   const shouldFetchNotificationFromDiscovery =
     useDiscoveryNotifications &&
-    discoveryNotificationsGenesisTimestamp &&
-    timeOffset > discoveryNotificationsGenesisTimestamp
+    discoveryNotificationsGenesisUnixTimestamp &&
+    timeOffset > discoveryNotificationsGenesisUnixTimestamp
 
   if (shouldFetchNotificationFromDiscovery) {
     const isRepostOfRepostEnabled = yield* call(
@@ -87,7 +87,8 @@ export function* fetchNotifications(config: FetchNotificationsParams) {
       const { notifications, totalUnread } = discoveryNotifications
       const [invalidNotifications, validNotifications] = partition(
         notifications,
-        ({ timestamp }) => timestamp < discoveryNotificationsGenesisTimestamp
+        ({ timestamp }) =>
+          timestamp < discoveryNotificationsGenesisUnixTimestamp
       )
 
       notificationsResponse.notifications = validNotifications

--- a/packages/web/src/common/store/notifications/fetchNotifications.ts
+++ b/packages/web/src/common/store/notifications/fetchNotifications.ts
@@ -5,20 +5,23 @@ import {
   removeNullable
 } from '@audius/common'
 import { partition } from 'lodash'
-import moment from 'moment'
 import { call, fork } from 'typed-redux-saga'
 
 import { recordPlaylistUpdatesAnalytics } from './playlistUpdates'
 
 type FetchNotificationsParams = {
   limit: number
-  // ISO string
-  timeOffset: string
+  // unix timestamp
+  timeOffset?: number
   groupIdOffset?: string
 }
 
 export function* fetchNotifications(config: FetchNotificationsParams) {
-  const { limit, timeOffset, groupIdOffset } = config
+  const {
+    limit,
+    timeOffset = Math.round(new Date().getTime() / 1000),
+    groupIdOffset
+  } = config
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
   const remoteConfig = yield* getContext('remoteConfigInstance')
@@ -53,11 +56,9 @@ export function* fetchNotifications(config: FetchNotificationsParams) {
   const shouldFetchNotificationFromDiscovery =
     useDiscoveryNotifications &&
     discoveryNotificationsGenesisTimestamp &&
-    Date.parse(timeOffset) > discoveryNotificationsGenesisTimestamp
+    timeOffset > discoveryNotificationsGenesisTimestamp
 
   if (shouldFetchNotificationFromDiscovery) {
-    const timestampParam = Math.trunc(Date.parse(timeOffset) / 1000)
-
     const isRepostOfRepostEnabled = yield* call(
       getFeatureEnabled,
       FeatureFlags.REPOST_OF_REPOST_NOTIFICATIONS
@@ -75,7 +76,7 @@ export function* fetchNotifications(config: FetchNotificationsParams) {
     const discoveryNotifications = yield* call(
       audiusBackendInstance.getDiscoveryNotifications,
       {
-        timestamp: timestampParam,
+        timestamp: timeOffset,
         groupIdOffset,
         limit,
         validTypes
@@ -83,21 +84,20 @@ export function* fetchNotifications(config: FetchNotificationsParams) {
     )
 
     if (discoveryNotifications) {
-      const { notifications } = discoveryNotifications
+      const { notifications, totalUnread } = discoveryNotifications
       const [invalidNotifications, validNotifications] = partition(
         notifications,
-        (notification) =>
-          Date.parse(notification.timestamp) <
-          discoveryNotificationsGenesisTimestamp
+        ({ timestamp }) => timestamp < discoveryNotificationsGenesisTimestamp
       )
 
       notificationsResponse.notifications = validNotifications
+      notificationsResponse.totalUnread = totalUnread
 
       if (invalidNotifications.length !== 0) {
         const newLimit = limit - validNotifications.length
-        const newTimestamp = moment(
-          validNotifications[validNotifications.length - 1]?.timestamp
-        ).toISOString()
+        const newTimestamp =
+          validNotifications[validNotifications.length - 1]?.timestamp ??
+          timeOffset
 
         const legacyNotificationsResponse = yield* call(
           audiusBackendInstance.getNotifications,

--- a/packages/web/src/common/store/notifications/fetchNotificationsSaga.ts
+++ b/packages/web/src/common/store/notifications/fetchNotificationsSaga.ts
@@ -4,7 +4,6 @@ import {
   notificationsActions,
   notificationsSelectors
 } from '@audius/common'
-import moment from 'moment'
 import { call, put, select, takeEvery } from 'typed-redux-saga'
 
 import { NOTIFICATION_LIMIT_DEFAULT } from './constants'
@@ -29,9 +28,7 @@ export function* watchFetchNotifications() {
 function* fetchNotificationsSaga(action: FetchNotificationsAction) {
   const pageSize = action.payload?.pageSize ?? NOTIFICATION_LIMIT_DEFAULT
   const lastNotification = yield* select(getLastNotification)
-  const timeOffset = lastNotification
-    ? lastNotification.timestamp
-    : moment().toISOString()
+  const timeOffset = lastNotification?.timestamp
 
   const notificationsResponse = yield* call(fetchNotifications, {
     limit: pageSize,

--- a/packages/web/src/common/store/notifications/parseAndProcessNotifications.ts
+++ b/packages/web/src/common/store/notifications/parseAndProcessNotifications.ts
@@ -25,8 +25,8 @@ const { getUserId } = accountSelectors
 // NOTE: the rest are loading in in the user list modal
 export const USER_INITIAL_LOAD_COUNT = 9
 
-const getTimeAgo = (now: moment.Moment, date: string) => {
-  const notifDate = moment(date)
+const getTimeAgo = (now: moment.Moment, date: number) => {
+  const notifDate = moment.unix(date)
   const weeksAgo = now.diff(notifDate, 'weeks')
   if (weeksAgo) return `${weeksAgo} Week${weeksAgo > 1 ? 's' : ''} ago`
   const daysAgo = now.diff(notifDate, 'days')

--- a/packages/web/src/common/store/notifications/refreshNotificationsSaga.ts
+++ b/packages/web/src/common/store/notifications/refreshNotificationsSaga.ts
@@ -1,5 +1,4 @@
 import { getErrorMessage, notificationsActions } from '@audius/common'
-import moment from 'moment'
 import { call, put, takeLatest } from 'typed-redux-saga'
 
 import { NOTIFICATION_LIMIT_DEFAULT } from './constants'
@@ -11,10 +10,8 @@ const { updateNotifications, fetchNotificationsFailed, refreshNotifications } =
 
 function* refreshNotificationsWorker() {
   const limit = NOTIFICATION_LIMIT_DEFAULT
-  const timeOffset = moment().toISOString()
   const notificationsResponse = yield* call(fetchNotifications, {
-    limit,
-    timeOffset
+    limit
   })
 
   if ('error' in notificationsResponse) {

--- a/packages/web/src/components/notification/Notification/FavoriteOfRepostNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FavoriteOfRepostNotification.tsx
@@ -44,7 +44,11 @@ export const FavoriteOfRepostNotification = (
   if (!users || !firstUser || !entity) return null
 
   return (
-    <NotificationTile notification={notification} onClick={handleGoToEntity}>
+    <NotificationTile
+      notification={notification}
+      onClick={handleGoToEntity}
+      disableClosePanel
+    >
       <NotificationHeader icon={<IconFavorite />}>
         <UserProfilePictureList
           users={users}

--- a/packages/web/src/components/notification/Notification/RepostOfRepostNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RepostOfRepostNotification.tsx
@@ -48,7 +48,7 @@ export const RepostOfRepostNotification = (
     <NotificationTile
       notification={notification}
       onClick={handleGoToEntity}
-      disableClosePanel={otherUsersCount > 0}
+      disableClosePanel
     >
       <NotificationHeader icon={<IconRepost />}>
         <UserProfilePictureList


### PR DESCRIPTION
### Description

Fixes notification timestamp logic and provides consistent experince between legacy and new system.
- Updates legacy timestamps to use unix timestamps, which is what discovery uses. This makes it easier to create appropriate request params, and sort notifs.
- Updates discovery notifications to use unix seconds, not milliseconds, which allows endpoint recent notifs.
- Adds query-string to make managing parameters much easier
