### PR TITLE
[C-2524] Fix mobile notification reactions

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -181,7 +181,7 @@ export const ReactionPopup = ({
                 handleReactionSelected(message, reaction)
               }
             }}
-            isVisible={true}
+            isVisible={shouldShowPopup}
             scale={1.6}
             style={{
               emoji: styles.emoji

--- a/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useCallback, useRef, useState } from 'react'
 
 import type { ReactionTypes } from '@audius/common'
 import type { AnimatedLottieViewProps } from 'lottie-react-native'
@@ -66,13 +66,15 @@ export const Reaction = (props: ReactionProps) => {
     }
   }, [status, autoPlay, isVisible])
 
-  const handleLayout = () => {
+  const measureReactions = useCallback(() => {
     if (isVisible && onMeasure) {
       ref.current?.measureInWindow((x, _, width) => {
         onMeasure({ x, width, reactionType })
       })
     }
-  }
+  }, [isVisible, onMeasure, reactionType])
+
+  useEffect(() => measureReactions(), [measureReactions])
 
   useEffect(() => {
     if (previousStatus !== 'interacting' && status === 'interacting') {
@@ -120,7 +122,7 @@ export const Reaction = (props: ReactionProps) => {
         ref={(animation) => {
           animationRef.current = animation
         }}
-        onLayout={handleLayout}
+        onLayout={measureReactions}
         autoPlay={isVisible && autoPlay}
         loop
         source={source}

--- a/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
@@ -120,7 +120,11 @@ export const ReactionList = (props: ReactionListProps) => {
 
   const handleMeasure: OnMeasure = useCallback((config) => {
     const { x, width, reactionType } = config
-    positions.current = { ...positions.current, [reactionType]: { x, width } }
+    // Sometimes this function is called before the View being measured is laid out,
+    // so check that x and width are valid before updating the positions.
+    if (x > 0 && width > 0) {
+      positions.current = { ...positions.current, [reactionType]: { x, width } }
+    }
   }, [])
 
   return (


### PR DESCRIPTION
### Description
Changes to the mobile `ReactionList` for chats broke the other usage of `ReactionList` in notifications (tip sent). The fix:
- Originally measurements were happening inside a `useEffect` that fired whenever `isVisible` changed. Re-add this back so notifications reactions work.
- Using `isVisible` properly on the chats `ReactionPopup` side, but this did not fix so also need to...
- Still perform measurements during `onLayout`.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web stage.
Test by confirming both chats `ReactionPopup` and notifications reactions work. Also check that notifications still works when navigating away/back to the notifications screen.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

