### PR TITLE
[PAY-1183] Make clicking ChatUser handle/displayname lead to profile

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatUser.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatUser.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, useCallback } from 'react'
 
 import { User } from '@audius/common'
 import cn from 'classnames'
@@ -6,6 +6,8 @@ import cn from 'classnames'
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import { ProfilePicture } from 'components/notification/Notification/components/ProfilePicture'
 import UserBadges from 'components/user-badges/UserBadges'
+import { useGoToRoute } from 'hooks/useGoToRoute'
+import { profilePage } from 'utils/route'
 
 import styles from './ChatUser.module.css'
 
@@ -17,20 +19,30 @@ export const ChatUser = ({
   user: User
   children?: ReactNode
   textClassName?: string
-}) => (
-  <div className={styles.root}>
-    <ProfilePicture user={user} className={styles.profilePicture} />
-    <div className={cn(styles.text, textClassName)}>
-      <ArtistPopover handle={user.handle}>
-        <div className={styles.nameAndBadge}>
-          <span className={styles.name}>{user.name}</span>
-          <UserBadges userId={user.user_id} badgeSize={14} />
-        </div>
-      </ArtistPopover>
-      <ArtistPopover handle={user.handle}>
-        <span className={styles.handle}>@{user.handle}</span>
-      </ArtistPopover>
+}) => {
+  const goToRoute = useGoToRoute()
+  const goToProfile = useCallback(
+    () => goToRoute(profilePage(user.handle)),
+    [goToRoute, user]
+  )
+
+  return (
+    <div className={styles.root}>
+      <ProfilePicture user={user} className={styles.profilePicture} />
+      <div className={cn(styles.text, textClassName)}>
+        <ArtistPopover handle={user.handle}>
+          <div className={styles.nameAndBadge} onClick={goToProfile}>
+            <span className={styles.name}>{user.name}</span>
+            <UserBadges userId={user.user_id} badgeSize={14} />
+          </div>
+        </ArtistPopover>
+        <ArtistPopover handle={user.handle}>
+          <span className={styles.handle} onClick={goToProfile}>
+            @{user.handle}
+          </span>
+        </ArtistPopover>
+      </div>
+      {children}
     </div>
-    {children}
-  </div>
-)
+  )
+}


### PR DESCRIPTION
### Description

<img width="1181" alt="Screen Shot 2023-05-16 at 8 39 43 PM" src="https://github.com/AudiusProject/audius-client/assets/6780028/2f46d3f5-6f37-4a8e-8121-4c9b0a4dbaf0">

Clicking the underlined text will now route to the user's profile. 

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

