### PR TITLE
[C-2516] Always filter followed users from suggested

### DIFF
--- a/packages/common/src/store/ui/related-artists/selectors.ts
+++ b/packages/common/src/store/ui/related-artists/selectors.ts
@@ -47,6 +47,7 @@ export const selectSuggestedFollowsUsers = createDeepEqualSelector(
     const relatedArtistsPopulated = relatedArtistIds
       .map((id) => users[id])
       .filter(removeNullable)
+      .filter((user) => !user?.does_current_user_follow)
     return relatedArtistsPopulated
   }
 )


### PR DESCRIPTION
### Description

Recently followed users were still showing up in suggested follows. This ensures they won't make it to the suggestion box.

