### PR TITLE
[PLAT-834]: Fix notifications last seen new tag

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2090,7 +2090,7 @@ export const audiusBackend = ({
     return {
       groupId: notification.group_id,
       timestamp,
-      isViewed: notification.seen_at == null,
+      isViewed: !!notification.seen_at,
       id: `timestamp:${timestamp}:group_id:${notification.group_id}`
     }
   }

--- a/packages/web/src/components/nav/desktop/NavColumn.tsx
+++ b/packages/web/src/components/nav/desktop/NavColumn.tsx
@@ -166,9 +166,9 @@ const NavColumn = ({
       record(make(Name.NOTIFICATIONS_OPEN, { source: 'button' }))
     } else {
       closeNotificationPanel()
-    }
-    if (notificationCount > 0) {
-      markAllNotificationsAsViewed()
+      if (notificationCount > 0) {
+        markAllNotificationsAsViewed()
+      }
     }
   }, [
     notificationPanelIsOpen,


### PR DESCRIPTION
### Description
Fixes the isViewed attribute on a notification to be whether a notification has a `seen_at` value. If a notification has seen_at timestamp, isViewed is true because it's been viewed.

Also marks notifications as viewed once we close the notifs menu as opposed to once we open the notif menu, to allow users to see the tag when they first open a new notif 
