### PR TITLE
[PAY-1136][PAY-1129] Add infinite loading to albums on desktop / mobile web

### DIFF
--- a/packages/common/src/hooks/useSavedCollections.ts
+++ b/packages/common/src/hooks/useSavedCollections.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -38,7 +38,7 @@ export function useSavedAlbumsDetails({
   pageSize = DEFAULT_PAGE_SIZE
 }: UseSavedAlbumDetailsConfig) {
   const dispatch = useDispatch()
-  const [hasFetched, setHasFetched] = useState(false)
+
   const { unfetched: unfetchedAlbums, fetched: albumsWithDetails } =
     useSelector(getFetchedAlbumsWithDetails)
   const { status } = useSelector(getSavedAlbumsState)
@@ -51,24 +51,14 @@ export function useSavedAlbumsDetails({
       .slice(0, Math.min(pageSize, unfetchedAlbums.length))
       .map((c) => c.id)
     dispatch(fetchCollections({ type: 'albums', ids }))
-    setHasFetched(true)
-  }, [status, unfetchedAlbums, pageSize, dispatch, setHasFetched])
+  }, [status, unfetchedAlbums, pageSize, dispatch])
 
-  // Fetch first page if we don't have any items fetched yet
-  // Needs to wait for at least some albums to be fetchable
-  useEffect(() => {
-    if (
-      !hasFetched &&
-      // TODO: This check should change once InfiniteScroll is implemented
-      status !== Status.LOADING /* &&
-      unfetchedAlbums.length > 0 &&
-      albumsWithDetails.length === 0 */
-    ) {
-      fetchMore()
-    }
-  }, [albumsWithDetails, status, hasFetched, unfetchedAlbums, fetchMore])
-
-  return { data: albumsWithDetails, status, fetchMore }
+  return {
+    data: albumsWithDetails,
+    status,
+    hasMore: unfetchedAlbums.length > 0,
+    fetchMore
+  }
 }
 
 export function useSavedPlaylists() {

--- a/packages/common/src/hooks/useSavedCollections.ts
+++ b/packages/common/src/hooks/useSavedCollections.ts
@@ -1,24 +1,22 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { useDispatch, useSelector } from 'react-redux'
 
+import { ID } from 'models/Identifiers'
 import { Status } from 'models/Status'
+import { CommonState } from 'store/index'
+import { getFetchedCollectionIds } from 'store/saved-collections/selectors'
 
-import { accountActions } from '../store/account'
 import {
+  CollectionType,
   savedCollectionsActions,
   savedCollectionsSelectors
 } from '../store/saved-collections'
 
-const { fetchSavedPlaylists } = accountActions
 const { fetchCollections } = savedCollectionsActions
 
-const {
-  getAccountAlbums,
-  getSavedAlbumsState,
-  getFetchedAlbumsWithDetails,
-  getAccountPlaylists
-} = savedCollectionsSelectors
+const { getAccountAlbums, getSavedCollectionsState, getAccountPlaylists } =
+  savedCollectionsSelectors
 
 const DEFAULT_PAGE_SIZE = 50
 
@@ -26,49 +24,69 @@ export function useSavedAlbums() {
   return useSelector(getAccountAlbums)
 }
 
-/* TODO: Handle filtering
- * Option 1: This hook takes the list of album ids to fetch and computes the unfetched
- * based on that.
- * Option 2: Bake filter into selectors which drive this. Downside: Can't use this in multiple places...
- */
-type UseSavedAlbumDetailsConfig = {
-  pageSize?: number
-}
-export function useSavedAlbumsDetails({
-  pageSize = DEFAULT_PAGE_SIZE
-}: UseSavedAlbumDetailsConfig) {
-  const dispatch = useDispatch()
-
-  const { unfetched: unfetchedAlbums, fetched: albumsWithDetails } =
-    useSelector(getFetchedAlbumsWithDetails)
-  const { status } = useSelector(getSavedAlbumsState)
-
-  const fetchMore = useCallback(() => {
-    if (status === Status.LOADING || unfetchedAlbums.length === 0) {
-      return
-    }
-    const ids = unfetchedAlbums
-      .slice(0, Math.min(pageSize, unfetchedAlbums.length))
-      .map((c) => c.id)
-    dispatch(fetchCollections({ type: 'albums', ids }))
-  }, [status, unfetchedAlbums, pageSize, dispatch])
-
-  return {
-    data: albumsWithDetails,
-    status,
-    hasMore: unfetchedAlbums.length > 0,
-    fetchMore
-  }
-}
-
 export function useSavedPlaylists() {
   return useSelector(getAccountPlaylists)
 }
 
-export function useSavedPlaylistsDetails() {
+type UseFetchedCollectionsConfig = {
+  collectionIds: ID[]
+  type: CollectionType
+  pageSize?: number
+}
+
+type UseFetchedSavedCollectionsResult = {
+  /** A list of IDs representing the subset of requested collections which have been fetched */
+  data: ID[]
+  /** The current fetching state of the list of collections requested */
+  status: Status
+  /** Whether any items remain unfetched */
+  hasMore: boolean
+  /** Triggers fetching of the next page of items */
+  fetchMore: () => void
+}
+/** Given a list of collectionIds and a type ('albums' or 'playlists'), returns state
+ * necessary to display a list of fully-fetched collections of that type, as well as
+ * load any remaining items which haven't been fetched.
+ */
+export function useFetchedSavedCollections({
+  collectionIds,
+  type,
+  pageSize = DEFAULT_PAGE_SIZE
+}: UseFetchedCollectionsConfig): UseFetchedSavedCollectionsResult {
   const dispatch = useDispatch()
 
-  useEffect(() => {
-    dispatch(fetchSavedPlaylists())
-  }, [dispatch])
+  const { status } = useSelector((state: CommonState) =>
+    getSavedCollectionsState(state, type)
+  )
+  const fetchedCollectionIDs = useSelector(getFetchedCollectionIds)
+
+  const { unfetched, fetched } = useMemo(() => {
+    const fetchedSet = new Set(fetchedCollectionIDs)
+    return collectionIds.reduce<{ fetched: ID[]; unfetched: ID[] }>(
+      (accum, id) => {
+        if (fetchedSet.has(id)) {
+          accum.fetched.push(id)
+        } else {
+          accum.unfetched.push(id)
+        }
+        return accum
+      },
+      { fetched: [], unfetched: [] }
+    )
+  }, [collectionIds, fetchedCollectionIDs])
+
+  const fetchMore = useCallback(() => {
+    if (status === Status.LOADING || unfetched.length === 0) {
+      return
+    }
+    const ids = unfetched.slice(0, Math.min(pageSize, unfetched.length))
+    dispatch(fetchCollections({ type, ids }))
+  }, [status, unfetched, pageSize, type, dispatch])
+
+  return {
+    data: fetched,
+    status,
+    hasMore: unfetched.length > 0,
+    fetchMore
+  }
 }

--- a/packages/common/src/store/saved-collections/selectors.ts
+++ b/packages/common/src/store/saved-collections/selectors.ts
@@ -1,19 +1,24 @@
 import { createSelector } from '@reduxjs/toolkit'
 
-import { getUsers } from 'store/cache/users/selectors'
-
-import { AccountCollection } from '../account'
 import { getAccountStatus } from '../account/selectors'
 import { getCollections } from '../cache/collections/selectors'
 import { CommonState } from '../commonStore'
 
-import { CollectionWithOwner } from './types'
+import { CollectionType } from './types'
 
 const getAccountCollections = (state: CommonState) => state.account.collections
-export const getSavedAlbumsState = (state: CommonState) =>
-  state.savedCollections.albums
-export const getSavedPlaylistsState = (state: CommonState) =>
-  state.savedCollections.playlists
+export const getSavedCollectionsState = (
+  state: CommonState,
+  type: CollectionType
+) =>
+  type === 'albums'
+    ? state.savedCollections.albums
+    : state.savedCollections.playlists
+
+export const getFetchedCollectionIds = createSelector(
+  [getCollections],
+  (collections) => Object.values(collections).map((c) => c.playlist_id)
+)
 
 export const getAccountAlbums = createSelector(
   [getAccountCollections, getAccountStatus],
@@ -21,32 +26,6 @@ export const getAccountAlbums = createSelector(
     status,
     data: Object.values(collections).filter((c) => c.is_album)
   })
-)
-
-type GetAlbumsWithDetailsResult = {
-  fetched: CollectionWithOwner[]
-  unfetched: AccountCollection[]
-}
-/** Returns a mapped list of albums for which we have fetched full details */
-export const getFetchedAlbumsWithDetails = createSelector(
-  [getAccountAlbums, getCollections, getUsers],
-  (albums, collections, users) => {
-    // TODO: Might want to read status, what happens for failed loads of parts of the collection?
-    return albums.data.reduce<GetAlbumsWithDetailsResult>(
-      (acc, cur) => {
-        const collectionMetadata = collections[cur.id]
-        if (collectionMetadata) {
-          const ownerHandle =
-            users[collectionMetadata.playlist_owner_id]?.handle ?? ''
-          acc.fetched.push({ ...collections[cur.id], ownerHandle })
-        } else {
-          acc.unfetched.push(cur)
-        }
-        return acc
-      },
-      { fetched: [], unfetched: [] }
-    )
-  }
 )
 
 export const getAccountPlaylists = createSelector(

--- a/packages/common/src/store/saved-collections/types.ts
+++ b/packages/common/src/store/saved-collections/types.ts
@@ -1,7 +1,1 @@
-import { Collection } from '../../models/Collection'
-
 export type CollectionType = 'albums' | 'playlists'
-
-export type CollectionWithOwner = Collection & {
-  ownerHandle: string
-}

--- a/packages/web/src/components/lineup/CardLineup.tsx
+++ b/packages/web/src/components/lineup/CardLineup.tsx
@@ -1,15 +1,15 @@
+import React from 'react'
+
 import cn from 'classnames'
-import { connect } from 'react-redux'
 
 import { EmptyCard } from 'components/card/mobile/Card'
 import { Draggable } from 'components/dragndrop'
 import CategoryHeader from 'components/header/desktop/CategoryHeader'
-import { AppState } from 'store/types'
-import { isMobile } from 'utils/clientUtil'
+import { useIsMobile } from 'utils/clientUtil'
 
 import styles from './CardLineup.module.css'
 
-type OwnProps = {
+export type CardLineupProps = {
   categoryName?: string
   cards: JSX.Element[]
   containerClassName?: string
@@ -23,7 +23,7 @@ const DesktopCardContainer = ({
   containerClassName,
   cardsClassName,
   onMore
-}: OwnProps) => {
+}: CardLineupProps) => {
   return (
     <div className={cn(containerClassName)}>
       {categoryName && (
@@ -74,7 +74,10 @@ const renderEmptyCards = (cardsLength: number) => {
   return null
 }
 
-const MobileCardContainer = ({ cards, containerClassName }: OwnProps) => {
+const MobileCardContainer = ({
+  cards,
+  containerClassName
+}: CardLineupProps) => {
   return (
     <div className={cn(styles.mobileContainer, containerClassName)}>
       {cards.map((card, index) => (
@@ -87,19 +90,11 @@ const MobileCardContainer = ({ cards, containerClassName }: OwnProps) => {
   )
 }
 
-type CardLineupProps = OwnProps & ReturnType<typeof mapStateToProps>
-
 const CardLineup = (props: CardLineupProps) => {
-  const { isMobile, ...containerProps } = props
+  const isMobile = useIsMobile()
   const Container = isMobile ? MobileCardContainer : DesktopCardContainer
 
-  return <Container {...containerProps} />
+  return React.createElement(Container, props)
 }
 
-function mapStateToProps(state: AppState) {
-  return {
-    isMobile: isMobile()
-  }
-}
-
-export default connect(mapStateToProps)(CardLineup)
+export default CardLineup

--- a/packages/web/src/components/lineup/InfiniteCardLineup.module.css
+++ b/packages/web/src/components/lineup/InfiniteCardLineup.module.css
@@ -1,6 +1,5 @@
-
-    .spinner {
-        margin: auto;
-        width: var(--unit-8);
-        height: 100px;
-      }
+.spinner {
+  margin: auto;
+  width: var(--unit-8);
+  height: 100px;
+}

--- a/packages/web/src/components/lineup/InfiniteCardLineup.module.css
+++ b/packages/web/src/components/lineup/InfiniteCardLineup.module.css
@@ -1,0 +1,6 @@
+
+    .spinner {
+        margin: auto;
+        width: var(--unit-8);
+        height: 100px;
+      }

--- a/packages/web/src/components/lineup/InfiniteCardLineup.tsx
+++ b/packages/web/src/components/lineup/InfiniteCardLineup.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback, useRef } from 'react'
+
+import InfiniteScroll from 'react-infinite-scroller'
+
+import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
+import { getScrollParent } from 'utils/scrollParent'
+
+import CardLineup, { CardLineupProps } from './CardLineup'
+import styles from './InfiniteCardLineup.module.css'
+
+type InfiniteLoadingProps = {
+  hasMore: boolean
+  loadMore: () => void
+}
+
+export type InfiniteCardLineupProps = CardLineupProps & InfiniteLoadingProps
+
+const InfiniteCardLineup = (props: InfiniteCardLineupProps) => {
+  const { hasMore, loadMore, ...lineupProps } = props
+  const scrollRef = useRef(null)
+
+  const getNearestScrollParent = useCallback(() => {
+    if (!scrollRef.current) {
+      return null
+    }
+    return (
+      (getScrollParent(scrollRef.current) as unknown as HTMLElement) ?? null
+    )
+  }, [])
+
+  return (
+    <>
+      <InfiniteScroll
+        hasMore={hasMore}
+        getScrollParent={getNearestScrollParent}
+        loadMore={loadMore}
+        loader={
+          <LoadingSpinner key='loading-spinner' className={styles.spinner} />
+        }
+        useWindow={false}
+      >
+        {React.createElement(CardLineup, lineupProps)}
+      </InfiniteScroll>
+      <div ref={scrollRef} />
+    </>
+  )
+}
+
+export default InfiniteCardLineup

--- a/packages/web/src/pages/saved-page/SavedPageProvider.tsx
+++ b/packages/web/src/pages/saved-page/SavedPageProvider.tsx
@@ -443,7 +443,6 @@ class SavedPage extends PureComponent<SavedPageProps, SavedPageState> {
       fetchSavedTracks: this.props.fetchSavedTracks,
       resetSavedTracks: this.props.resetSavedTracks,
       updateLineupOrder: this.props.updateLineupOrder,
-      fetchSavedAlbums: this.props.fetchSavedAlbums,
       goToRoute: this.props.goToRoute,
       play: this.props.play,
       pause: this.props.pause,
@@ -559,7 +558,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
     resetSavedTracks: () => dispatch(tracksActions.reset()),
     updateLineupOrder: (updatedOrderIndices: UID[]) =>
       dispatch(tracksActions.updateLineupOrder(updatedOrderIndices)),
-    fetchSavedAlbums: () => dispatch(accountActions.fetchSavedAlbums()),
     fetchSavedPlaylists: () => dispatch(accountActions.fetchSavedPlaylists()),
     updatePlaylistLastViewedAt: (playlistId: number) =>
       dispatch(updatedPlaylistViewed({ playlistId })),

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.module.css
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.module.css
@@ -77,11 +77,8 @@
 }
 
 /* Albums */
-.cardsContainer > * {
-  margin-top: 8px;
-  margin-left: 8px;
-  margin-right: 8px;
-  margin-bottom: 16px;
+.cardsContainer  {
+  gap: var(--unit-6) var(--unit-4)
 }
 
 .playButtonContainer {

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.module.css
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.module.css
@@ -77,8 +77,8 @@
 }
 
 /* Albums */
-.cardsContainer  {
-  gap: var(--unit-6) var(--unit-4)
+.cardsContainer {
+  gap: var(--unit-6) var(--unit-4);
 }
 
 .playButtonContainer {

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.module.css
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.module.css
@@ -112,6 +112,7 @@
 }
 
 .cardsContainer {
+  gap: var(--unit-6) var(--unit-4);
   margin-top: 16px;
   padding: 0px 11px;
 }


### PR DESCRIPTION
### Description
#### Refactored fetching code
* Now generic to all collections
* Accepts a list of IDs to fetch, which enables filtering of the list _before_ fetching and preserves proper `hasMore` / `fetchMore` behavior based on the filtered list
* Simplified logic which only returns the list of ids which have been fetched, allowing `Card` components to fetch the full metadata themselves

#### Pushed data connection down into Cards
For Desktop and Mobile web, the `AlbumCard` component now accepts an ID and fetches the collection and user info directly. This follows our normalized data patterns and will also help prevent excessive re-renders for already loaded cards just because we've added more items to the albums list.

#### Added infinite scrolling
* Created a version of `CardLineup` which does infinite scrolling. I didn't modify the existing `CardLineup` to do this because we use it in other places where we probably don't want infinite scrolling behavior
* Cleaned up `CardLineup` a little bit to remove unnecessary legacy redux patterns

### Dragons
N/A

### How Has This Been Tested?
Tested locally on desktop and mobile web

### How will this change be monitored?
Will test via normal RC flows and in staging

### Feature Flags ###
N/A

