### PR TITLE
[C-2435] Fix issue with collectibles cache update

### DIFF
--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -96,7 +96,7 @@ function* fetchProfileCustomizedCollectibles(user) {
           {
             id: user.user_id,
             metadata: {
-              ...metadata,
+              collectibles: metadata.collectibles,
               collectiblesOrderUnset: false
             }
           }
@@ -108,7 +108,6 @@ function* fetchProfileCustomizedCollectibles(user) {
           {
             id: user.user_id,
             metadata: {
-              ...metadata,
               collectiblesOrderUnset: true
             }
           }


### PR DESCRIPTION
### Description

Fixes weird issue where `fetchProfileCustomizedCollectibles` updates the entire user object, which as a lot of incorrect data from the `fetchCID` function, resulting in a profile screen going from "artist" to "user", which turns into runtime error as the profile tabs don't know how to transition focus (i think basically tabs are not expecting to drop by 3). not sure what is best here, but most likely we just want to update the collectibles key. Are there any other keys we want to include from this function? maybe @raymondjacobson would know the most here?