### PR TITLE
Fix React errors about `key` property when rendering tables

### DIFF
--- a/packages/web/src/components/table/Table.tsx
+++ b/packages/web/src/components/table/Table.tsx
@@ -277,11 +277,13 @@ export const Table = ({
         (header) => header.id === 'trackActions' || header.id === 'overflowMenu'
       )
 
+      const { key: headerGroupKey, ...headerGroupProps } =
+        headerGroup.getHeaderGroupProps()
       return (
         <tr
           className={styles.tableHeadRow}
-          {...headerGroup.getHeaderGroupProps()}
-          key={headerGroup.id}
+          {...headerGroupProps}
+          key={headerGroupKey}
         >
           <div className={styles.cellSection}>
             {headers.map(renderTableHeader)}


### PR DESCRIPTION
### Description
When rendering the table headers, we get errors about children not having keys.
![image](https://user-images.githubusercontent.com/1815175/233159710-1b230eaa-3b2a-443c-89f4-b9006d04d7aa.png)


I looked into this, and the rows in our table headers were not being assigned keys. This is due to a difference in behavior between react-table v7 and v8+. The examples demonstrate using `headerGroup.id` as the key property. However, this property is `undefined` in the version we are using. The examples for `v7` pull the key from the `headerGroupProps` instead.

The linter isn't able to determine that the `headerGroupProps` always has a `key` value and the spread should provide it. So I updated the logic to pull the key out individually and assign it explicitly.

### Dragons
None

### How Has This Been Tested?
Manual verification locally

### How will this change be monitored?
Will verify no table regressions in staging

### Feature Flags ###
N/A

