### PR TITLE
[C-574] Add migration path to @react-spring/web

### DIFF
--- a/packages/stems/.eslintrc.js
+++ b/packages/stems/.eslintrc.js
@@ -23,5 +23,18 @@ module.exports = {
         'import/no-default-export': 'off'
       }
     }
-  ]
+  ],
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['react-spring*'],
+            message: 'Please use @react-spring/web instead'
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/packages/stems/src/components/Modal/Modal.tsx
+++ b/packages/stems/src/components/Modal/Modal.tsx
@@ -11,6 +11,7 @@ import {
 import cn from 'classnames'
 import uniqueId from 'lodash/uniqueId'
 import ReactDOM from 'react-dom'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, useTransition } from 'react-spring'
 import { useEffectOnce } from 'react-use'
 

--- a/packages/stems/src/components/Modal/ModalContentPages.tsx
+++ b/packages/stems/src/components/Modal/ModalContentPages.tsx
@@ -2,6 +2,7 @@ import { Children, ReactChild, useState } from 'react'
 
 import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, Transition } from 'react-spring/renderprops'
 import useMeasure from 'react-use-measure'
 

--- a/packages/stems/src/components/Popup/Popup.tsx
+++ b/packages/stems/src/components/Popup/Popup.tsx
@@ -10,6 +10,7 @@ import * as React from 'react'
 
 import cn from 'classnames'
 import ReactDOM from 'react-dom'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useTransition, animated } from 'react-spring'
 
 import { IconButton } from 'components/IconButton'

--- a/packages/stems/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/stems/src/components/SegmentedControl/SegmentedControl.tsx
@@ -2,6 +2,7 @@ import { createRef, Fragment, useState, useEffect, useRef } from 'react'
 
 import cn from 'classnames'
 import { mergeRefs } from 'react-merge-refs'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 import useMeasure, { RectReadOnly } from 'react-use-measure'
 

--- a/packages/web/.eslintrc.js
+++ b/packages/web/.eslintrc.js
@@ -38,5 +38,18 @@ module.exports = {
         extensions: ['.ts', '.tsx', '.js', '.jsx', '.json']
       }
     }
+  },
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'react-spring',
+            message: 'Please use @react-spring/web instead'
+          }
+        ]
+      }
+    ]
   }
 }

--- a/packages/web/.eslintrc.js
+++ b/packages/web/.eslintrc.js
@@ -43,9 +43,9 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
-        paths: [
+        patterns: [
           {
-            name: 'react-spring',
+            group: ['react-spring*'],
             message: 'Please use @react-spring/web instead'
           }
         ]

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -2535,6 +2535,88 @@
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz",
       "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw=="
     },
+    "@cykura/sdk-core": {
+      "version": "npm:@jup-ag/cykura-sdk-core@0.1.8",
+      "resolved": "https://registry.npmjs.org/@jup-ag/cykura-sdk-core/-/cykura-sdk-core-0.1.8.tgz",
+      "integrity": "sha512-bVtDA4oEuzj/amuTPVlk1OFpdlYKK6H9nKWg6Tv6mn6MydS/ArC2EY2zuMHtWP+1YJ5CAwxHL/7Kl1k+7XBSoQ==",
+      "requires": {
+        "@project-serum/anchor": "^0.22.0",
+        "big.js": "^5.2.2",
+        "decimal.js": "^10.3.1",
+        "jsbi": "^4.1.0",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
+      },
+      "dependencies": {
+        "@project-serum/anchor": {
+          "version": "0.22.1",
+          "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.22.1.tgz",
+          "integrity": "sha512-5pHeyvQhzLahIQ8aZymmDMZJAJFklN0joZdI+YIqFkK2uU/mlKr6rBLQjxysf/j1mLLiNG00tdyLfUtTAdQz7w==",
+          "requires": {
+            "@project-serum/borsh": "^0.2.5",
+            "@solana/web3.js": "^1.17.0",
+            "base64-js": "^1.5.1",
+            "bn.js": "^5.1.2",
+            "bs58": "^4.0.1",
+            "buffer-layout": "^1.2.2",
+            "camelcase": "^5.3.1",
+            "cross-fetch": "^3.1.5",
+            "crypto-hash": "^1.3.0",
+            "eventemitter3": "^4.0.7",
+            "find": "^0.3.0",
+            "js-sha256": "^0.9.0",
+            "pako": "^2.0.3",
+            "snake-case": "^3.0.4",
+            "toml": "^3.0.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        },
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "pako": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+          "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "@develar/schema-utils": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
@@ -4476,40 +4558,7 @@
             "@solana/buffer-layout-utils": "^0.2.0",
             "@solana/web3.js": "^1.32.0",
             "start-server-and-test": "^1.14.0"
-          },
-          "dependencies": {
-            "@solana/buffer-layout-utils": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
-              "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
-              "requires": {
-                "@solana/buffer-layout": "^4.0.0",
-                "@solana/web3.js": "^1.32.0",
-                "bigint-buffer": "^1.1.5",
-                "bignumber.js": "^9.0.1"
-              }
-            },
-            "start-server-and-test": {
-              "version": "1.15.4",
-              "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.15.4.tgz",
-              "integrity": "sha512-ucQtp5+UCr0m4aHlY+aEV2JSYNTiMZKdSKK/bsIr6AlmwAWDYDnV7uGlWWEtWa7T4XvRI5cPYcPcQgeLqpz+Tg==",
-              "requires": {
-                "arg": "^5.0.2",
-                "bluebird": "3.7.2",
-                "check-more-types": "2.24.0",
-                "debug": "4.3.4",
-                "execa": "5.1.1",
-                "lazy-ass": "1.6.0",
-                "ps-tree": "1.2.0",
-                "wait-on": "7.0.1"
-              }
-            }
           }
-        },
-        "arg": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
         },
         "base-x": {
           "version": "4.0.0",
@@ -4529,19 +4578,6 @@
             "base-x": "^4.0.0"
           }
         },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
         "tiny-invariant": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -4560,19 +4596,6 @@
         "tiny-invariant": "^1.1.0"
       },
       "dependencies": {
-        "@cykura/sdk-core": {
-          "version": "npm:@jup-ag/cykura-sdk-core@0.1.8",
-          "resolved": "https://registry.npmjs.org/@jup-ag/cykura-sdk-core/-/cykura-sdk-core-0.1.8.tgz",
-          "integrity": "sha512-bVtDA4oEuzj/amuTPVlk1OFpdlYKK6H9nKWg6Tv6mn6MydS/ArC2EY2zuMHtWP+1YJ5CAwxHL/7Kl1k+7XBSoQ==",
-          "requires": {
-            "@project-serum/anchor": "^0.22.0",
-            "big.js": "^5.2.2",
-            "decimal.js": "^10.3.1",
-            "jsbi": "^4.1.0",
-            "tiny-invariant": "^1.1.0",
-            "toformat": "^2.0.0"
-          }
-        },
         "@project-serum/anchor": {
           "version": "0.22.1",
           "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.22.1.tgz",
@@ -4878,18 +4901,6 @@
         "tiny-invariant": "~1.2.0"
       },
       "dependencies": {
-        "@orca-so/whirlpool-client-sdk": {
-          "version": "npm:@jup-ag/whirlpool-client-sdk@0.0.8",
-          "resolved": "https://registry.npmjs.org/@jup-ag/whirlpool-client-sdk/-/whirlpool-client-sdk-0.0.8.tgz",
-          "integrity": "sha512-nlAE/huKAWNxJ9g9BhD7nWGqTg/s0kGjWYqccsYM1Nv6CjesvWdtl8N4k81enmYYU2jgjm6f4XYKA8zTLHsBsA==",
-          "requires": {
-            "@project-serum/anchor": "~0.23.0",
-            "@solana/spl-token": "~0.1.8",
-            "bn.js": "~5.2.0",
-            "decimal.js": "~10.3.1",
-            "lru-cache": "^7.9.0"
-          }
-        },
         "@project-serum/anchor": {
           "version": "0.23.0",
           "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.23.0.tgz",
@@ -4937,11 +4948,6 @@
           "version": "1.15.2",
           "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
           "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
-        },
-        "lru-cache": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
         },
         "node-fetch": {
           "version": "2.6.7",
@@ -5433,6 +5439,92 @@
         }
       }
     },
