### PR TITLE
[PLAT-908] Fix new notifications not tagged in ui

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/NotificationsScreen.tsx
+++ b/packages/mobile/src/screens/notifications-screen/NotificationsScreen.tsx
@@ -23,7 +23,9 @@ export const NotificationsScreen = () => {
 
   const handleMarkAsViewed = useCallback(() => {
     if (totalUnviewed > 0) {
-      dispatch(markAllAsViewed())
+      return () => {
+        dispatch(markAllAsViewed())
+      }
     }
   }, [dispatch, totalUnviewed])
 

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -118,7 +118,9 @@ export const NotificationPanel = ({ anchorRef }: NotificationPanelProps) => {
 
   useEffect(() => {
     if (panelIsOpen && unviewedNotificationCount > 0) {
-      dispatch(markAllAsViewed())
+      return () => {
+        dispatch(markAllAsViewed())
+      }
     }
   }, [panelIsOpen, unviewedNotificationCount, dispatch])
 


### PR DESCRIPTION
### Description

Fixes issue where new notifications were not tagged with `new` in ui. This was due to notification-panel and notification-screen dispatching `markAllAsViewed` on initial render, which removed `new` ui. Now we wait until the component unmounts to dispatch action.