### PR TITLE
[PAY-1148] Mobile chat user search row disabled when not permitted

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -1,4 +1,4 @@
-import type { UserChat } from '@audius/sdk'
+import type { UserChat, ValidatedChatPermissions } from '@audius/sdk'
 import { createSelector } from 'reselect'
 
 import type { ID } from 'models/Identifiers'
@@ -152,15 +152,26 @@ export const getUnfurlMetadata = (
   return message?.unfurlMetadata
 }
 
-export const isPermittedForUser = (state: CommonState, userId: ID) => {
-  const currentUserId = getUserId(state) ?? -1
-  const blockerList = getBlockers(state)
-  const hasBlocker = blockerList.includes(currentUserId)
-  const blockeeList = getBlockees(state)
-  const hasBlockee = blockeeList.includes(userId)
-  const permissionsMap = getUserChatPermissions(state)
-  const isPermitted =
-    permissionsMap[userId]?.current_user_has_permission ?? true
+export const isPermittedForUser = createSelector(
+  [
+    getUserId,
+    getBlockers,
+    getBlockees,
+    getUserChatPermissions,
+    (_: CommonState, userId: ID) => userId
+  ],
+  (
+    currentUserId,
+    blockerList,
+    blockeeList,
+    permissionsMap: Record<ID, ValidatedChatPermissions>,
+    userId
+  ) => {
+    const hasBlocker = blockerList.includes(currentUserId ?? -1)
+    const hasBlockee = blockeeList.includes(userId)
+    const isPermitted =
+      permissionsMap[userId]?.current_user_has_permission ?? true
 
-  return !hasBlocker && !hasBlockee && isPermitted
-}
+    return !hasBlocker && !hasBlockee && isPermitted
+  }
+)

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -152,26 +152,24 @@ export const getUnfurlMetadata = (
   return message?.unfurlMetadata
 }
 
-export const isPermittedForUser = createSelector(
+export const getCanMessageUser = createSelector(
   [
-    getUserId,
     getBlockers,
     getBlockees,
     getUserChatPermissions,
     (_: CommonState, userId: ID) => userId
   ],
   (
-    currentUserId,
     blockerList,
     blockeeList,
     permissionsMap: Record<ID, ValidatedChatPermissions>,
     userId
   ) => {
-    const hasBlocker = blockerList.includes(currentUserId ?? -1)
-    const hasBlockee = blockeeList.includes(userId)
+    const isBlocked = blockerList.includes(userId)
+    const doesBlock = blockeeList.includes(userId)
     const isPermitted =
       permissionsMap[userId]?.current_user_has_permission ?? true
 
-    return !hasBlocker && !hasBlockee && isPermitted
+    return !isBlocked && !doesBlock && isPermitted
   }
 )

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -1,6 +1,7 @@
 import type { UserChat } from '@audius/sdk'
 import { createSelector } from 'reselect'
 
+import type { ID } from 'models/Identifiers'
 import { accountSelectors } from 'store/account'
 import { cacheUsersSelectors } from 'store/cache'
 import { CommonState } from 'store/reducers'
@@ -149,4 +150,17 @@ export const getUnfurlMetadata = (
 ) => {
   const message = getChatMessageById(state, chatId, messageId)
   return message?.unfurlMetadata
+}
+
+export const isPermittedForUser = (state: CommonState, userId: ID) => {
+  const currentUserId = getUserId(state) ?? -1
+  const blockerList = getBlockers(state)
+  const hasBlocker = blockerList.includes(currentUserId)
+  const blockeeList = getBlockees(state)
+  const hasBlockee = blockeeList.includes(userId)
+  const permissionsMap = getUserChatPermissions(state)
+  const isPermitted =
+    permissionsMap[userId]?.current_user_has_permission ?? true
+
+  return !hasBlocker && !hasBlockee && isPermitted
 }

--- a/packages/common/src/store/ui/search-users-modal/sagas.ts
+++ b/packages/common/src/store/ui/search-users-modal/sagas.ts
@@ -26,7 +26,9 @@ function* doSearchUsers(action: ReturnType<typeof searchUsers>) {
     })
     const users = Object.values(res.users) as User[]
     yield* call(processAndCacheUsers, users)
-    yield* put(searchUsersSucceeded({ userIds: users.map((u) => u.user_id) }))
+    yield* put(
+      searchUsersSucceeded({ userIds: users.map((u) => u.user_id), limit })
+    )
   } catch (e) {
     console.error(e)
   }

