### PR TITLE
[C-2519] Ignore TOS deeplink

### DIFF
--- a/packages/web/public/.well-known/apple-app-site-association
+++ b/packages/web/public/.well-known/apple-app-site-association
@@ -1,11 +1,15 @@
 {
-    "applinks": {
-        "apps": [],
-        "details": [
-            {
-                "appID": "LRFCG93S85.co.audius.audiusmusic",
-                "paths": ["NOT /oauth/auth*", "*"]
-            }
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "LRFCG93S85.co.audius.audiusmusic",
+        "paths": [
+          "NOT /oauth/auth*",
+          "NOT /legal/terms-of-use",
+          "*"
         ]
-    }
+      }
+    ]
+  }
 }

--- a/packages/web/public/.well-known/apple-app-site-association
+++ b/packages/web/public/.well-known/apple-app-site-association
@@ -6,7 +6,7 @@
         "appID": "LRFCG93S85.co.audius.audiusmusic",
         "paths": [
           "NOT /oauth/auth*",
-          "NOT /legal/terms-of-use",
+          "NOT /legal*",
           "*"
         ]
       }

--- a/packages/web/public/.well-known/apple-app-site-association-stage
+++ b/packages/web/public/.well-known/apple-app-site-association-stage
@@ -6,6 +6,7 @@
         "appID": "LRFCG93S85.co.audius.audiusmusic.staging",
         "paths": [
           "NOT /oauth/auth*",
+          "NOT /legal/terms-of-use",
           "*"
         ]
       }

--- a/packages/web/public/.well-known/apple-app-site-association-stage
+++ b/packages/web/public/.well-known/apple-app-site-association-stage
@@ -6,7 +6,7 @@
         "appID": "LRFCG93S85.co.audius.audiusmusic.staging",
         "paths": [
           "NOT /oauth/auth*",
-          "NOT /legal/terms-of-use",
+          "NOT /legal*",
           "*"
         ]
       }


### PR DESCRIPTION
### Description

Updates apple-site-association file to ignore /legal/terms-of-use url. Unfortunately we cannot do the same thing for android. Their intent-filter's dont allow exclusions, and since we have audius.co/user/... scheme there is no way to exclude this specific url.

This SO answer is super clear regarding android limitations: https://stackoverflow.com/a/45247815
