### PR TITLE
[C-2353, C-2358] Update playback position tracking for web and mobile

### DIFF
--- a/packages/common/src/store/playback-position/sagas.ts
+++ b/packages/common/src/store/playback-position/sagas.ts
@@ -1,7 +1,11 @@
-import { call, put, select, takeEvery } from 'typed-redux-saga'
+import { call, delay, put, select, takeEvery } from 'typed-redux-saga'
 
+import { AudioPlayer } from 'services/audio-player'
 import { FeatureFlags } from 'services/remote-config'
+import { getTrack } from 'store/cache/tracks/selectors'
 import { getContext } from 'store/effects'
+import { getPlaying, getTrackId } from 'store/player/selectors'
+import { Genre } from 'utils/genres'
 
 import { getPlaybackPositions } from './selectors'
 import {
@@ -10,6 +14,8 @@ import {
   setTrackPosition
 } from './slice'
 import { PlaybackPositionState, PLAYBACK_POSITION_LS_KEY } from './types'
+
+const RECORD_PLAYBACK_POSITION_INTERVAL = 5000
 
 /**
  * Sets the playback rate from local storage when the app loads
@@ -51,6 +57,58 @@ function* watchTrackPositionUpdate() {
   )
 }
 
+const getPlayerSeekInfo = async (audioPlayer: AudioPlayer) => {
+  const position = await audioPlayer.getPosition()
+  const duration = await audioPlayer.getDuration()
+  return {
+    position,
+    duration
+  }
+}
+
+/**
+ * Poll for saving the playback position of tracks
+ */
+function* savePlaybackPositionWorker() {
+  const remoteConfigInstance = yield* getContext('remoteConfigInstance')
+  yield* call(remoteConfigInstance.waitForRemoteConfig)
+
+  const audioPlayer = yield* getContext('audioPlayer')
+  const getFeatureEnabled = yield* getContext('getFeatureEnabled')
+  const isNewPodcastControlsEnabled = yield* call(
+    getFeatureEnabled,
+    FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
+    FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
+  )
+
+  // eslint-disable-next-line no-unmodified-loop-condition
+  while (isNewPodcastControlsEnabled) {
+    const trackId = yield* select(getTrackId)
+    const track = yield* select(getTrack, { id: trackId })
+    const playing = yield* select(getPlaying)
+    const isLongFormContent =
+      track?.genre === Genre.PODCASTS || track?.genre === Genre.AUDIOBOOKS
+
+    if (trackId && isLongFormContent && playing) {
+      const { position } = yield* call(getPlayerSeekInfo, audioPlayer)
+      yield* put(
+        setTrackPosition({
+          trackId,
+          positionInfo: {
+            status: 'IN_PROGRESS',
+            playbackPosition: position
+          }
+        })
+      )
+    }
+    yield* delay(RECORD_PLAYBACK_POSITION_INTERVAL)
+  }
+}
+
 export const sagas = () => {
-  return [setInitialPlaybackPositionState, watchTrackPositionUpdate]
+  return [
+    setInitialPlaybackPositionState,
+    watchTrackPositionUpdate,
+    savePlaybackPositionWorker
+  ]
 }


### PR DESCRIPTION
### Description
Update mobile to handle track end complete updates and updates when the track player natively plays the next track

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

Still behind the podcast and podcast fallback flags
PODCAST_CONTROL_UPDATES_ENABLED
PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK

