### PR TITLE
Fix mobile prem content track headers

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -135,7 +135,9 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   headerContainer: {
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'center'
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing(4)
   },
   headerText: {
     marginTop: spacing(4),
@@ -165,8 +167,8 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     marginRight: spacing(2)
   },
   aiAttributedHeader: {
-    marginHorizontal: spacing(6),
     flexDirection: 'row',
+    width: '100%',
     justifyContent: 'center',
     gap: spacing(2),
     paddingVertical: spacing(2.5),


### PR DESCRIPTION
### Description
Premium content/special access mobile track headers were not centered after changes related to the AI track headers.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 13 01 05](https://user-images.githubusercontent.com/3893871/235988385-6da68486-a15f-46d8-a01b-219e25020328.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 13 03 28](https://user-images.githubusercontent.com/3893871/235988391-e4ca7c72-547c-428f-860a-58e69c8bb0ab.png)


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

