### PR TITLE
Fix eager fetch

### DIFF
--- a/packages/common/src/services/audius-backend/eagerLoadUtils.ts
+++ b/packages/common/src/services/audius-backend/eagerLoadUtils.ts
@@ -59,20 +59,14 @@ export const makeEagerRequest = async (
   let res: any
   if (req?.method?.toLowerCase() === 'post') {
     headers['Content-Type'] = 'application/json'
-    const url = `${baseUrl}?${paramsToQueryString(
-      req.queryParams,
-      discprovEndpoint === eagerDiscprov
-    )}`
+    const url = `${baseUrl}?${paramsToQueryString(req.queryParams)}`
     res = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify(req.data)
     })
   } else {
-    const url = `${baseUrl}?${paramsToQueryString(
-      req.queryParams,
-      discprovEndpoint === eagerDiscprov
-    )}`
+    const url = `${baseUrl}?${paramsToQueryString(req.queryParams)}`
     res = await fetch(url, {
       headers
     })

--- a/packages/common/src/utils/stringUtils.ts
+++ b/packages/common/src/utils/stringUtils.ts
@@ -1,25 +1,19 @@
 /**
  * Converts a provided URL params object to a query string
  */
-export const paramsToQueryString = (
-  params: { [key: string]: string | string[] },
-  formatWithoutArray = false
-) => {
+export const paramsToQueryString = (params: {
+  [key: string]: string | string[]
+}) => {
   if (!params) return ''
-  return Object.keys(params)
-    .map((k) => {
-      if (Array.isArray(params[k])) {
-        return (params[k] as string[])
-          .map((val: string) =>
-            formatWithoutArray
-              ? `${encodeURIComponent(k)}=${encodeURIComponent(val)}`
-              : `${encodeURIComponent(k)}[]=${encodeURIComponent(val)}`
-          )
-          .join('&')
+  return Object.entries(params)
+    .filter((p) => p[1] !== undefined && p[1] !== null)
+    .map((p) => {
+      if (Array.isArray(p[1])) {
+        // Otherwise, join in the form of
+        // ?key=val1&key=val2&key=val3...
+        return p[1].map((val) => `${p[0]}=${encodeURIComponent(val)}`).join('&')
       }
-      return (
-        encodeURIComponent(k) + '=' + encodeURIComponent(params[k] as string)
-      )
+      return `${p[0]}=${encodeURIComponent(p[1]!)}`
     })
     .join('&')
 }


### PR DESCRIPTION
### Description

Weird formatting of URL.

Bug: AudiusBackend eager requests (not even AudiusAPIClient... why we have so many API interaces 🤮 ) will send array args like ?id[]=1 instead of ?id=1. This causes initial load to do weird things if you have no discovery selected and are trying to fetch something via a numeric ID.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