+    "@orca-so/whirlpool-client-sdk": {
+      "version": "npm:@jup-ag/whirlpool-client-sdk@0.0.8",
+      "resolved": "https://registry.npmjs.org/@jup-ag/whirlpool-client-sdk/-/whirlpool-client-sdk-0.0.8.tgz",
+      "integrity": "sha512-nlAE/huKAWNxJ9g9BhD7nWGqTg/s0kGjWYqccsYM1Nv6CjesvWdtl8N4k81enmYYU2jgjm6f4XYKA8zTLHsBsA==",
+      "requires": {
+        "@project-serum/anchor": "~0.23.0",
+        "@solana/spl-token": "~0.1.8",
+        "bn.js": "~5.2.0",
+        "decimal.js": "~10.3.1",
+        "lru-cache": "^7.9.0"
+      },
+      "dependencies": {
+        "@project-serum/anchor": {
+          "version": "0.23.0",
+          "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.23.0.tgz",
+          "integrity": "sha512-LV2/ifZOJVFTZ4GbEloXln3iVfCvO1YM8i7BBCrUm4tehP7irMx4nr4/IabHWOzrQcQElsxSP/lb1tBp+2ff8A==",
+          "requires": {
+            "@project-serum/borsh": "^0.2.5",
+            "@solana/web3.js": "^1.36.0",
+            "base64-js": "^1.5.1",
+            "bn.js": "^5.1.2",
+            "bs58": "^4.0.1",
+            "buffer-layout": "^1.2.2",
+            "camelcase": "^5.3.1",
+            "cross-fetch": "^3.1.5",
+            "crypto-hash": "^1.3.0",
+            "eventemitter3": "^4.0.7",
+            "find": "^0.3.0",
+            "js-sha256": "^0.9.0",
+            "pako": "^2.0.3",
+            "snake-case": "^3.0.4",
+            "toml": "^3.0.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        },
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "pako": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+          "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "@pinata/sdk": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/@pinata/sdk/-/sdk-1.1.13.tgz",
@@ -5739,6 +5831,56 @@
       "requires": {
         "@coral-xyz/anchor": "^0.26.0",
         "buffer": "^6.0.1"
+      }
+    },
+    "@react-spring/animated": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.2.tgz",
+      "integrity": "sha512-ipvleJ99ipqlnHkz5qhSsgf/ny5aW0ZG8Q+/2Oj9cI7LCc7COdnrSO6V/v8MAX3JOoQNzfz6dye2s5Pt5jGaIA==",
+      "requires": {
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
+      }
+    },
+    "@react-spring/core": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.2.tgz",
+      "integrity": "sha512-fF512edZT/gKVCA90ZRxfw1DmELeVwiL4OC2J6bMUlNr707C0h4QRoec6DjzG27uLX2MvS1CEatf9KRjwZR9/w==",
+      "requires": {
+        "@react-spring/animated": "~9.7.2",
+        "@react-spring/rafz": "~9.7.2",
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
+      }
+    },
+    "@react-spring/rafz": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.2.tgz",
+      "integrity": "sha512-kDWMYDQto3+flkrX3vy6DU/l9pxQ4TVW91DglQEc11iDc7shF4+WVDRJvOVLX+xoMP7zyag1dMvlIgvQ+dvA/A=="
+    },
+    "@react-spring/shared": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.2.tgz",
+      "integrity": "sha512-6U9qkno+9DxlH5nSltnPs+kU6tYKf0bPLURX2te13aGel8YqgcpFYp5Av8DcN2x3sukinAsmzHUS/FRsdZMMBA==",
+      "requires": {
+        "@react-spring/rafz": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
+      }
+    },
+    "@react-spring/types": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.2.tgz",
+      "integrity": "sha512-GEflx2Ex/TKVMHq5g5MxQDNNPNhqg+4Db9m7+vGTm8ttZiyga7YQUF24shgRNebKIjahqCuei16SZga8h1pe4g=="
+    },
+    "@react-spring/web": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.2.tgz",
+      "integrity": "sha512-7qNc7/5KShu2D05x7o2Ols2nUE7mCKfKLaY2Ix70xPMfTle1sZisoQMBFgV9w/fSLZlHZHV9P0uWJqEXQnbV4Q==",
+      "requires": {
+        "@react-spring/animated": "~9.7.2",
+        "@react-spring/core": "~9.7.2",
+        "@react-spring/shared": "~9.7.2",
+        "@react-spring/types": "~9.7.2"
       }
     },
     "@redux-devtools/extension": {
@@ -6133,6 +6275,17 @@
       "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
       "requires": {
         "buffer": "~6.0.3"
+      }
+    },
+    "@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "requires": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
       }
     },
     "@solana/spl-token": {
@@ -7172,18 +7325,12 @@
       "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
       "dev": true
     },
-    "@types/hls.js": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@types/hls.js/-/hls.js-0.13.0.tgz",
-      "integrity": "sha512-zeW+kWWUvMF7x8/M1kLRCX6C41UcKyDZC/Xy6biGqLhd+rkpv2juVO+tCwPSQPQuqL1VtseoQYdONCOxUZ38Sw==",
-      "dev": true
-    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
       "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
       "requires": {
-        "@types/react": "18.0.26",
+        "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       },
       "dependencies": {
@@ -7373,7 +7520,7 @@
       "integrity": "sha512-V3Xt9wgaOvDPXcpOy3dC8qXCxy3cs0Lr/Hqgd9Bi6m3sf/vpbpTtfmVR0LJklrqYEjaAmc7e3Xh/INT2rCAKjQ==",
       "dev": true,
       "requires": {
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7522,7 +7669,7 @@
       "integrity": "sha512-BNdmvONKtsrZq3AGrujECQrIn8cDT+fZsxBLXuX3YWY/nHfZinUFx4W88eS0rkcXzuLbXpKOsu/1WCMPMLEpPg==",
       "dev": true,
       "requires": {
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7544,7 +7691,7 @@
       "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
       "dev": true,
       "requires": {
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7566,7 +7713,7 @@
       "integrity": "sha512-ZKcoOdW/Tg+kiUbkFCBtvDw0k3nD4HJ/h/B9yWxN4uDO8OkRksWTO+EL+z/Qu3aHTeTll3Ro0Cc/8UhwBCMG5A==",
       "dev": true,
       "requires": {
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7588,7 +7735,7 @@
       "integrity": "sha512-64bpbqdSgtmy1zSZ2AQoFzguwZO7TyKjqJRTEnfNMCAQbnrX90kz+rYufZyY9CmzhwpXMwRO8xR9fMQnbYUkgQ==",
       "dev": true,
       "requires": {
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7610,7 +7757,7 @@
       "integrity": "sha512-e1vOQ+poOGQwDAJkv8AIhXBOkUq9XctxUdFdbVsBIi2t9wgDrdjxUxnpzyy85XQNMwkRQF1VDDSyMN9whW2EVw==",
       "dev": true,
       "requires": {
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7639,7 +7786,7 @@
       "dev": true,
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7662,7 +7809,7 @@
       "dev": true,
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "18.0.26",
+        "@types/react": "*",
         "@types/react-router": "*"
       },
       "dependencies": {
@@ -7685,7 +7832,7 @@
       "integrity": "sha512-bRUent+NR/WwtDGwI/BqhZ8XnHghwHw0HUKeohzB5xN3K2qKWYE5w19e7GCuOkL1CXD9Gi1HFy7TIm2AvgWUHg==",
       "dev": true,
       "requires": {
-        "@types/react": "18.0.26"
+        "@types/react": "*"
       },
       "dependencies": {
         "@types/react": {
@@ -7713,7 +7860,7 @@
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
-        "@types/react": "18.0.26"
+        "@types/react": "^17"
       },
       "dependencies": {
         "@types/react": {
@@ -16932,136 +17079,66 @@
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI=",
       "dependencies": {
-        "timers-browserify": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-          "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+        "Base64": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+          "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw=="
+        },
+        "JSONStream": {
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "integrity": "sha512-l0NN3IcqrZfZBJp7JWDJIHsnPV7yzJWqsYxQzL8Fwdx1BmEMjLuvtYkv+P9pbvpyfP75/f4MeDZhWNU4is32uA==",
           "requires": {
-            "process": "~0.11.0"
+            "jsonparse": "0.0.5",
+            "through": ">=2.2.7 <3"
+          }
+        },
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug=="
+        },
+        "acorn-node": {
+          "version": "1.8.2",
+          "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+          "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+          "requires": {
+            "acorn": "^7.0.0",
+            "acorn-walk": "^7.0.0",
+            "xtend": "^4.0.2"
           },
           "dependencies": {
-            "process": {
-              "version": "0.11.10",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+            "acorn": {
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            },
+            "xtend": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+              "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
             }
           }
         },
-        "crypto-browserify": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-          "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-          "requires": {
-            "browserify-cipher": "^1.0.0",
-            "browserify-sign": "^4.0.0",
-            "create-ecdh": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "create-hmac": "^1.1.0",
-            "diffie-hellman": "^5.0.0",
-            "inherits": "^2.0.1",
-            "pbkdf2": "^3.0.3",
-            "public-encrypt": "^4.0.0",
-            "randombytes": "^2.0.0",
-            "randomfill": "^1.0.3"
-          }
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
         },
-        "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
-        "browserify-zlib": {
+        "align-text": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
           "requires": {
-            "pako": "~0.2.0"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
-        "evp_bytestokey": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-          "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-          "requires": {
-            "md5.js": "^1.3.4",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "yargs": {
-          "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
-          "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
-          "requires": {
-            "camelcase": "^1.0.2",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
-            }
-          }
-        },
-        "convert-source-map": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
-          "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg=="
-        },
-        "os-browserify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-          "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA=="
-        },
-        "randomfill": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-          "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-          "requires": {
-            "randombytes": "^2.0.5",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "lexical-scope": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-          "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
-          "requires": {
-            "astw": "^2.0.0"
-          }
-        },
-        "browserify-cipher": {
+        "amdefine": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-          "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-          "requires": {
-            "browserify-aes": "^1.0.4",
-            "browserify-des": "^1.0.0",
-            "evp_bytestokey": "^1.0.0"
-          }
-        },
-        "url": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-              "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
-            }
-          }
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
         },
         "asn1.js": {
           "version": "5.4.1",
@@ -17081,136 +17158,56 @@
             }
           }
         },
-        "diffie-hellman": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-          "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+        "assert": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
+          "integrity": "sha512-pSLN/C6u6JFR8L+0TzQ0Elc+VboxUXFtNw11RI1UcTcHEktQqIKIKK5S4nAZX4j8mpTpnCtmqpR+thPfqT11Kg==",
           "requires": {
-            "bn.js": "^4.1.0",
-            "miller-rabin": "^4.0.0",
-            "randombytes": "^2.0.0"
+            "util": "0.10.3"
           },
           "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
