### PR TITLE
[C-2325] Fix playlist table date-added column

### DIFF
--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -29,6 +29,7 @@ type RowInfo = UserTrack & {
   time: number
   plays: number
   dateSaved: string
+  dateAdded: string
   handle: string
   uid: UID
 }
@@ -49,6 +50,7 @@ export type TracksTableColumn =
   | 'plays'
   | 'releaseDate'
   | 'reposts'
+  | 'savedDate'
   | 'spacer'
   | 'trackName'
 
@@ -243,6 +245,11 @@ export const TracksTable = ({
 
   const renderAddedDateCell = useCallback((cellInfo: TrackCell) => {
     const track = cellInfo.row.original
+    return moment(track.dateAdded).format('M/D/YY')
+  }, [])
+
+  const renderSavedDateCell = useCallback((cellInfo: TrackCell) => {
+    const track = cellInfo.row.original
     return moment(track.dateSaved).format('M/D/YY')
   }, [])
 
@@ -371,11 +378,11 @@ export const TracksTable = ({
       addedDate: {
         id: 'dateAdded',
         Header: 'Added',
-        accessor: 'dateSaved',
+        accessor: 'dateAdded',
         Cell: renderAddedDateCell,
         maxWidth: 160,
         sortTitle: 'Date Added',
-        sorter: dateSorter('dateSaved'),
+        sorter: dateSorter('dateAdded'),
         align: 'right'
       },
       artistName: {
@@ -489,6 +496,16 @@ export const TracksTable = ({
         sorter: alphaSorter('title'),
         align: 'left'
       },
+      savedDate: {
+        id: 'dateSaved',
+        Header: 'Saved',
+        accessor: 'dateSaved',
+        Cell: renderSavedDateCell,
+        maxWidth: 160,
+        sortTitle: 'Date Saved',
+        sorter: dateSorter('dateSaved'),
+        align: 'right'
+      },
       spacer: {
         id: 'spacer',
         maxWidth: 24,
@@ -507,6 +524,7 @@ export const TracksTable = ({
       renderOverflowMenuCell,
       renderPlayButtonCell,
       renderPlaysCell,
+      renderSavedDateCell,
       renderReleaseDateCell,
       renderRepostsCell,
       renderTrackActions,

--- a/packages/web/src/pages/saved-page/SavedPageProvider.tsx
+++ b/packages/web/src/pages/saved-page/SavedPageProvider.tsx
@@ -58,7 +58,7 @@ const sortMethodMap: Record<string, string> = {
   artist: 'artist_name',
   created_at: 'release_date',
   dateListened: 'last_listen_date',
-  dateSaved: 'added_date',
+  dateSaved: 'saved_date',
   time: 'length',
   plays: 'plays',
   repost_count: 'reposts'

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -44,7 +44,7 @@ const tableColumns: TracksTableColumn[] = [
   'trackName',
   'artistName',
   'releaseDate',
-  'addedDate',
+  'savedDate',
   'length',
   'plays',
   'reposts',


### PR DESCRIPTION
### Description

- Fixes issue where playlist tables showed incorrect date for "date-added"
- Improves column names for favorites table (changed "added" to "saved")

Playlists with correct "added" dates: 
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/8230000/226718598-cb8182e4-0295-4315-af0f-b4ffac75fc1e.png">

Favorites with correct "saved" dates: 
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/8230000/226718697-01b0d151-9836-4d5b-8775-a7f54b56f1a2.png">
