### PR TITLE
[C-2406] Prevent non finite set of currentTime

### DIFF
--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -199,7 +199,9 @@ export class AudioPlayer {
           // Set the new time to the current plus the nudge. If this nudge
           // wasn't enough, this error will be thrown again and we will just continue
           // to nudge the playhead forward until the errors stop or the song ends.
-          this.audio.currentTime = newTime
+          if (isFinite(newTime)) {
+            this.audio.currentTime = newTime
+          }
           if (wasPlaying) {
             this.audio.play()
           }
@@ -436,7 +438,9 @@ export class AudioPlayer {
   }
 
   seek = (seconds: number) => {
-    this.audio.currentTime = seconds
+    if (isFinite(seconds)) {
+      this.audio.currentTime = seconds
+    }
   }
 
   setVolume = (value: number) => {


### PR DESCRIPTION
### Description

Fixes an app ending error when seeking a track: https://audius.sentry.io/discover/audius-client:150a6610d90e49369a416a7402b9f7d2/?field=title&field=event.type&field=project&field=user.display&field=timestamp&homepage=true&id=17670&query=%22Caught+saga+error%3A%22&sort=-timestamp&statsPeriod=7d&topEvents=5&widths=1236&yAxis=count%28%29

I was unable to repro, but this is a new bug maybe related to the podcast feature. I couldn't figure out why the time was potentially undefined, but decided to prevent this at the level where HTMLAudioElement.currentTime is being set. This should prevent this type of bug in the future too

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested seeking locally against prod

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

