### PR TITLE
SDK respects DN override using initialSelectedNode

### DIFF
--- a/packages/common/src/services/discovery-node-selector/DiscoveryNodeSelectorInstance.ts
+++ b/packages/common/src/services/discovery-node-selector/DiscoveryNodeSelectorInstance.ts
@@ -17,21 +17,21 @@ import {
 type DiscoveryNodeSelectorConfig = {
   env: Env
   remoteConfigInstance: RemoteConfigInstance
-  discoveryNodeOverrideEndpoint: Promise<CachedDiscoveryProviderType | null>
+  initialSelectedNode: Promise<CachedDiscoveryProviderType | null>
 }
 
 export class DiscoveryNodeSelectorInstance {
   private env: Env
   private remoteConfigInstance: RemoteConfigInstance
   private discoveryNodeSelectorPromise: Promise<DiscoveryNodeSelector> | null
-  private discoveryNodeOverride: Promise<CachedDiscoveryProviderType | null>
+  private initialSelectedNode: Promise<CachedDiscoveryProviderType | null>
 
   constructor(config: DiscoveryNodeSelectorConfig) {
-    const { env, remoteConfigInstance, discoveryNodeOverrideEndpoint } = config
+    const { env, remoteConfigInstance, initialSelectedNode } = config
     this.env = env
     this.remoteConfigInstance = remoteConfigInstance
     this.discoveryNodeSelectorPromise = null
-    this.discoveryNodeOverride = discoveryNodeOverrideEndpoint
+    this.initialSelectedNode = initialSelectedNode
   }
 
   private async makeDiscoveryNodeSelector() {
@@ -63,14 +63,14 @@ export class DiscoveryNodeSelectorInstance {
     const requestTimeout =
       getRemoteVar(IntKeys.DISCOVERY_PROVIDER_SELECTION_TIMEOUT_MS) ?? undefined
 
-    const discoveryNodeOverride = await this.discoveryNodeOverride
+    const initialSelectedNode = await this.initialSelectedNode
 
     return new DiscoveryNodeSelector({
       healthCheckThresholds,
       blocklist,
       requestTimeout,
       bootstrapServices: discoveryNodes,
-      overrideEndpoint: discoveryNodeOverride?.endpoint
+      initialSelectedNode: initialSelectedNode?.endpoint
     })
   }
 

--- a/packages/mobile/src/services/discovery-node-selector.ts
+++ b/packages/mobile/src/services/discovery-node-selector.ts
@@ -7,5 +7,5 @@ import { remoteConfigInstance } from './remote-config/remote-config-instance'
 export const discoveryNodeSelectorInstance = new DiscoveryNodeSelectorInstance({
   env,
   remoteConfigInstance,
-  discoveryNodeOverrideEndpoint: localStorage.getCachedDiscoveryProvider()
+  initialSelectedNode: localStorage.getCachedDiscoveryProvider()
 })

--- a/packages/web/src/services/discovery-node-selector.ts
+++ b/packages/web/src/services/discovery-node-selector.ts
@@ -8,5 +8,5 @@ import { remoteConfigInstance } from './remote-config/remote-config-instance'
 export const discoveryNodeSelectorInstance = new DiscoveryNodeSelectorInstance({
   env,
   remoteConfigInstance,
-  discoveryNodeOverrideEndpoint: localStorage.getCachedDiscoveryProvider()
+  initialSelectedNode: localStorage.getCachedDiscoveryProvider()
 })


### PR DESCRIPTION
### Description
Related to https://github.com/AudiusProject/audius-protocol/pull/5146.
There was already a way to specify an `initialSelectedNode` in the sdk so using that instead of the `overrideEndpoint` field I added.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web stage with linked libs.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

