### PR TITLE
[PAY-829][PAY-1044] Desktop: Chats search users modal permissions/blocks and profile page permissions/blocks

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -300,7 +300,7 @@ function* doFetchBlockers() {
       })
     )
   } catch (e) {
-    console.error('fetchBlockeesFailed', e)
+    console.error('fetchBlockersFailed', e)
   }
 }
 

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -41,6 +41,8 @@ const {
   addMessage,
   fetchBlockees,
   fetchBlockeesSucceeded,
+  fetchBlockers,
+  fetchBlockersSucceeded,
   unblockUser,
   blockUser,
   fetchPermissions,
@@ -285,6 +287,23 @@ function* doFetchBlockees() {
   }
 }
 
+function* doFetchBlockers() {
+  try {
+    const audiusSdk = yield* getContext('audiusSdk')
+    const sdk = yield* call(audiusSdk)
+    const { data } = yield* call([sdk.chats, sdk.chats.getBlockers])
+    yield* put(
+      fetchBlockersSucceeded({
+        blockers: data
+          .map((encodedId) => decodeHashId(encodedId))
+          .filter(removeNullable)
+      })
+    )
+  } catch (e) {
+    console.error('fetchBlockeesFailed', e)
+  }
+}
+
 function* doBlockUser(action: ReturnType<typeof blockUser>) {
   try {
     const audiusSdk = yield* getContext('audiusSdk')
@@ -360,6 +379,10 @@ function* watchFetchBlockees() {
   yield takeLatest(fetchBlockees, doFetchBlockees)
 }
 
+function* watchFetchBlockers() {
+  yield takeLatest(fetchBlockers, doFetchBlockers)
+}
+
 function* watchBlockUser() {
   yield takeEvery(blockUser, doBlockUser)
 }
@@ -382,6 +405,7 @@ export const sagas = () => {
     watchSendMessage,
     watchAddMessage,
     watchFetchBlockees,
+    watchFetchBlockers,
     watchBlockUser,
     watchUnblockUser,
     watchFetchPermissions

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -32,6 +32,9 @@ export const getOptimisticReactions = (state: CommonState) =>
 
 export const getBlockees = (state: CommonState) => state.pages.chat.blockees
 
+export const getPermissionsMap = (state: CommonState) =>
+  state.pages.chat.permissions
+
 export const getChats = createSelector(
   [selectAllChats, getOptimisticReads],
   (chats, optimisticReads) => {

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -32,6 +32,8 @@ export const getOptimisticReactions = (state: CommonState) =>
 
 export const getBlockees = (state: CommonState) => state.pages.chat.blockees
 
+export const getBlockers = (state: CommonState) => state.pages.chat.blockers
+
 export const getPermissionsMap = (state: CommonState) =>
   state.pages.chat.permissions
 

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -43,6 +43,7 @@ type ChatState = {
   optimisticChatRead: Record<string, UserChat>
   activeChatId: string | null
   blockees: ID[]
+  blockers: ID[]
   permissions: Record<ID, ChatPermissionResponse>
 }
 
@@ -86,6 +87,7 @@ const initialState: ChatState = {
   optimisticReactions: {},
   activeChatId: null,
   blockees: [],
+  blockers: [],
   permissions: {}
 }
 
@@ -354,6 +356,15 @@ const slice = createSlice({
       action: PayloadAction<{ blockees: ID[] }>
     ) => {
       state.blockees = action.payload.blockees
+    },
+    fetchBlockers: (_state, _action: Action) => {
+      // triggers saga
+    },
+    fetchBlockersSucceeded: (
+      state,
+      action: PayloadAction<{ blockers: ID[] }>
+    ) => {
+      state.blockers = action.payload.blockers
     },
     blockUser: (_state, _action: PayloadAction<{ userId: ID }>) => {
       // triggers saga

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -1,9 +1,10 @@
-import type {
+import {
   TypedCommsResponse,
   UserChat,
   ChatMessage,
   ChatMessageReaction,
-  ChatMessageNullableReaction
+  ChatMessageNullableReaction,
+  ChatPermissionResponse
 } from '@audius/sdk'
 import {
   Action,
@@ -42,6 +43,7 @@ type ChatState = {
   optimisticChatRead: Record<string, UserChat>
   activeChatId: string | null
   blockees: ID[]
+  permissions: Record<ID, ChatPermissionResponse>
 }
 
 type SetMessageReactionPayload = {
@@ -83,7 +85,8 @@ const initialState: ChatState = {
   optimisticChatRead: {},
   optimisticReactions: {},
   activeChatId: null,
-  blockees: []
+  blockees: [],
+  permissions: {}
 }
 
 const slice = createSlice({
@@ -357,6 +360,20 @@ const slice = createSlice({
     },
     unblockUser: (_state, _action: PayloadAction<{ userId: ID }>) => {
       // triggers saga
+    },
+    fetchPermissions: (_state, _action: PayloadAction<{ userIds: ID[] }>) => {
+      // triggers saga
+    },
+    fetchPermissionsSucceeded: (
+      state,
+      action: PayloadAction<{
+        permissions: Record<ID, ChatPermissionResponse>
+      }>
+    ) => {
+      state.permissions = {
+        ...state.permissions,
+        ...action.payload.permissions
+      }
     }
   }
 })

--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -23,7 +23,7 @@ import disconnectedWallets from './disconnected_wallet_fix.json'
 
 const { fetchProfile } = profilePageActions
 const { getFeePayer } = solanaSelectors
-const { fetchBlockees } = chatActions
+const { fetchBlockees, fetchBlockers } = chatActions
 
 const {
   getUserId,
@@ -259,8 +259,9 @@ function* cacheAccount(account) {
 
   yield put(fetchAccountSucceeded(formattedAccount))
 
-  // Fetch user's chat blockee list after fetching their account
+  // Fetch user's chat blockee and blocker list after fetching their account
   yield put(fetchBlockees())
+  yield put(fetchBlockers())
 }
 
 // Pull from redux cache and persist to local storage cache

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -19,7 +19,8 @@ import {
   MAX_PROFILE_SUPPORTING_TILES,
   MAX_PROFILE_TOP_SUPPORTERS,
   collectiblesActions,
-  processAndCacheUsers
+  processAndCacheUsers,
+  chatActions
 } from '@audius/common'
 import { merge } from 'lodash'
 import {
@@ -63,6 +64,8 @@ const {
   updateSolCollections,
   setHasUnsupportedCollection
 } = collectiblesActions
+
+const { fetchPermissions } = chatActions
 
 function* watchFetchProfile() {
   yield takeEvery(profileActions.FETCH_PROFILE, fetchProfileAsync)
@@ -319,6 +322,9 @@ function* fetchProfileAsync(action) {
       yield fork(fetchUserCollections, user.user_id)
       yield fork(fetchSupportersAndSupporting, user.user_id)
     }
+
+    // Get chat permissions
+    yield put(fetchPermissions({ userIds: [user.user_id] }))
 
     yield fork(fetchProfileCustomizedCollectibles, user)
     yield fork(fetchOpenSeaAssets, user)

--- a/packages/web/src/components/artist/ArtistChip.tsx
+++ b/packages/web/src/components/artist/ArtistChip.tsx
@@ -81,6 +81,7 @@ type ArtistChipProps = {
   showSupportFrom?: ID
   className?: string
   popoverMount?: MountPlacement
+  customChips?: React.ReactNode
   onNavigateAway?: () => void
 }
 const ArtistChip = ({
@@ -91,6 +92,7 @@ const ArtistChip = ({
   showSupportFrom,
   className = '',
   popoverMount = MountPlacement.PAGE,
+  customChips = null,
   onNavigateAway
 }: ArtistChipProps) => {
   const {
@@ -148,22 +150,26 @@ const ArtistChip = ({
             onNavigateAway={onNavigateAway}
           />
         </div>
-        <ArtistChipFollowers
-          followerCount={followers}
-          doesFollowCurrentUser={!!doesFollowCurrentUser}
-        />
-        {showSupportFor ? (
-          <ArtistChipSupportFor
-            artistId={user.user_id}
-            userId={showSupportFor}
-          />
-        ) : null}
-        {showSupportFrom ? (
-          <ArtistChipSupportFrom
-            artistId={user.user_id}
-            userId={showSupportFrom}
-          />
-        ) : null}
+        {customChips || (
+          <>
+            <ArtistChipFollowers
+              followerCount={followers}
+              doesFollowCurrentUser={!!doesFollowCurrentUser}
+            />
+            {showSupportFor ? (
+              <ArtistChipSupportFor
+                artistId={user.user_id}
+                userId={showSupportFor}
+              />
+            ) : null}
+            {showSupportFrom ? (
+              <ArtistChipSupportFrom
+                artistId={user.user_id}
+                userId={showSupportFrom}
+              />
+            ) : null}
+          </>
+        )}
       </div>
     </div>
   )

--- a/packages/web/src/components/stat-banner/StatBanner.tsx
+++ b/packages/web/src/components/stat-banner/StatBanner.tsx
@@ -179,14 +179,16 @@ export const StatBanner = (props: StatsBannerProps) => {
                   />
                 )}
               />
-              <Button
-                type={ButtonType.COMMON}
-                size={ButtonSize.SMALL}
-                className={cn(styles.iconButton, styles.statButton)}
-                aria-label={messages.message}
-                text={<IconMessage />}
-                onClick={onMessage}
-              />
+              {onMessage ? (
+                <Button
+                  type={ButtonType.COMMON}
+                  size={ButtonSize.SMALL}
+                  className={cn(styles.iconButton, styles.statButton)}
+                  aria-label={messages.message}
+                  text={<IconMessage />}
+                  onClick={onMessage}
+                />
+              ) : null}
             </>
           ) : (
             <Button

--- a/packages/web/src/pages/chat-page/components/CreateChatModal.tsx
+++ b/packages/web/src/pages/chat-page/components/CreateChatModal.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react'
 
 import {
   accountSelectors,
+  chatActions,
   mutualsUserListActions,
   mutualsUserListSelectors,
   MUTUALS_USER_LIST_TAG,
@@ -10,6 +11,7 @@ import {
 import { IconCompose } from '@audius/stems'
 import { useDispatch } from 'react-redux'
 
+import { useModalState } from 'common/hooks/useModalState'
 import { useSelector } from 'common/hooks/useSelector'
 import { SearchUsersModal } from 'components/search-users-modal/SearchUsersModal'
 import { MessageUserSearchResult } from 'pages/chat-page/components/CreateChatUserResult'
@@ -19,10 +21,14 @@ const messages = {
 }
 
 const { getAccountUser } = accountSelectors
+const { fetchBlockers } = chatActions
+
+const CREATE_CHAT_MODAL = 'CreateChat'
 
 export const CreateChatModal = () => {
   const dispatch = useDispatch()
   const currentUser = useSelector(getAccountUser)
+  const [isVisible] = useModalState(CREATE_CHAT_MODAL)
 
   const { userIds, loading, hasMore } = useSelector(
     mutualsUserListSelectors.getUserList
@@ -39,9 +45,15 @@ export const CreateChatModal = () => {
     loadMore()
   }, [loadMore])
 
+  useEffect(() => {
+    if (isVisible) {
+      dispatch(fetchBlockers())
+    }
+  }, [dispatch, isVisible])
+
   return (
     <SearchUsersModal
-      modalName='CreateChat'
+      modalName={CREATE_CHAT_MODAL}
       titleProps={{ title: messages.title, icon: <IconCompose /> }}
       defaultUserList={{
         userIds,

--- a/packages/web/src/pages/chat-page/components/CreateChatUserResult.module.css
+++ b/packages/web/src/pages/chat-page/components/CreateChatUserResult.module.css
@@ -5,7 +5,7 @@
   border-bottom: 1px solid var(--neutral-light-8);
 }
 
-.root:not(:disabled):hover {
+.root:not(.disabled):hover {
   cursor: pointer;
   background: var(--neutral-light-10);
 }
@@ -16,4 +16,9 @@
 
 .icon path {
   fill: var(--neutral-light-4);
+}
+
+.notPermitted {
+  font-weight: var(--font-bold);
+  line-height: 120%;
 }

--- a/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
+++ b/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
@@ -44,8 +44,8 @@ const { getUserId } = accountSelectors
 const { getOptimisticSupporters, getOptimisticSupporting } = tippingSelectors
 
 const { fetchSupportersForUser } = tippingActions
-const { createChat, blockUser, unblockUser } = chatActions
-const { getBlockees } = chatSelectors
+const { createChat, blockUser, unblockUser, fetchPermissions } = chatActions
+const { getBlockees, getPermissionsMap } = chatSelectors
 
 const renderTrigger = (
   anchorRef: React.MutableRefObject<any>,
@@ -67,6 +67,7 @@ export const MessageUserSearchResult = (props: UserResultComposeProps) => {
   const supportersMap = useSelector(getOptimisticSupporters)
   const blockeeList = useSelector(getBlockees)
   const isBlocked = blockeeList.includes(user.user_id)
+  const permissionsMap = useSelector(getPermissionsMap)
 
   const handleComposeClicked = useCallback(() => {
     dispatch(createChat({ userIds: [user.user_id] }))
@@ -114,6 +115,10 @@ export const MessageUserSearchResult = (props: UserResultComposeProps) => {
       dispatch(fetchSupportersForUser({ userId: user.user_id }))
     }
   }, [dispatch, currentUserId, supportingMap, supportersMap, user])
+
+  useEffect(() => {
+    dispatch(fetchPermissions({ userIds: [user.user_id] }))
+  }, [dispatch, user])
 
   return (
     <div className={styles.root}>

--- a/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
+++ b/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
@@ -74,7 +74,7 @@ export const MessageUserSearchResult = (props: UserResultComposeProps) => {
   const isBlocker = blockerList.includes(user.user_id)
   const permissionsMap = useSelector(getPermissionsMap)
   const isPermitted =
-    !isBlocker &&
+    !(isBlocker || isBlockee) &&
     (permissionsMap[user.user_id]?.current_user_has_permission ?? true)
 
   const handleComposeClicked = useCallback(() => {

--- a/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
+++ b/packages/web/src/pages/chat-page/components/CreateChatUserResult.tsx
@@ -48,7 +48,7 @@ const { getOptimisticSupporters, getOptimisticSupporting } = tippingSelectors
 
 const { fetchSupportersForUser } = tippingActions
 const { createChat, blockUser, unblockUser, fetchPermissions } = chatActions
-const { getBlockees, getPermissionsMap } = chatSelectors
+const { getBlockees, getBlockers, getPermissionsMap } = chatSelectors
 
 const renderTrigger = (
   anchorRef: React.MutableRefObject<any>,
@@ -69,10 +69,13 @@ export const MessageUserSearchResult = (props: UserResultComposeProps) => {
   const supportingMap = useSelector(getOptimisticSupporting)
   const supportersMap = useSelector(getOptimisticSupporters)
   const blockeeList = useSelector(getBlockees)
-  const isBlocked = blockeeList.includes(user.user_id)
+  const blockerList = useSelector(getBlockers)
+  const isBlockee = blockeeList.includes(user.user_id)
+  const isBlocker = blockerList.includes(user.user_id)
   const permissionsMap = useSelector(getPermissionsMap)
   const isPermitted =
-    permissionsMap[user.user_id]?.current_user_has_permission ?? true
+    !isBlocker &&
+    (permissionsMap[user.user_id]?.current_user_has_permission ?? true)
 
   const handleComposeClicked = useCallback(() => {
     dispatch(createChat({ userIds: [user.user_id] }))
@@ -100,7 +103,7 @@ export const MessageUserSearchResult = (props: UserResultComposeProps) => {
         }
       : null,
     { icon: <IconUser />, text: messages.visit, onClick: handleVisitClicked },
-    isBlocked
+    isBlockee
       ? {
           icon: <IconUnblockMessages />,
           text: messages.unblock,

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -75,7 +75,7 @@ const {
 } = profilePageSelectors
 const { getAccountUser } = accountSelectors
 const { createChat, blockUser, unblockUser } = chatActions
-const { getBlockees } = chatSelectors
+const { getBlockees, getBlockers, getPermissionsMap } = chatSelectors
 
 const INITIAL_UPDATE_FIELDS = {
   updatedName: null,
@@ -828,6 +828,12 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       activeTab === ProfilePageTabs.REPOSTS ||
       activeTab === ProfilePageTabs.COLLECTIBLES
     const following = !!profile && profile.does_current_user_follow
+    const hasChatPermission =
+      (this.props.profile.profile?.user_id &&
+        !this.props.blockerList.includes(this.props.profile.profile.user_id) &&
+        this.props.permissionsMap[this.props.profile.profile.user_id]
+          ?.current_user_has_permission) ??
+      false
 
     const childProps = {
       // Computed
@@ -899,7 +905,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
       updateDonation: this.updateDonation,
       updateCoverPhoto: this.updateCoverPhoto,
       didChangeTabsFrom: this.didChangeTabsFrom,
-      onMessage: this.onMessage,
+      onMessage: hasChatPermission ? this.onMessage : undefined,
       onBlock: this.onBlock,
       onUnblock: this.onUnblock
     }
@@ -944,7 +950,7 @@ class ProfilePage extends PureComponent<ProfilePageProps, ProfilePageState> {
 
       updateProfile: this.props.updateProfile,
       isBlocked: this.props.profile.profile
-        ? this.props.blockedList.includes(this.props.profile.profile.user_id)
+        ? this.props.blockeeList.includes(this.props.profile.profile.user_id)
         : false
     }
 
@@ -984,7 +990,9 @@ function makeMapStateToProps() {
       relatedArtists: getRelatedArtists(state, {
         id: getProfileUserId(state, handleLower) ?? 0
       }),
-      blockedList: getBlockees(state)
+      permissionsMap: getPermissionsMap(state),
+      blockeeList: getBlockees(state),
+      blockerList: getBlockers(state)
     }
   }
   return mapStateToProps

--- a/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfilePage.tsx
@@ -147,7 +147,7 @@ export type ProfilePageProps = {
   ) => void
   didChangeTabsFrom: (prevLabel: string, currentLabel: string) => void
   onCloseArtistRecommendations: () => void
-  onMessage: () => void
+  onMessage?: () => void
   onBlock: () => void
   onUnblock: () => void
 }


### PR DESCRIPTION
### Description

- Gray out profiles you can't message on the search user modal
- Hides message icon from people you can message on their profile (TEMPORARY until we get CTA)
- Binds chat inbox settings to existing data

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

