### PR TITLE
[PAY-918] Mobile chat link unfurling

### DIFF
--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -20514,6 +20514,11 @@
         "uc.micro": "^1.0.1"
       }
     },
+    "linkifyjs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.0.tgz",
+      "integrity": "sha512-Ffv8VoY3+ixI1b3aZ3O+jM6x17cOsgwfB1Wq7pkytbo1WlyRp6ZO0YDMqiWT/gQPY/CmtiGuKfzDIVqxh1aCTA=="
+    },
     "load-bmfont": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -88,6 +88,7 @@
     "formik": "2.2.9",
     "fxa-common-password-list": "0.0.4",
     "jimp": "0.14.0",
+    "linkifyjs": "4.1.0",
     "lodash.samplesize": "4.2.0",
     "lottie-react-native": "5.1.4",
     "module": "1.2.5",

--- a/packages/mobile/src/components/core/Hyperlink.tsx
+++ b/packages/mobile/src/components/core/Hyperlink.tsx
@@ -38,7 +38,7 @@ type PositionedLink = {
 }
 
 export type HyperlinkProps = ComponentProps<typeof Autolink> & {
-  source: 'profile page' | 'track page' | 'collection page'
+  source?: 'profile page' | 'track page' | 'collection page'
   // Pass touches through text elements
   allowPointerEventsToPassThrough?: boolean
   styles?: StylesProp<{ root: TextStyle; link: TextStyle }>

--- a/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
+++ b/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react'
+
+import type { GestureResponderEvent } from 'react-native'
+import { View, Image } from 'react-native'
+
+import { Text, Link } from 'app/components/core'
+import { audiusSdk } from 'app/services/audius-sdk'
+import { makeStyles } from 'app/styles'
+
+import { REACTION_LONGPRESS_DELAY } from './constants'
+
+const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+  root: {
+    backgroundColor: palette.white,
+    borderTopLeftRadius: spacing(3),
+    borderTopRightRadius: spacing(3),
+    overflow: 'hidden'
+  },
+  rootIsLinkPreviewOnly: {
+    borderRadius: spacing(3)
+  },
+  thumbnail: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    maxHeight: spacing(50)
+  },
+  image: {
+    display: 'flex',
+    flexGrow: 1,
+    width: '100%',
+    height: '100%'
+  },
+  domainContainer: {
+    borderBottomColor: palette.neutralLight7,
+    borderBottomWidth: 1,
+    backgroundColor: palette.white
+  },
+  domain: {
+    paddingHorizontal: spacing(4),
+    paddingVertical: spacing(1),
+    fontSize: typography.fontSize.small,
+    lineHeight: typography.fontSize.small * 1.5,
+    color: palette.neutral
+  },
+  textContainer: {
+    display: 'flex',
+    marginTop: spacing(4),
+    marginHorizontal: spacing(4),
+    backgroundColor: palette.white
+  },
+  title: {
+    fontSize: typography.fontSize.medium,
+    lineHeight: typography.fontSize.medium * 1.5,
+    fontFamily: typography.fontByWeight.bold
+  },
+  description: {
+    fontSize: typography.fontSize.medium,
+    lineHeight: typography.fontSize.medium * 1.5,
+    marginBottom: spacing(4)
+  },
+  noDescriptionMarginBottom: {
+    marginBottom: spacing(4)
+  }
+}))
+
+type LinkPreviewProps = {
+  href: string
+  isLinkPreviewOnly: boolean
+  onLongPress: (event: GestureResponderEvent) => void
+}
+
+type UnfurlResponse = {
+  url: string
+  url_type: string
+  site_name: string
+  title: string
+  description: string
+  image: string
+  html: string
+  favicon: string
+}
+
+export const LinkPreview = (props: LinkPreviewProps) => {
+  const styles = useStyles()
+  const { href, isLinkPreviewOnly, onLongPress } = props
+
+  const [metadata, setMetadata] = useState<Partial<UnfurlResponse>>()
+  const domain = metadata?.url ? new URL(metadata?.url).hostname : ''
+
+  useEffect(() => {
+    const fn = async () => {
+      try {
+        const sdk = await audiusSdk()
+        const unfurled = await sdk.chats.unfurl({ urls: [href] })
+        setMetadata(unfurled[0])
+      } catch (e) {
+        console.error('Failed to unfurl url', href, e)
+      }
+    }
+    fn()
+  }, [setMetadata, href])
+
+  if (!metadata) {
+    return null
+  }
+
+  return (
+    <Link
+      url={href}
+      delayLongPress={REACTION_LONGPRESS_DELAY}
+      onLongPress={onLongPress}
+    >
+      <View
+        style={[
+          styles.root,
+          isLinkPreviewOnly ? styles.rootIsLinkPreviewOnly : null
+        ]}
+      >
+        {metadata.description || metadata.title ? (
+          <>
+            {metadata.image ? (
+              <View style={styles.thumbnail}>
+                <Image
+                  source={{ uri: metadata.image }}
+                  style={styles.image}
+                  alt={metadata.site_name}
+                />
+              </View>
+            ) : null}
+            <View style={styles.domainContainer}>
+              <Text style={styles.domain}>{domain}</Text>
+            </View>
+            <View style={styles.textContainer}>
+              {metadata.title ? (
+                <Text style={styles.title}>{metadata.title}</Text>
+              ) : null}
+              {metadata.description ? (
+                <Text numberOfLines={1} style={styles.description}>
+                  {metadata.description}
+                </Text>
+              ) : (
+                <View style={styles.noDescriptionMarginBottom} />
+              )}
+            </View>
+          </>
+        ) : metadata.image ? (
+          <View>
+            <Image
+              style={styles.image}
+              source={{ uri: metadata.image }}
+              alt={metadata.site_name}
+            />
+          </View>
+        ) : null}
+      </View>
+    </Link>
+  )
+}