+            },
+            "util": {
+              "version": "0.10.3",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
+              "requires": {
+                "inherits": "2.0.1"
+              }
             }
           }
         },
-        "longest": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg=="
-        },
-        "hash.js": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+        "astw": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+          "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
           "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.1"
+            "acorn": "^4.0.3"
           }
         },
-        "resolve": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
-          "integrity": "sha512-zxmAcifDjKxmUbk7chQdKhDSn8ml08g+MYyU37xhEXBp+N81cfbYsm4e0Gn9jtLbAvbR8w8Ox09xqUZtPuCoeA=="
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
         },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        "balanced-match": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
-        "randombytes": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-          "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-          "requires": {
-            "safe-buffer": "^5.1.0"
-          }
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
         },
-        "public-encrypt": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-          "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-          "requires": {
-            "bn.js": "^4.1.0",
-            "browserify-rsa": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "parse-asn1": "^5.0.0",
-            "randombytes": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-            }
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "acorn-walk": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
-        },
-        "json-stable-stringify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-          "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
-          "requires": {
-            "jsonify": "~0.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-        },
-        "minimalistic-assert": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-        },
-        "shell-quote": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
-          "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ=="
-        },
-        "https-browserify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
-          "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ=="
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-        },
-        "create-ecdh": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-          "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
-          "requires": {
-            "bn.js": "^4.1.0",
-            "elliptic": "^6.5.3"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-            }
-          }
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -17221,323 +17218,10 @@
             "concat-map": "0.0.1"
           }
         },
-        "ruglify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-          "integrity": "sha512-XfRj1YJdm/gnZNvmpQ5L+2YGRHglDGMPgJRbitgCxC3GzKVQF/t+ij1aNcNg2AnEXGtLHJDwoSWrAq3TUm0EVg==",
-          "requires": {
-            "rfile": "~1.0",
-            "uglify-js": "~2.2"
-          },
-          "dependencies": {
-            "uglify-js": {
-              "version": "2.2.5",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-              "integrity": "sha512-viLk+/8G0zm2aKt1JJAVcz5J/5ytdiNaIsKgrre3yvSUjwVG6ZUujGH7E2TiPigZUwLYCe7eaIUEP2Zka2VJPA==",
-              "requires": {
-                "optimist": "~0.3.5",
-                "source-map": "~0.1.7"
-              }
-            }
-          }
-        },
-        "util": {
-          "version": "0.10.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-          "requires": {
-            "inherits": "2.0.3"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
-            }
-          }
-        },
-        "indexof": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-          "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
-        },
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug=="
-        },
-        "shasum": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-          "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
-          "requires": {
-            "json-stable-stringify": "~0.0.0",
-            "sha.js": "~2.4.4"
-          }
-        },
-        "syntax-error": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
-          "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
-          "requires": {
-            "acorn-node": "^1.2.0"
-          }
-        },
-        "pako": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "process": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz",
-          "integrity": "sha512-g7Lv2/7sZaS5oNElebRqsd40W/k0QCTmq8WeNZ/w3PVTqRsz0giER3sMsFQXobi+/Gmuy/qbnksrh76o21DEDA=="
-        },
-        "browser-resolve": {
-          "version": "1.11.3",
-          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-          "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-          "requires": {
-            "resolve": "1.1.7"
-          },
-          "dependencies": {
-            "resolve": {
-              "version": "1.1.7",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-              "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
-            }
-          }
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
-            }
-          }
-        },
-        "cipher-base": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "defined": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-          "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg=="
-        },
-        "stream-splicer": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-          "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
-          "requires": {
-            "indexof": "0.0.1",
-            "inherits": "^2.0.1",
-            "isarray": "~0.0.1",
-            "readable-stream": "^1.1.13-1",
-            "readable-wrap": "^1.0.0",
-            "through2": "^1.0.0"
-          }
-        },
-        "md5.js": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-          "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-          "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "http-browserify": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
-          "requires": {
-            "Base64": "~0.2.0",
-            "inherits": "~2.0.1"
-          }
-        },
-        "labeled-stream-splicer": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
-          "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "isarray": "~0.0.1",
-            "stream-splicer": "^1.1.0"
-          }
-        },
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg=="
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "sha.js": {
-          "version": "2.4.11",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "parse-asn1": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
-          "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
-          "requires": {
-            "asn1.js": "^5.2.0",
-            "browserify-aes": "^1.0.0",
-            "evp_bytestokey": "^1.0.0",
-            "pbkdf2": "^3.0.3",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "Base64": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-          "integrity": "sha512-reGEWshDmTDQDsCec/HduOO9Wyj6yMOupMfhIf3ugN1TDlK2NQW4DDJSqNNtp380SNcvRfXtO8HSCQot0d0SMw=="
-        },
-        "hash-base": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-          "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.6.0",
-            "safe-buffer": "^5.2.0"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "3.6.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-              "requires": {
-                "safe-buffer": "~5.2.0"
-              }
-            }
-          }
-        },
-        "console-browserify": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-          "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
-        },
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-          "requires": {
-            "wordwrap": "~0.0.2"
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q=="
-        },
-        "lodash.memoize": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-          "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A=="
-        },
-        "shallow-copy": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-          "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
-        },
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
-        },
-        "path-browserify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
-        },
-        "buffer": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.2.tgz",
-          "integrity": "sha512-c3M77NkHJxS0zx/ErxXhDLr1v3y2MDXPeTJPvLNOaIYJ4ymHBUFQ9EXzt9HYuqAJllMoNb/EZ8hIiulnQFAUuQ==",
-          "requires": {
-            "base64-js": "0.0.8",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-            }
-          }
-        },
-        "constants-browserify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-          "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA=="
-        },
-        "parents": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
-          "integrity": "sha512-ASkdjFPS2nrxujzSBZGt8ZCKeG0/K2ZZVKveqXt7XGtXfu+ssnk4DQhnK91KRvt83f36LjfxOfwi0cv1+Re0eA==",
-          "requires": {
-            "path-platform": "^0.0.1"
-          },
-          "dependencies": {
-            "path-platform": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
-              "integrity": "sha512-ydK1VKZFYwy0mT2JvimJfxt5z6Z6sjBbLfsFMoJczbwZ/ul0AjgpXLHinUzclf4/XYC8mtsWGuFERZ95Rnm8wA=="
-            }
-          }
-        },
-        "supports-preserve-symlinks-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-          "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+        "brorand": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+          "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
         },
         "browser-pack": {
           "version": "3.2.0",
@@ -17574,55 +17258,76 @@
             }
           }
         },
-        "browserify-des": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-          "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+        "browser-resolve": {
+          "version": "1.11.3",
+          "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+          "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
           "requires": {
-            "cipher-base": "^1.0.1",
-            "des.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
+            "resolve": "1.1.7"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+              "integrity": "sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg=="
+            }
           }
         },
-        "base64-js": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-          "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+        "browserify": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-7.1.0.tgz",
+          "integrity": "sha512-BHHshSNeACBbVMAo/QCeJ4chEVOfrF1S4/8YTdNPnmP4GmuyS+RmZKHcKD0SmjJjvjBiHsT4eYuv/VUA0/9XnA==",
           "requires": {
-            "core-util-is": "~1.0.0",
+            "JSONStream": "~0.8.3",
+            "assert": "~1.1.0",
+            "browser-pack": "^3.2.0",
+            "browser-resolve": "^1.3.0",
+            "browserify-zlib": "~0.1.2",
+            "buffer": "^3.0.0",
+            "builtins": "~0.0.3",
+            "commondir": "0.0.1",
+            "concat-stream": "~1.4.1",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~0.0.1",
+            "crypto-browserify": "^3.0.0",
+            "deep-equal": "~0.2.1",
+            "defined": "~0.0.0",
+            "deps-sort": "^1.3.5",
+            "domain-browser": "~1.1.0",
+            "duplexer2": "~0.0.2",
+            "events": "~1.0.0",
+            "glob": "^4.0.5",
+            "http-browserify": "^1.4.0",
+            "https-browserify": "~0.0.0",
             "inherits": "~2.0.1",
+            "insert-module-globals": "^6.1.0",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "labeled-stream-splicer": "^1.0.0",
+            "module-deps": "^3.6.3",
+            "os-browserify": "~0.1.1",
+            "parents": "~0.0.1",
+            "path-browserify": "~0.0.0",
+            "process": "^0.8.0",
+            "punycode": "~1.2.3",
+            "querystring-es3": "~0.2.0",
+            "readable-stream": "^1.0.33-1",
+            "resolve": "~0.7.1",
+            "shallow-copy": "0.0.1",
+            "shasum": "^1.0.0",
+            "shell-quote": "~0.0.1",
+            "stream-browserify": "^1.0.0",
+            "string_decoder": "~0.10.0",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^1.0.0",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "~0.0.0",
+            "umd": "~2.1.0",
+            "url": "~0.10.1",
+            "util": "~0.10.1",
+            "vm-browserify": "~0.0.1",
+            "xtend": "^3.0.0"
           }
-        },
-        "create-hmac": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-          "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-          "requires": {
-            "cipher-base": "^1.0.3",
-            "create-hash": "^1.1.0",
-            "inherits": "^2.0.1",
-            "ripemd160": "^2.0.0",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
-          }
-        },
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-        },
-        "tty-browserify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-          "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
         },
         "browserify-aes": {
           "version": "1.2.0",
@@ -17637,258 +17342,26 @@
             "safe-buffer": "^5.0.1"
           }
         },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-        },
