### PR TITLE
[C-2332] Fix follow artist stat

### DIFF
--- a/packages/common/src/store/cache/users/utils.ts
+++ b/packages/common/src/store/cache/users/utils.ts
@@ -56,5 +56,9 @@ export const reformatUser = (
   const withImages = audiusBackendInstance.getUserImages(user)
 
   const withNames = setDisplayNameToHandleIfUnset(withImages)
+
+  if (typeof withNames.follower_count === 'string') {
+    withNames.follower_count = parseInt(withNames.follower_count, 10)
+  }
   return withNames
 }


### PR DESCRIPTION
### Description

Fixes interesting edge-case where feed api returns follower_count as a string, which means following a user on feed triggers a `follower_count + 1` change to entity which means "1" + 1 is "11" giving the appearance your follow increased follow by a multiple. Fix for now is to marshall all user object's follower_count to number, and then giving protocol headsup to fix this value.

