### PR TITLE
[PLAT-863] Fix reaction endpoint when sdk-v2

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -732,16 +732,16 @@ export const audiusBackend = ({
       discoveryNodeSelector =
         await discoveryNodeSelectorInstance.getDiscoveryNodeSelector()
 
-      discoveryNodeSelector.addEventListener('change', (endpoint) => {
-        discoveryProviderSelectionCallback(endpoint, [])
-      })
-
       const initialSelectedNode =
         await discoveryNodeSelectorInstance.initialSelectedNode
 
       if (initialSelectedNode) {
         discoveryProviderSelectionCallback(initialSelectedNode.endpoint, [])
       }
+
+      discoveryNodeSelector.addEventListener('change', (endpoint) => {
+        discoveryProviderSelectionCallback(endpoint, [])
+      })
     }
 
     try {

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -735,6 +735,13 @@ export const audiusBackend = ({
       discoveryNodeSelector.addEventListener('change', (endpoint) => {
         discoveryProviderSelectionCallback(endpoint, [])
       })
+
+      const initialSelectedNode =
+        await discoveryNodeSelectorInstance.initialSelectedNode
+
+      if (initialSelectedNode) {
+        discoveryProviderSelectionCallback(initialSelectedNode.endpoint, [])
+      }
     }
 
     try {

--- a/packages/common/src/services/discovery-node-selector/DiscoveryNodeSelectorInstance.ts
+++ b/packages/common/src/services/discovery-node-selector/DiscoveryNodeSelectorInstance.ts
@@ -24,7 +24,7 @@ export class DiscoveryNodeSelectorInstance {
   private env: Env
   private remoteConfigInstance: RemoteConfigInstance
   private discoveryNodeSelectorPromise: Promise<DiscoveryNodeSelector> | null
-  private initialSelectedNode: Promise<CachedDiscoveryProviderType | null>
+  public initialSelectedNode: Promise<CachedDiscoveryProviderType | null>
 
   constructor(config: DiscoveryNodeSelectorConfig) {
     const { env, remoteConfigInstance, initialSelectedNode } = config


### PR DESCRIPTION
### Description

Fixes issue where we get a retry storm on `/reactions` endpoint when sdk service selector is active. This is due to a change in service-selector where we pass in a cached endpoint, as `initialSelectedNode`, and as a result the service "change" event never gets fired, meaning the callbacks waiting for change never get called. one of those callbacks is from audius-api, which sets libs state from 'eager' to 'libs'. since that never happenend, we continually stayed in the 'eager' state, which looped over forever.

