### PR TITLE
[PLAT-904] Fix duplicate notifications

### DIFF
--- a/packages/web/src/common/store/notifications/fetchNotifications.ts
+++ b/packages/web/src/common/store/notifications/fetchNotifications.ts
@@ -22,6 +22,8 @@ export function* fetchNotifications(config: FetchNotificationsParams) {
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
   const remoteConfig = yield* getContext('remoteConfigInstance')
 
+  yield* call(remoteConfig.waitForRemoteConfig)
+
   const useDiscoveryNotifications = yield* call(
     getFeatureEnabled,
     FeatureFlags.DISCOVERY_NOTIFICATIONS


### PR DESCRIPTION
### Description

Fixes issue where duplicate notifications sometimes showed up in users notification panel. this was due to not waiting for feature flags + remote config to be ready before making the initial notifications fetch.