### PR TITLE
[C-2364] Fix missing artist-card badges on android

### DIFF
--- a/packages/mobile/src/components/card/Card.tsx
+++ b/packages/mobile/src/components/card/Card.tsx
@@ -34,8 +34,14 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
   textContainer: {
     paddingVertical: spacing(1)
   },
+  primaryTextContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
   primaryText: {
     ...typography.h3,
+    marginBottom: 0,
     color: palette.neutral,
     textAlign: 'center',
     // needed to keep emojis from increasing text height
@@ -100,15 +106,17 @@ export const Card = (props: CardProps) => {
         style: [styles.cardImage, props.type === 'user' && styles.userImage]
       })}
       <View style={styles.textContainer}>
-        <Text
-          numberOfLines={1}
-          style={[styles.primaryText, stylesProp?.primaryText]}
-        >
-          {primaryText}
+        <View style={styles.primaryTextContainer}>
+          <Text
+            numberOfLines={1}
+            style={[styles.primaryText, stylesProp?.primaryText]}
+          >
+            {primaryText}
+          </Text>
           {props.type === 'user' ? (
             <UserBadges user={props.user} badgeSize={12} hideName />
           ) : null}
-        </Text>
+        </View>
         <View style={styles.secondaryTextContainer}>
           <Text
             numberOfLines={1}


### PR DESCRIPTION
### Description

Fix issue where artist-card badges were missing on android. This was part of a larger problem where artist-name had extra margin, and the badges were imbedded in Text component, leading to poor render layout. Splitting them out into a View fixes the issue
