### PR TITLE
[PAY-1215] Fix create new message crash

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -128,6 +128,7 @@ export const getChatMessageByIndex = (
   messageIndex: number
 ) => {
   const chatMessagesState = state.pages.chat.messages[chatId]
+  if (!chatMessagesState) return
   const messageIds = getChatMessageIds(chatMessagesState)
   const messageIdAtIndex = messageIds[messageIndex]
   return selectById(chatMessagesState, messageIdAtIndex)

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -128,7 +128,7 @@ export const getChatMessageByIndex = (
   messageIndex: number
 ) => {
   const chatMessagesState = state.pages.chat.messages[chatId]
-  if (!chatMessagesState) return
+  if (!chatMessagesState) return undefined
   const messageIds = getChatMessageIds(chatMessagesState)
   const messageIdAtIndex = messageIds[messageIndex]
   return selectById(chatMessagesState, messageIdAtIndex)
@@ -140,7 +140,7 @@ export const getChatMessageById = (
   messageId: string
 ) => {
   const chatMessagesState = state.pages.chat.messages[chatId]
-  if (!chatMessagesState) return
+  if (!chatMessagesState) return undefined
   return selectById(chatMessagesState, messageId)
 }
 

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -139,6 +139,7 @@ export const getChatMessageById = (
   messageId: string
 ) => {
   const chatMessagesState = state.pages.chat.messages[chatId]
+  if (!chatMessagesState) return
   return selectById(chatMessagesState, messageId)
 }
 


### PR DESCRIPTION
### Description
On a new chat, `getChatMessageById` would fail (used for the reactions popup on mobile) bc the `chatMessagesState` would be undefined (line 141) and we'd try to access `entities` of it.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage + web stage - tested with user Saliou_2 as well as others.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

