### PR TITLE
DMs: Don't increment unread if it's your own message

### DIFF
--- a/packages/common/src/store/pages/chat/middleware.ts
+++ b/packages/common/src/store/pages/chat/middleware.ts
@@ -2,6 +2,8 @@ import { type AudiusSdk, ChatEvents } from '@audius/sdk'
 import { Middleware } from 'redux'
 
 import { Status } from 'models/Status'
+import { getUserId } from 'store/account/selectors'
+import { encodeHashId } from 'utils/hashIds'
 
 import { actions as chatActions } from './slice'
 
@@ -35,7 +37,10 @@ export const chatMiddleware =
             store.dispatch(
               addMessage({ chatId, message, status: Status.SUCCESS })
             )
-            store.dispatch(incrementUnreadCount({ chatId }))
+            const currentUserId = getUserId(store.getState())
+            if (message.sender_user_id !== encodeHashId(currentUserId)) {
+              store.dispatch(incrementUnreadCount({ chatId }))
+            }
           }
           reactionListener = ({ chatId, messageId, reaction }) => {
             store.dispatch(


### PR DESCRIPTION
### Description

Now that we're sending a user's own chats to themselves in websocket land, we need to filter to not inc the unread count if the message comes from themselves

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

