### PR TITLE
[C-2187] Improve sign-up error messages

### DIFF
--- a/packages/mobile/src/screens/signon/SignOn.tsx
+++ b/packages/mobile/src/screens/signon/SignOn.tsx
@@ -264,7 +264,6 @@ const messages = {
 
 const errorMessages = {
   invalidEmail: 'Please enter a valid email',
-  emailInUse: 'Email is already in use, please sign-in',
   emptyPassword: 'Please enter a password',
   default: 'Invalid Credentials'
 }
@@ -333,7 +332,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
 
   const signedIn = signOnStatus === 'success'
   const isSigninError = passwordField.error
-  const emailIsAvailable = emailField.error !== 'inUse'
   const emailIsValid = emailField.error !== 'characters'
 
   const topDrawer = useRef(new Animated.Value(-800)).current
@@ -404,7 +402,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
   useEffect(() => {
     if (
       (isSignin && isSigninError && showDefaultError) ||
-      (!isSignin && !emailIsAvailable && email !== '') ||
       showInvalidEmailError ||
       showEmptyPasswordError
     ) {
@@ -421,7 +418,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
     isSignin,
     isSigninError,
     showDefaultError,
-    emailIsAvailable,
     email,
     showInvalidEmailError,
     showEmptyPasswordError
@@ -462,26 +458,6 @@ const SignOn = ({ navigation }: SignOnProps) => {
           <ValidationIconX style={styles.errorIcon} />
           <Text style={styles.errorText}>{errorMessages.default}</Text>
         </Animated.View>
-      )
-    }
-    if (!isSignin && !emailIsAvailable && email !== '') {
-      return (
-        <TouchableOpacity style={styles.errorButton} onPress={switchForm}>
-          <Animated.View
-            style={[styles.errorContainer, { opacity: errorOpacity }]}
-          >
-            <ValidationIconX style={styles.errorIcon} />
-            <Text
-              style={[
-                styles.errorText,
-                { flex: 0, textDecorationLine: 'underline' }
-              ]}
-            >
-              {errorMessages.emailInUse}
-            </Text>
-            <Text style={[styles.errorText, { fontSize: 13 }]}> ➔</Text>
-          </Animated.View>
-        </TouchableOpacity>
       )
     }
     if (showInvalidEmailError) {

--- a/packages/web/src/common/store/pages/signon/sagas.js
+++ b/packages/web/src/common/store/pages/signon/sagas.js
@@ -15,7 +15,8 @@ import {
   MAX_HANDLE_LENGTH,
   PushNotificationSetting,
   getCityAndRegion,
-  processAndCacheUsers
+  processAndCacheUsers,
+  toastActions
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { isEmpty } from 'lodash'
@@ -56,6 +57,7 @@ const { getFeePayer } = solanaSelectors
 const { saveCollection } = collectionsSocialActions
 const { getUsers } = cacheUsersSelectors
 const getAccountUser = accountSelectors.getAccountUser
+const { toast } = toastActions
 
 const IS_PRODUCTION_BUILD = process.env.NODE_ENV === 'production'
 const IS_PRODUCTION = process.env.REACT_APP_ENVIRONMENT === 'production'
@@ -65,7 +67,8 @@ const SIGN_UP_TIMEOUT_MILLIS = 20 /* min */ * 60 * 1000
 
 const messages = {
   incompleteAccount:
-    'Oops, it looks like your account was never fully completed!'
+    'Oops, it looks like your account was never fully completed!',
+  emailCheckFailed: 'Something has gone wrong, please try again later.'
 }
 
 // Users ID to filter out of the suggested artists to follow list and to follow by default
@@ -277,7 +280,7 @@ function* checkEmail(action) {
       }
     }
   } catch (err) {
-    yield put(signOnActions.validateEmailFailed(err.message))
+    yield put(toast({ content: messages.emailCheckFailed }))
     if (action.onError) {
       yield call(action.onError)
     }

--- a/packages/web/src/pages/sign-on/components/desktop/EmailPage.tsx
+++ b/packages/web/src/pages/sign-on/components/desktop/EmailPage.tsx
@@ -29,8 +29,7 @@ export const statusState = Object.freeze({
 })
 
 const errorMessages = {
-  characters: 'Please enter a valid email',
-  inUse: 'Email is already in use, please sign-in'
+  characters: 'Please enter a valid email'
 }
 
 type EmailPageProps = {
@@ -39,7 +38,7 @@ type EmailPageProps = {
   email: {
     value: string
     status: string
-    error: 'inUse' | 'characters'
+    error: 'characters'
   }
   onSubmit: (email: string) => void
   onEmailChange: (email: string) => void
@@ -103,7 +102,7 @@ export const EmailPage = ({
   const inputError = email.status === 'failure'
   const validInput = email.status === 'success'
   const shouldDisableInputs = isSubmitting && email.status === 'loading'
-  const showError = inputError && showValidation && email.error !== 'inUse'
+  const showError = inputError && showValidation
 
   return (
     <div


### PR DESCRIPTION
### Description

Improves sign-up error messages when a `checkEmailInUse` request fails, likely due to abuse trying to scrape existing emails. Instead of displaying an abstruse field level error, we display a "something went wrong" toast.

- Also cleans up the `emailInUse` error case, since web and mobile automatically switches user from sign-up to sign-in, meaning we would never hit this case.
