### PR TITLE
[C-2393] Cache pods in CI

### DIFF
--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -34,8 +34,8 @@ mobile-prepare-ios:
     - attach_workspace:
         at: ./
     - run:
-        name: update cocoapods
-        command: sudo gem install cocoapods
+        name: install cocoapods
+        command: sudo gem install cocoapods:1.12.0
     - run:
         name: copy bundle
         command: cd packages/mobile && npm run bundle:ios

--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -44,9 +44,15 @@ mobile-prepare-ios:
         command: |
           curl -sL https://sentry.io/get-cli/ | bash
           echo export SENTRY_BINARY=/usr/local/bin/sentry-cli >> "$BASH_ENV"
+    - restore_cache:
+        key: pods-{{ checksum "packages/mobile/ios/Podfile.lock" }}
     - run:
         name: install pods
         command: cd packages/mobile/ios && pod install
+    - save_cache:
+        key: pods-{{ checksum "packages/mobile/ios/Podfile.lock" }}
+        paths:
+          - packages/mobile/ios/pods
     - run:
         name: update bundler
         command: gem install bundler:1.17.3

--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -50,8 +50,7 @@ mobile-prepare-ios:
         name: install pods
         command: |
           cd packages/mobile/ios
-          pod repo update
-          pod install
+          pod install --deployment
     - save_cache:
         key: pods-{{ checksum "packages/mobile/ios/Podfile.lock" }}
         paths:

--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -48,7 +48,10 @@ mobile-prepare-ios:
         key: pods-{{ checksum "packages/mobile/ios/Podfile.lock" }}
     - run:
         name: install pods
-        command: cd packages/mobile/ios && pod install
+        command: |
+          cd packages/mobile/ios
+          pod repo update
+          pod install
     - save_cache:
         key: pods-{{ checksum "packages/mobile/ios/Podfile.lock" }}
         paths:


### PR DESCRIPTION
### Description
![image](https://user-images.githubusercontent.com/19916043/235995469-106952d1-0d93-47f4-8b3e-349fddd54b5d.png)

* Cache pods in mobile ci
* Ideally we would use the same version of `cocoapods` on CI as we do locally. Right now I've hardcoded the version to `1.12.0`, but in the future it may be better to include `cocoapods` in our Gemfile.lock
  Also added the `--deployment` flag which will cause the step to fail if any changes are generated in the Podfile.lock during installation

See: https://github.com/CocoaPods/CocoaPods/issues/8848

### Dragons

If we commit Podfile.lock with a new cocoapods version, ci will fail until we update the version in ci

### How Has This Been Tested?

Ran mobile ci pipeline and confirmed that cached pods improved run time

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

