### PR TITLE
Feature flag gates to send metadata directly through chain

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -676,7 +676,8 @@ export const audiusBackend = ({
 
   async function sanityChecks(audiusLibs: any) {
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
     try {
       const sanityCheckOptions = {
         skipRollover: getRemoteVar(
@@ -1285,7 +1286,8 @@ export const audiusBackend = ({
       FeatureFlags.STORAGE_V2_TRACK_UPLOAD
     )
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
     if (storageV2SignupEnabled || storageV2UploadEnabled) {
       try {
         return await audiusLibs.Track.uploadTrackV2(
@@ -1343,7 +1345,8 @@ export const audiusBackend = ({
     }[]
   ) {
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
     return audiusLibs.Track.addTracksToChainAndCnode(
       uploadedTracks,
       writeMetadataThroughChainEnabled
@@ -1352,7 +1355,8 @@ export const audiusBackend = ({
 
   async function uploadImage(file: File) {
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
     return audiusLibs.File.uploadImage(
       file,
       undefined,
@@ -1370,7 +1374,8 @@ export const audiusBackend = ({
       FeatureFlags.STORAGE_V2_TRACK_UPLOAD
     )
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
 
     if (storageV2UploadEnabled) {
       if (metadata.artwork) {
@@ -1513,7 +1518,8 @@ export const audiusBackend = ({
       associatedWallets?.associated_sol_wallets
 
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
     try {
       if (newMetadata.updatedProfilePicture) {
         const resp = await audiusLibs.File.uploadImage(
@@ -1577,7 +1583,8 @@ export const audiusBackend = ({
   async function updateUser(metadata: User, id: ID) {
     let newMetadata = { ...metadata }
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
     try {
       if (newMetadata.updatedProfilePicture) {
         const resp = await audiusLibs.File.uploadImage(
@@ -1752,7 +1759,8 @@ export const audiusBackend = ({
   async function updatePlaylist(metadata: Collection) {
     try {
       const writeMetadataThroughChainEnabled =
-        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+        false
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
           metadata,
@@ -1769,7 +1777,8 @@ export const audiusBackend = ({
   async function orderPlaylist(playlist: any) {
     try {
       const writeMetadataThroughChainEnabled =
-        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+        false
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
           playlist,
@@ -1786,7 +1795,8 @@ export const audiusBackend = ({
     try {
       playlist.is_private = false
       const writeMetadataThroughChainEnabled =
-        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+        false
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
           {
@@ -1805,7 +1815,8 @@ export const audiusBackend = ({
   async function addPlaylistTrack(playlist: Collection) {
     try {
       const writeMetadataThroughChainEnabled =
-        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+        false
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
           playlist,
@@ -1821,7 +1832,8 @@ export const audiusBackend = ({
   async function deletePlaylistTrack(playlist: Collection) {
     try {
       const writeMetadataThroughChainEnabled =
-        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+        false
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
           playlist,
@@ -2112,7 +2124,8 @@ export const audiusBackend = ({
       )
     }
     const writeMetadataThroughChainEnabled =
-      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
+      (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+      false
     // Returns { userId, error, phase }
     return await audiusLibs.Account.signUp(
       email,

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1726,15 +1726,18 @@ export const audiusBackend = ({
         metadata_time: currentBlock.timestamp
       }))
       const writeMetadataThroughChainEnabled =
-        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
-      const response = await audiusLibs.EntityManager.createPlaylist({
-        ...metadata,
-        playlist_id: playlistId,
-        playlist_contents: { track_ids: playlistTracks },
-        is_album: isAlbum,
-        is_private: isPrivate,
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ??
+        false
+      const response = await audiusLibs.EntityManager.createPlaylist(
+        {
+          ...metadata,
+          playlist_id: playlistId,
+          playlist_contents: { track_ids: playlistTracks },
+          is_album: isAlbum,
+          is_private: isPrivate
+        },
         writeMetadataThroughChainEnabled
-      })
+      )
       const { blockHash, blockNumber, error } = response
       if (error) return { playlistId, error }
       return { blockHash, blockNumber, playlistId }
@@ -1765,8 +1768,13 @@ export const audiusBackend = ({
 
   async function orderPlaylist(playlist: any) {
     try {
+      const writeMetadataThroughChainEnabled =
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
       const { blockHash, blockNumber } =
-        await audiusLibs.EntityManager.updatePlaylist(playlist)
+        await audiusLibs.EntityManager.updatePlaylist(
+          playlist,
+          writeMetadataThroughChainEnabled
+        )
       return { blockHash, blockNumber }
     } catch (error) {
       console.error(getErrorMessage(error))
@@ -1777,11 +1785,16 @@ export const audiusBackend = ({
   async function publishPlaylist(playlist: Collection) {
     try {
       playlist.is_private = false
+      const writeMetadataThroughChainEnabled =
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
       const { blockHash, blockNumber } =
-        await audiusLibs.EntityManager.updatePlaylist({
-          ...playlist,
-          is_private: false
-        })
+        await audiusLibs.EntityManager.updatePlaylist(
+          {
+            ...playlist,
+            is_private: false
+          },
+          writeMetadataThroughChainEnabled
+        )
       return { blockHash, blockNumber }
     } catch (error) {
       console.error(getErrorMessage(error))
@@ -1791,8 +1804,13 @@ export const audiusBackend = ({
 
   async function addPlaylistTrack(playlist: Collection) {
     try {
+      const writeMetadataThroughChainEnabled =
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
       const { blockHash, blockNumber } =
-        await audiusLibs.EntityManager.updatePlaylist(playlist)
+        await audiusLibs.EntityManager.updatePlaylist(
+          playlist,
+          writeMetadataThroughChainEnabled
+        )
       return { blockHash, blockNumber }
     } catch (error) {
       console.error(getErrorMessage(error))
@@ -1802,8 +1820,13 @@ export const audiusBackend = ({
 
   async function deletePlaylistTrack(playlist: Collection) {
     try {
+      const writeMetadataThroughChainEnabled =
+        (await getFeatureEnabled(FeatureFlags.WRITE_METADATA_THROUGH_CHAIN)) ?? false
       const { blockHash, blockNumber } =
-        await audiusLibs.EntityManager.updatePlaylist(playlist)
+        await audiusLibs.EntityManager.updatePlaylist(
+          playlist,
+          writeMetadataThroughChainEnabled
+        )
       return { blockHash, blockNumber }
     } catch (error) {
       console.error(getErrorMessage(error))

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -47,7 +47,8 @@ export enum FeatureFlags {
   STORAGE_V2_SIGNUP = 'storage_v2_signup',
   PLAYLIST_UPDATES_PRE_QA = 'playlist_updates_pre_qa',
   PLAYLIST_UPDATES_POST_QA = 'playlist_updates_post_qa',
-  AI_ATTRIBUTION = 'ai_attribution'
+  AI_ATTRIBUTION = 'ai_attribution',
+  WRITE_METADATA_THROUGH_CHAIN = 'write_metadata_through_chain'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -110,5 +111,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.STORAGE_V2_SIGNUP]: false,
   [FeatureFlags.PLAYLIST_UPDATES_PRE_QA]: false,
   [FeatureFlags.PLAYLIST_UPDATES_POST_QA]: false,
-  [FeatureFlags.AI_ATTRIBUTION]: false
+  [FeatureFlags.AI_ATTRIBUTION]: false,
+  [FeatureFlags.WRITE_METADATA_THROUGH_CHAIN]: false
 }


### PR DESCRIPTION
### Description
Accompanies https://github.com/AudiusProject/audius-protocol/pull/5171

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Deployed backend changes to stage, tested with client and libs changes. Made sure no "falling back to fetching cid metadata from content nodes..." logs when flag was on. Tested user updates, track updates/uploads, and playlist/album updates/uploads.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

`write_metadata_through_chain`
