### PR TITLE
[C-2418] Fix mobile web open in app banner

### DIFF
--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -41,7 +41,10 @@ async function handleEvent(event) {
 
   const is204 = pathname === '/204'
   if (is204) {
-    return new Response(undefined, { status: 204 })
+    const response = new Response(undefined, { status: 204 })
+    response.headers.set('access-control-allow-methods', '*')
+    response.headers.set('access-control-allow-origin', '*')
+    return response
   }
 
   const isBot = checkIsBot(userAgent)

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -20,7 +20,6 @@ import './services/webVitals'
 import './index.css'
 
 type AudiusAppProps = {
-  setReady: () => void
   shouldShowPopover: boolean
 }
 

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -21,15 +21,10 @@ import './index.css'
 
 type AudiusAppProps = {
   setReady: () => void
-  isReady: boolean
   shouldShowPopover: boolean
 }
 
-const AudiusApp = ({
-  setReady,
-  isReady,
-  shouldShowPopover
-}: AudiusAppProps) => {
+const AudiusApp = ({ shouldShowPopover }: AudiusAppProps) => {
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>
@@ -50,8 +45,6 @@ const AudiusApp = ({
                     <AppErrorBoundary>
                       <CoinbasePayButtonProvider>
                         <App
-                          setReady={setReady}
-                          isReady={isReady}
                           mainContentRef={mainContentRef}
                           shouldShowPopover={shouldShowPopover}
                         />

--- a/packages/web/src/components/app-redirect-popover/components/AppRedirectPopover.tsx
+++ b/packages/web/src/components/app-redirect-popover/components/AppRedirectPopover.tsx
@@ -72,7 +72,6 @@ const springProps = {
 }
 
 type AppRedirectPopoverProps = {
-  enablePopover: boolean
   incrementScroll: () => void
   decrementScroll: () => void
   onBeforeClickApp?: () => void
@@ -85,7 +84,6 @@ type AppRedirectPopoverProps = {
  * if no app is installed.
  */
 export const AppRedirectPopover = ({
-  enablePopover,
   incrementScroll,
   decrementScroll,
   onBeforeClickApp = () => {},
@@ -95,8 +93,8 @@ export const AppRedirectPopover = ({
 
   const [animDelay, setAnimDelay] = useState(false)
   useEffect(() => {
-    enablePopover && setTimeout(() => setAnimDelay(true), 1000)
-  }, [enablePopover])
+    setTimeout(() => setAnimDelay(true), 1000)
+  }, [])
 
   const shouldShow =
     !matchPath(window.location.pathname, { path: '/', exact: true }) &&

--- a/packages/web/src/pages/App.d.ts
+++ b/packages/web/src/pages/App.d.ts
@@ -1,8 +1,6 @@
 import { MutableRefObject } from 'react'
 
 type AppProps = {
-  setReady: () => void
-  isReady: boolean
   mainContentRef: MutableRefObject<HTMLDivElement | undefined>
   shouldShowPopover: boolean
 }

--- a/packages/web/src/pages/App.js
+++ b/packages/web/src/pages/App.js
@@ -364,21 +364,6 @@ class App extends Component {
       this.setState({ showWeb3ErrorBanner: true })
     }
 
-    // Once the user is loaded, we can mark the page as ready for UI
-    // Alternatively, if the page is the signup page, say we're ready without a user
-    // This is necessary for the AppRedirectPopover to load
-    if (
-      (prevProps.accountStatus === Status.LOADING &&
-        this.props.accountStatus !== Status.LOADING) ||
-      matchPath(getPathname(this.props.location), {
-        path: SIGN_UP_PAGE,
-        exact: true
-      })
-    ) {
-      // Let the UI flush
-      setImmediate(this.props.setReady)
-    }
-
     if (prevProps.theme !== this.props.theme) {
       this.handleTheme()
     }
@@ -452,7 +437,6 @@ class App extends Component {
   render() {
     const {
       theme,
-      isReady,
       incrementScroll,
       decrementScroll,
       shouldShowPopover,
@@ -971,11 +955,9 @@ class App extends Component {
           </Suspense>
         </div>
         <PlayBarProvider />
-
         <Suspense fallback={null}>
           <Modals />
         </Suspense>
-
         {
           <Suspense fallback={null}>
             <ConnectedMusicConfetti />
@@ -986,7 +968,6 @@ class App extends Component {
             <RewardClaimedToast />
           </Suspense>
         }
-
         {/* Non-mobile */}
         {!isMobileClient ? <Konami /> : null}
         {!isMobileClient ? <ConfirmerPreview /> : null}
@@ -994,11 +975,9 @@ class App extends Component {
         {!isMobileClient ? <Visualizer /> : null}
         {!isMobileClient ? <PinnedTrackConfirmation /> : null}
         {!isMobileClient ? <DevModeMananger /> : null}
-
         {/* Mobile-only */}
         {isMobileClient && shouldShowPopover ? (
           <AppRedirectPopover
-            enablePopover={isReady}
             incrementScroll={incrementScroll}
             decrementScroll={decrementScroll}
           />

--- a/packages/web/src/pages/App.test.tsx
+++ b/packages/web/src/pages/App.test.tsx
@@ -37,12 +37,7 @@ describe('smoke test', () => {
     ReactDOM.render(
       <Provider store={store}>
         <ConnectedRouter history={history}>
-          <App
-            shouldShowPopover={false}
-            isReady
-            setReady={() => {}}
-            mainContentRef={mainContentRef}
-          />
+          <App shouldShowPopover={false} mainContentRef={mainContentRef} />
         </ConnectedRouter>
       </Provider>,
       rootNode

--- a/packages/web/src/root.tsx
+++ b/packages/web/src/root.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState, useEffect, useCallback, lazy } from 'react'
+import { Suspense, useState, useEffect, lazy } from 'react'
 
 import { useAsync } from 'react-use'
 
@@ -23,7 +23,6 @@ const isPublicSiteSubRoute = (location = window.location) => {
 const clientIsElectron = isElectron()
 
 const Root = () => {
-  const [dappReady, setDappReady] = useState(false)
   const [renderPublicSite, setRenderPublicSite] = useState(isPublicSiteRoute())
   const isMobileClient = useIsMobile()
 
@@ -37,8 +36,6 @@ const Root = () => {
       setRenderPublicSite(isPublicSiteRoute())
     }
   }, [])
-
-  const setReady = useCallback(() => setDappReady(true), [])
 
   const [shouldShowPopover, setShouldShowPopover] = useState(true)
 
@@ -58,11 +55,7 @@ const Root = () => {
 
   return (
     <>
-      <Dapp
-        isReady={dappReady}
-        setReady={setReady}
-        shouldShowPopover={shouldShowPopover}
-      />
+      <Dapp shouldShowPopover={shouldShowPopover} />
     </>
   )
 }


### PR DESCRIPTION
### Description

* Fix /204 loop from localhost on CORS error
* Remove isready logic -- this was only used for the app banner (used to be used for more). No need to have it b/c we want this banner to show all the time, except the landing page (which i've confirmed it does not).

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

* Deep link to /trending => shows banner
* Deep link to /signup => shows banner
* Landing page => no banner
* Landing page (no banner) => sign up (shows banner)
* Landing page (no banner) => trending (shows banner)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

