### PR TITLE
Dismiss keyboard on mobile chat screen top right press

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -14,7 +14,7 @@ import {
 } from '@audius/common'
 import { Portal } from '@gorhom/portal'
 import { useFocusEffect } from '@react-navigation/native'
-import { View, Text, Pressable, FlatList } from 'react-native'
+import { Keyboard, View, Text, Pressable, FlatList } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import IconKebabHorizontal from 'app/assets/images/iconKebabHorizontal.svg'
@@ -292,6 +292,7 @@ export const ChatScreen = () => {
   )
 
   const handleTopRightPress = () => {
+    Keyboard.dismiss()
     dispatch(
       setVisibility({
         drawer: 'ChatActions',


### PR DESCRIPTION
### Description
Dismiss the keyboard when pressing top right kebab on chat screen so that the drawer isn't occluded by keyboard.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

