### PR TITLE
[PAY-1083] - Only allow prompt modal when single track is being uploaded

### DIFF
--- a/packages/web/src/components/data-entry/FormTile.js
+++ b/packages/web/src/components/data-entry/FormTile.js
@@ -534,9 +534,12 @@ const AdvancedForm = (props) => {
         Render the gated content upload prompt component which is responsible
         for whether or its content will modal will be displayed.
       */}
-      {props.type === 'track' && props.isUpload ? (
+      {props.allowPromptModal ? (
         <GatedContentUploadPromptModal
-          onSubmit={() => setIsAvailabilityModalOpen(true)}
+          onSubmit={() => {
+            props.toggleAdvanced()
+            setIsAvailabilityModalOpen(true)
+          }}
         />
       ) : null}
       {showAvailability && (
@@ -843,6 +846,7 @@ class FormTile extends Component {
         />
         <AdvancedForm
           {...this.props}
+          toggleAdvanced={this.toggleAdvanced}
           advancedShow={advancedShow}
           advancedVisible={advancedVisible}
           licenseType={licenseType}
@@ -916,6 +920,9 @@ FormTile.propTypes = {
   /** Whether we are in the track upload flow */
   isUpload: PropTypes.bool,
 
+  /** Whether we allow showing the gated track upload prompt modal */
+  allowPromptModal: PropTypes.bool,
+
   /** Initial form for in case we are in the edit track modal */
   initialForm: PropTypes.object,
 
@@ -962,6 +969,7 @@ FormTile.defaultProps = {
   onChangeOrder: () => {},
   onChangeField: () => {},
   isUpload: true,
+  allowPromptModal: false,
   initialForm: {},
   showUnlistedToggle: true,
   showHideTrackSectionInModal: true,

--- a/packages/web/src/pages/upload-page/components/EditPage.js
+++ b/packages/web/src/pages/upload-page/components/EditPage.js
@@ -232,6 +232,7 @@ class EditPage extends Component {
             requiredFields={requiredTracksFields[i]}
             playing={i === previewIndex}
             type={'track'}
+            allowPromptModal={tracks.length === 1}
             onAddStems={(stems) => this.props.onAddStems(stems, i)}
             onSelectStemCategory={(category, stemIndex) =>
               this.props.onSelectStemCategory(category, i, stemIndex)


### PR DESCRIPTION
### Description

Only allow prompt modal when single track is being uploaded.
Also automatically expand the advanced form section if user clicks on Got It.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local dapp vs stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

