### PR TITLE
[C-2369] Fix issue where notification poll can break app on signout

### DIFF
--- a/packages/web/src/common/store/notifications/checkForNewNotificationsSaga.ts
+++ b/packages/web/src/common/store/notifications/checkForNewNotificationsSaga.ts
@@ -1,4 +1,5 @@
 import {
+  accountSelectors,
   Notification,
   notificationsActions,
   notificationsSelectors,
@@ -15,6 +16,7 @@ const { updateNotifications } = notificationsActions
 const { makeGetAllNotifications } = notificationsSelectors
 const getAllNotifications = makeGetAllNotifications()
 const { getBalance } = walletActions
+const { getHasAccount } = accountSelectors
 
 // Notifications have changed if some of the incoming ones have
 // different ids or changed length in unique entities/users
@@ -62,6 +64,9 @@ export function* handleNewNotifications(notifications: Notification[]) {
 }
 
 export function* checkForNewNotificationsSaga() {
+  const hasAccount = yield* select(getHasAccount)
+  if (!hasAccount) return
+
   const limit = NOTIFICATION_LIMIT_DEFAULT
 
   const notificationsResponse = yield* call(fetchNotifications, {


### PR DESCRIPTION
### Description

When user signs out on mobile, there is a period where libs is reset, yet our "hasLibsInitted" watcher doesn't reset, causing any fetch that requires libs while it's reinitting to break with a root level saga error. Since notification polling wasn't checking if signed-in before fetching, this triggered this case :(

