### PR TITLE
Fix "Pick some for me" button on android

### DIFF
--- a/packages/mobile/src/components/core/TextButton.tsx
+++ b/packages/mobile/src/components/core/TextButton.tsx
@@ -1,13 +1,13 @@
 import type { ComponentType } from 'react'
 import { useState, useCallback } from 'react'
 
+import { TouchableOpacity } from 'react-native'
 import type {
   ButtonProps,
   TextStyle,
   TouchableOpacityProps,
   ViewStyle
 } from 'react-native'
-import { TouchableOpacity } from 'react-native-gesture-handler'
 import type { GenericTouchableProps } from 'react-native-gesture-handler/lib/typescript/components/touchables/GenericTouchable'
 import type { SvgProps } from 'react-native-svg'
 

--- a/packages/mobile/src/components/suggested-follows/PickArtistsForMeButton.tsx
+++ b/packages/mobile/src/components/suggested-follows/PickArtistsForMeButton.tsx
@@ -31,8 +31,8 @@ export const PickArtistsForMeButton = () => {
   const dispatch = useDispatch()
 
   // The autoselect or 'pick for me'
-  // Selects the first three aritsts in the current category along with 2 additinal
-  // random artist from the top 10
+  // Selects the first three artists in the current category along with 2 additional
+  // random artists from the top 10
   const handlePress = useCallback(() => {
     const selectedIds = new Set(followedArtistIds)
     const unselectedIds = suggestedArtistIds.filter(


### PR DESCRIPTION
### Description

Not sure exactly why but `TouchableOpacity` from `react-native-gesture-handler` didn't work in this context on android. Some relevant threads:
* https://stackoverflow.com/questions/53548361/react-native-touchableopacity-onpress-not-working-on-android
* https://github.com/software-mansion/react-native-gesture-handler/issues/578

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

