### PR TITLE
Fix prod build timeout

### DIFF
--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -74,6 +74,7 @@ web-build:
                 cp apple-app-site-association-stage apple-app-site-association
     - run:
         name: build
+        no_output_timeout: 30m
         command: |
           cd packages/web
           CI=false npm run build:<< parameters.build-type >>


### PR DESCRIPTION
### Description

* Prod build on release branch is timing out after 10mins without output. Bump to 30mins
https://app.circleci.com/pipelines/github/AudiusProject/audius-client?branch=release-v1.5.16

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

