### PR TITLE
Remove dependency on `download.cid` for determining download eligibility

### DIFF
--- a/packages/common/src/hooks/useDownloadTrackButtons.ts
+++ b/packages/common/src/hooks/useDownloadTrackButtons.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import moment from 'moment'
 import { useSelector as reduxUseSelector, shallowEqual } from 'react-redux'
 
@@ -155,8 +157,9 @@ const getStemButtons = ({
   isLoggedIn: boolean
   stems: LabeledStem[]
   parentTrackId: ID
-  track: Track
+  track: Track | null
 }) => {
+  if (!track) return []
   return stems.map((u) => {
     const state = (() => {
       if (!isLoggedIn) return ButtonState.LOG_IN_REQUIRED
@@ -191,7 +194,7 @@ const getStemButtons = ({
   })
 }
 
-const makeDownloadOriginalButton = ({
+const useMakeDownloadOriginalButton = ({
   following,
   isLoggedIn,
   isOwner,
@@ -204,34 +207,46 @@ const makeDownloadOriginalButton = ({
   track: Track | null
   stemButtonsLength: number
 }) => {
-  if (!track?.download?.is_downloadable) {
-    return undefined
-  }
+  return useMemo(() => {
+    if (!track?.download?.is_downloadable) {
+      return undefined
+    }
 
-  const label = messages.getDownloadTrack(stemButtonsLength)
-  const config = {
-    label,
-    type: ButtonType.TRACK
-  }
+    const label = messages.getDownloadTrack(stemButtonsLength)
+    const config = {
+      label,
+      type: ButtonType.TRACK
+    }
 
-  const requiresFollow = doesRequireFollow(isOwner, following, track)
-  if (isLoggedIn && requiresFollow) {
+    const requiresFollow = doesRequireFollow(isOwner, following, track)
+    if (isLoggedIn && requiresFollow) {
+      return {
+        ...config,
+        state: ButtonState.REQUIRES_FOLLOW
+      }
+    }
+
     return {
       ...config,
-      state: ButtonState.REQUIRES_FOLLOW
-    }
-  }
-
-  return {
-    ...config,
-    state: isLoggedIn ? ButtonState.DOWNLOADABLE : ButtonState.LOG_IN_REQUIRED,
-    onClick: () => {
-      if (!isLoggedIn) {
-        onNotLoggedInClick?.()
+      state: isLoggedIn
+        ? ButtonState.DOWNLOADABLE
+        : ButtonState.LOG_IN_REQUIRED,
+      onClick: () => {
+        if (!isLoggedIn) {
+          onNotLoggedInClick?.()
+        }
+        onDownload(track.track_id)
       }
-      onDownload(track.track_id)
     }
-  }
+  }, [
+    following,
+    isLoggedIn,
+    isOwner,
+    onDownload,
+    stemButtonsLength,
+    track,
+    onNotLoggedInClick
+  ])
 }
 export const useDownloadTrackButtons = ({
   following,
@@ -251,7 +266,6 @@ export const useDownloadTrackButtons = ({
 
   // Get the currently uploading stems
   const { uploadingTracks } = useUploadingStems({ trackId, useSelector })
-  if (!track) return []
 
   // Combine uploaded and uploading stems
   const combinedStems = [...stemTracks, ...uploadingTracks] as Stem[]
@@ -272,7 +286,7 @@ export const useDownloadTrackButtons = ({
   })
 
   // Make download original button
-  const originalTrackButton = makeDownloadOriginalButton({
+  const originalTrackButton = useMakeDownloadOriginalButton({
     following,
     isLoggedIn,
     isOwner,
@@ -281,6 +295,8 @@ export const useDownloadTrackButtons = ({
     stemButtonsLength: stemButtons.length,
     track
   })
+
+  if (!track) return []
 
   return [...(originalTrackButton ? [originalTrackButton] : []), ...stemButtons]
 }

--- a/packages/common/src/hooks/useDownloadTrackButtons.ts
+++ b/packages/common/src/hooks/useDownloadTrackButtons.ts
@@ -281,7 +281,6 @@ export const useDownloadTrackButtons = ({
     stemButtonsLength: stemButtons.length,
     track
   })
-  console.log({ originalTrackButton })
 
   return [...(originalTrackButton ? [originalTrackButton] : []), ...stemButtons]
 }

--- a/packages/common/src/hooks/useDownloadTrackButtons.ts
+++ b/packages/common/src/hooks/useDownloadTrackButtons.ts
@@ -209,8 +209,7 @@ const makeDownloadOriginalButton = ({
   }
 
   const label = messages.getDownloadTrack(stemButtonsLength)
-  const config: DownloadButtonConfig = {
-    state: ButtonState.PROCESSING,
+  const config = {
     label,
     type: ButtonType.TRACK
   }
@@ -223,24 +222,17 @@ const makeDownloadOriginalButton = ({
     }
   }
 
-  if (track.download.cid) {
-    return {
-      ...config,
-      state: isLoggedIn
-        ? ButtonState.DOWNLOADABLE
-        : ButtonState.LOG_IN_REQUIRED,
-      onClick: () => {
-        if (!isLoggedIn) {
-          onNotLoggedInClick?.()
-        }
-        onDownload(track.track_id)
+  return {
+    ...config,
+    state: isLoggedIn ? ButtonState.DOWNLOADABLE : ButtonState.LOG_IN_REQUIRED,
+    onClick: () => {
+      if (!isLoggedIn) {
+        onNotLoggedInClick?.()
       }
+      onDownload(track.track_id)
     }
   }
-
-  return config
 }
-
 export const useDownloadTrackButtons = ({
   following,
   isOwner,
@@ -289,6 +281,7 @@ export const useDownloadTrackButtons = ({
     stemButtonsLength: stemButtons.length,
     track
   })
+  console.log({ originalTrackButton })
 
   return [...(originalTrackButton ? [originalTrackButton] : []), ...stemButtons]
 }

--- a/packages/common/src/services/track-download/TrackDownload.ts
+++ b/packages/common/src/services/track-download/TrackDownload.ts
@@ -1,12 +1,5 @@
 import { AudiusBackend } from 'services/audius-backend'
 
-import { CID, ID, TrackMetadata } from '../../models'
-import { newTrackMetadata } from '../../schemas'
-
-const CHECK_DOWNLOAD_AVAILIBILITY_POLLING_INTERVAL = 3000
-
-const updateTrackDownloadCIDInProgress = new Set<number>([])
-
 export type TrackDownloadConfig = {
   audiusBackend: AudiusBackend
 }
@@ -20,56 +13,5 @@ export class TrackDownload {
 
   async downloadTrack(_args: { url: string; filename: string }) {
     throw new Error('downloadTrack not implemented')
-  }
-
-  /**
-   * Updates the download cid for a track
-   */
-  async updateTrackDownloadCID(
-    trackId: ID,
-    metadata: TrackMetadata,
-    // optional cid to update to, otherwise it is polled for
-    cid: CID
-  ) {
-    const audiusLibs = await this.audiusBackend.getAudiusLibs()
-    if (updateTrackDownloadCIDInProgress.has(trackId)) return
-    if (metadata.download && metadata.download.cid) return
-
-    updateTrackDownloadCIDInProgress.add(trackId)
-
-    const cleanedMetadata = newTrackMetadata(metadata, true)
-    const account = audiusLibs.Account.getCurrentUser()
-
-    if (!cid) {
-      cid = await this.checkIfDownloadAvailable(
-        trackId,
-        account.creator_node_endpoint
-      )
-    }
-    cleanedMetadata.download.cid = cid
-    const update = await audiusLibs.Track.updateTrack(cleanedMetadata)
-
-    updateTrackDownloadCIDInProgress.delete(trackId)
-    return update
-  }
-
-  async checkIfDownloadAvailable(trackId: ID, creatorNodeEndpoints: string[]) {
-    const audiusLibs = await this.audiusBackend.getAudiusLibs()
-    let cid
-    while (!cid) {
-      try {
-        cid = await audiusLibs.Track.checkIfDownloadAvailable(
-          creatorNodeEndpoints,
-          trackId
-        )
-      } catch (e) {
-        console.error(e)
-        return null
-      }
-      await new Promise((resolve) =>
-        setTimeout(resolve, CHECK_DOWNLOAD_AVAILIBILITY_POLLING_INTERVAL)
-      )
-    }
-    return cid
   }
 }

--- a/packages/common/src/store/cache/tracks/actions.ts
+++ b/packages/common/src/store/cache/tracks/actions.ts
@@ -13,8 +13,6 @@ export const SET_PERMALINK = 'CACHE/TRACKS/SET_PERMALINK'
 
 export const FETCH_COVER_ART = 'CACHE/TRACKS/FETCH_COVER_ART'
 
-export const CHECK_IS_DOWNLOADABLE = 'CACHE/TRACKS/CHECK_IS_DOWNLOADABLE'
-
 export function editTrack(trackId, formFields) {
   return { type: EDIT_TRACK, trackId, formFields }
 }
@@ -46,8 +44,3 @@ export function setPermalink(permalink: string, trackId: ID) {
 export function fetchCoverArt(trackId, size) {
   return { type: FETCH_COVER_ART, trackId, size }
 }
-
-export const checkIsDownloadable = (trackId) => ({
-  type: CHECK_IS_DOWNLOADABLE,
-  trackId
-})

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -196,20 +196,6 @@ function* watchFetchTrack() {
   })
 }
 
-function* watchFetchTrackSucceeded() {
-  yield takeEvery(trackPageActions.FETCH_TRACK_SUCCEEDED, function* (action) {
-    const { trackId } = action
-    const track = yield select(getCachedTrack, { id: trackId })
-    if (
-      track.download &&
-      track.download.is_downloadable &&
-      !track.download.cid
-    ) {
-      yield put(trackCacheActions.checkIsDownloadable(track.track_id))
-    }
-  })
-}
-
 function* watchRefetchLineup() {
   yield takeEvery(trackPageActions.REFETCH_LINEUP, function* (action) {
     const { permalink } = yield select(getTrack)
@@ -274,7 +260,6 @@ export default function sagas() {
   return [
     ...tracksSagas(),
     watchFetchTrack,
-    watchFetchTrackSucceeded,
     watchRefetchLineup,
     watchFetchTrackBadge,
     watchTrackPageMakePublic,

--- a/packages/web/src/common/store/upload/sagas.js
+++ b/packages/web/src/common/store/upload/sagas.js
@@ -5,7 +5,6 @@ import {
   formatUrlName,
   accountSelectors,
   accountActions,
-  cacheTracksActions as tracksActions,
   cacheUsersSelectors,
   cacheActions,
   waitForAccount,
@@ -1035,10 +1034,6 @@ function* uploadSingleTrack(track) {
     fieldName: 'track_count',
     delta: 1
   })
-
-  if (confirmedTrack.download && confirmedTrack.download.is_downloadable) {
-    yield put(tracksActions.checkIsDownloadable(confirmedTrack.track_id))
-  }
 
   // If the hide remixes is turned on, send analytics event
   if (

--- a/packages/web/src/services/track-download.ts
+++ b/packages/web/src/services/track-download.ts
@@ -16,8 +16,9 @@ class TrackDownload extends TrackDownloadBase {
         link.target = '_blank'
         link.download = filename
         link.click()
+      } else {
+        throw new Error('No document found')
       }
-      throw new Error('No document found')
     }
     downloadURL(response.url, filename)
   }


### PR DESCRIPTION
### Description

- In some places we were still showing the download button conditionally upon whether the track's `download` field has the CID in place. We no longer need to do this because we now rely on the stream endpoint to download files. Also, sometimes on stage `cid` is null even though it's downloadable.
- This means we can get rid of the 'processing' state of the download button and a lot of adjacent code

### Dragons

- Removes a lot of code. Testing thoroughly

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Tested against stage.

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

