### PR TITLE
[C-2349] Default download on wifi only to false

### DIFF
--- a/packages/mobile/src/screens/settings-screen/DownloadNetworkPreferenceRow.tsx
+++ b/packages/mobile/src/screens/settings-screen/DownloadNetworkPreferenceRow.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { Switch } from 'app/components/core'
 import { useIsOfflineModeEnabled } from 'app/hooks/useIsOfflineModeEnabled'
-import { getDownloadNetworkTypePreference } from 'app/store/offline-downloads/selectors'
+import { getPreferredDownloadNetworkType } from 'app/store/offline-downloads/selectors'
 import { setDownloadNetworkPreference } from 'app/store/offline-downloads/slice'
 import { makeStyles } from 'app/styles'
 
@@ -33,11 +33,11 @@ export const DownloadNetworkPreferenceRow = () => {
   const isOfflineDownloadEnabled = useIsOfflineModeEnabled()
   const dispatch = useDispatch()
   const styles = useStyles()
-  const downloadNetworkTypePreference = useSelector(
-    getDownloadNetworkTypePreference
+  const preferredDownloadNetworkType = useSelector(
+    getPreferredDownloadNetworkType
   )
   const downloadOverWifiOnly =
-    downloadNetworkTypePreference === NetInfoStateType.wifi
+    preferredDownloadNetworkType === NetInfoStateType.wifi
 
   const handleSetNetworkPreference = useCallback(
     (value: boolean) => {

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/watchNetworkType.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/watchNetworkType.ts
@@ -4,7 +4,7 @@ import { put, select, takeEvery } from 'typed-redux-saga'
 
 import {
   getCurrentNetworkType,
-  getDownloadNetworkTypePreference,
+  getPreferredDownloadNetworkType,
   getOfflineQueue,
   getQueueStatus
 } from '../../selectors'
@@ -29,8 +29,8 @@ export function* watchNetworkType() {
     ],
     function* handleNetworkTypeChange() {
       const currentNetworkType = yield* select(getCurrentNetworkType)
-      const downloadNetworkTypePreference = yield* select(
-        getDownloadNetworkTypePreference
+      const preferredDownloadNetworkType = yield* select(
+        getPreferredDownloadNetworkType
       )
       const isReachable = yield* select(getIsReachable)
       const downloadQueue = yield* select(getOfflineQueue)
@@ -40,7 +40,7 @@ export function* watchNetworkType() {
         !isReachable ||
         currentNetworkType === NetInfoStateType.none ||
         (currentNetworkType !== NetInfoStateType.wifi &&
-          downloadNetworkTypePreference === NetInfoStateType.wifi)
+          preferredDownloadNetworkType === NetInfoStateType.wifi)
 
       if (isDownloadDisabled) {
         if (queueStatus !== QueueStatus.PAUSED) {

--- a/packages/mobile/src/store/offline-downloads/sagas/utils/shouldCancelJob.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/utils/shouldCancelJob.ts
@@ -4,7 +4,7 @@ import { select, take } from 'typed-redux-saga'
 
 import {
   getCurrentNetworkType,
-  getDownloadNetworkTypePreference
+  getPreferredDownloadNetworkType
 } from '../../selectors'
 import {
   setCurrentNetworkType,
@@ -21,8 +21,8 @@ export function* shouldCancelJob() {
       SET_UNREACHABLE
     ])
     const currentNetworkType = yield* select(getCurrentNetworkType)
-    const downloadNetworkTypePreference = yield* select(
-      getDownloadNetworkTypePreference
+    const preferredDownloadNetworkType = yield* select(
+      getPreferredDownloadNetworkType
     )
     const isReachable = yield* select(getIsReachable)
 
@@ -31,7 +31,7 @@ export function* shouldCancelJob() {
 
     if (
       currentNetworkType !== NetInfoStateType.wifi &&
-      downloadNetworkTypePreference === NetInfoStateType.wifi
+      preferredDownloadNetworkType === NetInfoStateType.wifi
     )
       return true
   }

--- a/packages/mobile/src/store/offline-downloads/selectors.ts
+++ b/packages/mobile/src/store/offline-downloads/selectors.ts
@@ -111,8 +111,8 @@ export const getOfflineTracks = (state: AppState): TrackMetadata[] => {
     .filter(removeNullable)
 }
 
-export const getDownloadNetworkTypePreference = (state: AppState) =>
-  state.offlineDownloads.downloadNetworkTypePreference
+export const getPreferredDownloadNetworkType = (state: AppState) =>
+  state.offlineDownloads.preferredDownloadNetworkType
 
 export const getCurrentNetworkType = (state: AppState) =>
   state.offlineDownloads.currentNetworkType

--- a/packages/mobile/src/store/offline-downloads/slice.ts
+++ b/packages/mobile/src/store/offline-downloads/slice.ts
@@ -53,7 +53,7 @@ export type OfflineDownloadsState = {
   offlineCollectionMetadata: {
     [Key in CollectionId]?: OfflineCollectionMetadata
   }
-  downloadNetworkTypePreference: DownloadNetworkPreference
+  preferredDownloadNetworkType: DownloadNetworkPreference
   currentNetworkType: NetInfoStateType
 }
 
@@ -161,7 +161,7 @@ const initialState: OfflineDownloadsState = {
   queueStatus: QueueStatus.IDLE,
   offlineCollectionMetadata: {},
   offlineTrackMetadata: {},
-  downloadNetworkTypePreference: NetInfoStateType.wifi,
+  preferredDownloadNetworkType: NetInfoStateType.cellular,
   currentNetworkType: NetInfoStateType.unknown
 }
 
@@ -407,7 +407,7 @@ const slice = createSlice({
       action: SetDownloadNetworkPreferenceAction
     ) => {
       const { downloadNetworkPreference } = action.payload
-      state.downloadNetworkTypePreference = downloadNetworkPreference
+      state.preferredDownloadNetworkType = downloadNetworkPreference
     },
     // Lifecycle actions that trigger complex saga flows
     requestDownloadAllFavorites: () => {},


### PR DESCRIPTION
### Description

Change download network preference default to false
Also rename the key to invalidate redux persist value

`downloadNetworkTypePreference` -> `preferredDownloadNetworkType`

Impact:
1. For clients who used recent versions of the app, the old key will still be in redux persist unless we write a migration to remove it
2. Anyone who explicitly set the setting will also be defaulted back to cellular and have to re-enable it manually