### PR TITLE
[C-2412] Opaque id deeplinks

### DIFF
--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
 
-import { accountSelectors } from '@audius/common'
+import { accountSelectors, decodeHashId } from '@audius/common'
+import type { NavigationState, PartialState } from '@react-navigation/native'
 import {
   getStateFromPath,
   NavigationContainer as RNNavigationContainer,
@@ -22,6 +23,49 @@ type NavigationContainerProps = {
 }
 
 export const navigationRef = createNavigationContainerRef()
+
+const createAppTabState = (
+  state: PartialState<NavigationState>
+): PartialState<NavigationState> => ({
+  routes: [
+    {
+      name: 'HomeStack',
+      state: {
+        routes: [
+          {
+            name: 'App',
+            state: {
+              routes: [
+                {
+                  name: 'AppTabs',
+                  state
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+})
+
+const createFeedStackState = (route): PartialState<NavigationState> =>
+  createAppTabState({
+    routes: [
+      {
+        name: 'feed',
+        state: {
+          index: 1,
+          routes: [
+            {
+              name: 'Feed'
+            },
+            route
+          ]
+        }
+      }
+    ]
+  })
 
 /**
  * NavigationContainer contains the react-navigation context
@@ -140,7 +184,12 @@ const NavigationContainer = (props: NavigationContainerProps) => {
         }
       }
     },
+    // TODO: This should be unit tested
     getStateFromPath: (path, options) => {
+      const pathPart = (path: string) => (index: number) => {
+        return path.split('/')[index]
+      }
+
       // Add leading slash if it is missing
       if (path[0] !== '/') path = `/${path}`
 
@@ -169,6 +218,40 @@ const NavigationContainer = (props: NavigationContainerProps) => {
       // always go to ThisWeek
       if (path.match(/^\/trending/)) {
         path = '/trending'
+      }
+
+      // Opaque ID routes
+      // /tracks/Nz9yBb4
+      if (path.match(/^\/tracks\//)) {
+        const id = decodeHashId(pathPart(path)(2))
+        return createFeedStackState({
+          name: 'Track',
+          params: {
+            id
+          }
+        })
+      }
+
+      // /users/Nz9yBb4
+      if (path.match(/^\/users\//)) {
+        const id = decodeHashId(pathPart(path)(2))
+        return createFeedStackState({
+          name: 'Profile',
+          params: {
+            id
+          }
+        })
+      }
+
+      // /playlists/Nz9yBb4
+      if (path.match(/^\/playlists\//)) {
+        const id = decodeHashId(pathPart(path)(2))
+        return createFeedStackState({
+          name: 'Profile',
+          params: {
+            id
+          }
+        })
       }
 
       if (path.match(`^/${account?.handle}(/|$)`)) {

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -272,7 +272,6 @@ const NavigationContainer = (props: NavigationContainerProps) => {
               /^\/[^/]+\/(tracks|albums|playlists|reposts|collectibles)$/
             )
           ) {
-            console.log('HERE')
             path = `/track${path}`
           }
         }

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -193,6 +193,8 @@ const NavigationContainer = (props: NavigationContainerProps) => {
       // Add leading slash if it is missing
       if (path[0] !== '/') path = `/${path}`
 
+      path = path.replace('#embed', '')
+
       const walletConnectPath = /^\/(wallet-connect)/
       if (path.match(walletConnectPath)) {
         path = `${path.replace(
@@ -270,7 +272,8 @@ const NavigationContainer = (props: NavigationContainerProps) => {
               /^\/[^/]+\/(tracks|albums|playlists|reposts|collectibles)$/
             )
           ) {
-            path = `/track/${path}`
+            console.log('HERE')
+            path = `/track${path}`
           }
         }
 


### PR DESCRIPTION
### Description

* Support opaque id deeplinks (for example coming from linktree). Web supports these routes but mobile deeplinking did not
* Fix issue with embed player deeplinks

Coming in next PR:
* Jest setup (it's way more frustrating than anticipated)
* Refactor of this deep linking logic to return state objects instead of trying to mangle multiple urls into one mapping
* Unit test

### Dragons

Pretty low risk because I've only added new cases that match these specific routes

### How Has This Been Tested?

Tested locally on simulator

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

