### PR TITLE
Fix safari refresh event not being captured

### DIFF
--- a/packages/web/src/components/unload-dialog/UnloadDialog.js
+++ b/packages/web/src/components/unload-dialog/UnloadDialog.js
@@ -32,8 +32,8 @@ const UnloadDialog = (props) => {
   useEffect(() => {
     if (props.isConfirming) {
       const beforeUnload = (event) => {
-        if (!seenModalRef.current) event.returnValue = ''
         event.preventDefault()
+        if (!seenModalRef.current) event.returnValue = ''
       }
       window.addEventListener('beforeunload', beforeUnload)
 

--- a/packages/web/src/components/unload-dialog/UnloadDialog.js
+++ b/packages/web/src/components/unload-dialog/UnloadDialog.js
@@ -33,6 +33,7 @@ const UnloadDialog = (props) => {
     if (props.isConfirming) {
       const beforeUnload = (event) => {
         if (!seenModalRef.current) event.returnValue = ''
+        event.preventDefault()
       }
       window.addEventListener('beforeunload', beforeUnload)
 


### PR DESCRIPTION
### Description
Fixes safari beforeunload events not being captured properly.
Note: cmd+r hotkey remapping still doesn't work, we get the generic safari alert instead of our nice "hang tight" one. But with this fix at least we prevent a user losing their changes unknowingly.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web on safari, brave, chrome. Confirmed behavior on brave/chrome stayed the same.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