--- a/packages/common/src/store/ui/search-users-modal/slice.ts
+++ b/packages/common/src/store/ui/search-users-modal/slice.ts
@@ -38,13 +38,12 @@ const slice = createSlice({
     },
     searchUsersSucceeded: (
       state,
-      action: PayloadAction<{ userIds: number[] }>
+      action: PayloadAction<{ userIds: number[]; limit: number }>
     ) => {
-      state.userList.userIds = state.userList.userIds.concat(
-        action.payload.userIds
-      )
+      const { userIds, limit } = action.payload
+      state.userList.userIds = state.userList.userIds.concat(userIds)
       state.userList.status = Status.SUCCESS
-      state.userList.hasMore = action.payload.userIds.length > 0
+      state.userList.hasMore = userIds.length >= limit
     }
   }
 })

--- a/packages/common/src/store/ui/search-users-modal/slice.ts
+++ b/packages/common/src/store/ui/search-users-modal/slice.ts
@@ -43,7 +43,7 @@ const slice = createSlice({
       const { userIds, limit } = action.payload
       state.userList.userIds = state.userList.userIds.concat(userIds)
       state.userList.status = Status.SUCCESS
-      state.userList.hasMore = userIds.length >= limit
+      state.userList.hasMore = userIds.length === limit
     }
   }
 })

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -13,7 +13,7 @@ import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
 const { createChat } = chatActions
