### PR TITLE
Gate v2 signups

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1949,8 +1949,29 @@ export const audiusBackend = ({
       setLocalStorageItem('is-mobile-user', 'true')
     }
 
+    const storageV2Enabled = await getFeatureEnabled(FeatureFlags.STORAGE_V2)
+    if (storageV2Enabled || email?.startsWith('storage_v2_test_')) {
+      return await audiusLibs.Account.signUpV2(
+        email,
+        password,
+        metadata,
+        formFields.profilePicture,
+        formFields.coverPhoto,
+        hasWallet,
+        getHostUrl(),
+        (eventName: string, properties: Record<string, unknown>) =>
+          recordAnalytics({ eventName, properties }),
+        {
+          Request: Name.CREATE_USER_BANK_REQUEST,
+          Success: Name.CREATE_USER_BANK_SUCCESS,
+          Failure: Name.CREATE_USER_BANK_FAILURE
+        },
+        feePayerOverride,
+        true
+      )
+    }
     // Returns { userId, error, phase }
-    return audiusLibs.Account.signUp(
+    return await audiusLibs.Account.signUp(
       email,
       password,
       metadata,


### PR DESCRIPTION
### Description
Gates storage v2 replica-set-free signups on the existing `storage_v2` feature flag OR a user whose email starts with `storage_v2_test_` (kinda hacky but makes dev and demo easier since you can't press "f" and enable a feature flag before signing up).

### Dragons
As long as no poor soul has an email staring with "storage_v2_test_" we should be good.

### How Has This Been Tested?
Tested whole signup and subsequent upload flow with and without the prefixed email.

### How will this change be monitored?
Signups should continue working as usual.

### Feature Flags ###
Existing `storage_v2` flag

