### PR TITLE
PLAT-725: browser push misconfigured

### DIFF
--- a/packages/web/src/store/account/sagas.ts
+++ b/packages/web/src/store/account/sagas.ts
@@ -44,7 +44,7 @@ export function* showPushNotificationConfirmation() {
   setHasRequestedBrowserPermission()
   const account = yield* select(getAccountUser)
   if (!account) return
-  const browserPermission = yield* call(fetchBrowserPushNotifcationStatus)
+  const browserPermission = yield* call(fetchBrowserPushNotificationStatus)
   if (browserPermission === Permission.DEFAULT) {
     yield* put(setBrowerPushPermissionConfirmationModal)
   } else if (browserPermission === Permission.GRANTED) {
@@ -74,7 +74,7 @@ export function* showPushNotificationConfirmation() {
   }
 }
 
-export function* fetchBrowserPushNotifcationStatus() {
+export function* fetchBrowserPushNotificationStatus() {
   if (isElectron() || isMobile()) return
   if (isPushManagerAvailable) {
     const permission = yield* call(getPushManagerPermission)
@@ -85,7 +85,7 @@ export function* fetchBrowserPushNotifcationStatus() {
   }
 }
 
-export function* subscribeBrowserPushNotifcations() {
+export function* subscribeBrowserPushNotifications() {
   if (isPushManagerAvailable) {
     const pushManagerSubscription = yield* call(
       getPushManagerBrowserSubscription
@@ -132,10 +132,10 @@ export function* subscribeBrowserPushNotifcations() {
   }
 }
 
-export function* unsubscribeBrowserPushNotifcations() {
+export function* unsubscribeBrowserPushNotifications() {
   removeHasRequestedBrowserPermission()
   const browserPushSubscriptionStatus = yield* call(
-    fetchBrowserPushNotifcationStatus
+    fetchBrowserPushNotificationStatus
   )
   if (
     browserPushSubscriptionStatus === Permission.GRANTED &&
@@ -159,10 +159,10 @@ export function* unsubscribeBrowserPushNotifcations() {
   }
 }
 
-function* getBrowserPushNotifcations() {
+function* getBrowserPushNotifications() {
   yield* takeEvery(
     accountActions.fetchBrowserPushNotifications.type,
-    fetchBrowserPushNotifcationStatus
+    fetchBrowserPushNotificationStatus
   )
 }
 
@@ -176,14 +176,14 @@ function* watchShowPushNotificationConfirmation() {
 function* subscribeBrowserPushNotification() {
   yield* takeEvery(
     accountActions.subscribeBrowserPushNotifications.type,
-    subscribeBrowserPushNotifcations
+    subscribeBrowserPushNotifications
   )
 }
 
 function* unsubscribeBrowserPushNotification() {
   yield* takeEvery(
     accountActions.unsubscribeBrowserPushNotifications.type,
-    unsubscribeBrowserPushNotifcations
+    unsubscribeBrowserPushNotifications
   )
 }
 
@@ -191,7 +191,7 @@ export default function sagas() {
   return [
     ...commonAccountSagas(),
     watchShowPushNotificationConfirmation,
-    getBrowserPushNotifcations,
+    getBrowserPushNotifications,
     subscribeBrowserPushNotification,
     unsubscribeBrowserPushNotification
   ]


### PR DESCRIPTION
### Description
It looks like the subscribe function was misspelled as `notifcation` instead of `notification`. My hunch is other files referencing this name correctly were just returning undefined.

### Dragons
Spellcheckers?

### How Has This Been Tested?
Fixed the typo and did a repository search for both the old and correct name. Corrected all references to match the right one.

### How will this change be monitored?
Web push should correctly subscribe now because the func ref now matches up.

### Feature Flags ###
None

