### PR TITLE
Fix missing track on Sammie's page C-2342

### DIFF
--- a/packages/mobile/src/screens/profile-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/profile-screen/TracksTab.tsx
@@ -16,13 +16,11 @@ const { getProfileTracksLineup } = profilePageSelectors
 export const TracksTab = () => {
   const dispatch = useDispatch()
 
-  const { handle, user_id, track_count, artist_pick_track_id } =
-    useSelectProfile([
-      'handle',
-      'user_id',
-      'track_count',
-      'artist_pick_track_id'
-    ])
+  const { handle, user_id, artist_pick_track_id } = useSelectProfile([
+    'handle',
+    'user_id',
+    'artist_pick_track_id'
+  ])
 
   const handleLower = handle.toLowerCase()
 
@@ -52,7 +50,6 @@ export const TracksTab = () => {
       leadingElementId={artist_pick_track_id}
       actions={tracksActions}
       lineup={lineup}
-      limit={track_count}
       loadMore={loadMore}
       disableTopTabScroll
       LineupEmptyComponent={<EmptyProfileTile tab='tracks' />}


### PR DESCRIPTION
### Description
@amendelsohn turns out this was indeed related to the hidden tracks issue. Have a quick fix here for mobile, but we can close this if your PR is going to address it already!


Sammie's first track wasn't showing up on her profile on mobile, but only when she was logged in. This is because her total_count for # of tracks was 9, but she also had one hidden track. The code was setting the lineup limit to total_count, so it would only load the first 9 tracks (including her hidden track) but not that oldest track.
Previously all 10 tracks were loading for her because her oldest track was set to her artist pick, which is always loaded first/separately.

https://linear.app/audius/issue/C-2342/[qa]-track-missing-on-artist-pagez

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