-        "acorn-node": {
-          "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
-          "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
-          "requires": {
-            "acorn": "^7.0.0",
-            "acorn-walk": "^7.0.0",
-            "xtend": "^4.0.2"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "7.4.1",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-            },
-            "xtend": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-              "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-            }
-          }
-        },
-        "umd": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-          "integrity": "sha512-mEAJeceExHnblcAwN3BQtDPYOrTy4ALeBh6nQ9KW0cUCd0UU714jAfil2jvq09b67IizwJIiTVFOjE+/52Dyvw==",
-          "requires": {
-            "rfile": "~1.0.0",
-            "ruglify": "~1.0.0",
-            "through": "~2.3.4",
-            "uglify-js": "~2.4.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.34",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-              "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            },
-            "uglify-js": {
-              "version": "2.4.24",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
-              "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
-              "requires": {
-                "async": "~0.2.6",
-                "source-map": "0.1.34",
-                "uglify-to-browserify": "~1.0.0",
-                "yargs": "~3.5.4"
-              }
-            }
-          }
-        },
-        "astw": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-          "integrity": "sha512-E/4z//dvN0lfr8zAx8hXeQ8o3nRoQaL/wqI7fAALEvh/40mnyUxfFB9MwyDHYKVDtS3cp3Pow5s96djZR5lkWw==",
-          "requires": {
-            "acorn": "^4.0.3"
-          }
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "builtins": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-          "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw=="
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-        },
-        "minimalistic-crypto-utils": {
+        "browserify-cipher": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+          "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+          "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+          "requires": {
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
+          }
         },
-        "querystring": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
-        },
-        "create-hash": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-          "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+        "browserify-des": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+          "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
           "requires": {
             "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
             "inherits": "^2.0.1",
-            "md5.js": "^1.3.4",
-            "ripemd160": "^2.0.1",
-            "sha.js": "^2.4.0"
+            "safe-buffer": "^5.1.2"
           }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g=="
-        },
-        "rfile": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-          "integrity": "sha512-aNeTpY8g6DYmqPvakau22B0SipQTskO8FtYXzn8qg4X4bN9ExIH8VAhq/L9w7N8HvESYeSSwk3e4GmW+rLLAxQ==",
-          "requires": {
-            "callsite": "~1.0.0",
-            "resolve": "~0.3.0"
-          },
-          "dependencies": {
-            "resolve": {
-              "version": "0.3.1",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-              "integrity": "sha512-mxx/I/wLjxtryDBtrrb0ZNzaYERVWaHpJ0W0Arm8N4l8b+jiX/U5yKcsj0zQpF9UuKN1uz80EUTOudON6OPuaQ=="
-            }
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "domain-browser": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-          "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q=="
-        },
-        "browserify": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/browserify/-/browserify-7.1.0.tgz",
-          "integrity": "sha512-BHHshSNeACBbVMAo/QCeJ4chEVOfrF1S4/8YTdNPnmP4GmuyS+RmZKHcKD0SmjJjvjBiHsT4eYuv/VUA0/9XnA==",
-          "requires": {
-            "timers-browserify": "^1.0.1",
-            "crypto-browserify": "^3.0.0",
-            "browserify-zlib": "~0.1.2",
-            "os-browserify": "~0.1.1",
-            "url": "~0.10.1",
-            "resolve": "~0.7.1",
-            "shell-quote": "~0.0.1",
-            "https-browserify": "~0.0.0",
-            "util": "~0.10.1",
-            "shasum": "^1.0.0",
-            "syntax-error": "^1.1.1",
-            "process": "^0.8.0",
-            "browser-resolve": "^1.3.0",
-            "defined": "~0.0.0",
-            "http-browserify": "^1.4.0",
-            "labeled-stream-splicer": "^1.0.0",
-            "xtend": "^3.0.0",
-            "console-browserify": "^1.1.0",
-            "shallow-copy": "0.0.1",
-            "path-browserify": "~0.0.0",
-            "buffer": "^3.0.0",
-            "constants-browserify": "~0.0.1",
-            "parents": "~0.0.1",
-            "browser-pack": "^3.2.0",
-            "readable-stream": "^1.0.33-1",
-            "tty-browserify": "~0.0.0",
-            "umd": "~2.1.0",
-            "inherits": "~2.0.1",
-            "builtins": "~0.0.3",
-            "domain-browser": "~1.1.0",
-            "commondir": "0.0.1",
-            "deep-equal": "~0.2.1",
-            "events": "~1.0.0",
-            "stream-browserify": "^1.0.0",
-            "vm-browserify": "~0.0.1",
-            "querystring-es3": "~0.2.0",
-            "punycode": "~1.2.3",
-            "duplexer2": "~0.0.2",
-            "subarg": "^1.0.0",
-            "isarray": "0.0.1",
-            "deps-sort": "^1.3.5",
-            "insert-module-globals": "^6.1.0",
-            "glob": "^4.0.5",
-            "concat-stream": "~1.4.1",
-            "JSONStream": "~0.8.3",
-            "module-deps": "^3.6.3",
-            "through2": "^1.0.0",
-            "assert": "~1.1.0",
-            "string_decoder": "~0.10.0"
-          }
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-        },
-        "commondir": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
-          "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg=="
-        },
-        "deep-equal": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-          "integrity": "sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ=="
-        },
-        "events": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
-          "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ=="
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA=="
-        },
-        "stream-browserify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
-          "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "^1.0.27-1"
-          }
-        },
-        "path-platform": {
-          "version": "0.11.15",
-          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-          "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg=="
-        },
-        "is-core-module": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-          "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
-          "requires": {
-            "has": "^1.0.3"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="
-        },
-        "path-parse": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "browserify-rsa": {
           "version": "4.1.0",
@@ -17897,59 +17370,6 @@
           "requires": {
             "bn.js": "^5.0.0",
             "randombytes": "^2.0.1"
-          }
-        },
-        "des.js": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-          "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
-          "requires": {
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg=="
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "combine-source-map": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
-          "integrity": "sha512-HRKa6g9SC1xd6ifto8ay6SxvyHaaQ50/8NO1ZONXx2hsIF9t/52qXa7Eeivaf5KFOSowK7Nm8TkIL/VC4khdBA==",
-          "requires": {
-            "convert-source-map": "~0.3.0",
-            "inline-source-map": "~0.3.0",
-            "source-map": "~0.1.31"
-          }
-        },
-        "vm-browserify": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
-          "requires": {
-            "indexof": "0.0.1"
-          }
-        },
-        "querystring-es3": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-          "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-          "requires": {
-            "is-buffer": "^1.1.5"
           }
         },
         "browserify-sign": {
@@ -17988,128 +17408,209 @@
             }
           }
         },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-        },
-        "miller-rabin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-          "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
           "requires": {
-            "bn.js": "^4.0.0",
-            "brorand": "^1.0.1"
+            "pako": "~0.2.0"
+          }
+        },
+        "buffer": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.2.tgz",
+          "integrity": "sha512-c3M77NkHJxS0zx/ErxXhDLr1v3y2MDXPeTJPvLNOaIYJ4ymHBUFQ9EXzt9HYuqAJllMoNb/EZ8hIiulnQFAUuQ==",
+          "requires": {
+            "base64-js": "0.0.8",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           },
           "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
             }
           }
-        },
-        "punycode": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
-          "integrity": "sha512-h/vscxLPvI2l7k/0dFUKZ5I5TgMCJ/Pl+J6rw77PDuQM6UApf/GaRVkjv/YSm2k+fbp7Yw8dxsoe29DolT7h7w=="
-        },
-        "duplexer2": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
-          "requires": {
-            "readable-stream": "~1.1.9"
-          }
-        },
-        "readable-wrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-          "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
-          "requires": {
-            "readable-stream": "^1.1.13-1"
-          }
-        },
-        "elliptic": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-            }
-          }
-        },
-        "ripemd160": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-          "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-          "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1"
-          }
-        },
-        "brorand": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
-        },
-        "core-util-is": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-          "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-        },
-        "has": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
-        },
-        "jsonparse": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
-          "integrity": "sha512-fw7Q/8gFR8iSekUi9I+HqWIap6mywuoe7hQIg3buTVjuZgALKj4HAmm0X6f+TaL4c9NJbvyFQdaI2ppr5p6dnQ=="
         },
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
           "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
         },
-        "subarg": {
+        "builtins": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
+          "integrity": "sha512-T8uCGKc0/2aLVt6omt8JxDRBoWEMkku+wFesxnhxnt4NygVZG99zqxo7ciK8eebszceKamGoUiLdkXCgGQyrQw=="
+        },
+        "callsite": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-          "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+          "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ=="
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g=="
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
           "requires": {
-            "minimist": "^1.1.0"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
-        "isarray": {
+        "cipher-base": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+          "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
+            }
+          }
+        },
+        "combine-source-map": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+          "integrity": "sha512-HRKa6g9SC1xd6ifto8ay6SxvyHaaQ50/8NO1ZONXx2hsIF9t/52qXa7Eeivaf5KFOSowK7Nm8TkIL/VC4khdBA==",
+          "requires": {
+            "convert-source-map": "~0.3.0",
+            "inline-source-map": "~0.3.0",
+            "source-map": "~0.1.31"
+          }
+        },
+        "commondir": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz",
+          "integrity": "sha512-Ghe1LmLv3G3c0XJYu+c88MCRIPqWQ67qaqKY1KvuN4uPAjfUj+y4hvcpZ2kCPrjpRNyklW4dpAZZ8a7vOh50tg=="
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "concat-stream": {
+          "version": "1.4.11",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
+          "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "~1.1.9",
+            "typedarray": "~0.0.5"
+          }
+        },
+        "console-browserify": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+          "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
+          "integrity": "sha512-FL+diDS9AKR5BAA2M+GNk8lnH64tRE3zepTG9hucxc7o04LgCRhkQZhF7u/OKHZT8LLRT+sZEi9qFzXUchq9pA=="
+        },
+        "convert-source-map": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "integrity": "sha512-+4nRk0k3oEpwUB7/CalD7xE2z4VmtEnnq0GO2IPTkrooTrAhEsWvuLF5iWP1dXrwluki/azwXV1ve7gtYuPldg=="
+        },
+        "core-util-is": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+          "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+        },
+        "create-ecdh": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+          "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+          "requires": {
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.5.3"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "create-hash": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+          "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+          "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+          "requires": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+          "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+          "requires": {
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
+        },
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ=="
+        },
+        "defined": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+          "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg=="
         },
         "deps-sort": {
           "version": "1.3.9",
@@ -18138,6 +17639,164 @@
             }
           }
         },
