### PR TITLE
Fix search-results saga error due to yield*

### DIFF
--- a/packages/web/src/common/store/pages/search-page/sagas.js
+++ b/packages/web/src/common/store/pages/search-page/sagas.js
@@ -131,7 +131,7 @@ export function* getSearchResults(searchText, kind, limit, offset) {
       { tracks: [], albums: [], playlists: [], users: [] }
     )
   } else {
-    results = yield* call([apiClient, 'getSearchFull'], {
+    results = yield call([apiClient, 'getSearchFull'], {
       currentUserId: userId,
       query: searchText,
       kind,


### PR DESCRIPTION
### Description

Fixes issue in search-results saga where we use yield* instead of yield since it's a .js file
