### PR TITLE
Separate chat text input to own component

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -25,9 +25,8 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import IconKebabHorizontal from 'app/assets/images/iconKebabHorizontal.svg'
 import IconMessage from 'app/assets/images/iconMessage.svg'
-import IconSend from 'app/assets/images/iconSend.svg'
 import type { FlatListT } from 'app/components/core'
-import { TextInput, Screen, ScreenContent, FlatList } from 'app/components/core'
+import { Screen, ScreenContent, FlatList } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
 import { ProfilePicture } from 'app/components/user'
 import { UserBadges } from 'app/components/user-badges'
@@ -41,22 +40,21 @@ import { useThemePalette } from 'app/utils/theme'
 import type { AppTabScreenParamList } from '../app-screen'
 
 import { ChatMessageListItem } from './ChatMessageListItem'
+import { ChatTextInput } from './ChatTextInput'
 import { EmptyChatMessages } from './EmptyChatMessages'
 import { ReactionPopup } from './ReactionPopup'
 
 const { getChatMessages, getOtherChatUsers, getChat } = chatSelectors
 
-const { fetchMoreMessages, sendMessage, markChatAsRead } = chatActions
+const { fetchMoreMessages, markChatAsRead } = chatActions
 const { getUserId } = accountSelectors
+
+export const REACTION_CONTAINER_HEIGHT = 70
 
 const messages = {
   title: 'Messages',
-  startNewMessage: 'Start a New Message',
   newMessage: 'New Message'
 }
-const ICON_BLUR = 0.5
-const ICON_FOCUS = 1
-export const REACTION_CONTAINER_HEIGHT = 70
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   rootContainer: {
@@ -148,8 +146,6 @@ export const ChatScreen = () => {
   const { params } = useRoute<'Chat'>()
   const { chatId } = params
   const url = `/chat/${encodeUrlName(chatId ?? '')}`
-  const [iconOpacity, setIconOpacity] = useState(ICON_BLUR)
-  const [inputMessage, setInputMessage] = useState('')
   const [shouldShowPopup, setShouldShowPopup] = useState(false)
   const messageTop = useRef(0)
   const chatContainerBottom = useRef(0)
@@ -210,17 +206,6 @@ export const ChatScreen = () => {
         })
       ),
     [chatMessages, userIdEncoded]
-  )
-
-  const handleSubmit = useCallback(
-    (message) => {
-      if (chatId && message) {
-        dispatch(sendMessage({ chatId, message }))
-        setInputMessage('')
-        setIconOpacity(ICON_BLUR)
-      }
-    },
-    [chatId, setInputMessage, dispatch]
   )
 
   useEffect(() => {
@@ -432,33 +417,9 @@ export const ChatScreen = () => {
                 })
               }}
               ref={composeRef}
+              pointerEvents={'box-none'}
             >
-              <TextInput
-                placeholder={messages.startNewMessage}
-                Icon={() => (
-                  <IconSend
-                    width={styles.icon.width}
-                    height={styles.icon.height}
-                    opacity={iconOpacity}
-                    fill={styles.icon.fill}
-                    onPress={() => handleSubmit(inputMessage)}
-                  />
-                )}
-                styles={{
-                  root: styles.composeTextContainer,
-                  input: [
-                    styles.composeTextInput,
-                    Platform.OS === 'ios' ? { paddingBottom: spacing(1) } : null
-                  ]
-                }}
-                onChangeText={(text) => {
-                  setInputMessage(text)
-                  text ? setIconOpacity(ICON_FOCUS) : setIconOpacity(ICON_BLUR)
-                }}
-                inputAccessoryViewID='none'
-                multiline
-                value={inputMessage}
-              />
+              <ChatTextInput chatId={chatId} />
             </View>
           </KeyboardAvoidingView>
         </View>

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from 'react'
+
+import { chatActions } from '@audius/common'
+import { Platform } from 'react-native'
+import { useDispatch } from 'react-redux'
+
+import IconSend from 'app/assets/images/iconSend.svg'
+import { TextInput } from 'app/components/core'
+import { makeStyles } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
+
+const { sendMessage } = chatActions
+
+const ICON_BLUR = 0.5
+const ICON_FOCUS = 1
+
+const messages = {
+  startNewMessage: 'Start a New Message'
+}
+
+const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+  composeTextContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: palette.neutralLight10,
+    paddingLeft: spacing(4),
+    borderRadius: spacing(1)
+  },
+  composeTextInput: {
+    fontSize: typography.fontSize.medium,
+    lineHeight: spacing(6),
+    paddingTop: 0
+  },
+  icon: {
+    width: spacing(7),
+    height: spacing(7),
+    fill: palette.primary
+  }
+}))
+
+type ChatTextInputProps = {
+  chatId: string
+}
+
+export const ChatTextInput = ({ chatId }: ChatTextInputProps) => {
+  const styles = useStyles()
+  const dispatch = useDispatch()
+
+  const [inputMessage, setInputMessage] = useState('')
+
+  const handleSubmit = useCallback(
+    (message) => {
+      if (chatId && message) {
+        setInputMessage('')
+        dispatch(sendMessage({ chatId, message }))
+      }
+    },
+    [chatId, setInputMessage, dispatch]
+  )
+
+  return (
+    <TextInput
+      placeholder={messages.startNewMessage}
+      Icon={() => (
+        <IconSend
+          width={styles.icon.width}
+          height={styles.icon.height}
+          opacity={inputMessage ? ICON_FOCUS : ICON_BLUR}
+          fill={styles.icon.fill}
+          onPress={() => {
+            handleSubmit(inputMessage)
+          }}
+        />
+      )}
+      styles={{
+        root: styles.composeTextContainer,
+        input: [
+          styles.composeTextInput,
+          Platform.OS === 'ios' ? { paddingBottom: spacing(1) } : null
+        ]
+      }}
+      onChangeText={(text) => {
+        setInputMessage(text)
+      }}
+      inputAccessoryViewID='none'
+      multiline
+      value={inputMessage}
+    />
+  )
+}


### PR DESCRIPTION
### Description
Separates TextInput in ChatScreen to its own component to avoid re-rendering the entire screen every time the user enters a char.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

