### PR TITLE
Fix chat reactions with createEntityAdapter

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 import { call, put, select, takeEvery, takeLatest } from 'typed-redux-saga'
 import { ulid } from 'ulid'
 
+import { Status } from 'models/Status'
 import { getAccountUser, getUserId } from 'store/account/selectors'
 import { setVisibility } from 'store/ui/modals/slice'
 
@@ -12,7 +13,6 @@ import { getContext } from '../../effects'
 
 import * as chatSelectors from './selectors'
 import { actions as chatActions } from './slice'
-import { Status } from 'models/Status'
 
 const {
   createChat,

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -206,12 +206,16 @@ const slice = createSlice({
       })
       const existingMessage = getMessage(state.messages[chatId], messageId)
       const existingReactions = existingMessage?.reactions ?? []
-      state.messages.entities[messageId]!.reactions = existingReactions.filter(
+      const filteredReactions = existingReactions.filter(
         (r) => r.user_id !== reaction.user_id
       )
       if (reaction.reaction !== null) {
-        state.messages.entities[messageId]!.reactions.push(reaction)
+        filteredReactions.push(reaction)
       }
+      chatMessagesAdapter.updateOne(state.messages[chatId], {
+        id: messageId,
+        changes: { reactions: filteredReactions }
+      })
     },
     setMessageReactionFailed: (
       state,

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -158,7 +158,7 @@ export const ChatMessageListItem = forwardRef<View, ChatMessageListItemProps>(
         <View
           style={[
             isAuthor ? styles.rootIsAuthor : styles.rootOtherUser,
-            !hasTail && message.reactions.length > 0
+            !hasTail && message.reactions && message.reactions.length > 0
               ? styles.reactionMarginBottom
               : null,
             styleProp


### PR DESCRIPTION
### Description
Use createEntityAdapter api to update a message's reactions.
Also include a import re-ordering (lint) + an extra null check for reactions on mobile.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios + stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

