### PR TITLE
DMs: Use the optimistic unread count if applicable

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -351,7 +351,10 @@ const slice = createSlice({
       // Ignore the unread bump to prevent flicker
       if (state.activeChatId !== chatId) {
         const existingChat = getChat(state, chatId)
-        const existingUnreadCount = existingChat?.unread_message_count ?? 0
+        const optimisticRead = state.optimisticChatRead[chatId]
+        const existingUnreadCount = optimisticRead
+          ? optimisticRead.unread_message_count
+          : existingChat?.unread_message_count ?? 0
         chatsAdapter.updateOne(state.chats, {
           id: chatId,
           changes: { unread_message_count: existingUnreadCount + 1 }


### PR DESCRIPTION
### Description

If we are in the middle of an optimistic chat read and get a new message, we want the new unread count to reflect our optimism.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

