### PR TITLE
Fix signout test

### DIFF
--- a/packages/common/src/store/lineup/selectors.ts
+++ b/packages/common/src/store/lineup/selectors.ts
@@ -1,5 +1,6 @@
-import { Kind } from 'models'
 import { createSelector } from 'reselect'
+
+import { Kind } from 'models'
 import { getTracksByUid } from 'store/cache/tracks/selectors'
 import { getUsers } from 'store/cache/users/selectors'
 import { Nullable, removeNullable } from 'utils/typeUtils'

--- a/packages/common/src/store/lineup/selectors.ts
+++ b/packages/common/src/store/lineup/selectors.ts
@@ -1,9 +1,8 @@
-import { createSelector } from 'reselect'
-
 import { Kind } from 'models'
+import { createSelector } from 'reselect'
 import { getTracksByUid } from 'store/cache/tracks/selectors'
 import { getUsers } from 'store/cache/users/selectors'
-import { removeNullable } from 'utils/typeUtils'
+import { Nullable, removeNullable } from 'utils/typeUtils'
 
 import { LineupState } from '../../models/Lineup'
 
@@ -20,10 +19,10 @@ export const getLineupHasTracks = <T, State>(
 }
 
 export const getLineupEntries = <T, State>(
-  selector: LineupSelector<T, State>,
+  selector: (state: State) => Nullable<LineupState<T>>,
   state: State
 ) => {
-  return selector(state).entries
+  return selector(state)?.entries
 }
 
 export const makeGetTableMetadatas = <T, State>(

--- a/packages/web/src/components/play-bar/desktop/PlayBar.js
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.js
@@ -510,10 +510,8 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state) => {
     const premiumTrackSignatureMap = getPremiumTrackSignatureMap(state)
-    const lineupEntries = getLineupEntries(
-      getLineupSelectorForRoute(state),
-      state
-    )
+    const lineupEntries =
+      getLineupEntries(getLineupSelectorForRoute(state), state) ?? []
 
     // The lineup has accessible tracks when there is at least one track
     // the user has access to i.e. a non-gated track or an unlocked gated track.


### PR DESCRIPTION
### Description

The selector passed to `getLineupEntries` potentially returns null but this wasn't caught because `PlayBar.js` is not typescript. https://github.com/AudiusProject/audius-client/pull/3227

This was breaking the signout test when navigating to the settings page

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

