### PR TITLE
[CON-660] Prefer duration from track metadata over track_segments calculation

### DIFF
--- a/packages/common/src/schemas/index.ts
+++ b/packages/common/src/schemas/index.ts
@@ -6,6 +6,7 @@ const trackMetadataSchema = {
   track_cid: null,
   owner_id: null,
   title: null,
+  duration: null,
   length: null,
   cover_art: null,
   cover_art_sizes: null,

--- a/packages/common/src/services/audio-player.ts
+++ b/packages/common/src/services/audio-player.ts
@@ -1,6 +1,5 @@
 import { PlaybackRate } from 'store/player'
 
-import { TrackSegment } from '../models'
 import { Nullable } from '../utils'
 
 export type AudioInfo = {
@@ -16,11 +15,7 @@ export enum AudioError {
 
 export type AudioPlayer = {
   audio: HTMLAudioElement
-  load: (
-    segments: TrackSegment[],
-    onEnd: () => void,
-    mp3Url: Nullable<string>
-  ) => void
+  load: (duration: number, onEnd: () => void, mp3Url: Nullable<string>) => void
   play: () => void
   pause: () => void
   stop: () => void

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -577,10 +577,12 @@ export const audiusBackend = ({
     return {
       ...track,
       // TODO: This method should be renamed as it does more than images.
-      duration: track.track_segments.reduce(
-        (duration, segment) => duration + parseFloat(segment.duration),
-        0
-      ),
+      duration:
+        track.duration ||
+        track.track_segments.reduce(
+          (duration, segment) => duration + parseFloat(segment.duration),
+          0
+        ),
       _cover_art_sizes: coverArtSizes
     }
   }

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -132,7 +132,11 @@ export function* watchPlay() {
 
       const endChannel = eventChannel((emitter) => {
         audioPlayer.load(
-          track.track_segments,
+          track.duration ||
+            track.track_segments.reduce(
+              (duration, segment) => duration + parseFloat(segment.duration),
+              0
+            ),
           () => {
             if (onEnd) {
               emitter(onEnd({}))
@@ -212,7 +216,7 @@ export function* watchCollectiblePlay() {
       const audioPlayer = yield* getContext('audioPlayer')
       const endChannel = eventChannel((emitter) => {
         audioPlayer.load(
-          [],
+          0,
           () => {
             if (onEnd) {
               emitter(onEnd({}))

--- a/packages/web/src/services/audio-player/AudioPlayer.test.js
+++ b/packages/web/src/services/audio-player/AudioPlayer.test.js
@@ -32,7 +32,7 @@ describe('play', () => {
       play
     }))
     const audioStream = new AudioPlayer()
-    audioStream.load([{ duration: 6 }], () => {})
+    audioStream.load(6, () => {})
     audioStream.play()
 
     expect(play).toHaveBeenCalled()
@@ -51,7 +51,7 @@ describe('pause', () => {
       pause
     }))
     const audioStream = new AudioPlayer()
-    audioStream.load([{ duration: 6 }], () => {})
+    audioStream.load(6, () => {})
     audioStream.pause()
 
     expect(pause).toHaveBeenCalled()
@@ -68,7 +68,7 @@ describe('stop', () => {
       pause
     }))
     const audioStream = new AudioPlayer()
-    audioStream.load([{ duration: 6 }], () => {})
+    audioStream.load(6, () => {})
     audioStream.stop()
 
     expect(pause).toHaveBeenCalled()

--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -126,7 +126,7 @@ export class AudioPlayer {
   }
 
   load = (
-    segments: TrackSegment[],
+    duration: number,
     onEnd: () => void,
     mp3Url: string | null = null
   ) => {
@@ -155,10 +155,7 @@ export class AudioPlayer {
       this.audio.onloadedmetadata = () => (this.duration = this.audio.duration)
     }
 
-    this.duration = segments.reduce(
-      (duration, segment) => duration + parseFloat(segment.duration),
-      0
-    )
+    this.duration = duration
 
     // Set audio listeners.
     if (this.endedListener) {

--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -1,8 +1,4 @@
-import {
-  TrackSegment,
-  PlaybackRate,
-  playbackRateValueMap
-} from '@audius/common'
+import { PlaybackRate, playbackRateValueMap } from '@audius/common'
 
 declare global {
   interface Window {


### PR DESCRIPTION
### Description
- Displays and passes around `duration` from track metadata when it's truthy in all places that used `track_segments` to calculate duration. Keeps the calculation as a fallback if `duration` is not truthy
- See https://github.com/AudiusProject/audius-protocol/pull/5165

### Dragons
Everything still falls back to track_segments, so it should be safe

### How Has This Been Tested?
Uploaded (v1 and v2 flow) multiple times locally, checked the duration on the track page, and played around with moving the scrubber

### How will this change be monitored?
Manual testing of track playback on staging

### Feature Flags ###
None