### PR TITLE
[PAY-1139] Throttle calls to fetchMessages on web scroll

### DIFF
--- a/packages/common/src/utils/chatUtils.ts
+++ b/packages/common/src/utils/chatUtils.ts
@@ -1,6 +1,8 @@
 import type { ChatMessage } from '@audius/sdk'
 import dayjs from 'dayjs'
 
+import { Status } from 'models/Status'
+
 import { MESSAGE_GROUP_THRESHOLD_MINUTES } from './constants'
 
 /**
@@ -44,4 +46,15 @@ export const isEarliestUnread = ({
     (!lastReadAt || dayjs(prevMessage.created_at).isAfter(lastReadAt))
   const isAuthor = message.sender_user_id === currentUserId
   return isUnread && !isPreviousMessageUnread && !isAuthor
+}
+
+/**
+ * Can only fetch more messages if it's not in a loading state and
+ * there are previous messages to fetch
+ */
+export const chatCanFetchMoreMessages = (
+  messagesStatus?: Status,
+  prevCount?: number
+) => {
+  return !!messagesStatus && messagesStatus !== Status.LOADING && !!prevCount
 }

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useCallback, useRef, useMemo } from 'react'
 
 import type { ChatMessageWithExtras } from '@audius/common'
 import {
+  chatCanFetchMoreMessages,
   chatActions,
   accountSelectors,
   chatSelectors,
@@ -279,18 +280,18 @@ export const ChatScreen = () => {
     }, 10)
   }, [])
 
-  const shouldFetchMoreMessages =
-    chatId &&
-    chat?.messagesStatus !== Status.LOADING &&
-    chat?.messagesSummary &&
-    chat?.messagesSummary.prev_count > 0
-
   const handleScrollToTop = useCallback(() => {
-    if (shouldFetchMoreMessages) {
+    if (
+      chatId &&
+      chatCanFetchMoreMessages(
+        chat?.messagesStatus,
+        chat?.messagesSummary?.prev_count
+      )
+    ) {
       // Fetch more messages when user reaches the top
       dispatch(fetchMoreMessages({ chatId }))
     }
-  }, [chatId, dispatch, shouldFetchMoreMessages])
+  }, [chat?.messagesStatus, chat?.messagesSummary, chatId, dispatch])
 
   // Mark chat as read when user navigates away from screen
   useFocusEffect(

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -7,7 +7,8 @@ import {
   forwardRef,
   useRef,
   useLayoutEffect,
-  useState
+  useState,
+  useMemo
 } from 'react'
 
 import {
@@ -17,9 +18,11 @@ import {
   encodeHashId,
   Status,
   hasTail,
-  isEarliestUnread
+  isEarliestUnread,
+  chatCanFetchMoreMessages
 } from '@audius/common'
 import cn from 'classnames'
+import { throttle } from 'lodash'
 import { mergeRefs } from 'react-merge-refs'
 import { useDispatch } from 'react-redux'
 
@@ -46,13 +49,14 @@ type ChatMessageListProps = ComponentPropsWithoutRef<'div'> & {
 
 const SCROLL_TOP_THRESHOLD = 800
 const SCROLL_BOTTOM_THRESHOLD = 32
+const THROTTLE_DURATION_MS = 500
 
-const isScrolledToBottom = (element: HTMLElement) => {
+const isScrolledNearBottom = (element: HTMLElement) => {
   const { scrollTop, clientHeight, scrollHeight } = element
   return scrollTop + clientHeight >= scrollHeight - SCROLL_BOTTOM_THRESHOLD
 }
 
-const isScrolledToTop = (element: HTMLElement) => {
+const isScrolledNearTop = (element: HTMLElement) => {
   return element.scrollTop < SCROLL_TOP_THRESHOLD
 }
 
@@ -83,26 +87,50 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       }
     }, [chat, chatId])
 
-    const handleScroll = useCallback(
-      (e: UIEvent<HTMLDivElement>) => {
-        if (chatId && isScrolledToBottom(e.currentTarget)) {
-          // Mark chat as read when the user reaches the bottom (saga handles no-op if already read)
-          dispatch(markChatAsRead({ chatId }))
-          dispatch(setActiveChat({ chatId }))
-        } else {
-          dispatch(setActiveChat({ chatId: null }))
-          if (
-            chatId &&
-            isScrolledToTop(e.currentTarget) &&
-            chat?.messagesStatus !== Status.LOADING
-          ) {
-            // Fetch more messages when user reaches the top
-            dispatch(fetchMoreMessages({ chatId }))
-          }
-        }
-      },
-      [dispatch, chatId, chat?.messagesStatus]
+    // Memoize the creation of throttled scroll handler, to avoid
+    // creating a new throttled function each time and because useCallback
+    // doesn't like receiving a non-inlined fn
+    // https://dmitripavlutin.com/react-throttle-debounce/
+    const handleScroll = useMemo(
+      () =>
+        throttle(
+          (e: UIEvent<HTMLDivElement>) => {
+            if (!chatId) return
+
+            // Handle case where scrolled to bottom
+            if (isScrolledNearBottom(e.currentTarget)) {
+              // Mark chat as read when the user reaches the bottom (saga handles no-op if already read)
+              dispatch(markChatAsRead({ chatId }))
+              dispatch(setActiveChat({ chatId }))
+            } else {
+              dispatch(setActiveChat({ chatId: null }))
+
+              if (chat?.messagesSummary?.prev_count === undefined) {
+                return
+              }
+
+              if (
+                chatCanFetchMoreMessages(
+                  chat?.messagesStatus,
+                  chat?.messagesSummary?.prev_count
+                ) &&
+                isScrolledNearTop(e.currentTarget)
+              ) {
+                // Fetch more messages when user reaches the top
+                dispatch(fetchMoreMessages({ chatId }))
+              }
+            }
+          },
+          THROTTLE_DURATION_MS,
+          { leading: true, trailing: false }
+        ),
+      [dispatch, chatId, chat?.messagesStatus, chat?.messagesSummary]
     )
+
+    // Cancel any throttled scrolls when component dismounts
+    useEffect(() => () => {
+      handleScroll.cancel()
+    })
 
     const scrollIntoViewOnMount = useCallback((el: HTMLDivElement) => {
       if (el) {


### PR DESCRIPTION
### Description

- On web, throttle calls to fetchMessages once per 500ms.
- Fixes a bug the existing web scroll handlers where we failed to check if `prev_count > 0` when fetching at the top of the list, leading to spamming comms:
```
// old version:
if (
            chatId &&
            isScrolledToTop(e.currentTarget) &&
            chat?.messagesStatus !== Status.LOADING
          ) {
            // Fetch more messages when user reaches the top
            dispatch(fetchMoreMessages({ chatId }))
          }
```
Mobile was performing this check correctly, so I took this as opportunity to consolidate this code.


On Throttle vs Debounce:
- I picked throttle because debounce will only call the final invocation of a function; we want to call this periodically as a user scrolls if they're scrolling through a long list of messages.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Locally

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