+        "des.js": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+          "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "detective": {
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+          "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+          "requires": {
+            "acorn": "^5.2.1",
+            "defined": "^1.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "5.7.4",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+              "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+            },
+            "defined": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+            }
+          }
+        },
+        "diffie-hellman": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+          "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+          "requires": {
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+          "integrity": "sha512-fJ5MoHxe69h3E4/lJtFRhcWwLb04bhIBSfvCEMS1YDH+/9yEZTqBHTSTgch8nCP5tE5k2gdQEjodUqJzy7qJ9Q=="
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha512-+AWBwjGadtksxjOQSFDhPNQbed7icNXApT4+2BNpsXzcCBiInq2H9XW0O8sfHFaPmnQRs7cg/P0fAr2IWQSW0g==",
+          "requires": {
+            "readable-stream": "~1.1.9"
+          }
+        },
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "events": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+          "integrity": "sha512-XK19KwlDJo8XsceooxNDK1pObtcT44+Xte6V/jQc4a+fHq1qEouThyyX2ePmS0hS8RcCulmRxzg+T8jiLKAFFQ=="
+        },
+        "evp_bytestokey": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+          "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+          "requires": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "hash-base": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+          "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.6.0",
+            "safe-buffer": "^5.2.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              }
+            }
+          }
+        },
+        "hash.js": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+          }
+        },
         "hmac-drbg": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -18148,25 +17807,61 @@
             "minimalistic-crypto-utils": "^1.0.1"
           }
         },
-        "align-text": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+        "http-browserify": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "integrity": "sha512-Irf/LJXmE3cBzU1eaR4+NEX6bmVLqt1wkmDiA7kBwH7zmb0D8kBAXsDmQ88hhj/qv9iEZKlyGx/hrMcFi8sOHw==",
           "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
+            "Base64": "~0.2.0",
+            "inherits": "~2.0.1"
           }
         },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
+        "https-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+          "integrity": "sha512-EjDQFbgJr1vDD/175UJeSX3ncQ3+RUnCL5NkthQGHvF4VNHlzTy8ifJfTqz47qiPRqaFH58+CbuG3x51WuB1XQ=="
         },
-        "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+          "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "inline-source-map": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+          "integrity": "sha512-RNlldBXZ7BBcVm3HjXIXiwKxih1lnuKbzeLBRDSB/qaqk8/g4JEZBjxpBQMhqEthQyGv7ycu8r/8PKGgBdIqrA==",
+          "requires": {
+            "source-map": "~0.3.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
+              "integrity": "sha512-jz8leTIGS8+qJywWiO9mKza0hJxexdeIYXhDHw9avTQcXSNAGk3hiiRMpmI2Qf9dOrZDrDpgH9VNefzuacWC9A==",
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
         },
         "insert-module-globals": {
           "version": "6.6.3",
@@ -18241,80 +17936,131 @@
             }
           }
         },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha512-I0rTWUKSZKxPSIAIaqhSXTM/DiII6wame+rEC3cFA5Lqmr9YmdL7z6Hj9+bdWtTvoY1Su4/OiMLmb37Y7JzvJQ==",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "concat-stream": {
-          "version": "1.4.11",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.11.tgz",
-          "integrity": "sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==",
-          "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~1.1.9",
-            "typedarray": "~0.0.5"
-          }
-        },
-        "pbkdf2": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-          "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
-          "requires": {
-            "create-hash": "^1.1.2",
-            "create-hmac": "^1.1.4",
-            "ripemd160": "^2.0.1",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
-          }
-        },
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
-        "JSONStream": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
-          "integrity": "sha512-l0NN3IcqrZfZBJp7JWDJIHsnPV7yzJWqsYxQzL8Fwdx1BmEMjLuvtYkv+P9pbvpyfP75/f4MeDZhWNU4is32uA==",
+        "is-core-module": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+          "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
           "requires": {
-            "jsonparse": "0.0.5",
-            "through": ">=2.2.7 <3"
+            "has": "^1.0.3"
           }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "json-stable-stringify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+          "integrity": "sha512-nKtD/Qxm7tWdZqJoldEC7fF0S41v0mWbeaXG3637stOWfyGxTgWTYE2wtfKmjzpvxv2MA2xzxsXOIiwUpkX6Qw==",
+          "requires": {
+            "jsonify": "~0.0.0"
+          }
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA=="
+        },
+        "jsonparse": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+          "integrity": "sha512-fw7Q/8gFR8iSekUi9I+HqWIap6mywuoe7hQIg3buTVjuZgALKj4HAmm0X6f+TaL4c9NJbvyFQdaI2ppr5p6dnQ=="
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "labeled-stream-splicer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "integrity": "sha512-3KBjPRnXrYC5h2jEf/d6hO7Lcl+38QzRVTOyHA2sFzZVMYwsUFuejlrOMwAjmz13hVBr9ruDS1RwE4YEz8P58w==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "isarray": "~0.0.1",
+            "stream-splicer": "^1.1.0"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="
+        },
+        "lexical-scope": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+          "integrity": "sha512-ntJ8IcBCuKwudML7vAuT/L0aIMU0+9vO25K4CjLPYgzf1NZ0bAhJJBZrvkO+oUGgKcbdkH8UZdRsaEg+wULLRw==",
+          "requires": {
+            "astw": "^2.0.0"
+          }
+        },
+        "lodash.memoize": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+          "integrity": "sha512-eDn9kqrAmVUC1wmZvlQ6Uhde44n+tXpqPrN8olQJbttgh0oKclk+SF54P47VEGE9CEiMeRwAP8BaM7UHvBkz2A=="
+        },
+        "longest": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg=="
+        },
+        "md5.js": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+          "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "miller-rabin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+          "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+          "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "module-deps": {
           "version": "3.9.1",
@@ -18381,73 +18127,278 @@
             }
           }
         },
-        "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
           "requires": {
-            "readable-stream": ">=1.1.13-1 <1.2.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-              "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-            }
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-          "requires": {
-            "once": "^1.3.0",
             "wrappy": "1"
           }
         },
-        "detective": {
-          "version": "4.7.1",
-          "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-          "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+        "optimist": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
           "requires": {
-            "acorn": "^5.2.1",
-            "defined": "^1.0.0"
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+          "integrity": "sha512-aZicJZccvxWOZ0Bja2eAch2L8RIJWBuRYmM8Gwl/JjNtRltH0Itcz4eH/ESyuIWfse8cc93ZCf0XrzhXK2HEDA=="
+        },
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+        },
+        "parents": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+          "integrity": "sha512-ASkdjFPS2nrxujzSBZGt8ZCKeG0/K2ZZVKveqXt7XGtXfu+ssnk4DQhnK91KRvt83f36LjfxOfwi0cv1+Re0eA==",
+          "requires": {
+            "path-platform": "^0.0.1"
           },
           "dependencies": {
-            "acorn": {
-              "version": "5.7.4",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-              "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
-            },
-            "defined": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-              "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+            "path-platform": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz",
+              "integrity": "sha512-ydK1VKZFYwy0mT2JvimJfxt5z6Z6sjBbLfsFMoJczbwZ/ul0AjgpXLHinUzclf4/XYC8mtsWGuFERZ95Rnm8wA=="
             }
           }
         },
-        "assert": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz",
-          "integrity": "sha512-pSLN/C6u6JFR8L+0TzQ0Elc+VboxUXFtNw11RI1UcTcHEktQqIKIKK5S4nAZX4j8mpTpnCtmqpR+thPfqT11Kg==",
+        "parse-asn1": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+          "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
           "requires": {
-            "util": "0.10.3"
+            "asn1.js": "^5.2.0",
+            "browserify-aes": "^1.0.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "path-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+        },
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "path-platform": {
+          "version": "0.11.15",
+          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+          "integrity": "sha512-Y30dB6rab1A/nfEKsZxmr01nUotHX0c/ZiIAsCTatEe1CmS5Pm5He7fZ195bPT7RdquoaL8lLxFCMQi/bS7IJg=="
+        },
+        "pbkdf2": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+          "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+          "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "process": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz",
+          "integrity": "sha512-g7Lv2/7sZaS5oNElebRqsd40W/k0QCTmq8WeNZ/w3PVTqRsz0giER3sMsFQXobi+/Gmuy/qbnksrh76o21DEDA=="
+        },
+        "public-encrypt": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+          "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+          "requires": {
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.1.2"
           },
           "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
