### PR TITLE
[C-2484] Fix edit playlist actions

### DIFF
--- a/packages/common/src/store/cache/collections/actions.ts
+++ b/packages/common/src/store/cache/collections/actions.ts
@@ -1,5 +1,3 @@
-import { Collection } from '@metaplex-foundation/mpl-token-metadata'
-
 import { ID, UID, SquareSizes } from '../../../models'
 
 import { EditPlaylistValues } from './types'

--- a/packages/common/src/store/cache/collections/actions.ts
+++ b/packages/common/src/store/cache/collections/actions.ts
@@ -1,4 +1,8 @@
-import { ID, UID, Collection, SquareSizes } from '../../../models'
+import { Collection } from '@metaplex-foundation/mpl-token-metadata'
+
+import { ID, UID, SquareSizes } from '../../../models'
+
+import { EditPlaylistValues } from './types'
 
 export const CREATE_PLAYLIST = 'CREATE_PLAYLIST'
 export const CREATE_PLAYLIST_REQUESTED = 'CREATE_PLAYLIST_REQUESTED'
@@ -58,7 +62,10 @@ export function createPlaylistFailed(
   return { type: CREATE_PLAYLIST_FAILED, error, params, metadata }
 }
 
-export function editPlaylist(playlistId: number, formFields: Collection) {
+export function editPlaylist(
+  playlistId: number,
+  formFields: EditPlaylistValues
+) {
   return { type: EDIT_PLAYLIST, playlistId, formFields }
 }
 

--- a/packages/common/src/store/cache/collections/types.ts
+++ b/packages/common/src/store/cache/collections/types.ts
@@ -1,3 +1,6 @@
+import { createPlaylistModalUISelectors } from 'store/ui'
+import { Nullable } from 'utils/typeUtils'
+
 import { Track, UID, User, ID, Cache, Collection } from '../../../models'
 
 export enum PlaylistOperations {
@@ -10,4 +13,25 @@ export type EnhancedCollectionTrack = Track & { user: User; uid: UID }
 
 export interface CollectionsCacheState extends Cache<Collection> {
   permalinks: { [permalink: string]: ID }
+}
+
+export type Image = {
+  height?: number
+  width?: number
+  name?: string
+  size?: number
+  fileType?: string
+  url: string
+  file?: string
+}
+
+type PlaylistTrack = { time: number; metadata_time?: number; track: number }
+
+export type EditPlaylistValues = {
+  playlist_name: string
+  description: Nullable<string>
+  artwork: Image
+  tracks: ReturnType<typeof createPlaylistModalUISelectors.getTracks>
+  track_ids: PlaylistTrack[]
+  removedTracks: { trackId: ID; timestamp: number }[]
 }

--- a/packages/mobile/src/screens/edit-playlist-screen/CreatePlaylistScreen.tsx
+++ b/packages/mobile/src/screens/edit-playlist-screen/CreatePlaylistScreen.tsx
@@ -21,7 +21,7 @@ const messages = {
   playlistCreatedToast: 'Playlist Created!'
 }
 
-type PlaylistValues = {
+type CreatePlaylistValues = {
   playlist_name: string
   description: string
   artwork: {
@@ -35,7 +35,7 @@ type PlaylistValues = {
   }
 }
 
-const CreatePlaylistForm = (props: FormikProps<PlaylistValues>) => {
+const CreatePlaylistForm = (props: FormikProps<CreatePlaylistValues>) => {
   const { handleSubmit, handleReset, errors } = props
 
   return (
@@ -57,7 +57,7 @@ const CreatePlaylistForm = (props: FormikProps<PlaylistValues>) => {
   )
 }
 
-const initialValues: PlaylistValues = {
+const initialValues: CreatePlaylistValues = {
   playlist_name: '',
   description: '',
   artwork: { url: '' }
@@ -73,7 +73,7 @@ export const CreatePlaylistScreen = () => {
   const dispatch = useDispatch()
   const navigation = useNavigation()
   const handleSubmit = useCallback(
-    (values: PlaylistValues) => {
+    (values: CreatePlaylistValues) => {
       const tempId = getTempPlaylistId()
       dispatch(
         createPlaylist(tempId, values, CreatePlaylistSource.FAVORITES_PAGE)

--- a/packages/mobile/src/screens/edit-playlist-screen/types.ts
+++ b/packages/mobile/src/screens/edit-playlist-screen/types.ts
@@ -1,31 +1,5 @@
-import type {
-  ID,
-  Nullable,
-  createPlaylistModalUISelectors
-} from '@audius/common'
+import type { Image, EditPlaylistValues } from '@audius/common'
 
-export type Image = {
-  height?: number
-  width?: number
-  name?: string
-  size?: number
-  fileType?: string
-  url: string
-  file?: string
-}
-
-export type PlaylistValues = {
-  playlist_name: string
-  description: Nullable<string>
-  artwork: Image
-  tracks: ReturnType<typeof createPlaylistModalUISelectors.getTracks>
-  track_ids: {
-    time: number
-    track: ID
-  }[]
-  removedTracks: { trackId: ID; timestamp: number }[]
-}
-
-export type UpdatedPlaylist = Omit<PlaylistValues, 'cover_art'> & {
+export type UpdatedPlaylist = Omit<EditPlaylistValues, 'cover_art'> & {
   updatedCoverArt?: Image
 }

--- a/packages/web/src/common/store/cache/collections/sagas.js
+++ b/packages/web/src/common/store/cache/collections/sagas.js
@@ -560,24 +560,9 @@ function* removeTrackFromPlaylistAsync(action) {
 
   // Find the index of the track based on the track's id and timestamp
   const index = playlist.playlist_contents.track_ids.findIndex((t) => {
-    if (t.track !== action.trackId) {
-      return false
-    }
+    if (t.track !== action.trackId) return false
 
-    if (t.metadata_time) {
-      if (t.metadata_time === action.timestamp) {
-        // entity manager is enabled
-        return true
-      } else {
-        return false
-      }
-    }
-
-    if (t.time !== action.timestamp) {
-      return false
-    }
-
-    return true
+    return t.metadata_time === action.timestamp || t.time === action.timestamp
   })
   if (index === -1) {
     console.error('Could not find the index of to-be-deleted track')

--- a/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
+++ b/packages/web/src/components/edit-playlist/mobile/EditPlaylistPage.tsx
@@ -14,7 +14,8 @@ import {
   createPlaylistModalUIActions as createPlaylistActions,
   imageBlank as placeholderCoverArt,
   newCollectionMetadata,
-  usePremiumContentAccessMap
+  usePremiumContentAccessMap,
+  EditPlaylistValues
 } from '@audius/common'
 import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
@@ -232,7 +233,17 @@ const EditPlaylistPage = g(
           )
         }
         refreshLineup()
-        editPlaylist(metadata.playlist_id, formFields)
+
+        const editPlaylistData: EditPlaylistValues = {
+          playlist_name: formFields.playlist_name,
+          description: formFields.description,
+          artwork: formFields.artwork,
+          tracks: formFields.tracks as any,
+          track_ids: formFields.playlist_contents.track_ids,
+          removedTracks: []
+        }
+
+        editPlaylist(metadata.playlist_id, editPlaylistData)
 
         close()
       } else {
@@ -458,7 +469,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(
         createPlaylist(tempId, metadata, CreatePlaylistSource.CREATE_PAGE)
       ),
-    editPlaylist: (id: ID, metadata: Collection) =>
+    editPlaylist: (id: ID, metadata: EditPlaylistValues) =>
       dispatch(editPlaylist(id, metadata)),
     orderPlaylist: (playlistId: ID, idsAndTimes: any) =>
       dispatch(orderPlaylist(playlistId, idsAndTimes)),


### PR DESCRIPTION
### Description
Update data being passed by the formik edit playlist screen and update the actions and sagas to handle the data properly to handle the edit, reorder, and remove actions

### Dragons

Lots of updates to playlist updating actions so there is a change that a different flow is affected by this

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

