### PR TITLE
[PAY-901] hotfix: TransactionDetailsModal now expects wei amounts

### DIFF
--- a/packages/web/src/store/application/ui/buy-audio/sagas.ts
+++ b/packages/web/src/store/application/ui/buy-audio/sagas.ts
@@ -496,7 +496,6 @@ function* populateAndSaveTransactionDetails() {
   const postAUDIOBalanceWei = yield* select(
     walletSelectors.getAccountTotalBalance
   )
-  const postAUDIOBalance = formatWei(postAUDIOBalanceWei).replaceAll(',', '')
   const purchasedAUDIO = purchasedAudioWei
     ? formatWei(new BN(purchasedAudioWei ?? '0') as BNWei).replaceAll(',', '')
     : ''
@@ -527,8 +526,8 @@ function* populateAndSaveTransactionDetails() {
     transactionType: TransactionType.PURCHASE,
     method:
       PROVIDER_METHOD_MAP[localStorageState.provider ?? OnRampProvider.UNKNOWN],
-    balance: postAUDIOBalance,
-    change: purchasedAUDIO,
+    balance: postAUDIOBalanceWei.toString(),
+    change: purchasedAudioWei?.toString() ?? '',
     metadata: transactionMetadata
   }
 


### PR DESCRIPTION
### Description

The TransactionDetailsModal on success was showing incorrect values for balance and change, due to a difference in the values being sent from the final part of the buy audio process and the transaction history page

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

