### PR TITLE
[C-2501] Use proxy-wormhole libs

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -33,9 +33,9 @@
       }
     },
     "@audius/sdk": {
-      "version": "2.0.3-beta.6",
-      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-2.0.3-beta.6.tgz",
-      "integrity": "sha512-JKggAaH89o/liAbpJDGnWkM3isbrO9dXrPli7LQxXuDP3KYF1wkoElKh8d9FSFBwLU3whQ7bqouk6Eoi5da3KA==",
+      "version": "2.0.3-beta.8",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-2.0.3-beta.8.tgz",
+      "integrity": "sha512-eM1x5MG+ZxwwVLgpfYlcU6/deCezIWZ3EFYQ96lADUW6Bt3mxjtKav4PyyqUAtlg7QEjdfhpy8kZ8wFa77pjlQ==",
       "requires": {
         "@audius/hedgehog": "2.1.0",
         "@babel/runtime": "7.18.3",
@@ -55,6 +55,7 @@
         "borsh": "0.4.0",
         "bs58": "4.0.1",
         "cipher-base": "1.0.4",
+        "crc-32": "1.2.2",
         "cross-fetch": "3.1.5",
         "elliptic": "6.5.4",
         "esm": "3.2.25",
@@ -73,6 +74,7 @@
         "keccak256": "1.0.2",
         "lodash": "4.17.21",
         "micro-aes-gcm": "0.3.3",
+        "multiformats": "9.9.0",
         "node-abort-controller": "3.1.1",
         "node-localstorage": "1.3.1",
         "proper-url-join": "1.2.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/AudiusProject/audius-client/issues"
   },
   "dependencies": {
-    "@audius/sdk": "2.0.3-beta.6",
+    "@audius/sdk": "2.0.3-beta.8",
     "@fingerprintjs/fingerprintjs-pro": "3.5.6",
     "@metaplex-foundation/mpl-token-metadata": "2.5.2",
     "@optimizely/optimizely-sdk": "4.0.0",

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -44,7 +44,8 @@ export enum FeatureFlags {
   STORAGE_V2 = 'storage_v2',
   SDK_V2 = 'sdk_v2',
   GET_METADATA_FROM_DISCOVERY_ENABLED = 'get_metadata_from_discovery_enabled',
-  RELATED_ARTISTS_ON_PROFILE_ENABLED = 'related_artists_on_profile_enabled'
+  RELATED_ARTISTS_ON_PROFILE_ENABLED = 'related_artists_on_profile_enabled',
+  PROXY_WORMHOLE = 'proxy_wormhole'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -104,5 +105,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.STORAGE_V2]: false,
   [FeatureFlags.SDK_V2]: false,
   [FeatureFlags.GET_METADATA_FROM_DISCOVERY_ENABLED]: false,
-  [FeatureFlags.RELATED_ARTISTS_ON_PROFILE_ENABLED]: false
+  [FeatureFlags.RELATED_ARTISTS_ON_PROFILE_ENABLED]: false,
+  [FeatureFlags.PROXY_WORMHOLE]: false
 }

--- a/packages/mobile/package-lock.json
+++ b/packages/mobile/package-lock.json
@@ -73,9 +73,9 @@
       }
     },
     "@audius/sdk": {
-      "version": "2.0.3-beta.6",
-      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-2.0.3-beta.6.tgz",
-      "integrity": "sha512-JKggAaH89o/liAbpJDGnWkM3isbrO9dXrPli7LQxXuDP3KYF1wkoElKh8d9FSFBwLU3whQ7bqouk6Eoi5da3KA==",
+      "version": "2.0.3-beta.8",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-2.0.3-beta.8.tgz",
+      "integrity": "sha512-eM1x5MG+ZxwwVLgpfYlcU6/deCezIWZ3EFYQ96lADUW6Bt3mxjtKav4PyyqUAtlg7QEjdfhpy8kZ8wFa77pjlQ==",
       "requires": {
         "@audius/hedgehog": "2.1.0",
         "@babel/runtime": "7.18.3",
@@ -95,6 +95,7 @@
         "borsh": "0.4.0",
         "bs58": "4.0.1",
         "cipher-base": "1.0.4",
+        "crc-32": "1.2.2",
         "cross-fetch": "3.1.5",
         "elliptic": "6.5.4",
         "esm": "3.2.25",
@@ -113,6 +114,7 @@
         "keccak256": "1.0.2",
         "lodash": "4.17.21",
         "micro-aes-gcm": "0.3.3",
+        "multiformats": "9.9.0",
         "node-abort-controller": "3.1.1",
         "node-localstorage": "1.3.1",
         "proper-url-join": "1.2.0",
@@ -9788,12 +9790,6 @@
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.40.tgz",
       "integrity": "sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA=="
     },
-    "@types/hls.js": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@types/hls.js/-/hls.js-0.13.0.tgz",
-      "integrity": "sha512-zeW+kWWUvMF7x8/M1kLRCX6C41UcKyDZC/Xy6biGqLhd+rkpv2juVO+tCwPSQPQuqL1VtseoQYdONCOxUZ38Sw==",
-      "dev": true
-    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -10282,7 +10278,7 @@
         "@walletconnect/utils": "^1.8.0",
         "keyvaluestorage": "0.7.1",
         "react-native-qrcode-svg": "6.0.6",
-        "react-native-svg": "12.3.0",
+        "react-native-svg": "9.6.4",
         "use-deep-compare-effect": "1.6.1"
       },
       "dependencies": {
@@ -27058,36 +27054,6 @@
         "css-tree": "^1.0.0-alpha.39"
       },
       "dependencies": {
-        "dom-serializer": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-          "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^4.2.0",
-            "entities": "^2.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "domutils": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-          "requires": {
-            "dom-serializer": "^1.0.1",
-            "domelementtype": "^2.2.0",
-            "domhandler": "^4.2.0"
-          }
-        },
-        "domelementtype": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-          "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-        },
         "css-select": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -27100,11 +27066,6 @@
             "nth-check": "^2.0.1"
           }
         },
