### PR TITLE
[PAY-1128] Update logic for showing "earn/claim $AUDIO" pill

### DIFF
--- a/packages/common/src/store/wallet/selectors.ts
+++ b/packages/common/src/store/wallet/selectors.ts
@@ -18,6 +18,10 @@ export const getAccountBalance = createSelector(
   (balance) => (balance ? stringWeiToBN(balance) : zeroBNWei)
 )
 
+export const getAccountBalanceLoading = (state: CommonState) => {
+  return state.wallet.balanceLoading
+}
+
 const getAccountTotalBalanceStr = (state: CommonState) =>
   state.wallet.totalBalance
 

--- a/packages/common/src/store/wallet/slice.ts
+++ b/packages/common/src/store/wallet/slice.ts
@@ -8,6 +8,7 @@ import { StringWei } from '../../models/Wallet'
 
 type WalletState = {
   balance: Nullable<StringWei>
+  balanceLoading: boolean
   totalBalance: Nullable<StringWei>
   localBalanceDidChange: boolean
   freezeBalanceUntil: Nullable<number>
@@ -15,6 +16,7 @@ type WalletState = {
 
 const initialState: WalletState = {
   balance: null,
+  balanceLoading: true,
   totalBalance: null,
   localBalanceDidChange: false,
   freezeBalanceUntil: null
@@ -36,6 +38,7 @@ const slice = createSlice({
       }: PayloadAction<{ balance: StringWei; totalBalance?: StringWei }>
     ) => {
       state.balance = balance
+      state.balanceLoading = false
       if (totalBalance) state.totalBalance = totalBalance
       state.localBalanceDidChange = false
     },

--- a/packages/web/src/components/nav/desktop/NavAudio.module.css
+++ b/packages/web/src/components/nav/desktop/NavAudio.module.css
@@ -1,5 +1,11 @@
+.interactive:hover {
+  cursor: pointer;
+}
+
 .audio {
-  opacity: 0;
+  display: flex;
+  align-items: center;
+  padding-left: 8px;
   position: relative;
   min-height: 16px;
   flex-wrap: wrap;
@@ -16,25 +22,12 @@
   border-radius: 4px;
 }
 
-.audio.show {
-  display: flex;
-  align-items: center;
-  padding-left: 8px;
-  transition: opacity ease-in-out 0.5s;
-  opacity: 1;
-}
-
-.audio.hasBalance {
-  cursor: pointer;
-}
-
 .audioAmount {
   margin-left: 4px;
   font-size: var(--font-s);
   font-weight: var(--font-heavy);
   color: var(--neutral-light-4);
   transition: color 0.07s ease-in-out;
-  cursor: pointer;
 }
 
 .hasBalance .audioAmount:hover {
@@ -58,6 +51,7 @@
 }
 
 .actionBubble {
+  position: absolute;
   display: flex;
   align-items: center;
   padding: 4px 8px;
@@ -72,7 +66,6 @@
 }
 
 .actionBubble:hover {
-  cursor: pointer;
   transform: scale3d(1.03, 1.03, 1.03);
 }
 

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -1,8 +1,7 @@
-import { cloneElement, useCallback, useEffect, useState } from 'react'
+import { cloneElement, useCallback } from 'react'
 
 import {
   BadgeTier,
-  BNWei,
   StringKeys,
   formatWei,
   accountSelectors,
@@ -35,16 +34,11 @@ const messages = {
   claimRewards: 'Claim Rewards'
 }
 
-const NavAudio = () => {
+const RenderNavAudio = () => {
   const navigate = useNavigateToPage()
-  const userChallengesLoading = useSelector(getUserChallengesLoading)
   const account = useSelector(getAccountUser)
-  const balanceLoading = useSelector(getAccountBalanceLoading)
 
-  let totalBalance = useSelector(getAccountTotalBalance)
-  if (totalBalance.eq(new BN(0)) && account?.total_balance) {
-    totalBalance = new BN(account?.total_balance) as BNWei
-  }
+  const totalBalance = useSelector(getAccountTotalBalance)
   const positiveTotalBalance = totalBalance.gt(new BN(0))
   // we only show the audio balance and respective badge when there is an account
   // so below null-coalescing is okay
@@ -54,25 +48,15 @@ const NavAudio = () => {
   const challengeRewardIds = useRemoteVar(StringKeys.CHALLENGE_REWARD_IDS)
   const hasClaimableRewards = useAccountHasClaimableRewards(challengeRewardIds)
 
-  const [bubbleType, setBubbleType] = useState<BubbleType>('none')
-
   const goToAudioPage = useCallback(() => {
     navigate(AUDIO_PAGE)
   }, [navigate])
 
-  useEffect(() => {
-    if (hasClaimableRewards) {
-      setBubbleType('claim')
-    } else if (!positiveTotalBalance) {
-      setBubbleType('earn')
-    } else {
-    }
-  }, [setBubbleType, hasClaimableRewards, positiveTotalBalance])
-
-  // Wait for all the states we care about to load to prevent flashing
-  // of conditional content
-  if (balanceLoading || userChallengesLoading || !account) {
-    return null
+  let bubbleType: BubbleType = 'none'
+  if (hasClaimableRewards) {
+    bubbleType = 'claim'
+  } else if (!positiveTotalBalance) {
+    bubbleType = 'earn'
   }
 
   return (
@@ -124,6 +108,20 @@ const NavAudio = () => {
       </div>
     </div>
   )
+}
+
+const NavAudio = () => {
+  const userChallengesLoading = useSelector(getUserChallengesLoading)
+  const balanceLoading = useSelector(getAccountBalanceLoading)
+  const account = useSelector(getAccountUser)
+
+  // Wait for all the states we care about to load to prevent flashing
+  // of conditional content
+  if (balanceLoading || userChallengesLoading || !account) {
+    return null
+  }
+
+  return <RenderNavAudio />
 }
 
 export default NavAudio

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -34,6 +34,36 @@ const messages = {
   claimRewards: 'Claim Rewards'
 }
 
+type RewardsActionBubbleProps = {
+  bubbleType: BubbleType
+  onClick(): void
+  style?: React.CSSProperties
+}
+
+const RewardsActionBubble = ({
+  bubbleType,
+  onClick,
+  style
+}: RewardsActionBubbleProps) => {
+  if (bubbleType === 'none') {
+    return null
+  }
+  return (
+    <animated.span
+      style={style}
+      className={cn(styles.actionBubble, styles.interactive, {
+        [styles.claimRewards]: bubbleType === 'claim'
+      })}
+      onClick={onClick}
+    >
+      <span>
+        {bubbleType === 'claim' ? messages.claimRewards : messages.earnAudio}
+      </span>
+      <IconCaretRight className={styles.actionCaret} />
+    </animated.span>
+  )
+}
+
 const RenderNavAudio = () => {
   const navigate = useNavigateToPage()
   const account = useSelector(getAccountUser)
@@ -87,22 +117,13 @@ const RenderNavAudio = () => {
           leave={{ opacity: 0 }}
           config={{ duration: 100 }}
         >
-          {(item) => (props) =>
-            item !== 'none' && (
-              <animated.span
-                style={props}
-                className={cn(styles.actionBubble, styles.interactive, {
-                  [styles.claimRewards]: item === 'claim'
-                })}
+          {(bubbleType) => (bubbleStyle) =>
+            (
+              <RewardsActionBubble
+                bubbleType={bubbleType}
+                style={bubbleStyle}
                 onClick={goToAudioPage}
-              >
-                <span>
-                  {item === 'claim'
-                    ? messages.claimRewards
-                    : messages.earnAudio}
-                </span>
-                <IconCaretRight className={styles.actionCaret} />
-              </animated.span>
+              />
             )}
         </Transition>
       </div>

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -65,7 +65,8 @@ const RewardsActionBubble = ({
   )
 }
 
-/** Pulls balances from account and wallet selectors. Will prefer the wallet
+/**
+ * Pulls balances from account and wallet selectors. Will prefer the wallet
  * balance once it has loaded. Otherwise, will return the account balance if
  * available. Falls back to 0 if neither wallet or account balance are available.
  */
@@ -111,7 +112,8 @@ const NavAudio = () => {
   }
 
   let bubbleType: BubbleType = 'none'
-  /* Logic here is:
+  /*
+   * Logic here is:
    * - If user challenges have loaded and there are some to claim, show that immediately
    * - Otherwise, once wallet AND challenges have loaded (to prevent flashing),
    *   show the "earn" variant if the balance is zero.

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -117,11 +117,11 @@ const RenderNavAudio = () => {
           leave={{ opacity: 0 }}
           config={{ duration: 100 }}
         >
-          {(bubbleType) => (bubbleStyle) =>
+          {(bubbleType) => (style) =>
             (
               <RewardsActionBubble
                 bubbleType={bubbleType}
-                style={bubbleStyle}
+                style={style}
                 onClick={goToAudioPage}
               />
             )}


### PR DESCRIPTION
### Description
This updates the logic in `NavAudio` to wait on values used for conditional rendering to finish loading. The logic here uses information from 3 different calls. So depending on order, you could see the pill in multiple states in rapid succesion.

Also did some cleanup of the logic and styling:
* Updated balance calculations to prefer wallet balance if loaded, falling back to account balance and then a constant of `0`.
* Updated logic for displaying bubble to wait on loading of challenges and wallet for the two cases where we show "claim" and "earn" variants
* Removed the `useState` and `useEffect` pair for updating the bubble type. This should be unnecessary, since the hooks we use to select data will cause a re-render when the results change.
* Make the token counter and earn/claim pills separate click targets. They point to the same place now, but that may change. It also fixes a behavior where a big empty space to the right of the token count is clickable when there is no element there.
* Consolidate some styles that appear to have been originally applied conditionally, but are now always applied.
* Slightly odd: Due to the way `Transition` will render the component when it changes, we get two elements: one for the old text and one for the updated text. They were rendering side-by-side and animating together, which is what caused the temporary change in width. I updated the styling to stack them, so that we get a fade between the two in-place.

Here's what happens if the wallet loads and reflects a balance of zero (even if the balance from the account record originally showed positive), when there are no claimable rewards
![Kapture 2023-04-14 at 10 47 59](https://user-images.githubusercontent.com/1815175/232078172-4824b89d-53e6-4284-9aef-e7a30a9a889a.gif)

Here's a case where there are claimable challenges and the wallet loads and updates the balance to 0.
![Kapture 2023-04-14 at 11 02 11](https://user-images.githubusercontent.com/1815175/232080960-b10289cb-a438-4773-b727-77ac782e31b1.gif)

And then here's what happens if the challenges take longer to load than the wallet and the balance in the wallet is zero (the original source of the flashing bug)
![Kapture 2023-04-14 at 11 11 24](https://user-images.githubusercontent.com/1815175/232083803-02686b4e-c5b8-445b-8795-79242919a395.gif)

### Dragons
None

### How Has This Been Tested?
Tested manually in my local environment. I completed some challenges on a new account to try out the flow and also hard-coded some states and timers to mimic the behavior of the variables changing over time.

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

