### PR TITLE
Fix permissions message for adding to photos C-2379

### DIFF
--- a/packages/mobile/ios/AudiusReactNative/Info.plist
+++ b/packages/mobile/ios/AudiusReactNative/Info.plist
@@ -78,10 +78,10 @@
 		<string>${PRODUCT_NAME} uses the local network to discover Cast-enabled devices on your WiFi network.</string>
 		<key>NSLocationWhenInUseUsageDescription</key>
 		<string></string>
-		<key>NSPhotoLibraryAddUsageDescription</key>
-		<string>This lets you share tracks to TikTok.</string>
 		<key>NSPhotoLibraryUsageDescription</key>
 		<string>This lets you select photos for uploading to Audius, including setting your profile picture and track cover art.</string>
+		<key>NSPhotoLibraryAddUsageDescription</key>
+		<string>This lets you select photos for uploading to Audius, and lets you share tracks to TikTok and other social media.</string>
 		<key>SCSDKClientId</key>
 		<string>$(SCSDK_CLIENT_ID)</string>
 		<key>SCSDKRedirectUrl</key>


### PR DESCRIPTION
### Description
Weird bug (see linear ticket) that I was unable to repro, but might be related to this image picker issue https://github.com/react-native-image-picker/react-native-image-picker/issues/632

Bandaid by setting a more general permissions message.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

