### PR TITLE
[PAY-1090] - Subscribe to special access gates to unlock new tracks

### DIFF
--- a/packages/common/src/hooks/usePremiumContent.ts
+++ b/packages/common/src/hooks/usePremiumContent.ts
@@ -53,17 +53,20 @@ export const usePremiumContentAccessMap = (tracks: Partial<Track>[]) => {
   const user = useSelector(getAccountUser)
 
   const result = useMemo(() => {
-    let map: {[id: ID]: { isUserAccessTBD: boolean, doesUserHaveAccess: boolean }} = {}
+    const map: {
+      [id: ID]: { isUserAccessTBD: boolean; doesUserHaveAccess: boolean }
+    } = {}
 
-    tracks.forEach(track => {
+    tracks.forEach((track) => {
       if (!track.track_id) {
         return
       }
 
       const trackId = track.track_id
       const isPremium = track.is_premium
-      const hasPremiumContentSignature =
-        !!(track.premium_content_signature || premiumTrackSignatureMap[trackId])
+      const hasPremiumContentSignature = !!(
+        track.premium_content_signature || premiumTrackSignatureMap[trackId]
+      )
       const isCollectibleGated = !!track.premium_conditions?.nft_collection
       const isSignatureToBeFetched =
         isCollectibleGated &&

--- a/packages/common/src/store/premium-content/sagas.ts
+++ b/packages/common/src/store/premium-content/sagas.ts
@@ -498,7 +498,7 @@ function* pollPremiumTrack({
  * 3. Poll for premium content signatures for those tracks
  * 4. When the signatures are returned, set those track statuses as 'UNLOCKED'
  */
-function* updateGatedTracks(
+function* updateSpecialAccessTracks(
   trackOwnerId: ID,
   gate: 'follow' | 'tip',
   sourceTrackId?: Nullable<ID>
@@ -592,14 +592,14 @@ function* handleUnfollowUser(
 function* handleFollowUser(
   action: ReturnType<typeof usersSocialActions.followUser>
 ) {
-  yield* call(updateGatedTracks, action.userId, 'follow', action.trackId)
+  yield* call(updateSpecialAccessTracks, action.userId, 'follow', action.trackId)
 }
 
 function* handleTipGatedTracks(
   action: ReturnType<typeof refreshTipGatedTracks>
 ) {
   yield* call(
-    updateGatedTracks,
+    updateSpecialAccessTracks,
     action.payload.userId,
     'tip',
     action.payload.trackId

--- a/packages/common/src/store/premium-content/selectors.ts
+++ b/packages/common/src/store/premium-content/selectors.ts
@@ -8,3 +8,9 @@ export const getPremiumTrackStatusMap = (state: CommonState) =>
 
 export const getLockedContentId = (state: CommonState) =>
   state.premiumContent.lockedContentId
+
+export const getFolloweeIds = (state: CommonState) =>
+  state.premiumContent.followeeIds
+
+export const getTippedUserIds = (state: CommonState) =>
+  state.premiumContent.tippedUserIds

--- a/packages/common/src/store/premium-content/slice.ts
+++ b/packages/common/src/store/premium-content/slice.ts
@@ -7,12 +7,16 @@ type PremiumContentState = {
   premiumTrackSignatureMap: { [id: ID]: Nullable<PremiumContentSignature> }
   statusMap: { [id: ID]: PremiumTrackStatus }
   lockedContentId: Nullable<ID>
+  followeeIds: ID[]
+  tippedUserIds: ID[]
 }
 
 const initialState: PremiumContentState = {
   premiumTrackSignatureMap: {},
   statusMap: {},
-  lockedContentId: null
+  lockedContentId: null,
+  followeeIds: [],
+  tippedUserIds: []
 }
 
 type UpdatePremiumContentSignaturesPayload = {
@@ -32,7 +36,7 @@ type UpdatePremiumTrackStatusesPayload = {
   [id: ID]: PremiumTrackStatus
 }
 
-type SetLockedContentIdPayload = {
+type IdPayload = {
   id: ID
 }
 
@@ -72,14 +76,27 @@ const slice = createSlice({
         ...action.payload
       }
     },
-    setLockedContentId: (
-      state,
-      action: PayloadAction<SetLockedContentIdPayload>
-    ) => {
+    setLockedContentId: (state, action: PayloadAction<IdPayload>) => {
       state.lockedContentId = action.payload.id
     },
     resetLockedContentId: (state) => {
       state.lockedContentId = null
+    },
+    addFolloweeId: (state, action: PayloadAction<IdPayload>) => {
+      state.followeeIds.push(action.payload.id)
+    },
+    removeFolloweeId: (state, action: PayloadAction<IdPayload>) => {
+      state.followeeIds = state.followeeIds.filter(
+        (id) => id !== action.payload.id
+      )
+    },
+    addTippedUserId: (state, action: PayloadAction<IdPayload>) => {
+      state.tippedUserIds.push(action.payload.id)
+    },
+    removeTippedUserId: (state, action: PayloadAction<IdPayload>) => {
+      state.tippedUserIds = state.tippedUserIds.filter(
+        (id) => id !== action.payload.id
+      )
     }
   }
 })
@@ -90,7 +107,11 @@ export const {
   updatePremiumTrackStatus,
   updatePremiumTrackStatuses,
   setLockedContentId,
-  resetLockedContentId
+  resetLockedContentId,
+  addFolloweeId,
+  removeFolloweeId,
+  addTippedUserId,
+  removeTippedUserId
 } = slice.actions
 
 export const reducer = slice.reducer


### PR DESCRIPTION
### Description

There is an edge case where an artist can be followed or tipped before their tracks are loaded, and if their tracks happen to be loaded in the small window between the follow/tip and its confirmation, the UI will show a locked state instead of an unlocking/unlocked state for those tracks.
To handle this scenario, this PR stores followee and tipped user ids so that those the UI knows to be in an unlocking state as those users' special access tracks load.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local web app vs stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

