### PR TITLE
Mobile chats scrolling improvements

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -149,7 +149,7 @@ export const ChatScreen = () => {
   const url = `/chat/${encodeUrlName(chatId ?? '')}`
 
   const [shouldShowPopup, setShouldShowPopup] = useState(false)
-  const hasScrolledToUnreadTag = useRef(true)
+  const hasScrolledToUnreadTag = useRef(false)
   const [popupChatIndex, setPopupChatIndex] = useState<number | null>(null)
   const flatListRef = useRef<FlatListT<ChatMessage>>(null)
   const itemsRef = useRef<(View | null)[]>([])
@@ -218,14 +218,14 @@ export const ChatScreen = () => {
       chatMessages &&
       earliestUnreadIndex > 0 &&
       earliestUnreadIndex < chatMessages.length &&
-      hasScrolledToUnreadTag.current
+      !hasScrolledToUnreadTag.current
     ) {
       flatListRef.current?.scrollToIndex({
         index: earliestUnreadIndex,
         viewPosition: 0.95,
         animated: false
       })
-      hasScrolledToUnreadTag.current = false
+      hasScrolledToUnreadTag.current = true
     }
   }, [earliestUnreadIndex, chatMessages])
 

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -258,7 +258,6 @@ export const ChatScreen = () => {
   useFocusEffect(
     useCallback(() => {
       return () => {
-        firstRender.current = false
         dispatch(markChatAsRead({ chatId }))
       }
     }, [dispatch, chatId])

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -142,16 +142,21 @@ export const ChatScreen = () => {
   const styles = useStyles()
   const palette = useThemePalette()
   const dispatch = useDispatch()
+  const navigation = useNavigation<AppTabScreenParamList>()
 
   const { params } = useRoute<'Chat'>()
   const { chatId } = params
   const url = `/chat/${encodeUrlName(chatId ?? '')}`
+
   const [shouldShowPopup, setShouldShowPopup] = useState(false)
-  const messageTop = useRef(0)
-  const chatContainerBottom = useRef(0)
-  const chatContainerTop = useRef(0)
   const [popupChatIndex, setPopupChatIndex] = useState<number | null>(null)
-  const navigation = useNavigation<AppTabScreenParamList>()
+  const flatListRef = useRef<FlatListT<ChatMessage>>(null)
+  const itemsRef = useRef<(View | null)[]>([])
+  const composeRef = useRef<View | null>(null)
+  const chatContainerRef = useRef<View | null>(null)
+  const messageTop = useRef(0)
+  const chatContainerTop = useRef(0)
+  const chatContainerBottom = useRef(0)
 
   const userId = useSelector(getUserId)
   const userIdEncoded = encodeHashId(userId)
@@ -160,10 +165,6 @@ export const ChatScreen = () => {
   const chatMessages = useSelector((state) =>
     getChatMessages(state, chatId ?? '')
   )
-  const flatListRef = useRef<FlatListT<ChatMessage>>(null)
-  const itemsRef = useRef<(View | null)[]>([])
-  const composeRef = useRef<View | null>(null)
-  const chatContainerRef = useRef<View | null>(null)
   const unreadCount = chat?.unread_message_count ?? 0
   const isLoading =
     chat?.messagesStatus === Status.LOADING && chatMessages?.length === 0
@@ -276,14 +277,14 @@ export const ChatScreen = () => {
     if (index < 0 || index >= chatMessages.length) {
       return
     }
-    const popupViewRef = itemsRef.current[index]
-    if (popupViewRef === null || popupViewRef === undefined) {
+    const messageRef = itemsRef.current[index]
+    if (messageRef === null || messageRef === undefined) {
       return
     }
     // Measure position of selected message to create a copy of it on top
     // of the dimmed background inside the portal.
     const messageY = await new Promise<number>((resolve) => {
-      popupViewRef.measureInWindow((x, y, width, height) => {
+      messageRef.measureInWindow((x, y, width, height) => {
         resolve(y)
       })
     })

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -149,7 +149,7 @@ export const ChatScreen = () => {
   const url = `/chat/${encodeUrlName(chatId ?? '')}`
 
   const [shouldShowPopup, setShouldShowPopup] = useState(false)
-  const firstRender = useRef(true)
+  const hasScrolledToUnreadTag = useRef(true)
   const [popupChatIndex, setPopupChatIndex] = useState<number | null>(null)
   const flatListRef = useRef<FlatListT<ChatMessage>>(null)
   const itemsRef = useRef<(View | null)[]>([])
@@ -218,14 +218,14 @@ export const ChatScreen = () => {
       chatMessages &&
       earliestUnreadIndex > 0 &&
       earliestUnreadIndex < chatMessages.length &&
-      firstRender.current
+      hasScrolledToUnreadTag.current
     ) {
       flatListRef.current?.scrollToIndex({
         index: earliestUnreadIndex,
         viewPosition: 0.95,
         animated: false
       })
-      firstRender.current = false
+      hasScrolledToUnreadTag.current = false
     }
   }, [earliestUnreadIndex, chatMessages])
 


### PR DESCRIPTION
### Description

- Scroll to earliest unread message only on first page load. (Was scrolling randomly while on chat screen).
- Maintain scroll position even when new messages come in, if you've scrolled past a certain threshold away from the bottom (currently set to 1/4 of the screen height).
- Some code cleanup.

### Dragons

Noticed something is wrong with scrolling on android but don't think it's related to these changes.

### How Has This Been Tested?
Local ios stage

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

