### PR TITLE
[PAY-1221] Fix message hasTail recalculations when server resends messages

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -79,7 +79,7 @@ const {
   selectIds: getAllMessageIds
 } = chatMessagesAdapter.getSelectors()
 
-// Recalculate hasTail for the message at index - 1 (the previous message of
+// Recalculate hasTail for the message at index + 1 (the previous message of
 // the message at index).
 const recalculatePreviousMessageHasTail = (
   chatState: EntityState<ChatMessageWithExtras>,

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -73,7 +73,30 @@ export const chatMessagesAdapter = createEntityAdapter<ChatMessageWithExtras>({
   sortComparer: messageSortComparator
 })
 
-const { selectById: getMessage } = chatMessagesAdapter.getSelectors()
+const {
+  selectById: getMessage,
+  selectEntities: getAllMessages,
+  selectIds: getAllMessageIds
+} = chatMessagesAdapter.getSelectors()
+
+// Index of message for which to recalculate the hasTail property
+// of the _previous_ message
+const recalculatePreviousMessageHasTail = (
+  chatState: EntityState<ChatMessageWithExtras>,
+  index: number
+): void => {
+  const messageIds = getAllMessageIds(chatState)
+  const chatMessages = getAllMessages(chatState)
+  const prevMessageId = messageIds[index + 1]
+  const prevMessage = chatMessages[prevMessageId]
+  if (!prevMessage) return
+  const messageId = messageIds[index]
+  const message = chatMessages[messageId]
+  chatMessagesAdapter.updateOne(chatState, {
+    id: prevMessageId,
+    changes: { hasTail: hasTail(prevMessage, message) }
+  })
+}
 
 const initialState: ChatState = {
   chats: {
@@ -163,21 +186,11 @@ const slice = createSlice({
       const messagesWithTail = data.map((item, index) => {
         return { ...item, hasTail: hasTail(item, data[index - 1]) }
       })
-      // Recalculate hasTail for latest message of new batch
-      if (state.messages[chatId] && state.messages[chatId].ids.length > 0) {
-        const prevEarliestMessageId =
-          state.messages[chatId].ids[state.messages[chatId].ids.length - 1]
-        const prevEarliestMessage = getMessage(
-          state.messages[chatId],
-          prevEarliestMessageId
-        )
-        const newLatestMessage = messagesWithTail[0]
-        newLatestMessage.hasTail = hasTail(
-          newLatestMessage,
-          prevEarliestMessage
-        )
-      }
       chatMessagesAdapter.upsertMany(state.messages[chatId], messagesWithTail)
+      recalculatePreviousMessageHasTail(
+        state.messages[chatId],
+        state.messages[chatId].ids.length - 1 - data.length
+      )
     },
     fetchMoreMessagesFailed: (
       state,
@@ -307,32 +320,25 @@ const slice = createSlice({
       // triggers saga to get chat if not exists
       const { chatId, message, status } = action.payload
 
-      // Recalculate hasTail of previous message
-      if (state.messages[chatId] && state.messages[chatId].ids.length > 0) {
-        const prevLatestMessageId = state.messages[chatId].ids[0]
-        const prevLatestMessage = getMessage(
-          state.messages[chatId],
-          prevLatestMessageId
-        )!
-        const prevMsgHasTail = hasTail(prevLatestMessage, message)
-        chatMessagesAdapter.updateOne(state.messages[chatId], {
-          id: prevLatestMessageId,
-          changes: { hasTail: prevMsgHasTail }
+      const existingMessage = getMessage(
+        state.messages[chatId],
+        message.message_id
+      )
+      if (!existingMessage) {
+        chatMessagesAdapter.addOne(state.messages[chatId], {
+          ...message,
+          hasTail: true,
+          status: status ?? Status.IDLE
         })
+        chatsAdapter.updateOne(state.chats, {
+          id: chatId,
+          changes: {
+            last_message: message.message,
+            last_message_at: message.created_at
+          }
+        })
+        recalculatePreviousMessageHasTail(state.messages[chatId], 0)
       }
-
-      chatMessagesAdapter.upsertOne(state.messages[chatId], {
-        ...message,
-        hasTail: true,
-        status: status ?? Status.IDLE
-      })
-      chatsAdapter.updateOne(state.chats, {
-        id: chatId,
-        changes: {
-          last_message: message.message,
-          last_message_at: message.created_at
-        }
-      })
     },
     incrementUnreadCount: (
       state,

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -79,8 +79,8 @@ const {
   selectIds: getAllMessageIds
 } = chatMessagesAdapter.getSelectors()
 
-// Index of message for which to recalculate the hasTail property
-// of the _previous_ message
+// Recalculate hasTail for the message at index - 1 (the previous message of
+// the message at index).
 const recalculatePreviousMessageHasTail = (
   chatState: EntityState<ChatMessageWithExtras>,
   index: number
@@ -90,11 +90,11 @@ const recalculatePreviousMessageHasTail = (
   const prevMessageId = messageIds[index + 1]
   const prevMessage = chatMessages[prevMessageId]
   if (!prevMessage) return
-  const messageId = messageIds[index]
-  const message = chatMessages[messageId]
+  const newMessageId = messageIds[index]
+  const newMessage = chatMessages[newMessageId]
   chatMessagesAdapter.updateOne(chatState, {
     id: prevMessageId,
-    changes: { hasTail: hasTail(prevMessage, message) }
+    changes: { hasTail: hasTail(prevMessage, newMessage) }
   })
 }
 


### PR DESCRIPTION
### Description
Now that the backend is resending recent messages, hasTail calculations were getting re-triggered for old messages and they would randomly show tails when websocket reconnects happened. Unfortunately that means we do need to check if the incoming message already exists and don't add if it does.

Extracted hasTail recalculation to a helper function to be used in both `addMessages` and `fetchMoreMessagesSucceeded`.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

