### PR TITLE
[PLAT-819]: Fix copy for repost and save of albums notifications

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteNotification.tsx
@@ -4,7 +4,8 @@ import type { FavoriteNotification as FavoriteNotificationType } from '@audius/c
 import {
   formatCount,
   notificationsSelectors,
-  useProxySelector
+  useProxySelector,
+  Entity
 } from '@audius/common'
 
 import IconHeart from 'app/assets/images/iconHeart.svg'
@@ -50,6 +51,11 @@ export const FavoriteNotification = (props: FavoriteNotificationProps) => {
     [notification]
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const handlePress = useCallback(() => {
     navigation.navigate(notification)
   }, [navigation, notification])
@@ -64,7 +70,7 @@ export const FavoriteNotification = (props: FavoriteNotificationProps) => {
       <NotificationText>
         <UserNameLink user={firstUser} />
         {otherUsersCount > 0 ? messages.others(otherUsersCount) : null}
-        {messages.favorited} {entityType.toLowerCase()}{' '}
+        {messages.favorited} {entityTypeText.toLowerCase()}{' '}
         <EntityLink entity={entity} />
       </NotificationText>
     </NotificationTile>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteOfRepostNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/FavoriteOfRepostNotification.tsx
@@ -4,7 +4,8 @@ import type { FavoriteOfRepostNotification as FavoriteOfRepostNotificationType }
 import {
   formatCount,
   notificationsSelectors,
-  useProxySelector
+  useProxySelector,
+  Entity
 } from '@audius/common'
 
 import IconHeart from 'app/assets/images/iconHeart.svg'
@@ -52,6 +53,11 @@ export const FavoriteOfRepostNotification = (
     [notification]
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const handlePress = useCallback(() => {
     navigation.navigate(notification)
   }, [navigation, notification])
@@ -66,7 +72,7 @@ export const FavoriteOfRepostNotification = (
       <NotificationText>
         <UserNameLink user={firstUser} />
         {otherUsersCount > 0 ? messages.others(otherUsersCount) : null}
-        {messages.favorited} {entityType.toLowerCase()}{' '}
+        {messages.favorited} {entityTypeText.toLowerCase()}{' '}
         <EntityLink entity={entity} />
       </NotificationText>
     </NotificationTile>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RepostNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RepostNotification.tsx
@@ -4,7 +4,8 @@ import type { RepostNotification as RepostNotificationType } from '@audius/commo
 import {
   useProxySelector,
   formatCount,
-  notificationsSelectors
+  notificationsSelectors,
+  Entity
 } from '@audius/common'
 
 import IconRepost from 'app/assets/images/iconRepost.svg'
@@ -49,6 +50,11 @@ export const RepostNotification = (props: RepostNotificationProps) => {
     [notification]
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const handlePress = useCallback(() => {
     navigation.navigate(notification)
   }, [navigation, notification])
@@ -63,7 +69,7 @@ export const RepostNotification = (props: RepostNotificationProps) => {
       <NotificationText>
         <UserNameLink user={firstUser} />
         {otherUsersCount > 0 ? messages.others(otherUsersCount) : null}
-        {messages.reposted} {entityType.toLowerCase()}{' '}
+        {messages.reposted} {entityTypeText.toLowerCase()}{' '}
         <EntityLink entity={entity} />
       </NotificationText>
     </NotificationTile>

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RepostOfRepostNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RepostOfRepostNotification.tsx
@@ -4,7 +4,8 @@ import type { RepostOfRepostNotification as RepostOfRepostNotificationType } fro
 import {
   useProxySelector,
   formatCount,
-  notificationsSelectors
+  notificationsSelectors,
+  Entity
 } from '@audius/common'
 
 import IconRepost from 'app/assets/images/iconRepost.svg'
@@ -51,6 +52,11 @@ export const RepostOfRepostNotification = (
     [notification]
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const handlePress = useCallback(() => {
     navigation.navigate(notification)
   }, [navigation, notification])
@@ -65,7 +71,7 @@ export const RepostOfRepostNotification = (
       <NotificationText>
         <UserNameLink user={firstUser} />
         {otherUsersCount > 0 ? messages.others(otherUsersCount) : null}
-        {messages.reposted} {entityType.toLowerCase()}{' '}
+        {messages.reposted} {entityTypeText.toLowerCase()}{' '}
         <EntityLink entity={entity} />
       </NotificationText>
     </NotificationTile>

--- a/packages/web/src/components/notification/Notification/FavoriteNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FavoriteNotification.tsx
@@ -2,7 +2,8 @@ import { MouseEventHandler, useCallback } from 'react'
 
 import {
   notificationsSelectors,
-  FavoriteNotification as FavoriteNotificationType
+  FavoriteNotification as FavoriteNotificationType,
+  Entity
 } from '@audius/common'
 import { push } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
@@ -48,6 +49,11 @@ export const FavoriteNotification = (props: FavoriteNotificationProps) => {
     getNotificationEntity(state, notification)
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const dispatch = useDispatch()
 
   const handleGoToEntity = useGoToEntity(entity, entityType)
@@ -91,8 +97,8 @@ export const FavoriteNotification = (props: FavoriteNotificationProps) => {
           <OthersLink othersCount={otherUsersCount} onClick={handleClick} />
         ) : null}
         {messages.favorited}
-        {entityType.toLowerCase()}{' '}
-        <EntityLink entity={entity} entityType={entityType} />
+        {entityTypeText.toLowerCase()}{' '}
+        <EntityLink entity={entity} entityType={entityTypeText} />
       </NotificationBody>
       <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />
     </NotificationTile>

--- a/packages/web/src/components/notification/Notification/FavoriteOfRepostNotification.tsx
+++ b/packages/web/src/components/notification/Notification/FavoriteOfRepostNotification.tsx
@@ -1,6 +1,7 @@
 import {
   notificationsSelectors,
-  FavoriteOfRepostNotification as FavoriteOfRepostNotificationType
+  FavoriteOfRepostNotification as FavoriteOfRepostNotificationType,
+  Entity
 } from '@audius/common'
 
 import { useSelector } from 'utils/reducer'
@@ -39,6 +40,11 @@ export const FavoriteOfRepostNotification = (
     getNotificationEntity(state, notification)
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const handleGoToEntity = useGoToEntity(entity, entityType)
 
   if (!users || !firstUser || !entity) return null
@@ -62,8 +68,8 @@ export const FavoriteOfRepostNotification = (
           <OthersText othersCount={otherUsersCount} />
         ) : null}
         {messages.favorited}
-        {entityType.toLowerCase()}{' '}
-        <EntityLink entity={entity} entityType={entityType} />
+        {entityTypeText.toLowerCase()}{' '}
+        <EntityLink entity={entity} entityType={entityTypeText} />
       </NotificationBody>
       <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />
     </NotificationTile>

--- a/packages/web/src/components/notification/Notification/RepostNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RepostNotification.tsx
@@ -1,6 +1,7 @@
 import { MouseEventHandler, useCallback } from 'react'
 
 import {
+  Entity,
   notificationsSelectors,
   RepostNotification as RepostNotificationType
 } from '@audius/common'
@@ -49,6 +50,11 @@ export const RepostNotification = (props: RepostNotificationProps) => {
     getNotificationEntity(state, notification)
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const dispatch = useDispatch()
 
   const handleGoToEntity = useGoToEntity(entity, entityType)
@@ -95,8 +101,8 @@ export const RepostNotification = (props: RepostNotificationProps) => {
         {otherUsersCount > 0 ? (
           <OthersLink othersCount={otherUsersCount} onClick={handleClick} />
         ) : null}{' '}
-        {messages.reposted} {entityType.toLowerCase()}{' '}
-        <EntityLink entity={entity} entityType={entityType} />
+        {messages.reposted} {entityTypeText.toLowerCase()}{' '}
+        <EntityLink entity={entity} entityType={entityTypeText} />
       </NotificationBody>
       <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />
     </NotificationTile>

--- a/packages/web/src/components/notification/Notification/RepostOfRepostNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RepostOfRepostNotification.tsx
@@ -1,4 +1,5 @@
 import {
+  Entity,
   notificationsSelectors,
   RepostOfRepostNotification as RepostOfRepostNotificationType
 } from '@audius/common'
@@ -40,6 +41,11 @@ export const RepostOfRepostNotification = (
     getNotificationEntity(state, notification)
   )
 
+  const entityTypeText =
+    entity && 'is_album' in entity && entity.is_album
+      ? Entity.Album
+      : entityType
+
   const handleGoToEntity = useGoToEntity(entity, entityType)
 
   if (!users || !firstUser || !entity) return null
@@ -62,8 +68,8 @@ export const RepostOfRepostNotification = (
         {otherUsersCount > 0 ? (
           <OthersText othersCount={otherUsersCount} />
         ) : null}{' '}
-        {messages.reposted} {entityType.toLowerCase()}{' '}
-        <EntityLink entity={entity} entityType={entityType} />
+        {messages.reposted} {entityTypeText.toLowerCase()}{' '}
+        <EntityLink entity={entity} entityType={entityTypeText} />
       </NotificationBody>
       <NotificationFooter timeLabel={timeLabel} isViewed={isViewed} />
     </NotificationTile>


### PR DESCRIPTION
### Description
This updates the copy for repost and save notifications. It was printing `X reposted your playlist my_album` for albums which is wrong. this is because in the backend reposts are saved as either playlist or track so factoring in is_album when we generate the copy

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested locally by re enacting a repost notif for an album 

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

