### PR TITLE
Attempt to update circle config to move off python2.7-jessie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ parameters:
 setup: true
 
 orbs:
+  aws-cli: circleci/aws-cli@3.1.5
   continuation: circleci/continuation@0.2.0
   path-filtering: circleci/path-filtering@0.1.1
 

--- a/.circleci/src/commands/@web-commands.yml
+++ b/.circleci/src/commands/@web-commands.yml
@@ -109,11 +109,6 @@ web-distribute:
           cd packages/web
           npm run dist:<< parameters.build-type >>
 
-web-install-awscli:
-  steps:
-    - run:
-        name: install-awscli
-        command: sudo pip install awscli
 
 web-install-wrangler:
   steps:
@@ -164,9 +159,7 @@ web-deploy-cloudflare:
 
 web-deploy-sourcemaps-s3:
   steps:
-    - run:
-        name: install-awscli
-        command: pip install awscli
+    - aws-cli/install
     - attach_workspace:
         at: ./
     - run:

--- a/.circleci/src/jobs/@web-jobs.yml
+++ b/.circleci/src/jobs/@web-jobs.yml
@@ -116,10 +116,10 @@ web-build-production:
 web-deploy-demo:
   working_directory: ~/audius-client
   docker:
-    - image: circleci/python:2.7-jessie
+    - image: cimg/python:3.7.12-node
   steps:
     - checkout
-    - web-install-awscli
+    - aws-cli/install
     - attach_workspace:
         at: ./
     - run:
@@ -131,10 +131,10 @@ web-deploy-demo:
 web-deploy-staging-s3:
   working_directory: ~/audius-client
   docker:
-    - image: circleci/python:2.7-jessie
+    - image: cimg/python:3.7.12-node
   steps:
     - checkout
-    - web-install-awscli
+    - aws-cli/install
     - attach_workspace:
         at: ./
     - run:
@@ -183,10 +183,10 @@ web-deploy-staging-release-candidate:
 web-deploy-production-s3:
   working_directory: ~/audius-client
   docker:
-    - image: circleci/python:2.7-jessie
+    - image: cimg/python:3.7.12-node
   steps:
     - checkout
-    - web-install-awscli
+    - aws-cli/install
     - attach_workspace:
         at: ./
     - run:

--- a/packages/probers/.circleci/config.yml
+++ b/packages/probers/.circleci/config.yml
@@ -3,15 +3,13 @@ jobs:
   download-dapp:
     working_directory: ~/probers
     docker:
-      - image: circleci/python:2.7-jessie
+      - image: cimg/python:3.7.12-node
     steps:
       - checkout
-      - run:
-          name: install-awscli
-          command: sudo pip install awscli
+      - aws-cli/install
       - run:
           name: Download Dapp from S3
-          command: | 
+          command: |
             cd ../
             aws s3 sync s3://staging.audius.co ./build-staging
       - persist_to_workspace:
@@ -39,7 +37,7 @@ jobs:
           name: install probers dependencies
           command: |
             cd probers
-            npm ci 
+            npm ci
       - save_cache:
           key: probers-dependency-cache-{{ checksum "probers/package.json" }}
           paths:


### PR DESCRIPTION
### Description
We're seeing build failures for CircleCI steps which still leverage the `circleci/python:2.7-jessie` image. This is due to `jessie` being long deprecated and removed from distribution sites. We were only using that image to support installing the aws-cli package via pip. However, there is now an orb that we can use to install this package.

This PR updates the web workflows using the outdated image to use the orb for installation of aws-cli, and to build from the `cimg/python` image used by the other web workflows.

### Dragons
It's a new image and way of installing the SDK, so there could be dependency or configuration issues we aren't aware of.

### How Has This Been Tested?
The plan is to run through the workflows in CircleCI to verify things are working. There are no app code changes as part of this, so the deploy steps should result in identical code.

### How will this change be monitored?
Directly monitor output of all affected CI workflows. In the event the deployment workflows are unsuccessful, we can deploy an old branch to restore them and revert the PR.

### Feature Flags ###
No feature flags

