### PR TITLE
[PLAT-847]: Fix user subscription create album notification copy

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2248,11 +2248,14 @@ export const audiusBackend = ({
           const data = action.data
           if ('playlist_id' in data) {
             entityType = data.is_album ? Entity.Album : Entity.Playlist
-            return decodeHashId(data.playlist_id)
+            return data.playlist_id.map((playlist_id) =>
+              decodeHashId(playlist_id)
+            )
           }
           entityType = Entity.Track
           return decodeHashId(data.track_id)
         })
+        .flat()
         .filter(removeNullable)
       const userId = decodeHashId(notification.actions[0].specifier) as number
       return {

--- a/packages/common/src/store/notifications/types.ts
+++ b/packages/common/src/store/notifications/types.ts
@@ -232,7 +232,7 @@ export type DiscoveryCreateTrackNotificationAction = {
 }
 export type DiscoveryCreatePlaylistNotificationAction = {
   is_album: boolean
-  playlist_id: string
+  playlist_id: string[]
 }
 
 export type TrendingRange = 'week' | 'month' | 'year'


### PR DESCRIPTION
### Description
Was testing uploads and the create album notification for subscribed users was rending a weird copy. Fixed the id parsing in audius backend discovery notifications

before:
![IMG_1690](https://user-images.githubusercontent.com/109105561/229912147-9d45dece-ee4f-44b9-9d94-877646167ec8.png)

after:
<img width="410" alt="Screenshot 2023-04-04 at 4 24 56 PM" src="https://user-images.githubusercontent.com/109105561/229912095-6e079981-fb4b-4211-8df1-82186174bbd1.png">


### How Has This Been Tested?

tested locally against stage
