### PR TITLE
[PAY-1063][PAY-1085][PAY-1086] Update UI for inaccessible gated tracks from favorites and history pages

### DIFF
--- a/packages/common/src/hooks/usePremiumContent.ts
+++ b/packages/common/src/hooks/usePremiumContent.ts
@@ -14,6 +14,7 @@ const { getUser, getUsers } = cacheUsersSelectors
 const { getLockedContentId, getPremiumTrackSignatureMap } =
   premiumContentSelectors
 
+// Returns whether user has access to given track.
 export const usePremiumContentAccess = (track: Nullable<Partial<Track>>) => {
   const premiumTrackSignatureMap = useSelector(getPremiumTrackSignatureMap)
   const user = useSelector(getAccountUser)
@@ -44,6 +45,9 @@ export const usePremiumContentAccess = (track: Nullable<Partial<Track>>) => {
   return { isUserAccessTBD, doesUserHaveAccess }
 }
 
+// Similar to `usePremiumContentAccess` above, but for multiple tracks.
+// Returns a map of track id -> track access i.e.
+// {[id: ID]: { isUserAccessTBD: boolean, doesUserHaveAccess: boolean }}
 export const usePremiumContentAccessMap = (tracks: Partial<Track>[]) => {
   const premiumTrackSignatureMap = useSelector(getPremiumTrackSignatureMap)
   const user = useSelector(getAccountUser)

--- a/packages/mobile/src/components/details-tile/DetailsTileHasAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileHasAccess.tsx
@@ -50,11 +50,11 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   },
   headerContainer: {
     ...flexRowCentered(),
+    marginBottom: spacing(2),
     justifyContent: 'space-between'
   },
   titleContainer: {
-    ...flexRowCentered(),
-    marginBottom: spacing(2)
+    ...flexRowCentered()
   },
   title: {
     marginLeft: spacing(2),
@@ -79,6 +79,9 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   },
   collectionName: {
     color: palette.secondary
+  },
+  bottomMargin: {
+    marginBottom: spacing(2)
   }
 }))
 
@@ -125,7 +128,7 @@ const DetailsTileOwnerSection = ({
 
   return (
     <View style={[styles.root, style]}>
-      <View style={styles.titleContainer}>
+      <View style={[styles.titleContainer, styles.bottomMargin]}>
         {nftCollection && (
           <IconCollectible fill={neutral} width={16} height={16} />
         )}

--- a/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
@@ -61,11 +61,11 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   },
   headerContainer: {
     ...flexRowCentered(),
+    marginBottom: spacing(2),
     justifyContent: 'space-between'
   },
   titleContainer: {
-    ...flexRowCentered(),
-    marginBottom: spacing(2)
+    ...flexRowCentered()
   },
   title: {
     marginLeft: spacing(2),
@@ -122,6 +122,9 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   },
   mainButton: {
     marginTop: spacing(7)
+  },
+  bottomMargin: {
+    marginBottom: spacing(2)
   }
 }))
 
