### PR TITLE
Only mark notifications as viewed when notif panel is open

### DIFF
--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -117,10 +117,10 @@ export const NotificationPanel = ({ anchorRef }: NotificationPanelProps) => {
   }, [openNotifications, dispatch])
 
   useEffect(() => {
-    if (unviewedNotificationCount > 0) {
+    if (panelIsOpen && unviewedNotificationCount > 0) {
       dispatch(markAllAsViewed())
     }
-  }, [unviewedNotificationCount, dispatch])
+  }, [panelIsOpen, unviewedNotificationCount, dispatch])
 
   return (
     <>


### PR DESCRIPTION
### Description

Fixes bug where notifications are set to viewed on first load, not when the panel is actually open
