### PR TITLE
[PAY-1178] Fix new messages on new/unloaded chats

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -164,11 +164,13 @@ const slice = createSlice({
         return { ...item, hasTail: hasTail(item, data[index - 1]) }
       })
       // Recalculate hasTail for latest message of new batch
-      if (state.messages[chatId].ids.length > 0) {
+      if (state.messages[chatId] && state.messages[chatId].ids.length > 0) {
         const prevEarliestMessageId =
           state.messages[chatId].ids[state.messages[chatId].ids.length - 1]
-        const prevEarliestMessage =
-          state.messages[chatId].entities[prevEarliestMessageId]
+        const prevEarliestMessage = getMessage(
+          state.messages[chatId],
+          prevEarliestMessageId
+        )
         const newLatestMessage = messagesWithTail[0]
         newLatestMessage.hasTail = hasTail(
           newLatestMessage,
@@ -306,10 +308,12 @@ const slice = createSlice({
       const { chatId, message, status } = action.payload
 
       // Recalculate hasTail of previous message
-      const prevLatestMessageId = state.messages[chatId].ids[0]
-      const prevLatestMessage =
-        state.messages[chatId].entities[prevLatestMessageId]
-      if (prevLatestMessage) {
+      if (state.messages[chatId] && state.messages[chatId].ids.length > 0) {
+        const prevLatestMessageId = state.messages[chatId].ids[0]
+        const prevLatestMessage = getMessage(
+          state.chats[chatId],
+          prevLatestMessageId
+        )!
         const prevMsgHasTail = hasTail(prevLatestMessage, message)
         chatMessagesAdapter.updateOne(state.messages[chatId], {
           id: prevLatestMessageId,


### PR DESCRIPTION
### Description

Sending a message in a new or unloaded chat for the other user would fail if they have the chats page open, as `addMessage` was getting called for a chat that didn't exist and the `hasTail` check expects there to be one.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

