### PR TITLE
[CON-664] Split storage v2 feature flag into signup+upload

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1266,8 +1266,13 @@ export const audiusBackend = ({
     metadata: TrackMetadata,
     onProgress: (loaded: number, total: number) => void
   ) {
-    const storageV2Enabled = await getFeatureEnabled(FeatureFlags.STORAGE_V2)
-    if (storageV2Enabled) {
+    const storageV2SignupEnabled = await getFeatureEnabled(
+      FeatureFlags.STORAGE_V2_SIGNUP
+    )
+    const storageV2UploadEnabled = await getFeatureEnabled(
+      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
+    )
+    if (storageV2SignupEnabled || storageV2UploadEnabled) {
       try {
         return await audiusLibs.Track.uploadTrackV2(
           trackFile,
@@ -1296,7 +1301,6 @@ export const audiusBackend = ({
     metadata: TrackMetadata,
     onProgress: (loaded: number, total: number) => void
   ) {
-    // TODO: Call storage v2 upload if USE_STORAGE_V2_FEATURE_FLAG is true
     return audiusLibs.Track.uploadTrackContentToCreatorNode(
       trackFile,
       coverArtFile,
@@ -1981,8 +1985,10 @@ export const audiusBackend = ({
       setLocalStorageItem('is-mobile-user', 'true')
     }
 
-    const storageV2Enabled = await getFeatureEnabled(FeatureFlags.STORAGE_V2)
-    if (storageV2Enabled || email?.startsWith('storage_v2_test_')) {
+    const storageV2SignupEnabled = await getFeatureEnabled(
+      FeatureFlags.STORAGE_V2_SIGNUP
+    )
+    if (storageV2SignupEnabled) {
       return await audiusLibs.Account.signUpV2(
         email,
         password,

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -41,11 +41,12 @@ export enum FeatureFlags {
   TRENDING_PLAYLIST_NOTIFICATIONS = 'trending_playlist_notifications',
   TRENDING_UNDERGROUND_NOTIFICATIONS = 'trending_underground_notifications',
   TASTEMAKER_NOTIFICATIONS = 'tastemaker_notifications',
-  STORAGE_V2 = 'storage_v2',
   SDK_V2 = 'sdk_v2',
   GET_METADATA_FROM_DISCOVERY_ENABLED = 'get_metadata_from_discovery_enabled',
   RELATED_ARTISTS_ON_PROFILE_ENABLED = 'related_artists_on_profile_enabled',
-  PROXY_WORMHOLE = 'proxy_wormhole'
+  PROXY_WORMHOLE = 'proxy_wormhole',
+  STORAGE_V2_TRACK_UPLOAD = 'storage_v2_track_upload',
+  STORAGE_V2_SIGNUP = 'storage_v2_signup'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -102,9 +103,10 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.TRENDING_PLAYLIST_NOTIFICATIONS]: false,
   [FeatureFlags.TRENDING_UNDERGROUND_NOTIFICATIONS]: false,
   [FeatureFlags.TASTEMAKER_NOTIFICATIONS]: false,
-  [FeatureFlags.STORAGE_V2]: false,
   [FeatureFlags.SDK_V2]: false,
   [FeatureFlags.GET_METADATA_FROM_DISCOVERY_ENABLED]: false,
   [FeatureFlags.RELATED_ARTISTS_ON_PROFILE_ENABLED]: false,
-  [FeatureFlags.PROXY_WORMHOLE]: false
+  [FeatureFlags.PROXY_WORMHOLE]: false,
+  [FeatureFlags.STORAGE_V2_TRACK_UPLOAD]: false,
+  [FeatureFlags.STORAGE_V2_SIGNUP]: false
 }

--- a/packages/web/src/components/data-entry/FormTile.js
+++ b/packages/web/src/components/data-entry/FormTile.js
@@ -764,8 +764,15 @@ class FormTile extends Component {
     try {
       let file = selectedFiles[0]
       file = await this.props.transformArtworkFunction(file)
-      const storageV2Enabled = getFeatureEnabled(FeatureFlags.STORAGE_V2)
-      if (storageV2Enabled) file.name = selectedFiles[0].name
+      const storageV2SignupEnabled = await getFeatureEnabled(
+        FeatureFlags.STORAGE_V2_SIGNUP
+      )
+      const storageV2UploadEnabled = await getFeatureEnabled(
+        FeatureFlags.STORAGE_V2_TRACK_UPLOAD
+      )
+      if (storageV2SignupEnabled || storageV2UploadEnabled) {
+        file.name = selectedFiles[0].name
+      }
       const url = URL.createObjectURL(file)
       this.props.onChangeField('artwork', { url, file, source }, false)
       this.setState({ imageProcessingError: false })


### PR DESCRIPTION
### Description
Splits `storage_v2` feature flag into `storage_v2_track_upload` and `storage_v2_signup` so we can rollout uploads separately first.

@endline I removed the ability to prefix an email with "storage_v2_test_". We'll want to use real emails in prod/staging anyway so just run `localStorage.setItem('FeatureFlagOverride:storage_v2_signup', 'enabled')` in Console and then use a real email with the "+" like theo+42623@audius.co

### Dragons


### How Has This Been Tested?
Will be testing on staging today. Flags are set in optimizely as well

### How will this change be monitored?


### Feature Flags ###
removed: `storage_v2`
added: `storage_v2_track_upload` and `storage_v2_signup`