-            },
-            "util": {
-              "version": "0.10.3",
-              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "integrity": "sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==",
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+            }
+          }
+        },
+        "punycode": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz",
+          "integrity": "sha512-h/vscxLPvI2l7k/0dFUKZ5I5TgMCJ/Pl+J6rw77PDuQM6UApf/GaRVkjv/YSm2k+fbp7Yw8dxsoe29DolT7h7w=="
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+          "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA=="
+        },
+        "randombytes": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+          "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+          "requires": {
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "randomfill": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+          "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+          "requires": {
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "readable-wrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
+          "integrity": "sha512-/8n0Mr10S+HGKFygQ42Z40JIXwafPH3A72pwmlNClThgsImV5LJJiCue5Je1asxwY082sYxq/+kTxH6nTn0w3g==",
+          "requires": {
+            "readable-stream": "^1.1.13-1"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+        },
+        "resolve": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz",
+          "integrity": "sha512-zxmAcifDjKxmUbk7chQdKhDSn8ml08g+MYyU37xhEXBp+N81cfbYsm4e0Gn9jtLbAvbR8w8Ox09xqUZtPuCoeA=="
+        },
+        "rfile": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+          "integrity": "sha512-aNeTpY8g6DYmqPvakau22B0SipQTskO8FtYXzn8qg4X4bN9ExIH8VAhq/L9w7N8HvESYeSSwk3e4GmW+rLLAxQ==",
+          "requires": {
+            "callsite": "~1.0.0",
+            "resolve": "~0.3.0"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+              "integrity": "sha512-mxx/I/wLjxtryDBtrrb0ZNzaYERVWaHpJ0W0Arm8N4l8b+jiX/U5yKcsj0zQpF9UuKN1uz80EUTOudON6OPuaQ=="
+            }
+          }
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+          "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "ruglify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+          "integrity": "sha512-XfRj1YJdm/gnZNvmpQ5L+2YGRHglDGMPgJRbitgCxC3GzKVQF/t+ij1aNcNg2AnEXGtLHJDwoSWrAq3TUm0EVg==",
+          "requires": {
+            "rfile": "~1.0",
+            "uglify-js": "~2.2"
+          },
+          "dependencies": {
+            "uglify-js": {
+              "version": "2.2.5",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+              "integrity": "sha512-viLk+/8G0zm2aKt1JJAVcz5J/5ytdiNaIsKgrre3yvSUjwVG6ZUujGH7E2TiPigZUwLYCe7eaIUEP2Zka2VJPA==",
               "requires": {
-                "inherits": "2.0.1"
+                "optimist": "~0.3.5",
+                "source-map": "~0.1.7"
               }
             }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sha.js": {
+          "version": "2.4.11",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "shallow-copy": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+          "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
+        },
+        "shasum": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+          "integrity": "sha512-UTzHm/+AzKfO9RgPgRpDIuMSNie1ubXRaljjlhFMNGYoG7z+rm9AHLPMf70R7887xboDH9Q+5YQbWKObFHEAtw==",
+          "requires": {
+            "json-stable-stringify": "~0.0.0",
+            "sha.js": "~2.4.4"
+          }
+        },
+        "shell-quote": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz",
+          "integrity": "sha512-uEWz7wa9vnCi9w4mvKZMgbHFk3DCKjLQlZcy0tJxUH4NwZjRrPPHXAYIEt2TmJs600Dcgj0Z3fZLZKVPVdGNbQ=="
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "integrity": "sha512-e+V5xc4LlkOiRr64kZTUdb11exsbpSnwb9uwmXaHeDXCpfHg7vaefMJOxi21Pe74ZOqjZ87blBcqqpNAM4Ku0g==",
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "^1.0.27-1"
           }
         },
         "stream-combiner2": {
@@ -18481,22 +18432,17 @@
             }
           }
         },
-        "inline-source-map": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-          "integrity": "sha512-RNlldBXZ7BBcVm3HjXIXiwKxih1lnuKbzeLBRDSB/qaqk8/g4JEZBjxpBQMhqEthQyGv7ycu8r/8PKGgBdIqrA==",
+        "stream-splicer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
+          "integrity": "sha512-nmUMEbdm/sZYqe9dZs7mqJvTYpunsDbIWI5FiBCMc/hMVd6vwzy+ITmo7C3gcLYqrn+uQ1w+EJwooWvJ997JAA==",
           "requires": {
-            "source-map": "~0.3.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-              "integrity": "sha512-jz8leTIGS8+qJywWiO9mKza0hJxexdeIYXhDHw9avTQcXSNAGk3hiiRMpmI2Qf9dOrZDrDpgH9VNefzuacWC9A==",
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
+            "indexof": "0.0.1",
+            "inherits": "^2.0.1",
+            "isarray": "~0.0.1",
+            "readable-stream": "^1.1.13-1",
+            "readable-wrap": "^1.0.0",
+            "through2": "^1.0.0"
           }
         },
         "string_decoder": {
@@ -18504,18 +18450,219 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
         },
-        "right-align": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+        "subarg": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
           "requires": {
-            "align-text": "^0.1.1"
+            "minimist": "^1.1.0"
           }
         },
-        "callsite": {
+        "supports-preserve-symlinks-flag": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-          "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ=="
+          "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+          "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+        },
+        "syntax-error": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+          "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+          "requires": {
+            "acorn-node": "^1.2.0"
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+        },
+        "through2": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "integrity": "sha512-zEbpaeSMHxczpTzO1KkMHjBC1enTA68ojeaZGG4toqdASpb9t4xUZaYFBq2/9OHo5nTGFVSYd4c910OR+6wxbQ==",
+          "requires": {
+            "readable-stream": ">=1.1.13-1 <1.2.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+              "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+            }
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+          "integrity": "sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==",
+          "requires": {
+            "process": "~0.11.0"
+          },
+          "dependencies": {
+            "process": {
+              "version": "0.11.10",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+              "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+            }
+          }
+        },
+        "tty-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+          "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q=="
+        },
+        "umd": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
+          "integrity": "sha512-mEAJeceExHnblcAwN3BQtDPYOrTy4ALeBh6nQ9KW0cUCd0UU714jAfil2jvq09b67IizwJIiTVFOjE+/52Dyvw==",
+          "requires": {
+            "rfile": "~1.0.0",
+            "ruglify": "~1.0.0",
+            "through": "~2.3.4",
+            "uglify-js": "~2.4.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "integrity": "sha512-yfCwDj0vR9RTwt3pEzglgb3ZgmcXHt6DjG3bjJvzPwTL+5zDQ2MhmSzAcTy0GTiQuCiriSWXvWM1/NhKdXuoQA==",
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.24",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+              "integrity": "sha512-tktIjwackfZLd893KGJmXc1hrRHH1vH9Po3xFh1XBjjeGAnN02xJ3SuoA+n1L29/ZaCA18KzCFlckS+vfPugiA==",
+              "requires": {
+                "async": "~0.2.6",
+                "source-map": "0.1.34",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.5.4"
+              }
+            }
+          }
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+              "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+          "requires": {
+            "inherits": "2.0.3"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "integrity": "sha512-NyZNR3WDah+NPkjh/YmhuWSsT4a0mF0BJYgUmvrJ70zxjTXh5Y2Asobxlh0Nfs0PCFB5FVpRJft7NozAWFMwLQ==",
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg=="
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha512-sp/sT9OALMjRW1fKDlPeuSZlDQpkqReA0pyJukniWbTGoEKefHxhGJynE3PNhUMlcM8qWIjPwecwCw4LArS5Eg=="
+        },
+        "yargs": {
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+          "integrity": "sha512-5j382E4xQSs71p/xZQsU1PtRA2HXPAjX0E0DkoGLxwNASMOKX6A9doV1NrZmj85u2Pjquz402qonBzz/yLPbPA==",
+          "requires": {
+            "camelcase": "^1.0.2",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
+            }
+          }
         }
       }
     },
@@ -19947,22 +20094,6 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
         "value-equal": "^1.0.1"
-      }
-    },
-    "hls.js": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.13.2.tgz",
-      "integrity": "sha512-sIg2t4uGpWQLzuK1Iid9614WOKqxj4OYg+EbFbhhTDCsxpENBN+Du3yBFnoi+a83DuOOHdiQd1ydnti9loSGXw==",
-      "requires": {
-        "eventemitter3": "3.1.0",
-        "url-toolkit": "^2.1.6"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
-        }
       }
     },
     "hmac-drbg": {
@@ -27417,7 +27548,7 @@
           "integrity": "sha512-bAGh4e+w5D8dajd6InASVIyCo4pZLJ66oLb80F9OBLO1gKESbZcRCJpTT6uLXX+HAB57zw1WTdwJdAsewuTweg==",
           "requires": {
             "@types/hoist-non-react-statics": "^3.3.0",
-            "@types/react": "18.0.26",
+            "@types/react": "*",
             "hoist-non-react-statics": "^3.3.0",
             "redux": "^4.0.0"
           },
@@ -30517,6 +30648,41 @@
         "stacktrace-gps": "^3.0.4"
       }
     },
