### PR TITLE
[C-2406] Null check localStorage

### DIFF
--- a/packages/web/src/store/storeContext.ts
+++ b/packages/web/src/store/storeContext.ts
@@ -26,9 +26,10 @@ import { share } from 'utils/share'
 import { getLineupSelectorForRoute } from './lineup/lineupForRoute'
 
 export const storeContext: CommonStoreContext = {
-  getLocalStorageItem: async (key: string) => window.localStorage.getItem(key),
+  getLocalStorageItem: async (key: string) =>
+    window?.localStorage?.getItem(key),
   setLocalStorageItem: async (key: string, value: string) =>
-    window.localStorage.setItem(key, value),
+    window?.localStorage?.setItem(key, value),
   // Note: casting return type to Promise<boolean> to maintain pairity with mobile, but
   // it may be best to update mobile to not be async
   getFeatureEnabled: getFeatureEnabled as unknown as (


### PR DESCRIPTION
### Description

Fix issue were apparently window.localStorage is null in some cases: https://audius.sentry.io/discover/homepage/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=tags%5Bdevice.family%5D&id=17670&query=%22Caught+saga+error%3A%22+%22%28evaluating+%27window.localStorage.getItem%27%29%22&sort=-timestamp&statsPeriod=90d&topEvents=5&widths=737&yAxis=count%28%29

Not sure how this is possible, but this null check should fix it

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested setting and retrieving localStorage items locally

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

