### PR TITLE
Remove canBeUnlisted and clean up fetchTrack

### DIFF
--- a/packages/common/src/store/pages/track/actions.ts
+++ b/packages/common/src/store/pages/track/actions.ts
@@ -38,7 +38,6 @@ export const fetchTrack = (
   trackId: Nullable<number>,
   slug?: string,
   handle?: string,
-  canBeUnlisted?: boolean,
   forceRetrieveFromSource?: boolean,
   withRemixes?: boolean
 ) => ({
@@ -46,7 +45,6 @@ export const fetchTrack = (
   trackId,
   slug,
   handle,
-  canBeUnlisted,
   forceRetrieveFromSource,
   withRemixes
 })

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -60,7 +60,6 @@ export type AppTabScreenParamList = {
   Track: {
     id?: ID
     searchTrack?: SearchTrack
-    canBeUnlisted?: boolean
     handle?: string
     slug?: string
   }

--- a/packages/mobile/src/screens/search-screen/SearchResults/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchResults/SearchItem.tsx
@@ -85,8 +85,7 @@ const TrackSearchResult = (props: TrackSearchResultProps) => {
     dispatch(addItem({ searchItem: track.title }))
     navigation.push('Track', {
       id: track.track_id,
-      searchTrack: track,
-      canBeUnlisted: false
+      searchTrack: track
     })
   }, [track, navigation, dispatch])
 

--- a/packages/mobile/src/screens/track-screen/TrackScreen.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreen.tsx
@@ -58,7 +58,7 @@ export const TrackScreen = () => {
   const isOfflineModeEnabled = useIsOfflineModeEnabled()
   const isReachable = useSelector(getIsReachable)
 
-  const { searchTrack, id, canBeUnlisted = true, handle, slug } = params ?? {}
+  const { searchTrack, id, handle, slug } = params ?? {}
 
   const cachedTrack = useSelector((state) => getTrack(state, params))
 
@@ -77,14 +77,9 @@ export const TrackScreen = () => {
   const handleFetchTrack = useCallback(() => {
     dispatch(tracksActions.reset())
     dispatch(
-      fetchTrack(
-        id,
-        decodeURIComponent(slug ?? ''),
-        handle ?? user?.handle,
-        canBeUnlisted
-      )
+      fetchTrack(id, decodeURIComponent(slug ?? ''), handle ?? user?.handle)
     )
-  }, [dispatch, canBeUnlisted, id, slug, handle, user?.handle])
+  }, [dispatch, id, slug, handle, user?.handle])
 
   useFocusEffect(handleFetchTrack)
 

--- a/packages/web/src/common/store/pages/track/sagas.js
+++ b/packages/web/src/common/store/pages/track/sagas.js
@@ -138,13 +138,12 @@ function* watchFetchTrack() {
       trackId,
       handle,
       slug,
-      canBeUnlisted,
       forceRetrieveFromSource,
       withRemixes = true
     } = action
     try {
       let track
-      if (!trackId) {
+      if (handle && slug) {
         track = yield call(retrieveTrackByHandleAndSlug, {
           handle,
           slug,
@@ -153,18 +152,17 @@ function* watchFetchTrack() {
           withRemixParents: true,
           forceRetrieveFromSource
         })
-      } else {
-        const ids = canBeUnlisted
-          ? [{ id: trackId, url_title: slug, handle }]
-          : [trackId]
+      } else if (trackId) {
+        const ids = [trackId]
         const tracks = yield call(retrieveTracks, {
           trackIds: ids,
-          canBeUnlisted,
           withStems: true,
           withRemixes,
           withRemixParents: true
         })
         track = tracks && tracks.length === 1 ? tracks[0] : null
+      } else {
+        return
       }
       const isReachable = yield select(getIsReachable)
       if (!track) {

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -237,7 +237,7 @@ class TrackPageProvider extends Component<
     if (slug && handle) {
       this.props.setTrackPermalink(`/${handle}/${slug}`)
     }
-    this.props.fetchTrack(trackId, slug || '', handle || '', !!(slug && handle))
+    this.props.fetchTrack(trackId, slug || '', handle || '')
     if (handle) {
       this.setState({ ownerHandle: handle })
     }
@@ -529,15 +529,8 @@ function makeMapStateToProps() {
 
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
-    fetchTrack: (
-      trackId: number | null,
-      slug: string,
-      ownerHandle: string,
-      canBeUnlisted: boolean
-    ) =>
-      dispatch(
-        trackPageActions.fetchTrack(trackId, slug, ownerHandle, canBeUnlisted)
-      ),
+    fetchTrack: (trackId: number | null, slug: string, ownerHandle: string) =>
+      dispatch(trackPageActions.fetchTrack(trackId, slug, ownerHandle)),
     setTrackId: (trackId: number) =>
       dispatch(trackPageActions.setTrackId(trackId)),
     setTrackPermalink: (permalink: string) =>

--- a/packages/web/src/store/application/ui/stemsUpload/sagas.ts
+++ b/packages/web/src/store/application/ui/stemsUpload/sagas.ts
@@ -9,7 +9,7 @@ import {
 import { takeEvery, put, call, select } from 'redux-saga/effects'
 
 import { make } from 'common/store/analytics/actions'
-import { retrieveTracks } from 'common/store/cache/tracks/utils'
+import { retrieveTrackByHandleAndSlug } from 'common/store/cache/tracks/utils/retrieveTracks'
 import { handleUploads } from 'common/store/upload/sagas'
 import { createStemMetadata } from 'pages/upload-page/store/utils/stems'
 const { getUser } = cacheUsersSelectors
@@ -59,12 +59,10 @@ function* watchUploadStems() {
       // Retrieve the parent track to refresh stems
       const track: Track = yield select(getTrack, { id: parentId })
       const ownerUser: User = yield select(getUser, { id: track.owner_id })
-      yield call(retrieveTracks, {
-        trackIds: [
-          { id: parentId, handle: ownerUser.handle, url_title: track.title }
-        ],
-        withStems: true,
-        canBeUnlisted: true
+      yield call(retrieveTrackByHandleAndSlug, {
+        handle: ownerUser.handle,
+        slug: track.title,
+        withStems: true
       })
     }
   )


### PR DESCRIPTION
### Description

Removes `canBeUnlisted` option for `fetchTrack` flow, instead favoring `retrieveByHandleAndSlug` for most requests, and `retrieveTracks` for the case where there is only a trackId.

This should essentially cover all our cases:
   - If you have a track permalink, you can view the track, whether or not it's hidden
   - If you only have the trackId, you can only view the track if its public.

### Dragons
  - Need to ensure stem uploads on a hidden track work with this new system. In particular @rickyrombo can i use `track.title` for slug, or should i use `permalink` and grab the slug part of it?