### PR TITLE
Fix heavy rotation playlist on client

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -411,6 +411,7 @@ type GetUserTrackHistoryArgs = {
   currentUserId: Nullable<ID>
   limit?: number
   offset?: number
+  sortMethod?: string
 }
 
 type GetReactionArgs = {
@@ -1523,16 +1524,19 @@ export class AudiusAPIClient {
     currentUserId,
     userId,
     offset = 0,
-    limit = 100
+    limit = 100,
+    sortMethod = ''
   }: GetUserTrackHistoryArgs) {
     const encodedUserId = this._encodeOrThrow(userId)
     const encodedCurrentUserId = encodeHashId(currentUserId)
     this._assertInitialized()
-    const params = {
+    let params = {
       user_id: encodedCurrentUserId || undefined,
       limit,
-      offset
+      offset,
+      sort_method: sortMethod || undefined
     }
+    params = sortMethod ? { ...params, sort_method: sortMethod } : params
 
     const response: Nullable<APIResponse<APIActivity[]>> =
       await this._getResponse(

--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1525,18 +1525,17 @@ export class AudiusAPIClient {
     userId,
     offset = 0,
     limit = 100,
-    sortMethod = ''
+    sortMethod
   }: GetUserTrackHistoryArgs) {
     const encodedUserId = this._encodeOrThrow(userId)
     const encodedCurrentUserId = encodeHashId(currentUserId)
     this._assertInitialized()
-    let params = {
+    const params = {
       user_id: encodedCurrentUserId || undefined,
       limit,
       offset,
-      sort_method: sortMethod || undefined
+      sort_method: sortMethod
     }
-    params = sortMethod ? { ...params, sort_method: sortMethod } : params
 
     const response: Nullable<APIResponse<APIActivity[]>> =
       await this._getResponse(

--- a/packages/web/src/common/store/smart-collection/sagas.ts
+++ b/packages/web/src/common/store/smart-collection/sagas.ts
@@ -6,7 +6,8 @@ import {
   accountSelectors,
   smartCollectionPageActions,
   collectionPageActions,
-  getContext
+  getContext,
+  removeNullable
 } from '@audius/common'
 import { takeEvery, put, call, select } from 'typed-redux-saga'
 
@@ -46,9 +47,11 @@ function* fetchHeavyRotation() {
       sortMethod: 'most_listens_by_user'
     }
   )
-  const mostListenedTracks = userListeningHistoryMostListenedByUser.map(
-    ({ track }) => track
-  )
+
+  const mostListenedTracks = userListeningHistoryMostListenedByUser
+    .map((listeningHistoryWithTrack) => listeningHistoryWithTrack.track)
+    .filter(removeNullable)
+
   const users = yield* call(
     retrieveUsers,
     mostListenedTracks.map((t) => t.owner_id)
@@ -60,8 +63,8 @@ function* fetchHeavyRotation() {
         users.entries[track.owner_id] &&
         !users.entries[track.owner_id].is_deactivated
     )
-    .map((listen) => ({
-      track: listen.track_id
+    .map((track) => ({
+      track: track.track_id
     }))
 
   return {

--- a/packages/web/src/common/store/smart-collection/sagas.ts
+++ b/packages/web/src/common/store/smart-collection/sagas.ts
@@ -40,10 +40,10 @@ function* fetchHeavyRotation() {
   const userListeningHistoryMostListenedByUser = yield* call(
     [apiClient, apiClient.getUserTrackHistory],
     {
-      userId: currentUserId!, // userId
+      userId: currentUserId!,
       currentUserId,
-      limit: 20, // limit
-      offset: 0, // offset
+      limit: 20,
+      offset: 0,
       sortMethod: 'most_listens_by_user'
     }
   )
@@ -61,7 +61,8 @@ function* fetchHeavyRotation() {
     .filter(
       (track) =>
         users.entries[track.owner_id] &&
-        !users.entries[track.owner_id].is_deactivated
+        !users.entries[track.owner_id].is_deactivated &&
+        !track.is_delete
     )
     .map((track) => ({
       track: track.track_id


### PR DESCRIPTION
### Description
This updates the heavy rotation playlist to hit a discovery endpoint for getting user track listen histories. Previously it was hitting an identity endpoint which was outdated when we migrated listening info from identity to discovery, so the rotation playlist page was either blank entirely for new users or contained really old listening data.

This gets a playlist of the top 20 listened to tracks, but can easily change the value to whatever seems best

Note: we've recently updated the GetUserTrackHistory endpoint on the discovery side to start collecting play counts of tracks for a user from now moving forward, and we did not backfill for previous play counts of tracks. So the playlist may reflect most recently played songs for a bit until we've been indexing play counts in listening history for long enough

### How Has This Been Tested?

Tested locally against stage. Logged in and go to explore -> heavy rotation. also confirmed the history page under `Library` on the left panel still works as it uses the same endpoint


