### PR TITLE
Better fix for reactions using LayoutEvent

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
@@ -3,7 +3,13 @@ import { useEffect, useCallback, useRef, useState } from 'react'
 import type { ReactionTypes } from '@audius/common'
 import type { AnimatedLottieViewProps } from 'lottie-react-native'
 import LottieView from 'lottie-react-native'
-import type { StyleProp, View, ViewProps, ViewStyle } from 'react-native'
+import type {
+  LayoutChangeEvent,
+  StyleProp,
+  View,
+  ViewProps,
+  ViewStyle
+} from 'react-native'
 import { Animated } from 'react-native'
 import { usePrevious } from 'react-use'
 
@@ -66,15 +72,13 @@ export const Reaction = (props: ReactionProps) => {
     }
   }, [status, autoPlay, isVisible])
 
-  const measureReactions = useCallback(() => {
-    if (isVisible && onMeasure) {
-      ref.current?.measureInWindow((x, _, width) => {
-        onMeasure({ x, width, reactionType })
-      })
-    }
-  }, [isVisible, onMeasure, reactionType])
-
-  useEffect(() => measureReactions(), [measureReactions])
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      const { x, width } = event.nativeEvent.layout
+      onMeasure?.({ x, width, reactionType })
+    },
+    [onMeasure, reactionType]
+  )
 
   useEffect(() => {
     if (previousStatus !== 'interacting' && status === 'interacting') {
@@ -116,13 +120,13 @@ export const Reaction = (props: ReactionProps) => {
     <Animated.View
       ref={ref}
       style={[styles.root, animatedStyles, style]}
+      onLayout={handleLayout}
       {...other}
     >
       <LottieView
         ref={(animation) => {
           animationRef.current = animation
         }}
-        onLayout={measureReactions}
         autoPlay={isVisible && autoPlay}
         loop
         source={source}

--- a/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/Reaction.tsx
@@ -6,7 +6,6 @@ import LottieView from 'lottie-react-native'
 import type {
   LayoutChangeEvent,
   StyleProp,
-  View,
   ViewProps,
   ViewStyle
 } from 'react-native'
@@ -56,7 +55,6 @@ export const Reaction = (props: ReactionProps) => {
   const styles = useStyles()
   const [status, setStatus] = useState(statusProp)
   const animationRef = useRef<LottieView | null>(null)
-  const ref = useRef<View | null>(null)
   const scale = useRef(new Animated.Value(1)).current
   const previousStatus = usePrevious(status)
 
@@ -118,7 +116,6 @@ export const Reaction = (props: ReactionProps) => {
 
   return (
     <Animated.View
-      ref={ref}
       style={[styles.root, animatedStyles, style]}
       onLayout={handleLayout}
       {...other}

--- a/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
@@ -120,11 +120,7 @@ export const ReactionList = (props: ReactionListProps) => {
 
   const handleMeasure: OnMeasure = useCallback((config) => {
     const { x, width, reactionType } = config
-    // Sometimes this function is called before the View being measured is laid out,
-    // so check that x and width are valid before updating the positions.
-    if (x > 0 && width > 0) {
-      positions.current = { ...positions.current, [reactionType]: { x, width } }
-    }
+    positions.current = { ...positions.current, [reactionType]: { x, width } }
   }, [])
 
   return (


### PR DESCRIPTION
### Description
Better fix for https://github.com/AudiusProject/audius-client/pull/3279/files that uses values from `LayoutEvent` in the parent `Animated.View` `onLayout` handler.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage - tested both chat reactions and notification reactions.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