-const { isPermittedForUser } = chatSelectors
+const { getCanMessageUser } = chatSelectors
 
 const messages = {
   followsYou: 'Follows You',
@@ -107,8 +107,8 @@ export const ChatUserListItem = ({ user }: ChatUserListItemProps) => {
   const styles = useStyles()
   const palette = useThemeColors()
   const dispatch = useDispatch()
-  const isPermitted = useSelector((state) =>
-    isPermittedForUser(state, user.user_id)
+  const canMessageUser = useSelector((state) =>
+    getCanMessageUser(state, user.user_id)
   )
 
   const handlePress = useCallback(
@@ -123,16 +123,21 @@ export const ChatUserListItem = ({ user }: ChatUserListItemProps) => {
   }
 
   return (
-    <TouchableOpacity onPress={() => handlePress(user)} disabled={!isPermitted}>
+    <TouchableOpacity
+      onPress={() => handlePress(user)}
+      disabled={!canMessageUser}
+    >
       <View style={styles.border}>
-        <View style={[styles.userContainer, !isPermitted ? styles.dim : null]}>
+        <View
+          style={[styles.userContainer, !canMessageUser ? styles.dim : null]}
+        >
           <ProfilePicture profile={user} style={styles.profilePicture} />
           <View style={styles.userNameContainer}>
             <UserBadges user={user} nameStyle={styles.userName} />
             <Text style={styles.handle}>@{user.handle}</Text>
             <View style={styles.followContainer}>
               <View style={styles.followersContainer}>
-                {isPermitted ? (
+                {canMessageUser ? (
                   <>
                     <IconUser
                       fill={palette.neutralLight4}
@@ -148,7 +153,7 @@ export const ChatUserListItem = ({ user }: ChatUserListItemProps) => {
                   <Text style={styles.userName}>{messages.cannotMessage}</Text>
                 )}
               </View>
-              {user.does_follow_current_user && isPermitted ? (
+              {user.does_follow_current_user && canMessageUser ? (
                 <Text style={styles.followsYouTag}>{messages.followsYou}</Text>
               ) : null}
             </View>

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -118,10 +118,6 @@ export const ChatUserListItem = ({ user }: ChatUserListItemProps) => {
     [dispatch]
   )
 
-  if (!user) {
-    return <LoadingSpinner />
-  }
-
   return (
     <TouchableOpacity
       onPress={() => handlePress(user)}

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -125,10 +125,7 @@ export const ChatUserListItem = ({ user }: ChatUserListItemProps) => {
   return (
     <TouchableOpacity onPress={() => handlePress(user)} disabled={!isPermitted}>
       <View style={styles.border}>
-        <View
-          style={[styles.userContainer, !isPermitted ? styles.dim : null]}
-          key={user.key}
-        >
+        <View style={[styles.userContainer, !isPermitted ? styles.dim : null]}>
           <ProfilePicture profile={user} style={styles.profilePicture} />
           <View style={styles.userNameContainer}>
             <UserBadges user={user} nameStyle={styles.userName} />

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -6,7 +6,6 @@ import { Text, View, TouchableOpacity } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconUser from 'app/assets/images/iconUser.svg'
-import LoadingSpinner from 'app/components/loading-spinner'
 import { ProfilePicture } from 'app/components/user'
 import { UserBadges } from 'app/components/user-badges'
 import { makeStyles } from 'app/styles'

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -69,7 +69,7 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     alignItems: 'center'
   },
   followersCount: {
-    fontWeight: '800',
+    fontWeight: 'bold',
     marginHorizontal: spacing(1),
     color: palette.neutralLight4,
     fontSize: typography.fontSize.small

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 
 import { chatActions, chatSelectors } from '@audius/common'
 import type { User } from '@audius/common'

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect } from 'react'
+
+import { chatActions, chatSelectors } from '@audius/common'
+import type { User } from '@audius/common'
+import { Text, View, TouchableOpacity } from 'react-native'
+import { useDispatch, useSelector } from 'react-redux'
+
+import IconUser from 'app/assets/images/iconUser.svg'
+import LoadingSpinner from 'app/components/loading-spinner'
+import { ProfilePicture } from 'app/components/user'
+import { UserBadges } from 'app/components/user-badges'
+import { makeStyles } from 'app/styles'
+import { useThemeColors } from 'app/utils/theme'
+
+const { createChat } = chatActions
+const { isPermittedForUser } = chatSelectors
+
+const messages = {
+  followsYou: 'Follows You',
+  followers: 'Followers',
+  cannotMessage: 'Cannot Be Messaged'
+}
+
+const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+  rootContainer: {
+    backgroundColor: palette.white,
+    flexGrow: 1
+  },
+  profilePicture: {
+    height: spacing(18),
+    width: spacing(18)
+  },
+  border: {
+    borderBottomColor: palette.neutralLight4,
+    borderBottomWidth: 1
+  },
+  userContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing(4)
+  },
+  userNameContainer: {
+    flexGrow: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    marginLeft: spacing(2.5),
+    gap: spacing(1)
+  },
+  userName: {
+    fontSize: typography.fontSize.small,
+    fontWeight: 'bold',
+    color: palette.neutral
+  },
+  followContainer: {
+    marginTop: spacing(1),
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
+  handle: {
+    fontSize: typography.fontSize.small,
+    color: palette.neutral
+  },
+  followersContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  followersCount: {
+    fontWeight: '800',
+    marginHorizontal: spacing(1),
+    color: palette.neutralLight4,
+    fontSize: typography.fontSize.small
+  },
+  followers: {
+    color: palette.neutralLight4,
+    fontSize: typography.fontSize.small
+  },
+  iconUser: {
+    height: spacing(4),
+    width: spacing(4)
+  },
+  followsYouTag: {
+    fontSize: typography.fontSize.xxs,
+    fontFamily: typography.fontByWeight.heavy,
+    letterSpacing: 0.64,
+    textTransform: 'uppercase',
+    color: palette.neutralLight4,
+    borderWidth: 1,
+    borderRadius: spacing(1),
+    borderColor: palette.neutralLight4,
+    paddingVertical: spacing(1),
+    paddingHorizontal: spacing(2)
+  },
+  dim: {
+    opacity: 0.5
+  }
+}))
+
+type ChatUserListItemProps = {
+  user: User
+}
+
+export const ChatUserListItem = ({ user }: ChatUserListItemProps) => {
+  const styles = useStyles()
+  const palette = useThemeColors()
+  const dispatch = useDispatch()
+  const isPermitted = useSelector((state) =>
+    isPermittedForUser(state, user.user_id)
+  )
+
+  const handlePress = useCallback(
+    (user) => {
+      dispatch(createChat({ userIds: [user.user_id] }))
+    },
+    [dispatch]
+  )
+
+  if (!user) {
+    return <LoadingSpinner />
+  }
+
+  return (
+    <TouchableOpacity onPress={() => handlePress(user)} disabled={!isPermitted}>
+      <View style={styles.border}>
+        <View
+          style={[styles.userContainer, !isPermitted ? styles.dim : null]}
+          key={user.key}
+        >
+          <ProfilePicture profile={user} style={styles.profilePicture} />
+          <View style={styles.userNameContainer}>
+            <UserBadges user={user} nameStyle={styles.userName} />
+            <Text style={styles.handle}>@{user.handle}</Text>
+            <View style={styles.followContainer}>
+              <View style={styles.followersContainer}>
+                {isPermitted ? (
+                  <>
+                    <IconUser
+                      fill={palette.neutralLight4}
+                      height={styles.iconUser.height}
+                      width={styles.iconUser.width}
+                    />
+                    <Text style={styles.followersCount}>
+                      {user.follower_count}
+                    </Text>
+                    <Text style={styles.followers}>{messages.followers}</Text>
+                  </>
+                ) : (
+                  <Text style={styles.userName}>{messages.cannotMessage}</Text>
+                )}
+              </View>
+              {user.does_follow_current_user && isPermitted ? (
+                <Text style={styles.followsYouTag}>{messages.followsYou}</Text>
+              ) : null}
+            </View>
+          </View>
+        </View>
+      </View>
+    </TouchableOpacity>
+  )
+}

--- a/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
@@ -75,6 +75,9 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     borderBottomColor: palette.neutralLight6,
     borderBottomWidth: 3,
     borderBottomLeftRadius: 1
+  },
+  flatListContainer: {
+    minHeight: '100%'
   }
 }))
 
@@ -111,7 +114,8 @@ export const ChatUserListScreen = (props: ChatUserListScreenProps) => {
     },
     [hasQuery, userIds]
   )
-  const isLoading = hasQuery && status === Status.LOADING
+  const isLoading =
+    hasQuery && status === Status.LOADING && userIds.length === 0
 
   useEffect(() => {
     dispatch(fetchBlockees())
@@ -188,6 +192,7 @@ export const ChatUserListScreen = (props: ChatUserListScreenProps) => {
               data={users}
               renderItem={({ item }) => <ChatUserListItem user={item} />}
               keyExtractor={(user: User) => user.handle}
+              contentContainerStyle={styles.flatListContainer}
             />
           ) : (
             <View style={styles.spinnerContainer}>

--- a/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
@@ -119,7 +119,9 @@ export const ChatUserListScreen = (props: ChatUserListScreenProps) => {
   }, [dispatch])
 
   useEffect(() => {
-    dispatch(fetchPermissions({ userIds }))
+    if (userIds.length > 0) {
+      dispatch(fetchPermissions({ userIds }))
+    }
   }, [dispatch, userIds])
 
   useDebounce(

--- a/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListScreen.tsx
@@ -102,7 +102,7 @@ export const ChatUserListScreen = (props: ChatUserListScreenProps) => {
   const [hasQuery, setHasQuery] = useState(false)
   const dispatch = useDispatch()
 
-  const { userIds, status } = useSelector(getUserList)
+  const { userIds, hasMore, status } = useSelector(getUserList)
   const users = useProxySelector(
     (state) => {
       const ids = hasQuery ? userIds : defaultUserList.userIds
@@ -139,7 +139,7 @@ export const ChatUserListScreen = (props: ChatUserListScreenProps) => {
   )
 
   const handleLoadMore = useCallback(() => {
-    if (status === Status.LOADING || defaultUserList.loading) {
+    if (status === Status.LOADING || defaultUserList.loading || !hasMore) {
       return
     }
     if (hasQuery) {
@@ -147,7 +147,7 @@ export const ChatUserListScreen = (props: ChatUserListScreenProps) => {
     } else {
       defaultUserList.loadMore()
     }
-  }, [hasQuery, query, status, defaultUserList, dispatch])
+  }, [status, defaultUserList, hasMore, hasQuery, dispatch, query])
 
   return (
     <Screen


### PR DESCRIPTION
### Description
On search users screen, disable row when not permitted to message user.

Per @sliptype's suggestion, selecting relevant data in flatlist item component rather than passing it in from parent.

Also fixed a bug where `searchUsers` would dispatch infinitely when result count was low.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios simulator stage tested with blocker, blockee, account with followers only inbox settings. Tested that `searchUsers` changes didn't break web.
![Simulator Screen Shot - iPhone 14 Pro - 2023-04-27 at 00 27 53](https://user-images.githubusercontent.com/3893871/234760200-580f1473-35ee-4910-832c-f591c2495f87.png)


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

