### PR TITLE
Pass metadata to libs for addTracksToChainAndCnode

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1287,7 +1287,7 @@ export const audiusBackend = ({
   }
 
   // Used to upload multiple tracks as part of an album/playlist
-  // Returns { metadataMultihash, metadataFileUUID, transcodedTrackCID, transcodedTrackUUID }
+  // Returns { metadataMultihash, metadataFileUUID, transcodedTrackCID, transcodedTrackUUID, metadata }
   async function uploadTrackToCreatorNode(
     trackFile: File,
     coverArtFile: File,

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1315,7 +1315,11 @@ export const audiusBackend = ({
    * Associates tracks with user on creatorNode
    */
   async function registerUploadedTracks(
-    uploadedTracks: { metadataMultihash: string; metadataFileUUID: string }[]
+    uploadedTracks: {
+      metadataMultihash: string
+      metadataFileUUID: string
+      metadata: TrackMetadata
+    }[]
   ) {
     return audiusLibs.Track.addTracksToChainAndCnode(uploadedTracks)
   }

--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -267,7 +267,8 @@ function* uploadWorker(requestChan, respChan, progressChan) {
       metadataMultihash,
       metadataFileUUID,
       transcodedTrackCID,
-      transcodedTrackUUID
+      transcodedTrackUUID,
+      metadata
     }) {
       console.debug({
         metadataMultihash,
@@ -284,7 +285,8 @@ function* uploadWorker(requestChan, respChan, progressChan) {
         metadataMultihash,
         metadataFileUUID,
         transcodedTrackCID,
-        transcodedTrackUUID
+        transcodedTrackUUID,
+        metadata
       }
 
       console.debug(`Finished creator node upload of: ${JSON.stringify(resp)}`)
@@ -476,7 +478,8 @@ export function* handleUploads({
       metadataMultihash,
       metadataFileUUID,
       transcodedTrackCID,
-      transcodedTrackUUID
+      transcodedTrackUUID,
+      metadata
     } = yield take(respChan)
 
     if (error) {
@@ -501,11 +504,6 @@ export function* handleUploads({
     // If it's not a collection, rejoice because we have the trackId already.
     // Otherwise, save our metadata and continue on.
     if (isCollection) {
-      const trackObj = idToTrackMap[originalId]
-      const metadata = {
-        ...trackObj.metadata,
-        is_playlist_upload: isCollection
-      }
       creatorNodeMetadata.push({
         metadataMultihash,
         metadataFileUUID,

--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -501,12 +501,18 @@ export function* handleUploads({
     // If it's not a collection, rejoice because we have the trackId already.
     // Otherwise, save our metadata and continue on.
     if (isCollection) {
+      const trackObj = idToTrackMap[originalId]
+      const metadata = {
+        ...trackObj.metadata,
+        is_playlist_upload: isCollection
+      }
       creatorNodeMetadata.push({
         metadataMultihash,
         metadataFileUUID,
         transcodedTrackCID,
         transcodedTrackUUID,
-        originalId
+        originalId,
+        metadata
       })
     } else {
       const trackObj = idToTrackMap[originalId]


### PR DESCRIPTION
### Description
Frontend changes for https://github.com/AudiusProject/audius-protocol/pull/5171. Want to pass metadata blob directly to `addTracksToChainAndCnode` so it can pass that directly through chain so discovery doesn't have to query content nodes when indexing the event. Use the metadata uploaded to content in libs `uploadTrackContentToCreatorNode`.

This is only triggered by collection uploads (albums and playlists).

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Test against staging 
- with backend changes: verify discovery doesn't query content for metadata and albums/playlists upload successfully and are streamable
- without backend changes: albums/playlists upload successfully and are streamable
- with backend and without frontend changes: verify discovery falls back to querying content (bc the client is passing only the multihash) and albums/playlists upload successfully and are streamable

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