+    "start-server-and-test": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.15.4.tgz",
+      "integrity": "sha512-ucQtp5+UCr0m4aHlY+aEV2JSYNTiMZKdSKK/bsIr6AlmwAWDYDnV7uGlWWEtWa7T4XvRI5cPYcPcQgeLqpz+Tg==",
+      "requires": {
+        "arg": "^5.0.2",
+        "bluebird": "3.7.2",
+        "check-more-types": "2.24.0",
+        "debug": "4.3.4",
+        "execa": "5.1.1",
+        "lazy-ass": "1.6.0",
+        "ps-tree": "1.2.0",
+        "wait-on": "7.0.1"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -32918,11 +33084,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
       "integrity": "sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg=="
-    },
-    "url-toolkit": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.3.tgz",
-      "integrity": "sha512-Da75SQoxsZ+2wXS56CZBrj2nukQ4nlGUZUP/dqUBG5E1su5GKThgT94Q00x81eVII7AyS1Pn+CtTTZ4Z0pLUtQ=="
     },
     "use-memo-one": {
       "version": "1.1.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -75,7 +75,7 @@
     "@opentelemetry/semantic-conventions": "1.6.0",
     "@optimizely/optimizely-sdk": "4.9.2",
     "@project-serum/sol-wallet-adapter": "0.2.5",
-    "@react-spring/web": "^9.7.2",
+    "@react-spring/web": "9.7.2",
     "@reduxjs/toolkit": "1.6.1",
     "@sentry/browser": "6.16.1",
     "@sentry/integrations": "6.16.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -75,6 +75,7 @@
     "@opentelemetry/semantic-conventions": "1.6.0",
     "@optimizely/optimizely-sdk": "4.9.2",
     "@project-serum/sol-wallet-adapter": "0.2.5",
+    "@react-spring/web": "^9.7.2",
     "@reduxjs/toolkit": "1.6.1",
     "@sentry/browser": "6.16.1",
     "@sentry/integrations": "6.16.1",

--- a/packages/web/src/components/animated-switch/AnimatedSwitch.tsx
+++ b/packages/web/src/components/animated-switch/AnimatedSwitch.tsx
@@ -9,6 +9,7 @@ import {
 
 import { useInstanceVar } from '@audius/common'
 import { Switch, useHistory } from 'react-router-dom'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useTransition, animated } from 'react-spring'
 
 import { getIsIOS } from 'utils/browser'

--- a/packages/web/src/components/app-redirect-popover/components/AppRedirectPopover.tsx
+++ b/packages/web/src/components/app-redirect-popover/components/AppRedirectPopover.tsx
@@ -2,6 +2,7 @@ import { Fragment, useState, useEffect } from 'react'
 
 import { Button, ButtonType } from '@audius/stems'
 import { matchPath } from 'react-router-dom'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, useTransition } from 'react-spring'
 
 import AppIcon from 'assets/img/appIcon240.png'

--- a/packages/web/src/components/artist-recommendations/ArtistRecommendationsDropdown.tsx
+++ b/packages/web/src/components/artist-recommendations/ArtistRecommendationsDropdown.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import {

--- a/packages/web/src/components/change-password/ConfirmCredentials.tsx
+++ b/packages/web/src/components/change-password/ConfirmCredentials.tsx
@@ -8,6 +8,7 @@ import {
 import { Button, ButtonType, IconArrow } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 
 import Input from 'components/data-entry/Input'

--- a/packages/web/src/components/drawer/Drawer.tsx
+++ b/packages/web/src/components/drawer/Drawer.tsx
@@ -4,6 +4,7 @@ import { useInstanceVar } from '@audius/common'
 import { IconRemove } from '@audius/stems'
 import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated, useTransition } from 'react-spring'
 import { useDrag } from 'react-use-gesture'
 

--- a/packages/web/src/components/lineup/LineupProvider.tsx
+++ b/packages/web/src/components/lineup/LineupProvider.tsx
@@ -15,6 +15,7 @@ import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import InfiniteScroll from 'react-infinite-scroller'
 import { connect } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Transition } from 'react-spring/renderprops'
 import { Dispatch } from 'redux'
 

--- a/packages/web/src/components/nav/desktop/NavAudio.tsx
+++ b/packages/web/src/components/nav/desktop/NavAudio.tsx
@@ -13,6 +13,7 @@ import {
 } from '@audius/common'
 import BN from 'bn.js'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, Transition } from 'react-spring/renderprops'
 
 import { ReactComponent as IconCaretRight } from 'assets/img/iconCaretRight.svg'

--- a/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
+++ b/packages/web/src/components/nav/desktop/NowPlayingArtworkTile.tsx
@@ -9,9 +9,9 @@ import {
   averageColorSelectors
 } from '@audius/common'
 import { IconButton } from '@audius/stems'
+import { animated, useSpring } from '@react-spring/web'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link, useHistory } from 'react-router-dom'
-import { animated, useSpring } from 'react-spring/web'
 
 import { ReactComponent as IconVisualizer } from 'assets/img/iconVisualizer.svg'
 import { Draggable } from 'components/dragndrop'

--- a/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistFolderNavItem.tsx
@@ -16,6 +16,7 @@ import {
 } from '@audius/stems'
 import { ResizeObserver } from '@juggle/resize-observer'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 import useMeasure from 'react-use-measure'
 

--- a/packages/web/src/components/nav/mobile/NavBar.tsx
+++ b/packages/web/src/components/nav/mobile/NavBar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@audius/stems'
 import cn from 'classnames'
 import { History } from 'history'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useTransition, animated } from 'react-spring'
 
 import { ReactComponent as AudiusLogo } from 'assets/img/audiusLogoHorizontal.svg'

--- a/packages/web/src/components/now-playing/NowPlayingDrawer.tsx
+++ b/packages/web/src/components/now-playing/NowPlayingDrawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback } from 'react'
 
 import { useInstanceVar, nowPlayingUIActions } from '@audius/common'
 import { useDispatch } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 import { useDrag } from 'react-use-gesture'
 

--- a/packages/web/src/components/page/Page.js
+++ b/packages/web/src/components/page/Page.js
@@ -3,6 +3,7 @@ import { cloneElement, useRef, useState, useEffect, useCallback } from 'react'
 import cn from 'classnames'
 import PropTypes from 'prop-types'
 import { Helmet } from 'react-helmet'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 import calcScrollbarWidth from 'scrollbar-width'
 

--- a/packages/web/src/components/perspective-card/PerspectiveCard.tsx
+++ b/packages/web/src/components/perspective-card/PerspectiveCard.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 
 import { ReactComponent as IconAudioRewardsPill } from 'assets/img/iconAudioRewardsPill.svg'

--- a/packages/web/src/components/play-bar/desktop/components/PlayingTrackInfo.tsx
+++ b/packages/web/src/components/play-bar/desktop/components/PlayingTrackInfo.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect } from 'react'
 
 import { ID, Color, ProfilePictureSizes, SquareSizes } from '@audius/common'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, useSpring } from 'react-spring'
 
 import { Draggable } from 'components/dragndrop'

--- a/packages/web/src/components/profile-progress/ConnectedProfileCompletionHeroCard.js
+++ b/packages/web/src/components/profile-progress/ConnectedProfileCompletionHeroCard.js
@@ -1,5 +1,6 @@
 import { challengesSelectors, profilePageActions } from '@audius/common'
 import { connect } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 
 import ProfileCompletionHeroCard from 'components/profile-progress/components/ProfileCompletionHeroCard'

--- a/packages/web/src/components/profile-progress/ConnectedProfileCompletionPane.js
+++ b/packages/web/src/components/profile-progress/ConnectedProfileCompletionPane.js
@@ -6,6 +6,7 @@ import {
   challengesSelectors
 } from '@audius/common'
 import { connect, useDispatch } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 
 import ProfileCompletionPanel from 'components/profile-progress/components/ProfileCompletionPanel'

--- a/packages/web/src/components/profile-progress/components/ProfileCompletionHeroCard.js
+++ b/packages/web/src/components/profile-progress/components/ProfileCompletionHeroCard.js
@@ -1,6 +1,7 @@
 import { memo } from 'react'
 
 import PropTypes from 'prop-types'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import SegmentedProgressBar from 'components/segmented-progress-bar/SegmentedProgressBar'

--- a/packages/web/src/components/profile-progress/components/ProfileCompletionPanel.js
+++ b/packages/web/src/components/profile-progress/components/ProfileCompletionPanel.js
@@ -1,6 +1,7 @@
 import { memo } from 'react'
 
 import PropTypes from 'prop-types'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import SegmentedProgressBar from 'components/segmented-progress-bar/SegmentedProgressBar'

--- a/packages/web/src/components/profile-progress/hooks/index.js
+++ b/packages/web/src/components/profile-progress/hooks/index.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 
 import { Name } from '@audius/common'
 import { useDispatch } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useTransition } from 'react-spring'
 
 import { make } from 'common/store/analytics/actions'

--- a/packages/web/src/components/pull-to-refresh/PullToRefresh.tsx
+++ b/packages/web/src/components/pull-to-refresh/PullToRefresh.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, ReactNode, memo } from 'react'
 import { useInstanceVar } from '@audius/common'
 import cn from 'classnames'
 import Lottie, { EventListener } from 'react-lottie'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 
 import iconRefreshPull from 'assets/animations/iconRefreshPull.json'

--- a/packages/web/src/components/pull-to-refresh/hooks.ts
+++ b/packages/web/src/components/pull-to-refresh/hooks.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 
 import { useInstanceVar } from '@audius/common'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { config, useSpring } from 'react-spring'
 
 type UseHasReachedTopPointProps = {

--- a/packages/web/src/components/search/SearchBar.js
+++ b/packages/web/src/components/search/SearchBar.js
@@ -7,6 +7,7 @@ import cn from 'classnames'
 import { isEqual } from 'lodash'
 import PropTypes from 'prop-types'
 import Lottie from 'react-lottie'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Transition } from 'react-spring/renderprops'
 
 import loadingSpinner from 'assets/animations/loadingSpinner.json'

