### PR TITLE
[C-2361, C-2360, C-2355, C-2346] Update skip 15s button behavior on mobile for podcasts

### DIFF
--- a/packages/common/src/store/player/selectors.ts
+++ b/packages/common/src/store/player/selectors.ts
@@ -15,6 +15,7 @@ export const getPaused = (state: CommonState) => !state.player.playing
 export const getCounter = (state: CommonState) => state.player.counter
 export const getBuffering = (state: CommonState) => state.player.buffering
 export const getSeek = (state: CommonState) => state.player.seek
+export const getSeekCounter = (state: CommonState) => state.player.seekCounter
 export const getPlaybackRate = (state: CommonState) => state.player.playbackRate
 
 export const getCurrentTrack = (state: CommonState) =>

--- a/packages/common/src/store/player/slice.ts
+++ b/packages/common/src/store/player/slice.ts
@@ -30,6 +30,9 @@ export type PlayerState = {
 
   // Seek time into the track when a user scrubs forward or backward
   seek: number | null
+
+  // Counter to track seek calls for times where we seek to the same position multiple times
+  seekCounter: number
 }
 
 export const initialState: PlayerState = {
@@ -42,7 +45,8 @@ export const initialState: PlayerState = {
   buffering: false,
   counter: 0,
   playbackRate: '1x',
-  seek: null
+  seek: null,
+  seekCounter: 0
 }
 
 type PlayPayload = Maybe<{
@@ -160,6 +164,7 @@ const slice = createSlice({
     seek: (state, action: PayloadAction<SeekPayload>) => {
       const { seconds } = action.payload
       state.seek = seconds
+      state.seekCounter++
     },
     setPlaybackRate: (state, action: PayloadAction<SetPlaybackRatePayload>) => {
       const { rate } = action.payload

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -128,6 +128,11 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     textTransform: 'uppercase'
   },
 
+  playButtonIcon: {
+    height: 20,
+    width: 20
+  },
+
   infoSection: {
     flexWrap: 'wrap',
     flexDirection: 'row',
@@ -356,7 +361,10 @@ export const DetailsTile = ({
               )}
             {!isGatedContentEnabled || doesUserHaveAccess ? (
               <Button
-                styles={{ text: styles.playButtonText }}
+                styles={{
+                  text: styles.playButtonText,
+                  icon: styles.playButtonIcon
+                }}
                 title={isPlaying ? messages.pause : playText}
                 size='large'
                 iconPosition='left'

--- a/packages/mobile/src/components/scrubber/Slider.tsx
+++ b/packages/mobile/src/components/scrubber/Slider.tsx
@@ -14,7 +14,7 @@ import { makeStyles } from 'app/styles'
 import { attachToDx } from 'app/utils/animation'
 import { useThemeColors } from 'app/utils/theme'
 
-const { getPlaybackRate, getSeek } = playerSelectors
+const { getPlaybackRate, getSeek, getSeekCounter } = playerSelectors
 
 // How much the handle "grows" when pressing
 const HANDLE_GROW_SCALE = 1.1
@@ -120,6 +120,7 @@ export const Slider = memo((props: SliderProps) => {
   const styles = useStyles()
   const { primaryLight2, primaryDark2 } = useThemeColors()
   const seek = useSelector(getSeek)
+  const seekCounter = useSelector(getSeekCounter)
 
   // Animation to translate the handle and tracker
   const translationAnim = useRef(new Animated.Value(0)).current
@@ -219,7 +220,7 @@ export const Slider = memo((props: SliderProps) => {
       animateFromNowToEnd(percentComplete)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [seek, duration, translationAnim, railWidth])
+  }, [seek, seekCounter, duration, translationAnim, railWidth])
 
   const handlePressOut = useCallback(() => {
     handlePressHandleOut()

--- a/packages/mobile/src/components/scrubber/usePosition.ts
+++ b/packages/mobile/src/components/scrubber/usePosition.ts
@@ -11,7 +11,7 @@ import TrackPlayer from 'react-native-track-player'
 import { useSelector } from 'react-redux'
 import { useAsync } from 'react-use'
 
-const { getPlaybackRate, getSeek } = playerSelectors
+const { getPlaybackRate, getSeek, getSeekCounter } = playerSelectors
 
 export const usePosition = (
   mediaKey: string,
@@ -23,6 +23,7 @@ export const usePosition = (
   const positionElementRef = useRef<TextInput>(null)
   const playbackRate = useSelector(getPlaybackRate)
   const seek = useSelector(getSeek)
+  const seekCounter = useSelector(getSeekCounter)
 
   const setPosition = useCallback((position: number) => {
     positionRef.current = position
@@ -75,7 +76,7 @@ export const usePosition = (
 
   useEffect(() => {
     if (seek !== null) setPosition(seek)
-  }, [seek, setPosition])
+  }, [seek, seekCounter, setPosition])
 
   return { ref: positionElementRef, setPosition }
 }

--- a/packages/mobile/src/services/audio-player/NativeMobileAudio.ts
+++ b/packages/mobile/src/services/audio-player/NativeMobileAudio.ts
@@ -12,7 +12,10 @@ export class NativeMobileAudio {
   play = () => {}
   pause = () => {}
   stop = () => {}
-  seek = () => {}
+  seek = (position: number) => {
+    TrackPlayer.seekTo(position)
+  }
+
   setVolume = () => null
   setPlaybackRate = () => {}
   isBuffering = () => false


### PR DESCRIPTION
### Description
Fix the 15s button behavior when interacting with the track player
Update the icon size for the play button on the track screen

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

