### PR TITLE
[C-2508] Update playback positions to be tracked per user id

### DIFF
--- a/packages/common/src/store/playback-position/selectors.ts
+++ b/packages/common/src/store/playback-position/selectors.ts
@@ -7,15 +7,22 @@ import { PlaybackPositionInfo } from './types'
 export const getPlaybackPositions = (state: CommonState) =>
   state.playbackPosition
 
-export const getTrackPositions = (state: CommonState) =>
-  state.playbackPosition.trackPositions
+export const getUserTrackPositions = (
+  state: CommonState,
+  props: { userId?: ID | null }
+) => {
+  const { userId } = props
+  if (!userId) return null
+
+  return state.playbackPosition[userId]?.trackPositions ?? null
+}
 
 export const getTrackPosition = (
   state: CommonState,
-  props: { trackId?: ID | null }
+  props: { userId?: ID | null; trackId?: ID | null }
 ): PlaybackPositionInfo | null => {
-  const { trackId } = props
-  if (!trackId) return null
+  const { userId, trackId } = props
+  if (!trackId || !userId) return null
 
-  return state.playbackPosition.trackPositions[trackId] ?? null
+  return state.playbackPosition[userId]?.trackPositions[trackId] ?? null
 }

--- a/packages/common/src/store/playback-position/slice.ts
+++ b/packages/common/src/store/playback-position/slice.ts
@@ -10,16 +10,16 @@ type InitializePlaybackPositionStatePayload = {
 
 type SetTrackPositionPayload = {
   trackId: ID
+  userId?: ID | null
   positionInfo: PlaybackPositionInfo
 }
 
 type ClearTrackPositionPayload = {
   trackId: ID
+  userId?: ID | null
 }
 
-const initialState: PlaybackPositionState = {
-  trackPositions: {}
-}
+const initialState: PlaybackPositionState = {}
 
 const slice = createSlice({
   name: 'playback-position',
@@ -31,22 +31,29 @@ const slice = createSlice({
       action: PayloadAction<InitializePlaybackPositionStatePayload>
     ) => {
       const { playbackPositionState } = action.payload
-      state.trackPositions =
-        playbackPositionState.trackPositions ?? state.trackPositions
+      const userIds = Object.keys(playbackPositionState)
+      userIds.forEach((userId) => {
+        state[userId] = playbackPositionState[userId]
+      })
     },
     setTrackPosition: (
       state,
       action: PayloadAction<SetTrackPositionPayload>
     ) => {
-      const { trackId, positionInfo } = action.payload
-      state.trackPositions[trackId] = positionInfo
+      const { userId, trackId, positionInfo } = action.payload
+      if (!userId) return
+
+      const userState = state[userId] ?? { trackPositions: {} }
+      userState.trackPositions[trackId] = positionInfo
+      state[userId] = userState
     },
     clearTrackPosition: (
       state,
       action: PayloadAction<ClearTrackPositionPayload>
     ) => {
-      const { trackId } = action.payload
-      delete state.trackPositions[trackId]
+      const { userId, trackId } = action.payload
+      if (!userId) return
+      delete state[userId]?.trackPositions[trackId]
     }
   }
 })

--- a/packages/common/src/store/playback-position/types.ts
+++ b/packages/common/src/store/playback-position/types.ts
@@ -1,6 +1,7 @@
 import { ID } from 'models/Identifiers'
 
-export const PLAYBACK_POSITION_LS_KEY = 'playbackPosition'
+export const LEGACY_PLAYBACK_POSITION_LS_KEY = 'playbackPosition'
+export const PLAYBACK_POSITION_LS_KEY = 'userPlaybackPositions'
 
 export type PlaybackStatus = 'IN_PROGRESS' | 'COMPLETED'
 
@@ -10,5 +11,7 @@ export type PlaybackPositionInfo = {
 }
 
 export type PlaybackPositionState = {
-  trackPositions: { [Key in ID]?: PlaybackPositionInfo }
+  [UserIdKey in ID]?: {
+    trackPositions: { [TrackIdKey in ID]?: PlaybackPositionInfo }
+  }
 }

--- a/packages/common/src/store/storeContext.ts
+++ b/packages/common/src/store/storeContext.ts
@@ -19,6 +19,7 @@ import { CommonState } from './reducers'
 export type CommonStoreContext = {
   getLocalStorageItem: (key: string) => Promise<string | null>
   setLocalStorageItem: (key: string, value: string) => Promise<void>
+  removeLocalStorageItem: (key: string) => Promise<void>
   getFeatureEnabled: (
     flag: FeatureFlags,
     fallbackFlag?: FeatureFlags

--- a/packages/mobile/src/components/details-tile/DetailsProgressInfo.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsProgressInfo.tsx
@@ -1,5 +1,6 @@
 import type { SearchTrack, Track } from '@audius/common'
 import {
+  accountSelectors,
   formatLineupTileDuration,
   playbackPositionSelectors
 } from '@audius/common'
@@ -13,6 +14,7 @@ import { useThemeColors } from 'app/utils/theme'
 
 import { ProgressBar } from '../progress-bar'
 
+const { getUserId } = accountSelectors
 const { getTrackPosition } = playbackPositionSelectors
 
 const messages = {
@@ -64,8 +66,9 @@ export const DetailsProgressInfo = ({ track }: DetailsProgressInfoProps) => {
   const { duration } = track
   const { neutralLight4 } = useThemeColors()
   const styles = useStyles()
+  const currentUserId = useSelector(getUserId)
   const playbackPositionInfo = useSelector((state) =>
-    getTrackPosition(state, { trackId: track.track_id })
+    getTrackPosition(state, { trackId: track.track_id, userId: currentUserId })
   )
 
   const progressText = playbackPositionInfo

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -310,7 +310,7 @@ export const DetailsTile = ({
   )
 
   const playbackPositionInfo = useSelector((state) =>
-    getTrackPosition(state, { trackId })
+    getTrackPosition(state, { trackId, userId: currentUserId })
   )
 
   const playText =

--- a/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileTopRight.tsx
@@ -1,6 +1,7 @@
 import type { PremiumConditions, Nullable } from '@audius/common'
 import {
   FeatureFlags,
+  accountSelectors,
   playbackPositionSelectors,
   formatLineupTileDuration
 } from '@audius/common'
@@ -25,6 +26,7 @@ import { ProgressBar } from '../progress-bar'
 
 import { useStyles as useTrackTileStyles } from './styles'
 
+const { getUserId } = accountSelectors
 const { getTrackPosition } = playbackPositionSelectors
 
 const messages = {
@@ -139,8 +141,9 @@ export const LineupTileTopRight = ({
   const { neutralLight4, secondary } = useThemeColors()
   const accentBlue = useColor('accentBlue')
   const trackTileStyles = useTrackTileStyles()
+  const currentUserId = useSelector(getUserId)
   const playbackPositionInfo = useSelector((state) =>
-    getTrackPosition(state, { trackId })
+    getTrackPosition(state, { trackId, userId: currentUserId })
   )
 
   const isInProgress =

--- a/packages/mobile/src/components/lineup-tile/TrackTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/TrackTile.tsx
@@ -130,7 +130,7 @@ export const TrackTileComponent = ({
   }, [navigation, track_id])
 
   const playbackPositionInfo = useSelector((state) =>
-    getTrackPosition(state, { trackId: track_id })
+    getTrackPosition(state, { trackId: track_id, userId: currentUserId })
   )
   const handlePressOverflow = useCallback(() => {
     if (track_id === undefined) {

--- a/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/ActionsBar.tsx
@@ -142,7 +142,10 @@ export const ActionsBar = ({ track }: ActionsBarProps) => {
   }, [dispatch, track])
 
   const playbackPositionInfo = useSelector((state) =>
-    getTrackPosition(state, { trackId: track?.track_id })
+    getTrackPosition(state, {
+      trackId: track?.track_id,
+      userId: accountUser?.user_id
+    })
   )
   const onPressOverflow = useCallback(() => {
     if (track) {

--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -7,6 +7,7 @@ import {
   FollowSource,
   RepostSource,
   ShareSource,
+  accountSelectors,
   cacheTracksSelectors,
   cacheUsersSelectors,
   tracksSocialActions,
@@ -23,6 +24,7 @@ import { useToast } from 'app/hooks/useToast'
 import { AppTabNavigationContext } from 'app/screens/app-screen'
 import { setVisibility } from 'app/store/drawers/slice'
 
+const { getUserId } = accountSelectors
 const { getMobileOverflowModal } = mobileOverflowMenuUISelectors
 const { requestOpen: openAddToPlaylistModal } = addToPlaylistUIActions
 const { followUser, unfollowUser } = usersSocialActions
@@ -44,6 +46,7 @@ const messages = {
 const TrackOverflowMenuDrawer = ({ render }: Props) => {
   const { onClose: closeNowPlayingDrawer } = useDrawer('NowPlaying')
   const { navigation: contextNavigation } = useContext(AppTabNavigationContext)
+  const currentUserId = useSelector(getUserId)
   const navigation = useNavigation({ customNavigation: contextNavigation })
   const dispatch = useDispatch()
   const { toast } = useToast()
@@ -110,6 +113,7 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
     [OverflowAction.MARK_AS_PLAYED]: () => {
       dispatch(
         setTrackPosition({
+          userId: currentUserId,
           trackId: id,
           positionInfo: { status: 'COMPLETED', playbackPosition: 0 }
         })
@@ -117,7 +121,7 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
       toast({ content: messages.markedAsPlayed })
     },
     [OverflowAction.MARK_AS_UNPLAYED]: () => {
-      dispatch(clearTrackPosition({ trackId: id }))
+      dispatch(clearTrackPosition({ trackId: id, userId: currentUserId }))
       toast({ content: messages.markedAsUnplayed })
     }
   }

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -10,6 +10,7 @@ import {
   OverflowAction,
   OverflowSource,
   mobileOverflowMenuUIActions,
+  accountSelectors,
   cacheUsersSelectors,
   cacheTracksSelectors,
   playerSelectors
@@ -36,6 +37,7 @@ import { TablePlayButton } from './TablePlayButton'
 import { TrackArtwork } from './TrackArtwork'
 const { open: openOverflowMenu } = mobileOverflowMenuUIActions
 
+const { getUserId } = accountSelectors
 const { getUserFromTrack } = cacheUsersSelectors
 const { getTrack } = cacheTracksSelectors
 const { getPlaying, getUid } = playerSelectors
@@ -260,10 +262,12 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
 
+  const currentUserId = useSelector(getUserId)
+
   const isLongFormContent =
     track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
   const playbackPositionInfo = useSelector((state) =>
-    getTrackPosition(state, { trackId: track_id })
+    getTrackPosition(state, { trackId: track_id, userId: currentUserId })
   )
 
   const handleOpenOverflowMenu = useCallback(() => {

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -350,7 +350,7 @@ export const TrackScreenDetailsTile = ({
   }
 
   const playbackPositionInfo = useSelector((state) =>
-    getTrackPosition(state, { trackId: track_id })
+    getTrackPosition(state, { trackId: track_id, userId: currentUserId })
   )
   const handlePressOverflow = () => {
     const isLongFormContent =

--- a/packages/mobile/src/store/storeContext.ts
+++ b/packages/mobile/src/store/storeContext.ts
@@ -24,6 +24,7 @@ import share from 'app/utils/share'
 export const storeContext: CommonStoreContext = {
   getLocalStorageItem: async (key) => AsyncStorage.getItem(key),
   setLocalStorageItem: async (key, value) => AsyncStorage.setItem(key, value),
+  removeLocalStorageItem: async (key) => AsyncStorage.removeItem(key),
   getFeatureEnabled,
   analytics,
   remoteConfigInstance,

--- a/packages/web/src/components/track/GiantTrackTileProgressInfo.tsx
+++ b/packages/web/src/components/track/GiantTrackTileProgressInfo.tsx
@@ -1,9 +1,8 @@
-import React from 'react'
-
 import {
   CommonState,
   formatLineupTileDuration,
   ID,
+  accountSelectors,
   playbackPositionSelectors
 } from '@audius/common'
 import { IconCheck, ProgressBar } from '@audius/stems'
@@ -11,6 +10,7 @@ import { useSelector } from 'react-redux'
 
 import styles from './GiantTrackTile.module.css'
 
+const { getUserId } = accountSelectors
 const { getTrackPosition } = playbackPositionSelectors
 
 const messages = {
@@ -28,8 +28,9 @@ export const GiantTrackTileProgressInfo = ({
   duration,
   trackId
 }: GiantTrackTileProgressInfoProps) => {
+  const currentUserId = useSelector(getUserId)
   const trackPositionInfo = useSelector((state: CommonState) =>
-    getTrackPosition(state, { trackId })
+    getTrackPosition(state, { trackId, userId: currentUserId })
   )
 
   if (trackPositionInfo) {

--- a/packages/web/src/components/track/PlayPauseButton.tsx
+++ b/packages/web/src/components/track/PlayPauseButton.tsx
@@ -1,6 +1,7 @@
 import {
   FeatureFlags,
   ID,
+  accountSelectors,
   playerSelectors,
   playbackPositionSelectors,
   CommonState
@@ -13,6 +14,7 @@ import { useFlag } from 'hooks/useRemoteConfig'
 
 import styles from './GiantTrackTile.module.css'
 
+const { getUserId } = accountSelectors
 const { getTrackId } = playerSelectors
 const { getTrackPosition } = playbackPositionSelectors
 
@@ -43,9 +45,9 @@ export const PlayPauseButton = ({
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
-
+  const currentUserId = useSelector(getUserId)
   const trackPlaybackInfo = useSelector((state: CommonState) =>
-    getTrackPosition(state, { trackId })
+    getTrackPosition(state, { trackId, userId: currentUserId })
   )
   const isCurrentTrack = useSelector(
     (state: CommonState) => trackId === getTrackId(state)

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -2,6 +2,7 @@ import { memo, MouseEvent, useCallback } from 'react'
 
 import {
   formatCount,
+  accountSelectors,
   playbackPositionSelectors,
   pluralize,
   FeatureFlags,
@@ -28,6 +29,7 @@ import {
 import { BottomRow } from './BottomRow'
 import styles from './TrackTile.module.css'
 
+const { getUserId } = accountSelectors
 const { getTrackPosition } = playbackPositionSelectors
 
 const messages = {
@@ -117,8 +119,9 @@ const TrackTile = ({
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
+  const currentUserId = useSelector(getUserId)
   const trackPositionInfo = useSelector((state: CommonState) =>
-    getTrackPosition(state, { trackId })
+    getTrackPosition(state, { trackId, userId: currentUserId })
   )
 
   const hasOrdering = order !== undefined

--- a/packages/web/src/store/storeContext.ts
+++ b/packages/web/src/store/storeContext.ts
@@ -29,6 +29,8 @@ export const storeContext: CommonStoreContext = {
     window?.localStorage?.getItem(key),
   setLocalStorageItem: async (key: string, value: string) =>
     window?.localStorage?.setItem(key, value),
+  removeLocalStorageItem: async (key: string) =>
+    window?.localStorage?.removeItem(key),
   // Note: casting return type to Promise<boolean> to maintain pairity with mobile, but
   // it may be best to update mobile to not be async
   getFeatureEnabled: getFeatureEnabled as unknown as (


### PR DESCRIPTION
### Description
Update podcast playback positions to be tracked per user id so that users can log out and log into different accounts with predictable behaviour

### Dragons

N/A

### How Has This Been Tested?

Manually tested on web and mobile

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

