### PR TITLE
[C-2526] Remove pagination from related artists as endpoint doesn't support it

### DIFF
--- a/packages/web/src/common/store/user-list/related-artists/sagas.ts
+++ b/packages/web/src/common/store/user-list/related-artists/sagas.ts
@@ -30,19 +30,15 @@ function* fetchRelatedArtists({
   const apiClient = yield* getContext('apiClient')
   const response = yield* call([apiClient, apiClient.getRelatedArtists], {
     userId: artistId,
-    limit: pageSize,
+    limit: MAX_RELATED_ARTISTS,
     offset
   })
 
   const users = response || []
-
   const userIds = users.map((user) => user.user_id)
-  const existingUserIds = yield* select((state) => getUserList(state).userIds)
-  const combinedUserIds = [...existingUserIds, ...userIds]
-  const hasMore = combinedUserIds.length < MAX_RELATED_ARTISTS
   return {
-    userIds: combinedUserIds,
-    hasMore
+    userIds,
+    hasMore: false
   }
 }
 


### PR DESCRIPTION
### Description

Pagination fails for related artists because the endpoint supports limit but not offset. So when we try to request the second page of results (e.g. `limit: 15, offset: 15`), we are returned the identical first page of results.

Given that we don't need a lot of related artists at once, just removing the client-side expectation of pagination is sufficient.

