### PR TITLE
[C-2321] Update notification entity link styles to prevent overflow

### DIFF
--- a/packages/web/src/components/notification/Notification/components/EntityLink.module.css
+++ b/packages/web/src/components/notification/Notification/components/EntityLink.module.css
@@ -2,7 +2,7 @@
   color: var(--secondary);
   font-weight: var(--font-medium);
   line-height: 21px;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 .link:hover {


### PR DESCRIPTION
### Description
Small update to make sure that long entity links do not overflow.
Interestingly enough, the user name links do not overflow in the same way. css is crazy

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

