### PR TITLE
Fix internal/external audius urls

### DIFF
--- a/packages/common/src/utils/urlUtils.ts
+++ b/packages/common/src/utils/urlUtils.ts
@@ -1,6 +1,6 @@
 const audiusUrlRegex =
   // eslint-disable-next-line no-useless-escape
-  /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?(audius.co)(\/.+)?/gim
+  /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?(audius.co|staging.audius.co)(\/.+)?/gim
 
 export const isAudiusUrl = (url: string) => new RegExp(audiusUrlRegex).test(url)
 export const getPathFromAudiusUrl = (url: string) =>

--- a/packages/common/src/utils/urlUtils.ts
+++ b/packages/common/src/utils/urlUtils.ts
@@ -1,7 +1,7 @@
 const audiusUrlRegex =
   // eslint-disable-next-line no-useless-escape
-  /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?([^:\/?\n]+\.)?(audius.co)(\/.+)?/gim
+  /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?(audius.co)(\/.+)?/gim
 
 export const isAudiusUrl = (url: string) => new RegExp(audiusUrlRegex).test(url)
 export const getPathFromAudiusUrl = (url: string) =>
-  new RegExp(audiusUrlRegex).exec(url)?.[3] ?? null
+  new RegExp(audiusUrlRegex).exec(url)?.[2] ?? null

--- a/packages/common/src/utils/urlUtils.ts
+++ b/packages/common/src/utils/urlUtils.ts
@@ -1,7 +1,7 @@
 const audiusUrlRegex =
   // eslint-disable-next-line no-useless-escape
-  /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?(audius.co|staging.audius.co)(\/.+)?/gim
+  /^(?:https?:\/\/)?(?:[^@\/\n]+@)?(?:www\.)?(staging\.)?(audius.co)(\/.+)?/gim
 
 export const isAudiusUrl = (url: string) => new RegExp(audiusUrlRegex).test(url)
 export const getPathFromAudiusUrl = (url: string) =>
-  new RegExp(audiusUrlRegex).exec(url)?.[2] ?? null
+  new RegExp(audiusUrlRegex).exec(url)?.[3] ?? null


### PR DESCRIPTION
### Description

Fixes issue where remix.audius.co was marked as an "internal" audius url, causing a redirect issue. The fix was to remove the capture group between https:// and audius.co

### Dragons

There may have been an important reason for this capture group. @Kyle-Shanks would love your insight here
