### PR TITLE
[PAY-1107][PAY-1112] Center mobile chat text input, enlarge icon

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -76,15 +76,16 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     alignItems: 'center',
     backgroundColor: palette.neutralLight10,
     paddingLeft: spacing(4),
-    paddingRight: spacing(3),
     borderRadius: spacing(1)
   },
   composeTextInput: {
-    fontSize: typography.fontSize.medium
+    fontSize: typography.fontSize.medium,
+    lineHeight: spacing(6),
+    paddingTop: 0
   },
   icon: {
-    width: spacing(5),
-    height: spacing(5),
+    width: spacing(7),
+    height: spacing(7),
     fill: palette.primary
   },
   userBadgeTitle: {
@@ -416,23 +417,25 @@ export const ChatScreen = () => {
                 placeholder={messages.startNewMessage}
                 Icon={() => (
                   <IconSend
-                    fill={palette.primary}
                     width={styles.icon.width}
                     height={styles.icon.height}
                     opacity={iconOpacity}
+                    fill={styles.icon.fill}
                     onPress={() => handleSubmit(inputMessage)}
                   />
                 )}
                 styles={{
                   root: styles.composeTextContainer,
-                  input: styles.composeTextInput
+                  input: [
+                    styles.composeTextInput,
+                    Platform.OS === 'ios' ? { paddingBottom: spacing(1) } : null
+                  ]
                 }}
                 onChangeText={(text) => {
                   setInputMessage(text)
                   text ? setIconOpacity(ICON_FOCUS) : setIconOpacity(ICON_BLUR)
                 }}
                 inputAccessoryViewID='none'
-                onBlur={() => setIconOpacity(ICON_BLUR)}
                 multiline
                 value={inputMessage}
               />


### PR DESCRIPTION
### Description
Centers the text in the textinput. This was a bit tricky because using `multiline` in the textinput disallows centering. This feels a bit janky but unfortunately it's the only way I got it to work!

@sliptype including you because you helped me find the first fix, which was to use `lineHeight`, but we actually need to use lineHeight for its intended purpose (line spacing) unfortunately.

### Dragons

on iOS the cursor is larger than the text.. punting for now.

### How Has This Been Tested?

Local ios/android on stage
<img width="390" alt="Screenshot 2023-03-30 at 7 03 19 PM" src="https://user-images.githubusercontent.com/3893871/228983962-dfb1fa17-98d6-4bbc-8f7f-bc02a4a5d75d.png">
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-30 at 19 03 08](https://user-images.githubusercontent.com/3893871/228983965-e7f97db8-5b5e-4d01-b263-f758abad9ac4.png)


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

