### PR TITLE
[C-2309] Fix track title hover state

### DIFF
--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -250,7 +250,6 @@ const TrackTile = ({
           <div
             className={cn(
               styles.titleRow,
-              styles.title,
               isPremium ? styles.withPremium : null
             )}
           >


### PR DESCRIPTION
### Description

FIxes issue where hovering at bottom edge of track tile track name results in just the link underline appearing, but the text doesn't have hover state. by removing the duplicate style on the surrounding div, this solves the problem, so the link can be treated as one unit