### PR TITLE
Mobile chats block/unblock users

### DIFF
--- a/packages/mobile/src/components/block-messages/BlockMessages.tsx
+++ b/packages/mobile/src/components/block-messages/BlockMessages.tsx
@@ -1,4 +1,4 @@
-import { cacheUsersSelectors } from '@audius/common'
+import { cacheUsersSelectors, chatActions, chatSelectors } from '@audius/common'
 import { View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -14,6 +14,8 @@ import { spacing } from 'app/styles/spacing'
 import { useColor } from 'app/utils/theme'
 
 const { getUser } = cacheUsersSelectors
+const { getBlockees } = chatSelectors
+const { blockUser, unblockUser } = chatActions
 
 const BLOCK_MESSAGES_MODAL_NAME = 'BlockMessages'
 
@@ -23,6 +25,7 @@ const messages = {
   confirmText2: ' from sending messages to your inbox?',
   info: 'This will not affect their ability to view your profile or interact with your content.',
   blockUser: 'Block User',
+  unblockUser: 'Unblock User',
   cancel: 'Cancel'
 }
 
@@ -93,8 +96,16 @@ export const BlockMessagesDrawer = () => {
     getData<'BlockMessages'>(state)
   )
   const user = useSelector((state) => getUser(state, { id: userId }))
+  // Assuming blockees have already been fetched in ProfileActionsDrawer.
+  const blockeeList = useSelector(getBlockees)
+  const isBlockee = blockeeList.includes(userId)
 
   const handleConfirmPress = () => {
+    if (isBlockee) {
+      dispatch(unblockUser({ userId }))
+    } else {
+      dispatch(blockUser({ userId }))
+    }
     dispatch(
       setVisibility({
         drawer: 'BlockMessages',
@@ -134,9 +145,9 @@ export const BlockMessagesDrawer = () => {
           <Text style={styles.infoText}>{messages.info}</Text>
         </View>
         <Button
-          title={messages.blockUser}
+          title={isBlockee ? messages.unblockUser : messages.blockUser}
           onPress={handleConfirmPress}
-          variant='destructive'
+          variant={isBlockee ? 'primary' : 'destructive'}
           styles={{
             root: styles.button,
             text: styles.blockText
@@ -146,7 +157,7 @@ export const BlockMessagesDrawer = () => {
         <Button
           title={messages.cancel}
           onPress={handleCancelPress}
-          variant='primary'
+          variant={isBlockee ? 'common' : 'primary'}
           styles={{
             root: styles.button,
             text: styles.blockText

--- a/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
+++ b/packages/mobile/src/components/profile-actions-drawer/ProfileActionsDrawer.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import {
   ShareSource,
   shareModalUIActions,
-  profilePageSelectors
+  profilePageSelectors,
+  chatSelectors,
+  chatActions
 } from '@audius/common'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -12,17 +14,26 @@ import type { AppState } from 'app/store'
 import { setVisibility } from 'app/store/drawers/slice'
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { getProfileUserId } = profilePageSelectors
+const { getBlockees } = chatSelectors
+const { fetchBlockees } = chatActions
 
 const PROFILE_ACTIONS_MODAL_NAME = 'ProfileActions'
 
 const messages = {
   shareProfile: 'Share Profile',
-  blockMessages: 'Block Messages'
+  blockMessages: 'Block Messages',
+  unblockMessages: 'Unblock Messages'
 }
 
 export const ProfileActionsDrawer = () => {
   const dispatch = useDispatch()
   const userId = useSelector((state: AppState) => getProfileUserId(state))
+  const blockeeList = useSelector(getBlockees)
+  const isBlockee = userId ? blockeeList.includes(userId) : false
+
+  useEffect(() => {
+    dispatch(fetchBlockees())
+  }, [dispatch])
 
   const handleShareProfilePress = useCallback(() => {
     dispatch(
@@ -63,9 +74,12 @@ export const ProfileActionsDrawer = () => {
   const rows = useMemo(
     () => [
       { text: messages.shareProfile, callback: handleShareProfilePress },
-      { text: messages.blockMessages, callback: handleBlockMessagesPress }
+      {
+        text: isBlockee ? messages.unblockMessages : messages.blockMessages,
+        callback: handleBlockMessagesPress
+      }
     ],
-    [handleShareProfilePress, handleBlockMessagesPress]
+    [handleShareProfilePress, handleBlockMessagesPress, isBlockee]
   )
 
   return <ActionDrawer modalName={PROFILE_ACTIONS_MODAL_NAME} rows={rows} />


### PR DESCRIPTION
### Description
Wire up block/unblock actions to the block messages drawer.

### Dragons

It seems like `getProfileUserId` could potentially return `undefined`, but I don't understand how that could be possible if we've successfully navigated to a user's profile screen, so I assume it exists in the `BlockMessages` drawer.

### How Has This Been Tested?

Local web vs stage.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

