### PR TITLE
[C-2493] separate state for suggested follows vs related artists

### DIFF
--- a/packages/common/src/store/ui/related-artists/sagas.ts
+++ b/packages/common/src/store/ui/related-artists/sagas.ts
@@ -32,10 +32,13 @@ export function* fetchRelatedArtists(action: PayloadAction<{ artistId: ID }>) {
     )
 
     let showingTopArtists = false
-    let filteredArtists = relatedArtists
-      .filter((user) => !user.does_current_user_follow && !user.is_deactivated)
+    const filteredArtists = relatedArtists.filter(
+      (user) => !user.is_deactivated
+    )
+    let suggestedFollows = relatedArtists
+      .filter((user) => !user.does_current_user_follow)
       .slice(0, 5)
-    if (filteredArtists.length === 0) {
+    if (suggestedFollows.length === 0) {
       const showTopArtistRecommendationsPercent =
         remoteConfigInstance.getRemoteVar(
           DoubleKeys.SHOW_ARTIST_RECOMMENDATIONS_FALLBACK_PERCENT
@@ -43,16 +46,18 @@ export function* fetchRelatedArtists(action: PayloadAction<{ artistId: ID }>) {
       const showTopArtists = Math.random() < showTopArtistRecommendationsPercent
 
       if (showTopArtists) {
-        filteredArtists = yield fetchTopArtists()
+        suggestedFollows = yield fetchTopArtists()
         showingTopArtists = true
       }
     }
-    if (filteredArtists.length > 0) {
+    if (filteredArtists.length > 0 || suggestedFollows.length > 0) {
       const relatedArtistIds = yield* cacheUsers(filteredArtists)
+      const suggestedFollowIds = yield* cacheUsers(suggestedFollows)
       yield* put(
         relatedArtistsActions.fetchRelatedArtistsSucceeded({
           artistId,
           relatedArtistIds,
+          suggestedFollowIds,
           isTopArtistsRecommendation: showingTopArtists
         })
       )

--- a/packages/common/src/store/ui/related-artists/sagas.ts
+++ b/packages/common/src/store/ui/related-artists/sagas.ts
@@ -46,7 +46,7 @@ export function* fetchRelatedArtists(action: PayloadAction<{ artistId: ID }>) {
       const showTopArtists = Math.random() < showTopArtistRecommendationsPercent
 
       if (showTopArtists) {
-        suggestedFollows = yield fetchTopArtists()
+        suggestedFollows = yield* call(fetchTopArtists)
         showingTopArtists = true
       }
     }

--- a/packages/common/src/store/ui/related-artists/selectors.ts
+++ b/packages/common/src/store/ui/related-artists/selectors.ts
@@ -19,6 +19,10 @@ const selectRelatedArtistIds = (state: CommonState, props: { id: ID }) => {
   return selectRelatedArtistsById(state, props.id)?.relatedArtistIds
 }
 
+const selectSuggestedFollowsIds = (state: CommonState, props: { id: ID }) => {
+  return selectRelatedArtistsById(state, props.id)?.suggestedFollowIds
+}
+
 export const selectRelatedArtists = (state: CommonState, props: { id: ID }) => {
   return selectRelatedArtistsById(state, props.id)
 }
@@ -27,6 +31,17 @@ const emptyRelatedArtists: User[] = []
 
 export const selectRelatedArtistsUsers = createDeepEqualSelector(
   [selectRelatedArtistIds, getUsers],
+  (relatedArtistIds, users) => {
+    if (!relatedArtistIds) return emptyRelatedArtists
+    const relatedArtistsPopulated = relatedArtistIds
+      .map((id) => users[id])
+      .filter(removeNullable)
+    return relatedArtistsPopulated
+  }
+)
+
+export const selectSuggestedFollowsUsers = createDeepEqualSelector(
+  [selectSuggestedFollowsIds, getUsers],
   (relatedArtistIds, users) => {
     if (!relatedArtistIds) return emptyRelatedArtists
     const relatedArtistsPopulated = relatedArtistIds

--- a/packages/common/src/store/ui/related-artists/slice.ts
+++ b/packages/common/src/store/ui/related-artists/slice.ts
@@ -21,6 +21,7 @@ const relatedArtistsSlice = createSlice({
       relatedArtistsAdapater.addOne(state, {
         artistId,
         relatedArtistIds: [],
+        suggestedFollowIds: [],
         isTopArtistsRecommendation: false,
         status: Status.LOADING
       })

--- a/packages/common/src/store/ui/related-artists/types.ts
+++ b/packages/common/src/store/ui/related-artists/types.ts
@@ -5,6 +5,7 @@ import { ID, Status } from 'models'
 export type RelatedArtists = {
   artistId: ID
   relatedArtistIds: ID[]
+  suggestedFollowIds: ID[]
   isTopArtistsRecommendation: boolean
   status: Status
 }

--- a/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
+++ b/packages/mobile/src/screens/profile-screen/ArtistRecommendations/ArtistRecommendations.tsx
@@ -24,7 +24,7 @@ import { EventNames } from 'app/types/analytics'
 import { useSelectProfile } from '../selectors'
 
 import { ArtistLink } from './ArtistLink'
-const { selectRelatedArtistsUsers } = relatedArtistsUISelectors
+const { selectSuggestedFollowsUsers } = relatedArtistsUISelectors
 const { fetchRelatedArtists } = relatedArtistsUIActions
 const { followUser, unfollowUser } = usersSocialActions
 
@@ -101,7 +101,7 @@ export const ArtistRecommendations = (props: ArtistRecommendationsProps) => {
   })
 
   const suggestedArtists = useSelector((state) =>
-    selectRelatedArtistsUsers(state, { id: user_id })
+    selectSuggestedFollowsUsers(state, { id: user_id })
   )
 
   const isFollowingAllArtists = suggestedArtists.every(

--- a/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
+++ b/packages/web/src/components/artist-recommendations/ArtistRecommendations.tsx
@@ -35,7 +35,7 @@ import { useIsMobile } from 'utils/clientUtil'
 import { profilePage } from 'utils/route'
 
 import styles from './ArtistRecommendations.module.css'
-const { selectRelatedArtistsUsers } = relatedArtistsUISelectors
+const { selectSuggestedFollowsUsers } = relatedArtistsUISelectors
 const { fetchRelatedArtists } = relatedArtistsUIActions
 
 export type ArtistRecommendationsProps = {
@@ -147,7 +147,7 @@ export const ArtistRecommendations = forwardRef(
     }, [dispatch, artistId])
 
     const suggestedArtists = useSelector<CommonState, User[]>((state) =>
-      selectRelatedArtistsUsers(state, { id: artistId })
+      selectSuggestedFollowsUsers(state, { id: artistId })
     )
 
     // Follow/Unfollow listeners

--- a/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
+++ b/packages/web/src/pages/profile-page/ProfilePageProvider.tsx
@@ -62,7 +62,7 @@ const { setFollowers } = followersUserListActions
 const { setFollowing } = followingUserListActions
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { open } = mobileOverflowMenuUIActions
-const { selectRelatedArtistsUsers } = relatedArtistsUISelectors
+const { selectSuggestedFollowsUsers } = relatedArtistsUISelectors
 
 const {
   makeGetProfile,
@@ -976,7 +976,7 @@ function makeMapStateToProps() {
       playing: getPlaying(state),
       buffering: getBuffering(state),
       pathname: getLocationPathname(state),
-      relatedArtists: selectRelatedArtistsUsers(state, {
+      relatedArtists: selectSuggestedFollowsUsers(state, {
         id: getProfileUserId(state, handleLower) ?? 0
       }),
       permissionsMap: getPermissionsMap(state),


### PR DESCRIPTION
### Description

Artists you already follow were being filtered out from the related artists preview. This stores a separate state for each type so when suggestedFollows falls back to showing topArtists instead of related artists, we will still show the related artists.