### PR TITLE
Fix invite reward claimable state on mobile

### DIFF
--- a/packages/mobile/src/screens/audio-screen/Panel.tsx
+++ b/packages/mobile/src/screens/audio-screen/Panel.tsx
@@ -120,7 +120,6 @@ export const Panel = ({
   const stepCount = challenge?.max_steps ?? 0
   const shouldShowCompleted =
     challenge?.state === 'completed' || challenge?.state === 'disbursed'
-  const hasCompleted = challenge?.state === 'completed'
   const hasDisbursed = challenge?.state === 'disbursed'
   const shouldShowProgressBar =
     stepCount > 1 && challenge?.challenge_type !== 'aggregate' && !hasDisbursed

--- a/packages/mobile/src/screens/audio-screen/Panel.tsx
+++ b/packages/mobile/src/screens/audio-screen/Panel.tsx
@@ -124,6 +124,7 @@ export const Panel = ({
   const hasDisbursed = challenge?.state === 'disbursed'
   const shouldShowProgressBar =
     stepCount > 1 && challenge?.challenge_type !== 'aggregate' && !hasDisbursed
+  const needsDisbursement = challenge && challenge.claimableAmount > 0
 
   const shouldShowProgress = !!progressLabel
   let progressLabelFilled: string | null = null
@@ -148,13 +149,13 @@ export const Panel = ({
     }
   }
 
-  const buttonType = hasCompleted
+  const buttonType = needsDisbursement
     ? 'primary'
     : hasDisbursed
     ? 'commonAlt'
     : 'common'
 
-  const buttonMessage = hasCompleted
+  const buttonMessage = needsDisbursement
     ? messages.claimReward
     : hasDisbursed
     ? messages.viewDetails
@@ -167,7 +168,7 @@ export const Panel = ({
       activeOpacity={0.7}
     >
       <View style={styles.pillContainer}>
-        {hasCompleted ? (
+        {needsDisbursement ? (
           <Text style={styles.pillMessage}>{messages.readyToClaim}</Text>
         ) : null}
       </View>


### PR DESCRIPTION
### Description
Noticed that invite challenge was not showing correct claimable state on mobile. I'd fixed this on web a while ago but forgot to fix on mobile as well. (10 points for shared code cc @piazzatron).

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

