### PR TITLE
C-2483 Fix queue overshot empty track player bug

### DIFF
--- a/packages/common/src/store/queue/slice.ts
+++ b/packages/common/src/store/queue/slice.ts
@@ -144,11 +144,9 @@ const slice = createSlice({
           state.index = 0
           return
         }
-        if (!state.queueAutoplay) {
-          // Reset to last track
-          state.overshot = true
-          return
-        }
+        // Reset to last track
+        state.overshot = true
+        return
       }
 
       state.index = state.index + 1

--- a/packages/web/src/common/store/queue/sagas.ts
+++ b/packages/web/src/common/store/queue/sagas.ts
@@ -117,17 +117,12 @@ function* handleQueueAutoplay({
   const length = yield* select(getLength)
   const shuffle = yield* select(getShuffle)
   const repeatMode = yield* select(getRepeat)
-  const isCloseToEndOfQueue = index + 1 >= length
-  const isOnlySongInQueue = index === 0 && length === 1
+  const isCloseToEndOfQueue = index + 9 >= length
   const isNotRepeating =
     repeatMode === RepeatMode.OFF ||
     (repeatMode === RepeatMode.SINGLE && (skip || ignoreSkip))
 
-  if (
-    !shuffle &&
-    isNotRepeating &&
-    (isCloseToEndOfQueue || isOnlySongInQueue)
-  ) {
+  if (!shuffle && isNotRepeating && isCloseToEndOfQueue) {
     yield* waitForAccount()
     const userId = yield* select(getUserId)
     yield* put(


### PR DESCRIPTION
### Description
Before:  If a user skips to the end of their favorites lineup, they run into a blank/empty track player. From this state, if the user either clicks the play button or the rewind button, the final track in the lineup will start playing without updating the track player to indicate what is playing.

After: 
Load the autoplay queue early in order to avoid overshooting the queue.
Fallback: If the queue is still overshot, replay the last track while we wait for the autoplay queue to load.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

