### PR TITLE
Mobile chats use push instead of navigate

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -286,7 +286,14 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
       <Stack.Group>
         <Stack.Screen name='ChatList' component={ChatListScreen} />
         <Stack.Screen name='ChatUserList' component={ChatUserListScreen} />
-        <Stack.Screen name='Chat' component={ChatScreen} />
+        <Stack.Screen
+          name='Chat'
+          component={ChatScreen}
+          getId={({ params }) => {
+            // @ts-ignore
+            return params?.chatId
+          }}
+        />
       </Stack.Group>
     </Stack.Navigator>
   )

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -289,10 +289,10 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
         <Stack.Screen
           name='Chat'
           component={ChatScreen}
-          getId={({ params }) => {
-            // @ts-ignore
-            return params?.chatId
-          }}
+          getId={({ params }) =>
+            // @ts-ignore hard to correctly type navigation params (PAY-1141)
+            params?.chatId
+          }
         />
       </Stack.Group>
     </Stack.Navigator>

--- a/packages/mobile/src/screens/chat-screen/ChatListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatListItem.tsx
@@ -37,7 +37,7 @@ export const ChatListItem = ({ chat }: { chat: UserChat }) => {
   )
 
   const handlePress = useCallback(() => {
-    navigation.navigate('Chat', { chatId: currentChatId })
+    navigation.push('Chat', { chatId: currentChatId })
   }, [navigation, currentChatId])
 
   if (!users[0]) {

--- a/packages/mobile/src/store/chat/sagas.ts
+++ b/packages/mobile/src/store/chat/sagas.ts
@@ -11,7 +11,7 @@ function* watchGoToChat() {
       payload: { chatId }
     } = action
     if (navigationRef.isReady()) {
-      // @ts-ignore navigationRef is not parametrized correctly (PAY-954)
+      // @ts-ignore navigationRef is not parametrized correctly (PAY-1141)
       navigationRef.navigate('Chat', { chatId })
     }
   })


### PR DESCRIPTION
### Description
Use `navigation.push` instead of `navigate` to navigate to chat screens. Also pass in a `getId` function so that the chats are unique. Otherwise, if a user
- navs to a chat
- clicks on the username header to nav to the profile
- then navs somewhere else and lands on a different user
- then hits the chat entry from that new user's profile page
the navigator will go back (left) instead of forwards.

### Dragons

Had to ts-ignore the type warning in `getId`. I think it's a known issue that typing is pretty wonky with react navigation, have run into this before and confirmed with client team. cc @sliptype in case i'm wrong.

### How Has This Been Tested?

local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

