### PR TITLE
[C-2443] Dont show tip tile on empty feed

### DIFF
--- a/packages/mobile/src/components/core/SectionList.tsx
+++ b/packages/mobile/src/components/core/SectionList.tsx
@@ -152,7 +152,7 @@ export const SectionList = forwardRef(function SectionList<
   props: Animated.AnimatedProps<RNSectionListProps<ItemT, SectionT>>,
   ref: Ref<RNSectionList<ItemT, SectionT>>
 ) {
-  const { ListFooterComponent, sections, ...other } = props
+  const { ListFooterComponent, ...other } = props
   const { sceneName } = useContext(CollapsibleTabNavigatorContext)
 
   const FooterComponent = ListFooterComponent ? (
@@ -164,15 +164,8 @@ export const SectionList = forwardRef(function SectionList<
     PlayBarChin
   )
 
-  const areSectionsEmpty = sections.every(
-    (section) => section.data.length === 0
-  )
-
   const sectionListProps = {
     ...other,
-    // Need to disable refresh so scrolling the "ListEmptyComponent" doesn't trigger refresh
-    onRefresh: areSectionsEmpty ? undefined : other.onRefresh,
-    sections: areSectionsEmpty ? [] : sections,
     ListFooterComponent: FooterComponent
   }
 

--- a/packages/mobile/src/components/lineup/Lineup.tsx
+++ b/packages/mobile/src/components/lineup/Lineup.tsx
@@ -204,12 +204,13 @@ export const Lineup = ({
   disableTopTabScroll,
   fetchPayload,
   header,
-  LineupEmptyComponent,
+  hideHeaderOnEmpty,
   isTrending,
   lazy,
   leadingElementId,
   leadingElementDelineator,
   lineup: lineupProp,
+  LineupEmptyComponent,
   lineupSelector = fallbackLineupSelector,
   loadMore,
   pullToRefresh,
@@ -507,7 +508,10 @@ export const Lineup = ({
   )
 
   const pullToRefreshProps =
-    pullToRefresh || refreshProp ? { onRefresh: refresh, refreshing } : {}
+    pullToRefresh || refreshProp
+      ? // Need to disable refresh so scrolling the "ListEmptyComponent" doesn't trigger refresh
+        { onRefresh: areSectionsEmpty ? undefined : refresh, refreshing }
+      : {}
 
   const handleEndReached = useCallback(() => handleLoadMore(), [handleLoadMore])
 
@@ -518,14 +522,16 @@ export const Lineup = ({
         {...pullToRefreshProps}
         ref={ref}
         onScroll={handleScroll}
-        ListHeaderComponent={header}
+        ListHeaderComponent={
+          hideHeaderOnEmpty && areSectionsEmpty ? undefined : header
+        }
         ListFooterComponent={
           lineup.hasMore ? <View style={{ height: 16 }} /> : ListFooterComponent
         }
         ListEmptyComponent={LineupEmptyComponent}
         onEndReached={handleEndReached}
         onEndReachedThreshold={LOAD_MORE_THRESHOLD}
-        sections={sections}
+        sections={areSectionsEmpty ? [] : sections}
         stickySectionHeadersEnabled={false}
         keyExtractor={(item, index) => `${item?.id}  ${index}`}
         renderItem={renderItem}

--- a/packages/mobile/src/components/lineup/types.ts
+++ b/packages/mobile/src/components/lineup/types.ts
@@ -60,6 +60,11 @@ export type LineupProps = {
   extraFetchOptions?: Record<string, unknown>
 
   /**
+   * When `true` hide the header when the lineup is empty
+   */
+  hideHeaderOnEmpty?: boolean
+
+  /**
    * A header to display at the top of the lineup,
    * will scroll with the rest of the content
    */

--- a/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
+++ b/packages/mobile/src/screens/feed-screen/FeedScreen.tsx
@@ -54,6 +54,7 @@ export const FeedScreen = () => {
           delineate
           selfLoad
           header={<FeedTipTile />}
+          hideHeaderOnEmpty
           ListFooterComponent={<EndOfFeedNotice />}
           LineupEmptyComponent={<EmptyFeedSuggestedFollows />}
           actions={feedActions}


### PR DESCRIPTION
### Description

Improves empty feed experience by removing tip tile when the feed is empty. slightly unideal to have to pass another config prop to lineup, but couldn't find another way.