### PR TITLE
[C-2566] Prevent player error on skip

### DIFF
--- a/packages/web/src/services/audio-player/AudioPlayer.ts
+++ b/packages/web/src/services/audio-player/AudioPlayer.ts
@@ -131,7 +131,6 @@ export class AudioPlayer {
       this.stop()
       const prevVolume = this.audio.volume
       if (this.audio) {
-        this.audio.src = ''
         this.audio.remove()
       }
       this.audio = new Audio()


### PR DESCRIPTION
### Description

Prevents play error on skip.

### Dragons

Not sure if simply calling `.remove()` is enough, or if setting `src = ''` is also required. @raymondjacobson for thoughts 😄 
