### PR TITLE
[PAY-1152] Chats selector to check if is equal to popupMessageId

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -131,13 +131,16 @@ export const getChatMessageById = (
   return selectById(chatMessagesState, messageId)
 }
 
-export const getPopupMessageId = (state: CommonState) => {
-  return state.pages.chat.popupMessageId
+export const getReactionsPopupMessageId = (state: CommonState) => {
+  return state.pages.chat.reactionsPopupMessageId
 }
 
-export const isEqualToPopupMessageId = createSelector(
-  [getPopupMessageId, (_state: CommonState, messageId: string) => messageId],
-  (popupMessageId: string | null, messageId: string) => {
-    return messageId === popupMessageId
+export const isIdEqualToReactionsPopupMessageId = createSelector(
+  [
+    getReactionsPopupMessageId,
+    (_state: CommonState, messageId: string) => messageId
+  ],
+  (reactionsPopupMessageId: string | null, messageId: string) => {
+    return messageId === reactionsPopupMessageId
   }
 )

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -130,3 +130,14 @@ export const getChatMessageById = (
   const chatMessagesState = state.pages.chat.messages[chatId]
   return selectById(chatMessagesState, messageId)
 }
+
+export const getPopupMessageId = (state: CommonState) => {
+  return state.pages.chat.popupMessageId
+}
+
+export const isEqualToPopupMessageId = createSelector(
+  [getPopupMessageId, (_state: CommonState, messageId: string) => messageId],
+  (popupMessageId: string | null, messageId: string) => {
+    return messageId === popupMessageId
+  }
+)

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -135,12 +135,9 @@ export const getReactionsPopupMessageId = (state: CommonState) => {
   return state.pages.chat.reactionsPopupMessageId
 }
 
-export const isIdEqualToReactionsPopupMessageId = createSelector(
-  [
-    getReactionsPopupMessageId,
-    (_state: CommonState, messageId: string) => messageId
-  ],
-  (reactionsPopupMessageId: string | null, messageId: string) => {
-    return messageId === reactionsPopupMessageId
-  }
-)
+export const isIdEqualToReactionsPopupMessageId = (
+  state: CommonState,
+  messageId: string
+) => {
+  return messageId === getReactionsPopupMessageId(state)
+}

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -42,7 +42,7 @@ type ChatState = {
   blockees: ID[]
   blockers: ID[]
   permissions: Record<ID, ChatPermissionResponse>
-  popupMessageId: string | null
+  reactionsPopupMessageId: string | null
 }
 
 type SetMessageReactionPayload = {
@@ -86,7 +86,7 @@ const initialState: ChatState = {
   blockees: [],
   blockers: [],
   permissions: {},
-  popupMessageId: null
+  reactionsPopupMessageId: null
 }
 
 const slice = createSlice({
@@ -416,13 +416,13 @@ const slice = createSlice({
     },
     // Note: is not associated with any chatId because there will be at most
     // one popup message at a time. Used for reactions popup overlay in mobile.
-    setPopupMessageId: (
+    setReactionsPopupMessageId: (
       state,
       action: PayloadAction<{
         messageId: string | null
       }>
     ) => {
-      state.popupMessageId = action.payload.messageId
+      state.reactionsPopupMessageId = action.payload.messageId
     }
   }
 })

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -42,6 +42,7 @@ type ChatState = {
   blockees: ID[]
   blockers: ID[]
   permissions: Record<ID, ChatPermissionResponse>
+  popupMessageId: string | null
 }
 
 type SetMessageReactionPayload = {
@@ -84,7 +85,8 @@ const initialState: ChatState = {
   activeChatId: null,
   blockees: [],
   blockers: [],
-  permissions: {}
+  permissions: {},
+  popupMessageId: null
 }
 
 const slice = createSlice({
@@ -411,6 +413,16 @@ const slice = createSlice({
         ...state.permissions,
         ...action.payload.permissions
       }
+    },
+    // Note: is not associated with any chatId because there will be at most
+    // one popup message at a time. Used for reactions popup overlay in mobile.
+    setPopupMessageId: (
+      state,
+      action: PayloadAction<{
+        messageId: string | null
+      }>
+    ) => {
+      state.popupMessageId = action.payload.messageId
     }
   }
 })

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -24,7 +24,7 @@ import { LinkPreview } from './LinkPreview'
 import { REACTION_LONGPRESS_DELAY } from './constants'
 
 const { getUserId } = accountSelectors
-const { isEqualToPopupMessageId } = chatSelectors
+const { isIdEqualToReactionsPopupMessageId } = chatSelectors
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   rootOtherUser: {
@@ -163,7 +163,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   const isAuthor = senderUserId === userId
   const isUnderneathPopup =
     useSelector((state) =>
-      isEqualToPopupMessageId(state, message.message_id)
+      isIdEqualToReactionsPopupMessageId(state, message.message_id)
     ) && !isPopup
 
   const handleLongPress = useCallback(() => {

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback } from 'react'
 import type { ReactionTypes, ChatMessageWithExtras } from '@audius/common'
 import {
   accountSelectors,
+  chatSelectors,
   decodeHashId,
   formatMessageDate
 } from '@audius/common'
@@ -23,6 +24,7 @@ import { LinkPreview } from './LinkPreview'
 import { REACTION_LONGPRESS_DELAY } from './constants'
 
 const { getUserId } = accountSelectors
+const { isEqualToPopupMessageId } = chatSelectors
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   rootOtherUser: {
@@ -159,6 +161,10 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   const userId = useSelector(getUserId)
   const senderUserId = decodeHashId(message.sender_user_id)
   const isAuthor = senderUserId === userId
+  const isUnderneathPopup =
+    useSelector((state) =>
+      isEqualToPopupMessageId(state, message.message_id)
+    ) && !isPopup
 
   const handleLongPress = useCallback(() => {
     onLongPress?.(message.message_id)
@@ -218,7 +224,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
             </View>
             {message.reactions?.length > 0 ? (
               <>
-                {!isPopup ? (
+                {!isUnderneathPopup ? (
                   <View
                     style={[
                       styles.reactionContainer,

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -176,7 +176,7 @@ export const ChatScreen = () => {
     chat?.messagesStatus === Status.LOADING && chatMessages?.length === 0
   const popupMessageId = useSelector(getPopupMessageId)
   const popupMessage = useSelector((state) =>
-    getChatMessageById(state, chatId, popupMessageId)
+    getChatMessageById(state, chatId, popupMessageId ?? '')
   )
 
   // A ref so that the unread separator doesn't disappear immediately when the chat is marked as read
@@ -383,12 +383,12 @@ export const ChatScreen = () => {
       <ScreenContent>
         {/* Everything inside the portal displays on top of all other screen contents. */}
         <Portal hostName='ChatReactionsPortal'>
-          {shouldShowPopup ? (
+          {shouldShowPopup && popupMessage ? (
             <ReactionPopup
               chatId={chatId}
               messageTop={messageTop.current}
               containerBottom={chatContainerBottom.current}
-              isAuthor={decodeHashId(popupMessage.sender_user_id) === userId}
+              isAuthor={decodeHashId(popupMessage?.sender_user_id) === userId}
               message={popupMessage}
               closePopup={closeReactionPopup}
             />

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -49,10 +49,11 @@ const {
   getChat,
   getChatMessageById,
   getChatMessageByIndex,
-  getPopupMessageId
+  getReactionsPopupMessageId
 } = chatSelectors
 
-const { fetchMoreMessages, markChatAsRead, setPopupMessageId } = chatActions
+const { fetchMoreMessages, markChatAsRead, setReactionsPopupMessageId } =
+  chatActions
 const { getUserId } = accountSelectors
 
 export const REACTION_CONTAINER_HEIGHT = 70
@@ -174,7 +175,7 @@ export const ChatScreen = () => {
   const unreadCount = chat?.unread_message_count ?? 0
   const isLoading =
     chat?.messagesStatus === Status.LOADING && chatMessages?.length === 0
-  const popupMessageId = useSelector(getPopupMessageId)
+  const popupMessageId = useSelector(getReactionsPopupMessageId)
   const popupMessage = useSelector((state) =>
     getChatMessageById(state, chatId, popupMessageId ?? '')
   )
@@ -280,7 +281,7 @@ export const ChatScreen = () => {
 
   const closeReactionPopup = useCallback(() => {
     setShouldShowPopup(false)
-    dispatch(setPopupMessageId({ messageId: null }))
+    dispatch(setReactionsPopupMessageId({ messageId: null }))
   }, [setShouldShowPopup, dispatch])
 
   const handleMessagePress = useCallback(
@@ -298,7 +299,7 @@ export const ChatScreen = () => {
       })
       // Need to subtract spacing(2) to account for padding in message View.
       messageTop.current = messageY - spacing(2)
-      dispatch(setPopupMessageId({ messageId: id }))
+      dispatch(setReactionsPopupMessageId({ messageId: id }))
       setShouldShowPopup(true)
     },
     [dispatch]


### PR DESCRIPTION
### Description
There was one more dependency on index in `ChatMessageListItem` that was used to determine whether to show/hide the reactions. This was because without this, we would render 2 reactions on top of each other which looked jank. Moved all the logic to a selector so we can still memoize `ChatMessageListItem`.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