-        "css-what": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-          "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
-        },
         "css-tree": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
@@ -27114,6 +27075,41 @@
             "source-map": "^0.6.1"
           }
         },
+        "css-what": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+          "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+        },
+        "dom-serializer": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+          "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+          "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+        },
         "nth-check": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -27122,10 +27118,10 @@
             "boolbase": "^1.0.0"
           }
         },
-        "mdn-data": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@amplitude/react-native": "2.6.0",
     "@audius/common": "1.5.20",
-    "@audius/sdk": "2.0.3-beta.6",
+    "@audius/sdk": "2.0.3-beta.8",
     "@fingerprintjs/fingerprintjs-pro-react-native": "2.0.0-test.2",
     "@gorhom/portal": "1.0.9",
     "@hcaptcha/react-native-hcaptcha": "1.3.4",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -121,9 +121,9 @@
       }
     },
     "@audius/sdk": {
-      "version": "2.0.3-beta.6",
-      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-2.0.3-beta.6.tgz",
-      "integrity": "sha512-JKggAaH89o/liAbpJDGnWkM3isbrO9dXrPli7LQxXuDP3KYF1wkoElKh8d9FSFBwLU3whQ7bqouk6Eoi5da3KA==",
+      "version": "2.0.3-beta.8",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-2.0.3-beta.8.tgz",
+      "integrity": "sha512-eM1x5MG+ZxwwVLgpfYlcU6/deCezIWZ3EFYQ96lADUW6Bt3mxjtKav4PyyqUAtlg7QEjdfhpy8kZ8wFa77pjlQ==",
       "requires": {
         "@audius/hedgehog": "2.1.0",
         "@babel/runtime": "7.18.3",
@@ -143,6 +143,7 @@
         "borsh": "0.4.0",
         "bs58": "4.0.1",
         "cipher-base": "1.0.4",
+        "crc-32": "1.2.2",
         "cross-fetch": "3.1.5",
         "elliptic": "6.5.4",
         "esm": "3.2.25",
@@ -161,6 +162,7 @@
         "keccak256": "1.0.2",
         "lodash": "4.17.21",
         "micro-aes-gcm": "0.3.3",
+        "multiformats": "9.9.0",
         "node-abort-controller": "3.1.1",
         "node-localstorage": "1.3.1",
         "proper-url-join": "1.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@audius/common": "1.5.20",
-    "@audius/sdk": "2.0.3-beta.6",
+    "@audius/sdk": "2.0.3-beta.8",
     "@audius/stems": "1.5.19",
     "@coinbase/cbpay-js": "1.2.0",
     "@craco/craco": "7.0.0-alpha.3",

--- a/packages/web/src/services/audius-backend/audius-backend-instance.ts
+++ b/packages/web/src/services/audius-backend/audius-backend-instance.ts
@@ -16,6 +16,8 @@ import { isElectron, isMobile } from 'utils/clientUtil'
 
 import { env } from '../env'
 
+import { getLibs } from './getLibs'
+
 declare global {
   interface Window {
     audiusLibs: any
@@ -35,7 +37,7 @@ export const audiusBackendInstance = audiusBackend({
   ethTokenAddress: process.env.REACT_APP_ETH_TOKEN_ADDRESS,
   getFeatureEnabled,
   getHostUrl: () => window.location.origin,
-  getLibs: () => import('@audius/sdk/dist/legacy'),
+  getLibs: () => getLibs(remoteConfigInstance),
   discoveryNodeSelectorInstance,
   getWeb3Config: async (
     libs,

--- a/packages/web/src/services/audius-backend/getLibs.ts
+++ b/packages/web/src/services/audius-backend/getLibs.ts
@@ -1,0 +1,11 @@
+import { FeatureFlags, RemoteConfigInstance } from '@audius/common'
+
+export const getLibs = async (remoteConfig: RemoteConfigInstance) => {
+  await remoteConfig.waitForRemoteConfig()
+  const isProxyWormholeEnabled = remoteConfig.getFeatureEnabled(
+    FeatureFlags.PROXY_WORMHOLE
+  )
+  return isProxyWormholeEnabled
+    ? import('@audius/sdk/dist/web-libs')
+    : import('@audius/sdk/dist/legacy')
+}


### PR DESCRIPTION
### Description

Updates web client to use proxy-wormhole libs, shoutout @nicoback for enabling this. This results in 30% smaller overall bundle, and a 20% higher (49 to 60) lighthouse score on trending!

- Re-enables our analyzeBundle command
- Adds "proxy-wormhole" feature flag that allows us to switch back between performant an non-performant libs depending on any errors we figure out
- Also merges tons of duplicate libraries, moment, lodash, @solana/web3.js, and bn.js, resulting in many more savings across the board.