--- a/packages/web/src/components/sign-on/SignOnModal.js
+++ b/packages/web/src/components/sign-on/SignOnModal.js
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 
 import cn from 'classnames'
 import PropTypes from 'prop-types'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useTransition, animated, config } from 'react-spring'
 
 import styles from './SignOnModal.module.css'

--- a/packages/web/src/components/status-message/StatusMessage.js
+++ b/packages/web/src/components/status-message/StatusMessage.js
@@ -1,5 +1,6 @@
 import cn from 'classnames'
 import PropTypes from 'prop-types'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, useTransition } from 'react-spring'
 
 import { ReactComponent as IconArrow } from 'assets/img/iconArrow.svg'

--- a/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
+++ b/packages/web/src/components/tipping/tip-audio/ConfirmSendTip.tsx
@@ -4,6 +4,7 @@ import { tippingSelectors, tippingActions } from '@audius/common'
 import { Button, ButtonType, IconCheck } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Transition, animated } from 'react-spring/renderprops'
 
 import { ReactComponent as IconCaretLeft } from 'assets/img/iconCaretLeft.svg'

--- a/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
+++ b/packages/web/src/components/tipping/tip-audio/TipAudioModal.tsx
@@ -11,6 +11,7 @@ import {
 import { Modal, ModalHeader, ModalTitle } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, Transition } from 'react-spring/renderprops'
 import { usePrevious } from 'react-use'
 

--- a/packages/web/src/components/toast/ToastContext.tsx
+++ b/packages/web/src/components/toast/ToastContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback } from 'react'
 
 import { CommonState, toastActions } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useTransition, animated } from 'react-spring'
 
 import { getSafeArea, SafeAreaDirection } from 'utils/safeArea'

--- a/packages/web/src/components/transition-container/TransitionContainer.tsx
+++ b/packages/web/src/components/transition-container/TransitionContainer.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react'
 
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, Transition } from 'react-spring/renderprops'
 
 type TransitionContainerProps<T> = {

--- a/packages/web/src/components/upload/InvalidFileType.js
+++ b/packages/web/src/components/upload/InvalidFileType.js
@@ -1,5 +1,6 @@
 import cn from 'classnames'
 import PropTypes from 'prop-types'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 
 import styles from './InvalidFileType.module.css'

--- a/packages/web/src/hooks/useCardWeight.ts
+++ b/packages/web/src/hooks/useCardWeight.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, MutableRefObject } from 'react'
 
 import { useInstanceVar } from '@audius/common'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { InterpolationChain, useSpring } from 'react-spring'
 
 type Transform = {

--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -17,6 +17,7 @@ import { useInstanceVar } from '@audius/common'
 import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 import cn from 'classnames'
 import { throttle } from 'lodash'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated, useTransition, useSpring } from 'react-spring'
 import { useDrag } from 'react-use-gesture'
 

--- a/packages/web/src/pages/landing-page/components/ArtistTestimonials.tsx
+++ b/packages/web/src/pages/landing-page/components/ArtistTestimonials.tsx
@@ -1,4 +1,5 @@
 import { Parallax } from 'react-scroll-parallax'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import artist3lau from 'assets/img/publicSite/ImgArtist3LAU.jpg'

--- a/packages/web/src/pages/landing-page/components/CTAListening.tsx
+++ b/packages/web/src/pages/landing-page/components/CTAListening.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import { IconArrow } from '@audius/stems'
 import cn from 'classnames'
 import { Parallax } from 'react-scroll-parallax'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useChain, useTrail, animated } from 'react-spring'
 
 import appImg from 'assets/img/publicSite/AudiusAppAlt@2x.png'

--- a/packages/web/src/pages/landing-page/components/Description.tsx
+++ b/packages/web/src/pages/landing-page/components/Description.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useChain, useSpring, useTrail, animated } from 'react-spring'
 
 import productShot from 'assets/img/publicSite/AudiusWeb@2x.png'

--- a/packages/web/src/pages/landing-page/components/FeaturedContent.tsx
+++ b/packages/web/src/pages/landing-page/components/FeaturedContent.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { UserCollectionMetadata } from '@audius/common'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 import { useAsyncFn } from 'react-use'
 

--- a/packages/web/src/pages/landing-page/components/JoinTheCommunity.tsx
+++ b/packages/web/src/pages/landing-page/components/JoinTheCommunity.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import imgMerch from 'assets/img/publicSite/ImgMerch.jpg'

--- a/packages/web/src/pages/landing-page/components/PlatformFeatures.tsx
+++ b/packages/web/src/pages/landing-page/components/PlatformFeatures.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import crowdImg from 'assets/img/publicSite/ImgCrowd.jpg'

--- a/packages/web/src/pages/landing-page/components/PlatformTagline.tsx
+++ b/packages/web/src/pages/landing-page/components/PlatformTagline.tsx
@@ -1,5 +1,6 @@
 import cn from 'classnames'
 import { Parallax } from 'react-scroll-parallax'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import { ReactComponent as IconQuotePyramid } from 'assets/img/publicSite/quote-pyramid.svg'

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileBio.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileBio.tsx
@@ -11,6 +11,7 @@ import cn from 'classnames'
 import { push as pushRoute } from 'connected-react-router'
 import Linkify from 'linkify-react'
 import { useDispatch } from 'react-redux'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 import useMeasure from 'react-use-measure'
 

--- a/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
+++ b/packages/web/src/pages/profile-page/components/desktop/ProfileLeftNav.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import { ID, Name, accountSelectors } from '@audius/common'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 
 import { useSelector } from 'common/hooks/useSelector'

--- a/packages/web/src/pages/profile-page/components/mobile/GrowingCoverPhoto.tsx
+++ b/packages/web/src/pages/profile-page/components/mobile/GrowingCoverPhoto.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback } from 'react'
 
 import { useInstanceVar } from '@audius/common'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { useSpring, animated } from 'react-spring'
 
 import DynamicImage, {

--- a/packages/web/src/pages/sign-on/components/CompleteProfileWithSocial.tsx
+++ b/packages/web/src/pages/sign-on/components/CompleteProfileWithSocial.tsx
@@ -8,6 +8,7 @@ import {
 } from '@audius/common'
 import { IconImage, IconUser, IconVerified } from '@audius/stems'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Transition } from 'react-spring/renderprops'
 
 import { InstagramAuthButton } from 'components/instagram-auth/InstagramAuthButton'

--- a/packages/web/src/pages/sign-on/components/ProfileForm.tsx
+++ b/packages/web/src/pages/sign-on/components/ProfileForm.tsx
@@ -8,6 +8,7 @@ import {
 } from '@audius/common'
 import { Button, ButtonType, IconArrow } from '@audius/stems'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 import TwitterLogin from 'react-twitter-auth'
 

--- a/packages/web/src/pages/sign-on/components/desktop/EmailPage.tsx
+++ b/packages/web/src/pages/sign-on/components/desktop/EmailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { Button, ButtonSize, ButtonType, IconArrow } from '@audius/stems'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 
 import audiusLogoColored from 'assets/img/audiusLogoColored.png'

--- a/packages/web/src/pages/sign-on/components/desktop/SignInPage.tsx
+++ b/packages/web/src/pages/sign-on/components/desktop/SignInPage.tsx
@@ -9,6 +9,7 @@ import {
 import { useInstanceVar } from '@audius/common'
 import { Button, ButtonType, IconArrow } from '@audius/stems'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 
 import audiusLogoColored from 'assets/img/audiusLogoColored.png'

--- a/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
@@ -13,6 +13,7 @@ import {
 import cn from 'classnames'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Transition } from 'react-spring/renderprops'
 
 import imageSignUp1 from 'assets/img/2-DJ-4-3.jpg'

--- a/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
@@ -11,6 +11,7 @@ import {
   TikTokProfile
 } from '@audius/common'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 import { Transition } from 'react-spring/renderprops'
 

--- a/packages/web/src/pages/sign-on/components/mobile/InitialPage.tsx
+++ b/packages/web/src/pages/sign-on/components/mobile/InitialPage.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Button, ButtonType, IconArrow } from '@audius/stems'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 
 import djBackgroundImage from 'assets/img/2-DJ-4-3.jpg'

--- a/packages/web/src/pages/sign-on/components/mobile/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on/components/mobile/SignOnPage.tsx
@@ -9,6 +9,7 @@ import {
   TikTokProfile
 } from '@audius/common'
 import cn from 'classnames'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
 import { Transition } from 'react-spring/renderprops'
 

--- a/packages/web/src/pages/sign-on/components/mobile/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on/components/mobile/SignOnPage.tsx
@@ -11,6 +11,7 @@ import {
 import cn from 'classnames'
 // eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { animated } from 'react-spring'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Transition } from 'react-spring/renderprops'
 
 import { Pages, FollowArtistsCategory } from 'common/store/pages/signon/types'

--- a/packages/web/src/pages/upload-page/UploadPage.js
+++ b/packages/web/src/pages/upload-page/UploadPage.js
@@ -11,6 +11,7 @@ import {
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
+// eslint-disable-next-line no-restricted-imports -- TODO: migrate to @react-spring/web
 import { Spring } from 'react-spring/renderprops'
 
 import { make } from 'common/store/analytics/actions'


### PR DESCRIPTION
### Description

- Adds @react-spring/web (v9 of react-spring), as a step towards migrating off react-spring (v8)
- Implements change on one component: NowPlayingArtworkTile
- Adds eslint-rule to ensure no new components are implemented with v8
- Adds eslint-ignores to all current instances of v8, with comment to migrate