### PR TITLE
Fix parsing create notification track owner id

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2341,12 +2341,12 @@ export const audiusBackend = ({
         .filter(removeNullable)
       // playlist owner ids are the specifier of the playlist create notif
       const userId =
-        entityType !== Entity.Track
-          ? // album/playlist create notifications store album owner
+        entityType === Entity.Track
+          ? // track create notifs store track owner id in the group id
+            parseInt(notification.group_id.split(':')[3])
+          : // album/playlist create notifications store album owner
             // id as the specifier
             (decodeHashId(notification.actions[0].specifier) as number)
-          : // track create notifs store track owner id in the group id
-            parseInt(notification.group_id.split(':')[3])
       return {
         type: NotificationType.UserSubscription,
         userId,

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -2339,7 +2339,14 @@ export const audiusBackend = ({
         })
         .flat()
         .filter(removeNullable)
-      const userId = decodeHashId(notification.actions[0].specifier) as number
+      // playlist owner ids are the specifier of the playlist create notif
+      const userId =
+        entityType !== Entity.Track
+          ? // album/playlist create notifications store album owner
+            // id as the specifier
+            (decodeHashId(notification.actions[0].specifier) as number)
+          : // track create notifs store track owner id in the group id
+            parseInt(notification.group_id.split(':')[3])
       return {
         type: NotificationType.UserSubscription,
         userId,


### PR DESCRIPTION
### Description
Create notifications for tracks weren't showing up in discovery UI 🤦 not sure how we missed this. a while ago joe changed the specifier of track create notifications which audiusbackend was expecting for tracks, so had to update audiusbackend to parse for the information elsewhere in the notif