### PR TITLE
[C-2406] Fix repeated edits of same track

### DIFF
--- a/packages/web/src/common/store/cache/tracks/sagas.js
+++ b/packages/web/src/common/store/cache/tracks/sagas.js
@@ -203,11 +203,12 @@ function* confirmEditTrack(
           confirmedTrack._is_publishing = false
         }
         // Update the cached track so it no longer contains image upload artifacts
+        const { artwork: ignoredArtwork, ...metadata } = confirmedTrack
         yield put(
           cacheActions.update(Kind.TRACKS, [
             {
               id: confirmedTrack.track_id,
-              metadata: { ...confirmedTrack, artwork: {} }
+              metadata
             }
           ])
         )


### PR DESCRIPTION
### Description

Editing a track multiple times in one session caused an app ending bug: https://audius.sentry.io/discover/audius-client:02ae98b2b3f845c8b2f1ee92ce2aca6c/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=tags%5Bdevice.family%5D&homepage=true&id=17670&query=%22Caught+saga+error%3A%22+%22edit+track+failed%22&sort=-timestamp&statsPeriod=90d&topEvents=5&widths=737&widths=-1&widths=-179&widths=236&yAxis=count%28%29

This was because we were setting `artwork: {}` which caused this branch to be hit https://github.com/AudiusProject/audius-client/blob/main/packages/common/src/services/audius-backend/AudiusBackend.ts#L1274

Deleting the `artwork` key fixes this

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Tested editing track locally against stage, tested updating images etc.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

