### PR TITLE
Fix index issue with constructUrl

### DIFF
--- a/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
+++ b/packages/common/src/services/audius-api-client/AudiusAPIClient.ts
@@ -1955,7 +1955,7 @@ export class AudiusAPIClient {
           if (splitArrayParams) {
             // If we split, join in the form of
             // ?key=val1,val2,val3...
-            return `${p[0]}=${[1]
+            return `${p[0]}=${p[1]
               .map((val) => encodeURIComponent(val))
               .join(',')}`
           } else {


### PR DESCRIPTION
### Description

Fixes issue where we are not indexing the param, just creating an array `[1]` 😢 
