### PR TITLE
[PAY-1108] Chats Screen avoids play bar

### DIFF
--- a/packages/mobile/src/components/core/KeyboardAvoidingView.tsx
+++ b/packages/mobile/src/components/core/KeyboardAvoidingView.tsx
@@ -18,6 +18,8 @@ type KeyboardAvoidingViewProps = {
   heightOffsetRatio?: number
   keyboardShowingDuration?: number
   keyboardHidingDuration?: number
+  // Offset is subtracted from the desired height when the keyboard is showing.
+  keyboardShowingOffset?: number
   children: React.ReactNode
 }
 
@@ -35,6 +37,7 @@ export const KeyboardAvoidingView = ({
   heightOffsetRatio = 0.75,
   keyboardShowingDuration = 100,
   keyboardHidingDuration = 100,
+  keyboardShowingOffset = 0,
   children
 }: KeyboardAvoidingViewProps) => {
   const styles = useStyles()
@@ -43,13 +46,15 @@ export const KeyboardAvoidingView = ({
   const handleKeyboardWillShow = useCallback(
     (event) => {
       Animated.timing(keyboardHeight.current, {
-        toValue: -event.endCoordinates.height * heightOffsetRatio,
+        toValue:
+          -event.endCoordinates.height * heightOffsetRatio +
+          keyboardShowingOffset,
         duration: keyboardShowingDuration,
         easing: Easing.inOut(Easing.quad),
         useNativeDriver: true
       }).start()
     },
-    [heightOffsetRatio, keyboardShowingDuration]
+    [heightOffsetRatio, keyboardShowingDuration, keyboardShowingOffset]
   )
 
   const handleKeyboardWillHide = useCallback(

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -9,6 +9,7 @@ import {
   decodeHashId,
   encodeHashId,
   Status,
+  playerSelectors,
   isEarliestUnread
 } from '@audius/common'
 import { Portal } from '@gorhom/portal'
@@ -24,12 +25,14 @@ import {
   KeyboardAvoidingView
 } from 'app/components/core'
 import LoadingSpinner from 'app/components/loading-spinner'
+import { PLAY_BAR_HEIGHT } from 'app/components/now-playing-drawer'
 import { ProfilePicture } from 'app/components/user'
 import { UserBadges } from 'app/components/user-badges'
 import { light } from 'app/haptics'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { useRoute } from 'app/hooks/useRoute'
 import { setVisibility } from 'app/store/drawers/slice'
+import { getIsKeyboardOpen } from 'app/store/keyboard/selectors'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemePalette } from 'app/utils/theme'
@@ -53,6 +56,7 @@ const {
 const { fetchMoreMessages, markChatAsRead, setReactionsPopupMessageId } =
   chatActions
 const { getUserId } = accountSelectors
+const { getHasTrack } = playerSelectors
 
 export const REACTION_CONTAINER_HEIGHT = 70
 
@@ -168,7 +172,9 @@ export const ChatScreen = () => {
   const messageTop = useRef(0)
   const chatContainerTop = useRef(0)
   const chatContainerBottom = useRef(0)
+  const isKeyboardOpen = useSelector(getIsKeyboardOpen)
 
+  const hasTrack = useSelector(getHasTrack)
   const userId = useSelector(getUserId)
   const userIdEncoded = encodeHashId(userId)
   const chat = useSelector((state) => getChat(state, chatId ?? ''))
@@ -411,7 +417,13 @@ export const ChatScreen = () => {
             })
           }}
         >
-          <KeyboardAvoidingView style={styles.keyboardAvoiding}>
+          <KeyboardAvoidingView
+            keyboardShowingOffset={PLAY_BAR_HEIGHT}
+            style={[
+              styles.keyboardAvoiding,
+              hasTrack ? { bottom: PLAY_BAR_HEIGHT } : null
+            ]}
+          >
             {!isLoading ? (
               chatMessages?.length > 0 ? (
                 <View style={styles.listContainer}>


### PR DESCRIPTION
### Description
Tried a couple of approaches but landed here. Flatlist only supports sticky headers, no sticky footers, and since we're using inverted we need a sticky header! There was a `stickyHeaderInverted` boolean prop but that didn't work. (Also no documentation for these.) Stackoverflow crawling indicates that a view outside the flatlist is the way to go.

Still need to figure out how to disable the shadow above the play bar.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