--- a/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
+++ b/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
@@ -5,7 +5,7 @@ import { View, Image } from 'react-native'
 
 import { Text, Link } from 'app/components/core'
 import { audiusSdk } from 'app/services/audius-sdk'
-import { makeStyles } from 'app/styles'
+import { makeStyles, flexRowCentered } from 'app/styles'
 
 import { REACTION_LONGPRESS_DELAY } from './constants'
 
@@ -20,9 +20,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     borderRadius: spacing(3)
   },
   thumbnail: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
+    ...flexRowCentered(),
     width: '100%',
     maxHeight: spacing(50)
   },
@@ -87,7 +85,7 @@ export const LinkPreview = (props: LinkPreviewProps) => {
   const { href, isLinkPreviewOnly, onLongPress } = props
 
   const [metadata, setMetadata] = useState<Partial<UnfurlResponse>>()
-  const domain = metadata?.url ? new URL(metadata?.url).hostname : ''
+  const domain = metadata?.url ? new URL(metadata.url).hostname : ''
 
   useEffect(() => {
     const fn = async () => {

--- a/packages/mobile/src/screens/chat-screen/constants.ts
+++ b/packages/mobile/src/screens/chat-screen/constants.ts
@@ -1,0 +1,1 @@
+export const REACTION_LONGPRESS_DELAY = 100


### PR DESCRIPTION
### Description
Link unfurling on mobile chats.
Known issues:
- Flicker on long press for reactions popup bc we are fetching the unfurl metadata again.. def could do something smart here but punting for now.

### Dragons

cc @sliptype bc I'm making `source` prop in `Hyperlink` optional, hope this is ok.

### How Has This Been Tested?

Local ios stage.
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-06 at 16 25 47](https://user-images.githubusercontent.com/3893871/230645168-8e61efdb-829f-45ec-af10-677dbdb2b463.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-06 at 16 25 33](https://user-images.githubusercontent.com/3893871/230645174-b149ec6e-bdce-45ab-ba9c-14d3ee30de21.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-06 at 16 25 42](https://user-images.githubusercontent.com/3893871/230645176-d3ee4a0c-082f-43bc-90dc-39d70681699c.png)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

