### PR TITLE
[PLAT-903] Fix missing remix notifications

### DIFF
--- a/packages/common/src/store/notifications/notificationsSelectors.ts
+++ b/packages/common/src/store/notifications/notificationsSelectors.ts
@@ -10,7 +10,7 @@ import { getUser, getUsers } from 'store/cache/users/selectors'
 import { CommonState } from 'store/commonStore'
 import { Nullable } from 'utils'
 
-import { Collection, Status, Track } from '../../models'
+import { Collection, ID, Status, Track } from '../../models'
 
 import { notificationsAdapter } from './notificationsSlice'
 import {
@@ -165,4 +165,13 @@ export const getNotificationEntities = <
     return entities as EntityTypes<T>
   }
   return null as EntityTypes<T>
+}
+
+export const getNotificationTrack = (state: CommonState, trackId: ID) => {
+  const track = getTrack(state, { id: trackId })
+  if (!track) return null
+  const { owner_id } = track
+  const owner = getUser(state, { id: owner_id })
+  if (!owner) return null
+  return { ...track, user: owner }
 }

--- a/packages/mobile/src/screens/notifications-screen/Notification/EntityLink.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notification/EntityLink.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from 'react'
 
-import type { EntityType } from '@audius/common'
+import type { Collection, Track } from '@audius/common'
 
 import { Text } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
 
 type EntityLinkProps = {
-  entity: EntityType
+  entity: Track | Collection
 }
 
 export const EntityLink = (props: EntityLinkProps) => {
@@ -19,7 +19,7 @@ export const EntityLink = (props: EntityLinkProps) => {
         id: entity.track_id,
         fromNotifications: true
       })
-    } else if (entity.user) {
+    } else if ('playlist_id' in entity) {
       navigation.navigate('Collection', {
         id: entity.playlist_id,
         fromNotifications: true

--- a/packages/mobile/src/screens/notifications-screen/Notifications/RemixCreateNotification.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Notifications/RemixCreateNotification.tsx
@@ -1,11 +1,7 @@
 import { useCallback } from 'react'
 
-import type {
-  EntityType,
-  TrackEntity,
-  RemixCreateNotification as RemixCreateNotificationType
-} from '@audius/common'
-import { useProxySelector, notificationsSelectors } from '@audius/common'
+import type { RemixCreateNotification as RemixCreateNotificationType } from '@audius/common'
+import { cacheTracksSelectors, notificationsSelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import IconRemix from 'app/assets/images/iconRemix.svg'
@@ -22,7 +18,8 @@ import {
   UserNameLink,
   NotificationTwitterButton
 } from '../Notification'
-const { getNotificationEntities, getNotificationUser } = notificationsSelectors
+const { getNotificationUser } = notificationsSelectors
+const { getTrack } = cacheTracksSelectors
 
 const messages = {
   title: 'New Remix of Your Track',
@@ -40,22 +37,18 @@ export const RemixCreateNotification = (
 ) => {
   const { notification } = props
   const { childTrackId, parentTrackId } = notification
+
   const navigation = useNotificationNavigation()
   const user = useSelector((state) => getNotificationUser(state, notification))
-  const tracks = useProxySelector(
-    (state) => getNotificationEntities(state, notification),
-    [notification]
-  ) as EntityType[]
 
-  const childTrack = tracks?.find(
-    (track): track is TrackEntity =>
-      'track_id' in track && track.track_id === childTrackId
+  const childTrack = useSelector((state) =>
+    getTrack(state, { id: childTrackId })
   )
 
-  const parentTrack = tracks?.find(
-    (track): track is TrackEntity =>
-      'track_id' in track && track.track_id === parentTrackId
+  const parentTrack = useSelector((state) =>
+    getTrack(state, { id: parentTrackId })
   )
+
   const parentTrackTitle = parentTrack?.title
 
   const handlePress = useCallback(() => {

--- a/packages/web/src/components/notification/Notification/RemixCreateNotification.tsx
+++ b/packages/web/src/components/notification/Notification/RemixCreateNotification.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 
 import {
   Name,
-  Nullable,
   notificationsSelectors,
   RemixCreateNotification as RemixCreateNotificationType,
   TrackEntity
@@ -23,7 +22,7 @@ import { TwitterShareButton } from './components/TwitterShareButton'
 import { UserNameLink } from './components/UserNameLink'
 import { IconRemix } from './components/icons'
 import { getEntityLink } from './utils'
-const { getNotificationEntities, getNotificationUser } = notificationsSelectors
+const { getNotificationUser, getNotificationTrack } = notificationsSelectors
 
 const messages = {
   title: 'New remix of your track',
@@ -45,15 +44,12 @@ export const RemixCreateNotification = (
   const dispatch = useDispatch()
   const user = useSelector((state) => getNotificationUser(state, notification))
 
-  // TODO: casting from EntityType to TrackEntity here, but
-  // getNotificationEntities should be smart enough based on notif type
-  const tracks = useSelector((state) =>
-    getNotificationEntities(state, notification)
-  ) as Nullable<TrackEntity[]>
-
-  const childTrack = tracks?.find((track) => track.track_id === childTrackId)
-
-  const parentTrack = tracks?.find((track) => track.track_id === parentTrackId)
+  const childTrack = useSelector((state) =>
+    getNotificationTrack(state, childTrackId)
+  )
+  const parentTrack = useSelector((state) =>
+    getNotificationTrack(state, parentTrackId)
+  )
 
   const handleClick = useCallback(() => {
     if (childTrack) {


### PR DESCRIPTION
### Description

Fixes issue where remix notifications relied on legacy selectors for old notification data shape. Now it's simply selecting tracks based on parent/child id, rather that picking tracks out of a list.
