### PR TITLE
[PAY-937] Fix empty state for transactions table

### DIFF
--- a/packages/common/src/models/Status.ts
+++ b/packages/common/src/models/Status.ts
@@ -4,3 +4,8 @@ export enum Status {
   SUCCESS = 'SUCCESS',
   ERROR = 'ERROR'
 }
+
+/** Detects if a status is in a non-terminal state */
+export function statusIsUnloaded(status: Status) {
+  return [Status.IDLE, Status.LOADING].includes(status)
+}

--- a/packages/common/src/models/Status.ts
+++ b/packages/common/src/models/Status.ts
@@ -6,6 +6,6 @@ export enum Status {
 }
 
 /** Detects if a status is in a non-terminal state */
-export function statusIsUnloaded(status: Status) {
+export function statusIsNotTerminal(status: Status) {
   return [Status.IDLE, Status.LOADING].includes(status)
 }

--- a/packages/common/src/models/Status.ts
+++ b/packages/common/src/models/Status.ts
@@ -6,6 +6,6 @@ export enum Status {
 }
 
 /** Detects if a status is in a non-terminal state */
-export function statusIsNotTerminal(status: Status) {
+export function statusIsNotFinalized(status: Status) {
   return [Status.IDLE, Status.LOADING].includes(status)
 }

--- a/packages/common/src/store/pages/audio-transactions/selectors.ts
+++ b/packages/common/src/store/pages/audio-transactions/selectors.ts
@@ -2,5 +2,9 @@ import { CommonState } from '../../commonStore'
 
 export const getAudioTransactions = (state: CommonState) =>
   state.pages.audioTransactions.transactions
+export const getAudioTransactionsStatus = (state: CommonState) =>
+  state.pages.audioTransactions.transactionsStatus
 export const getAudioTransactionsCount = (state: CommonState) =>
   state.pages.audioTransactions.transactionsCount
+export const getAudioTransactionsCountStatus = (state: CommonState) =>
+  state.pages.audioTransactions.transactionsCountStatus

--- a/packages/web/src/common/store/pages/audio-transactions/sagas.ts
+++ b/packages/web/src/common/store/pages/audio-transactions/sagas.ts
@@ -19,10 +19,10 @@ import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
 
 const {
   fetchAudioTransactions,
+  fetchAudioTransactionsSucceeded,
   fetchAudioTransactionMetadata,
   fetchAudioTransactionsCount,
-  setAudioTransactions,
-  setAudioTransactionsCount
+  fetchAudioTransactionsCountSucceeded
 } = audioTransactionsPageActions
 const { fetchTransactionDetailsSucceeded } = transactionDetailsActions
 
@@ -128,7 +128,7 @@ function* fetchAudioTransactionsAsync() {
       const txDetails: TransactionDetails[] =
         response.data?.map((tx) => parseTransaction(tx)) ?? []
       const { offset } = action.payload
-      yield put(setAudioTransactions({ txDetails, offset }))
+      yield put(fetchAudioTransactionsSucceeded({ txDetails, offset }))
       const userIds = txDetails
         .map((tx) => {
           if (tx.transactionType === TransactionType.TIP) {
@@ -199,7 +199,7 @@ function* fetchTransactionsCount() {
       return
     }
     yield put(
-      setAudioTransactionsCount({
+      fetchAudioTransactionsCountSucceeded({
         count: response.data ?? 0
       })
     )

--- a/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.tsx
+++ b/packages/web/src/components/audio-transactions-table/AudioTransactionsTable.tsx
@@ -74,6 +74,114 @@ export const isChangePositive = (tx: TransactionDetails) => {
   )
 }
 
+// Cell Render Functions
+const renderTransactionTypeCell = (cellInfo: TransactionCell) => {
+  const { transactionType, method } = cellInfo.row.original
+  const typeText = transactionTypeLabelMap[transactionType as TransactionType]
+  const methodText =
+    transactionMethodLabelMap[method as TransactionMethod] ?? ''
+
+  const isTransferType =
+    transactionType === TransactionType.TIP ||
+    transactionType === TransactionType.TRANSFER
+  return (
+    <>
+      <div className={styles.icon}>
+        <AudioTransactionIcon type={transactionType} method={method} />
+      </div>
+      <span className={styles.typeText}>
+        {`${typeText} ${isTransferType ? methodText : ''}`.trim()}
+      </span>
+    </>
+  )
+}
+
+const renderBalanceCell = (cellInfo: TransactionCell) => {
+  const transaction = cellInfo.row.original
+  return formatAudio(transaction.balance)
+}
+
+const renderDateCell = (cellInfo: TransactionCell) => {
+  const transaction = cellInfo.row.original
+  return moment(transaction.date).format('M/D/YY')
+}
+
+const renderChangeCell = (cellInfo: TransactionCell) => {
+  const tx = cellInfo.row.original
+  const isPositive = isChangePositive(tx)
+  const { change } = tx
+  return (
+    <Tooltip text={`${formatAudio(tx.change, 2)} $AUDIO`} mount={'body'}>
+      <div
+        className={cn(
+          styles.changeCell,
+          isChangePositive(tx) ? styles.increase : styles.decrease
+        )}
+      >
+        {isPositive ? '' : '-'}
+        {formatAudio(change)}
+      </div>
+    </Tooltip>
+  )
+}
+
+const isEmptyRow = (row: any) => {
+  return Boolean(
+    !row?.original?.signature || row?.original?.kind === Kind.EMPTY
+  )
+}
+
+// Columns
+const tableColumnMap = {
+  transactionType: {
+    id: 'transactionType',
+    Header: 'Transaction Type',
+    accessor: 'type',
+    Cell: renderTransactionTypeCell,
+    width: 150,
+    disableSortBy: false,
+    align: 'left'
+  },
+  date: {
+    id: 'date',
+    Header: 'Date',
+    accessor: 'date',
+    Cell: renderDateCell,
+    disableSortBy: false,
+    align: 'right'
+  },
+  change: {
+    id: 'change',
+    Header: 'Change',
+    accessor: 'change',
+    Cell: renderChangeCell,
+    disableSortBy: true,
+    align: 'right'
+  },
+  balance: {
+    id: 'balance',
+    Header: 'Balance',
+    accessor: 'balance',
+    Cell: renderBalanceCell,
+    disableSortBy: true,
+    align: 'right'
+  },
+  spacer: {
+    id: 'spacer',
+    maxWidth: 24,
+    minWidth: 24,
+    disableSortBy: true,
+    disableResizing: true
+  },
+  spacer2: {
+    id: 'spacer2',
+    maxWidth: 24,
+    minWidth: 24,
+    disableSortBy: true,
+    disableResizing: true
+  }
+}
+
 export const AudioTransactionsTable = ({
   columns = defaultColumns,
   data,
@@ -88,125 +196,9 @@ export const AudioTransactionsTable = ({
   scrollRef,
   fetchBatchSize
 }: AudioTransactionsTableProps) => {
-  // Cell Render Functions
-  const renderTransactionTypeCell = useCallback((cellInfo: TransactionCell) => {
-    const { transactionType, method } = cellInfo.row.original
-    const typeText = transactionTypeLabelMap[transactionType as TransactionType]
-    const methodText =
-      transactionMethodLabelMap[method as TransactionMethod] ?? ''
-
-    const isTransferType =
-      transactionType === TransactionType.TIP ||
-      transactionType === TransactionType.TRANSFER
-    return (
-      <>
-        <div className={styles.icon}>
-          <AudioTransactionIcon type={transactionType} method={method} />
-        </div>
-        <span className={styles.typeText}>
-          {`${typeText} ${isTransferType ? methodText : ''}`.trim()}
-        </span>
-      </>
-    )
-  }, [])
-
-  const renderBalanceCell = useCallback((cellInfo: TransactionCell) => {
-    const transaction = cellInfo.row.original
-    return formatAudio(transaction.balance)
-  }, [])
-
-  const renderDateCell = useCallback((cellInfo: TransactionCell) => {
-    const transaction = cellInfo.row.original
-    return moment(transaction.date).format('M/D/YY')
-  }, [])
-
-  const renderChangeCell = useCallback((cellInfo: TransactionCell) => {
-    const tx = cellInfo.row.original
-    const isPositive = isChangePositive(tx)
-    const { change } = tx
-    return (
-      <Tooltip text={`${formatAudio(tx.change, 2)} $AUDIO`} mount={'body'}>
-        <div
-          className={cn(
-            styles.changeCell,
-            isChangePositive(tx) ? styles.increase : styles.decrease
-          )}
-        >
-          {isPositive ? '' : '-'}
-          {formatAudio(change)}
-        </div>
-      </Tooltip>
-    )
-  }, [])
-
-  const isEmptyRow = (row: any) => {
-    return Boolean(
-      !row?.original?.signature || row?.original?.kind === Kind.EMPTY
-    )
-  }
-
-  // Columns
-  const tableColumnMap = useMemo(
-    () => ({
-      transactionType: {
-        id: 'transactionType',
-        Header: 'Transaction Type',
-        accessor: 'type',
-        Cell: renderTransactionTypeCell,
-        width: 150,
-        disableSortBy: false,
-        align: 'left'
-      },
-      date: {
-        id: 'date',
-        Header: 'Date',
-        accessor: 'date',
-        Cell: renderDateCell,
-        disableSortBy: false,
-        align: 'right'
-      },
-      change: {
-        id: 'change',
-        Header: 'Change',
-        accessor: 'change',
-        Cell: renderChangeCell,
-        disableSortBy: true,
-        align: 'right'
-      },
-      balance: {
-        id: 'balance',
-        Header: 'Balance',
-        accessor: 'balance',
-        Cell: renderBalanceCell,
-        disableSortBy: true,
-        align: 'right'
-      },
-      spacer: {
-        id: 'spacer',
-        maxWidth: 24,
-        minWidth: 24,
-        disableSortBy: true,
-        disableResizing: true
-      },
-      spacer2: {
-        id: 'spacer2',
-        maxWidth: 24,
-        minWidth: 24,
-        disableSortBy: true,
-        disableResizing: true
-      }
-    }),
-    [
-      renderTransactionTypeCell,
-      renderDateCell,
-      renderChangeCell,
-      renderBalanceCell
-    ]
-  )
-
   const tableColumns = useMemo(
     () => columns.map((id) => tableColumnMap[id]),
-    [columns, tableColumnMap]
+    [columns]
   )
 
   const handleClickRow = useCallback(

--- a/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
+++ b/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
@@ -12,7 +12,7 @@ import {
   audioTransactionsPageActions,
   audioTransactionsPageSelectors,
   transactionDetailsActions,
-  statusIsUnloaded
+  statusIsNotTerminal
 } from '@audius/common'
 import { full } from '@audius/sdk'
 import { IconCaretRight } from '@audius/stems'
@@ -149,8 +149,8 @@ export const AudioTransactionsPage = () => {
   )
 
   const tableLoading =
-    statusIsUnloaded(audioTransactionsStatus) ||
-    statusIsUnloaded(audioTransactionsCountStatus)
+    statusIsNotTerminal(audioTransactionsStatus) ||
+    statusIsNotTerminal(audioTransactionsCountStatus)
   const isEmpty = audioTransactions.length === 0
 
   return (

--- a/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
+++ b/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
@@ -151,7 +151,7 @@ export const AudioTransactionsPage = () => {
   const tableLoading =
     statusIsNotFinalized(audioTransactionsStatus) ||
     statusIsNotFinalized(audioTransactionsCountStatus)
-  const isEmpty = true // audioTransactions.length === 0
+  const isEmpty = audioTransactions.length === 0
 
   return (
     <Page

--- a/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
+++ b/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
@@ -12,7 +12,7 @@ import {
   audioTransactionsPageActions,
   audioTransactionsPageSelectors,
   transactionDetailsActions,
-  statusIsNotTerminal
+  statusIsNotFinalized
 } from '@audius/common'
 import { full } from '@audius/sdk'
 import { IconCaretRight } from '@audius/stems'
@@ -149,8 +149,8 @@ export const AudioTransactionsPage = () => {
   )
 
   const tableLoading =
-    statusIsNotTerminal(audioTransactionsStatus) ||
-    statusIsNotTerminal(audioTransactionsCountStatus)
+    statusIsNotFinalized(audioTransactionsStatus) ||
+    statusIsNotFinalized(audioTransactionsCountStatus)
   const isEmpty = audioTransactions.length === 0
 
   return (

--- a/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
+++ b/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
@@ -11,7 +11,8 @@ import {
   TransactionType,
   audioTransactionsPageActions,
   audioTransactionsPageSelectors,
-  transactionDetailsActions
+  transactionDetailsActions,
+  statusIsUnloaded
 } from '@audius/common'
 import { full } from '@audius/sdk'
 import { IconCaretRight } from '@audius/stems'
@@ -28,12 +29,15 @@ import { useSelector } from 'utils/reducer'
 import styles from './AudioTransactionsPage.module.css'
 const {
   fetchAudioTransactions,
-  setAudioTransactions,
   fetchAudioTransactionMetadata,
   fetchAudioTransactionsCount
 } = audioTransactionsPageActions
-const { getAudioTransactions, getAudioTransactionsCount } =
-  audioTransactionsPageSelectors
+const {
+  getAudioTransactions,
+  getAudioTransactionsStatus,
+  getAudioTransactionsCount,
+  getAudioTransactionsCountStatus
+} = audioTransactionsPageSelectors
 const { fetchTransactionDetailsSucceeded } = transactionDetailsActions
 
 const messages = {
@@ -82,22 +86,15 @@ export const AudioTransactionsPage = () => {
 
   const audioTransactions: (TransactionDetails | {})[] =
     useSelector(getAudioTransactions)
+  const audioTransactionsStatus = useSelector(getAudioTransactionsStatus)
   const audioTransactionsCount: number = useSelector(getAudioTransactionsCount)
+  const audioTransactionsCountStatus = useSelector(
+    getAudioTransactionsCountStatus
+  )
 
   useEffect(() => {
     dispatch(fetchAudioTransactionsCount())
   }, [dispatch])
-
-  // Reset audio transactions data on sort change, but not on offset and
-  // limit change to allow pagination.
-  useEffect(() => {
-    dispatch(
-      setAudioTransactions({
-        txDetails: Array(audioTransactionsCount ?? 0).fill({}) as {}[],
-        offset: 0
-      })
-    )
-  }, [dispatch, sortMethod, sortDirection, audioTransactionsCount])
 
   useLayoutEffect(() => {
     dispatch(
@@ -118,6 +115,7 @@ export const AudioTransactionsPage = () => {
           ? full.GetAudioTransactionHistorySortDirectionEnum.Asc
           : full.GetAudioTransactionHistorySortDirectionEnum.Desc
       setSortDirection(sortDirectionRes)
+      setOffset(0)
     },
     [setSortMethod, setSortDirection]
   )
@@ -131,7 +129,7 @@ export const AudioTransactionsPage = () => {
   )
 
   const onClickRow = useCallback(
-    (txDetails: TransactionDetails, index: number) => {
+    (txDetails: TransactionDetails) => {
       dispatch(
         fetchTransactionDetailsSucceeded({
           transactionId: txDetails.signature,
@@ -150,9 +148,9 @@ export const AudioTransactionsPage = () => {
     [dispatch, setVisibility]
   )
 
-  const tableLoading = audioTransactions.every(
-    (transaction: any) => !transaction.signature
-  )
+  const tableLoading =
+    statusIsUnloaded(audioTransactionsStatus) ||
+    statusIsUnloaded(audioTransactionsCountStatus)
   const isEmpty = audioTransactions.length === 0
 
   return (

--- a/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
+++ b/packages/web/src/pages/audio-transactions-page/AudioTransactionsPage.tsx
@@ -151,7 +151,7 @@ export const AudioTransactionsPage = () => {
   const tableLoading =
     statusIsNotFinalized(audioTransactionsStatus) ||
     statusIsNotFinalized(audioTransactionsCountStatus)
-  const isEmpty = audioTransactions.length === 0
+  const isEmpty = true // audioTransactions.length === 0
 
   return (
     <Page
@@ -160,27 +160,25 @@ export const AudioTransactionsPage = () => {
       header={<Header primary={messages.headerText} />}
     >
       <div className={styles.bodyWrapper}>
+        <Disclaimer />
         {isEmpty && !tableLoading ? (
           <EmptyTable
             primaryText={messages.emptyTableText}
             secondaryText={messages.emptyTableSecondaryText}
           />
         ) : (
-          <>
-            <Disclaimer />
-            <AudioTransactionsTable
-              key='audioTransactions'
-              data={audioTransactions}
-              loading={tableLoading}
-              onSort={onSort}
-              onClickRow={onClickRow}
-              fetchMore={fetchMore}
-              isVirtualized={true}
-              totalRowCount={audioTransactionsCount}
-              scrollRef={mainContentRef}
-              fetchBatchSize={AUDIO_TRANSACTIONS_BATCH_SIZE}
-            />
-          </>
+          <AudioTransactionsTable
+            key='audioTransactions'
+            data={audioTransactions}
+            loading={tableLoading}
+            onSort={onSort}
+            onClickRow={onClickRow}
+            fetchMore={fetchMore}
+            isVirtualized={true}
+            totalRowCount={audioTransactionsCount}
+            scrollRef={mainContentRef}
+            fetchBatchSize={AUDIO_TRANSACTIONS_BATCH_SIZE}
+          />
         )}
       </div>
     </Page>


### PR DESCRIPTION
### Description
The `isLoading` logic for the AudioTransactionsTable was previous relying on an `every` check against the loaded data, instead of tracking success of the fetch. Due to the way `Array.prototype.every()` works, an empty array will always cause the loading condition to be true.

To fix this, I added loading state tracking to the slice for both transactions and count, and then wait on them explicitly to determine table loading state.
Additionally, I moved the reset logic mostly into the slice to simplify the component. The slice will now reset the items array when a fetch begins and the offset is zero (fetching the first page). This means the component doesn't have to manually clear items when paginating, and gets us closer to a pagination functionality that is separate from the display logic.

I also moved most of the helper functions in `AudioTransactionsTable` out to constants. They weren't referencing any props, so they don't need to be defined in the component with `useCallback`.


Previous behavior:
![Kapture 2023-04-18 at 00 00 05](https://user-images.githubusercontent.com/1815175/232667892-165f54e5-7ecf-476a-8d67-09f3b666e87b.gif)

New behavior:
![Kapture 2023-04-18 at 00 02 11](https://user-images.githubusercontent.com/1815175/232668182-85d7d1c5-9596-4753-bc5e-5f9d3b6abc03.gif)


### Dragons
Nope

### How Has This Been Tested?
Tested manually.

### How will this change be monitored?
Verify functionality in staging and RC

### Feature Flags ###
N/A

