### PR TITLE
[C-2511] Don't delay mutuals fetch

### DIFF
--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -353,9 +353,6 @@ function* fetchProfileAsync(action) {
     }
 
     if (!isNativeMobile) {
-      // Delay so the page can load before we fetch mutual followers
-      yield delay(2000)
-
       yield put(
         profileActions.fetchFollowUsers(
           FollowType.FOLLOWEE_FOLLOWS,

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -26,7 +26,6 @@ import { merge } from 'lodash'
 import {
   all,
   call,
-  delay,
   fork,
   getContext,
   put,


### PR DESCRIPTION
### Description

- mutuals were loading in well after top supporters and related artists, pushing the others down the page
- fix removes the delay loading mutual follows

### Dragons

There must have been a reason we did it this way in the past.
Maybe perf concerns with this happening during initial loading.

We could defer all of the fetches if that's more correct.