@@ -156,7 +159,7 @@ const DetailsTileNoAccessSection = ({
 
   return (
     <View style={[styles.root, style]}>
-      <View style={styles.titleContainer}>
+      <View style={[styles.titleContainer, styles.bottomMargin]}>
         <IconLock fill={neutral} width={16} height={16} />
         <Text style={styles.title}>{messages.howToUnlock}</Text>
       </View>

--- a/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
+++ b/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
@@ -13,7 +13,8 @@ import {
   createPlaylistModalUISelectors,
   createPlaylistModalUIActions as createPlaylistActions,
   imageBlank as placeholderCoverArt,
-  newCollectionMetadata
+  newCollectionMetadata,
+  usePremiumContentAccessMap
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -339,6 +340,8 @@ const EditPlaylistPage = g(
 
     useTemporaryNavContext(setters)
 
+    const trackAccessMap = usePremiumContentAccessMap(tracks ?? [])
+
     // Put together track list if necessary
     let trackList = null
     if (tracks && reorderedTracks.length > 0) {
@@ -349,6 +352,10 @@ const EditPlaylistPage = g(
           showRemoveTrackDrawer &&
           t.track_id === confirmRemoveTrack?.trackId &&
           playlistTrack?.time === confirmRemoveTrack?.timestamp
+        const { isUserAccessTBD, doesUserHaveAccess } = trackAccessMap[
+          t.track_id
+        ] ?? { isUserAccessTBD: false, doesUserHaveAccess: true }
+        const isLocked = !isUserAccessTBD && !doesUserHaveAccess
 
         return {
           isLoading: false,
@@ -359,6 +366,7 @@ const EditPlaylistPage = g(
           time: playlistTrack?.time,
           isPremium: t.is_premium,
           isDeleted: t.is_delete || !!t.user.is_deactivated,
+          isLocked,
           isRemoveActive
         }
       })

--- a/packages/web/src/components/table/components/OverflowMenuButton.tsx
+++ b/packages/web/src/components/table/components/OverflowMenuButton.tsx
@@ -14,6 +14,8 @@ type OverflowMenuButtonProps = {
   handle: string
   hiddenUntilHover?: boolean
   includeEdit?: boolean
+  includeAddToPlaylist?: boolean
+  includeFavorite?: boolean
   index?: number
   isArtistPick?: boolean
   isDeleted?: boolean

--- a/packages/web/src/components/track-availability-modal/SpecialAccessAvailability.tsx
+++ b/packages/web/src/components/track-availability-modal/SpecialAccessAvailability.tsx
@@ -80,6 +80,7 @@ export const SpecialAccessAvailability = ({
           text={messages.supportersInfo}
           mouseEnterDelay={0.1}
           mount={'parent'}
+          color='--secondary'
         >
           <IconInfo className={styles.icon} />
         </Tooltip>

--- a/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/ConnectedTrackListItem.tsx
@@ -40,8 +40,16 @@ const ConnectedTrackListItem = (props: ConnectedTrackListItemProps) => {
 
   const onClickOverflow = () => {
     const overflowActions = [
-      props.isReposted ? OverflowAction.UNREPOST : OverflowAction.REPOST,
-      props.isSaved ? OverflowAction.UNFAVORITE : OverflowAction.FAVORITE,
+      props.isLocked
+        ? null
+        : props.isReposted
+        ? OverflowAction.UNREPOST
+        : OverflowAction.REPOST,
+      props.isLocked
+        ? null
+        : props.isSaved
+        ? OverflowAction.UNFAVORITE
+        : OverflowAction.FAVORITE,
       !isGatedContentEnabled || !props.isPremium
         ? OverflowAction.ADD_TO_PLAYLIST
         : null,

--- a/packages/web/src/components/track/mobile/TrackList.tsx
+++ b/packages/web/src/components/track/mobile/TrackList.tsx
@@ -27,6 +27,7 @@ type TrackListProps = {
     time?: number
     coverArtSizes?: CoverArtSizes
     isDeleted: boolean
+    isLocked: boolean
   }>
   showTopDivider?: boolean
   showDivider?: boolean
@@ -102,6 +103,7 @@ const TrackList = ({
           coverArtSizes={track.coverArtSizes}
           uid={track.uid}
           isDeleted={track.isDeleted}
+          isLocked={track.isLocked}
           onSave={onSave}
           isRemoveActive={track.isRemoveActive}
           onRemove={onRemove}

--- a/packages/web/src/components/track/mobile/TrackListItem.module.css
+++ b/packages/web/src/components/track/mobile/TrackListItem.module.css
@@ -10,7 +10,7 @@
   transition: background 0.17s ease-in-out, border 0.17s ease-in-out;
 }
 
-.trackContainer:active {
+.trackContainer:active:not(:has(.locked)) {
   background-color: var(--neutral-light-9);
 }
 
@@ -183,4 +183,29 @@
 
 .removeTrackContainer.isRemoveActive {
   transform: rotate(-90deg);
+}
+
+.locked {
+  display: flex;
+  align-items: center;
+  padding: 2px var(--unit-2);
+  background: var(--accent-blue);
+  border-radius: 80px;
+  font-weight: var(--font-demi-bold);
+  font-size: var(--font-2xs);
+  color: var(--white);
+}
+
+.locked svg {
+  margin-right: 2px;
+  width: 10px;
+  height: 10px;
+}
+
+.locked svg path {
+  fill: var(--white);
+}
+
+.lockedTrackTitle, .lockedBadges {
+  opacity: 0.5;
 }

--- a/packages/web/src/components/track/mobile/TrackListItem.module.css
+++ b/packages/web/src/components/track/mobile/TrackListItem.module.css
@@ -206,6 +206,7 @@
   fill: var(--white);
 }
 
-.lockedTrackTitle, .lockedBadges {
+.lockedTrackTitle,
+.lockedBadges {
   opacity: 0.5;
 }

--- a/packages/web/src/components/track/mobile/TrackListItem.tsx
+++ b/packages/web/src/components/track/mobile/TrackListItem.tsx
@@ -1,7 +1,7 @@
 import { memo, MouseEvent } from 'react'
 
 import { ID, CoverArtSizes, SquareSizes } from '@audius/common'
-import { IconKebabHorizontal, IconButton } from '@audius/stems'
+import { IconKebabHorizontal, IconButton, IconLock } from '@audius/stems'
 import cn from 'classnames'
 import Lottie from 'react-lottie'
 
@@ -90,7 +90,8 @@ const Artwork = ({
 }
 
 const getMessages = ({ isDeleted = false }: { isDeleted?: boolean } = {}) => ({
-  deleted: isDeleted ? ' [Deleted By Artist]' : ''
+  deleted: isDeleted ? ' [Deleted By Artist]' : '',
+  locked: 'Locked'
 })
 
 export type TrackListItemProps = {
@@ -104,6 +105,7 @@ export type TrackListItemProps = {
   isPlaying?: boolean
   isRemoveActive?: boolean
   isDeleted: boolean
+  isLocked: boolean
   coverArtSizes?: CoverArtSizes
   artistName: string
   artistHandle: string
@@ -135,6 +137,7 @@ const TrackListItem = ({
   uid,
   coverArtSizes,
   isDeleted,
+  isLocked,
   onSave,
   onRemove,
   togglePlay,
@@ -146,7 +149,7 @@ const TrackListItem = ({
   const messages = getMessages({ isDeleted })
 
   const onClickTrack = () => {
-    if (uid && !isDeleted && togglePlay) togglePlay(uid, trackId)
+    if (uid && !isLocked && !isDeleted && togglePlay) togglePlay(uid, trackId)
   }
 
   const onSaveTrack = (e: MouseEvent) => {
@@ -192,7 +195,11 @@ const TrackListItem = ({
       {isReorderable && <IconDrag className={styles.dragIcon} />}
 
       <div className={styles.nameArtistContainer}>
-        <div className={styles.trackTitle}>
+        <div
+          className={cn(styles.trackTitle, {
+            [styles.lockedTrackTitle]: !isDeleted && isLocked
+          })}
+        >
           {trackTitle}
           {messages.deleted}
         </div>
@@ -201,17 +208,25 @@ const TrackListItem = ({
           <UserBadges
             userId={userId}
             badgeSize={12}
-            className={styles.badges}
+            className={cn(styles.badges, {
+              [styles.lockedBadges]: !isDeleted && isLocked
+            })}
           />
         </div>
       </div>
-      {onSaveTrack && trackItemAction === TrackItemAction.Save && (
+      {!isDeleted && isLocked ? (
+        <div className={styles.locked}>
+          <IconLock />
+          <span>{messages.locked}</span>
+        </div>
+      ) : null}
+      {!isLocked && trackItemAction === TrackItemAction.Save ? (
         <div className={styles.iconContainer} onClick={onSaveTrack}>
           <IconHeart
             className={cn(styles.heartIcon, { [styles.isSaved]: isSaved })}
           />
         </div>
-      )}
+      ) : null}
       {onClickOverflow && trackItemAction === TrackItemAction.Overflow && (
         <div className={styles.iconContainer}>
           <IconButton

--- a/packages/web/src/components/tracks-table/TracksTable.module.css
+++ b/packages/web/src/components/tracks-table/TracksTable.module.css
@@ -12,8 +12,13 @@
   line-height: 1.2;
 }
 
+.trackName {
+  display: flex;
+  align-items: center;
+}
+
 .artistName:hover,
-.trackName:hover {
+.trackName:hover:not(:has(.locked)) {
   cursor: pointer;
   transition: color 0.07s ease-out;
   color: var(--primary);
@@ -69,4 +74,41 @@
 .tableRow.disabled:hover .tablePlayButton {
   opacity: 0;
   pointer-events: none;
+}
+
+.tableRow.lockedRow {
+  background: var(--white);
+}
+
+.locked {
+  margin-left: var(--unit-1);
+  display: flex;
+  align-items: center;
+  padding: 2px var(--unit-2);
+  background: var(--accent-blue);
+  border-radius: 80px;
+  font-weight: var(--font-demi-bold);
+  font-size: var(--font-2xs);
+  color: var(--white);
+}
+
+.locked:hover {
+  text-decoration: none;
+}
+
+.locked svg {
+  margin-right: 2px;
+  width: 10px;
+  height: 10px;
+}
+
+.locked svg path {
+  fill: var(--white);
+}
+
+.lockedTrackName {
+  max-width: calc(100% - 64px);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }

--- a/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/components/mobile/CollectionPage.tsx
@@ -10,7 +10,8 @@ import {
   User,
   CollectionsPageType,
   CollectionTrack,
-  OverflowAction
+  OverflowAction,
+  usePremiumContentAccessMap
 } from '@audius/common'
 
 import CollectionHeader from 'components/collection/mobile/CollectionHeader'
@@ -204,20 +205,28 @@ const CollectionPage = ({
 
   const playingUid = getPlayingUid()
 
-  const trackList = tracks.entries.map((entry) => ({
-    isLoading: false,
-    isSaved: entry.has_current_user_saved,
-    isReposted: entry.has_current_user_reposted,
-    isActive: playingUid === entry.uid,
-    isPlaying: queuedAndPlaying && playingUid === entry.uid,
-    artistName: entry?.user?.name,
-    artistHandle: entry?.user?.handle,
-    trackTitle: entry.title,
-    trackId: entry.track_id,
-    uid: entry.uid,
-    isPremium: entry.is_premium,
-    isDeleted: entry.is_delete || !!entry?.user?.is_deactivated
-  }))
+  const trackAccessMap = usePremiumContentAccessMap(tracks.entries)
+  const trackList = tracks.entries.map((entry) => {
+    const { isUserAccessTBD, doesUserHaveAccess } = trackAccessMap[
+      entry.track_id
+    ] ?? { isUserAccessTBD: false, doesUserHaveAccess: true }
+    const isLocked = !isUserAccessTBD && !doesUserHaveAccess
+    return {
+      isLoading: false,
+      isSaved: entry.has_current_user_saved,
+      isReposted: entry.has_current_user_reposted,
+      isActive: playingUid === entry.uid,
+      isPlaying: queuedAndPlaying && playingUid === entry.uid,
+      artistName: entry?.user?.name,
+      artistHandle: entry?.user?.handle,
+      trackTitle: entry.title,
+      trackId: entry.track_id,
+      uid: entry.uid,
+      isPremium: entry.is_premium,
+      isDeleted: entry.is_delete || !!entry?.user?.is_deactivated,
+      isLocked
+    }
+  })
 
   return (
     <MobilePageContainer

--- a/packages/web/src/pages/history-page/components/mobile/HistoryPage.tsx
+++ b/packages/web/src/pages/history-page/components/mobile/HistoryPage.tsx
@@ -1,6 +1,11 @@
 import { memo, useEffect, useCallback, useContext } from 'react'
 
-import { ID, UID, LineupTrack } from '@audius/common'
+import {
+  ID,
+  UID,
+  LineupTrack,
+  usePremiumContentAccessMap
+} from '@audius/common'
 import { Button, ButtonType } from '@audius/stems'
 
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
@@ -55,8 +60,14 @@ const HistoryPage = ({
     setRight(null)
   }, [setLeft, setCenter, setRight])
 
+  const trackAccessMap = usePremiumContentAccessMap(entries)
+
   const tracks = entries.map((track: LineupTrack, index: number) => {
     const isActive = track.uid === currentQueueItem.uid
+    const { isUserAccessTBD, doesUserHaveAccess } = trackAccessMap[
+      track.track_id
+    ] ?? { isUserAccessTBD: false, doesUserHaveAccess: true }
+    const isLocked = !isUserAccessTBD && !doesUserHaveAccess
     return {
       isLoading: loading,
       isPremium: track.is_premium,
@@ -70,7 +81,8 @@ const HistoryPage = ({
       trackId: track.track_id,
       uid: track.uid,
       coverArtSizes: track._cover_art_sizes,
-      isDeleted: track.is_delete || !!track.user.is_deactivated
+      isDeleted: track.is_delete || !!track.user.is_deactivated,
+      isLocked
     }
   })
 

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -10,7 +10,8 @@ import {
   SavedPageTabs,
   SavedPageTrack,
   SavedPageCollection,
-  QueueItem
+  QueueItem,
+  usePremiumContentAccessMap
 } from '@audius/common'
 import { Button, ButtonType } from '@audius/stems'
 import cn from 'classnames'
@@ -108,20 +109,28 @@ const TracksLineup = ({
   onTogglePlay: (uid: UID, trackId: ID) => void
 }) => {
   const [trackEntries] = getFilteredData(tracks.entries)
-  const trackList = trackEntries.map((entry) => ({
-    isLoading: false,
-    isPremium: entry.is_premium,
-    isSaved: entry.has_current_user_saved,
-    isReposted: entry.has_current_user_reposted,
-    isActive: playingUid === entry.uid,
-    isPlaying: queuedAndPlaying && playingUid === entry.uid,
-    artistName: entry.user.name,
-    artistHandle: entry.user.handle,
-    trackTitle: entry.title,
-    trackId: entry.track_id,
-    uid: entry.uid,
-    isDeleted: entry.is_delete || !!entry.user.is_deactivated
-  }))
+  const trackAccessMap = usePremiumContentAccessMap(trackEntries)
+  const trackList = trackEntries.map((entry) => {
+    const { isUserAccessTBD, doesUserHaveAccess } = trackAccessMap[
+      entry.track_id
+    ] ?? { isUserAccessTBD: false, doesUserHaveAccess: true }
+    const isLocked = !isUserAccessTBD && !doesUserHaveAccess
+    return {
+      isLoading: false,
+      isPremium: entry.is_premium,
+      isSaved: entry.has_current_user_saved,
+      isReposted: entry.has_current_user_reposted,
+      isActive: playingUid === entry.uid,
+      isPlaying: queuedAndPlaying && playingUid === entry.uid,
+      artistName: entry.user.name,
+      artistHandle: entry.user.handle,
+      trackTitle: entry.title,
+      trackId: entry.track_id,
+      uid: entry.uid,
+      isDeleted: entry.is_delete || !!entry.user.is_deactivated,
+      isLocked
+    }
+  })
   const contentRefCallback = useOffsetScroll()
   return (
     <div className={styles.tracksLineupContainer}>


### PR DESCRIPTION
### Description

Update UI for inaccessible gated tracks from favorites page for both web and mobile.

<img width="1006" alt="Screenshot 2023-03-24 at 11 53 38 AM" src="https://user-images.githubusercontent.com/9600175/227581839-ed0573c6-e735-4441-9b82-90715a469ad8.png">

<img width="784" alt="Screenshot 2023-03-24 at 1 10 14 PM" src="https://user-images.githubusercontent.com/9600175/227594118-6aaf0b52-1b5c-45eb-9f75-361d3ba9d2c5.png">

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-24 at 15 06 29](https://user-images.githubusercontent.com/9600175/227617956-f075ec8d-1748-475d-92b7-4ca646545c3b.png)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local web and mobile apps vs stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

