### PR TITLE
Clean up artist_pick_track_id in APIUser

### DIFF
--- a/packages/common/src/services/audius-api-client/ResponseAdapter.ts
+++ b/packages/common/src/services/audius-api-client/ResponseAdapter.ts
@@ -38,14 +38,9 @@ export const makeUser = (
     return undefined
   }
 
-  // TODO remove conditional once all DNs are encoding the artist pick ID
-  let decoded_artist_pick_track_id: number | null
-  if (typeof user.artist_pick_track_id === 'string') {
-    decoded_artist_pick_track_id = decodeHashId(user.artist_pick_track_id)
-  } else {
-    decoded_artist_pick_track_id = user.artist_pick_track_id
-  }
-
+  const decoded_artist_pick_track_id = user.artist_pick_track_id
+    ? decodeHashId(user.artist_pick_track_id)
+    : null
   const balance = user.balance as StringWei
   const associated_wallets_balance =
     user.associated_wallets_balance as StringWei

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -23,8 +23,7 @@ export type OpaqueID = string
 
 export type APIUser = {
   album_count: number
-  // TODO remove number type once all DNs are encoding the artist pick ID
-  artist_pick_track_id: Nullable<number | OpaqueID>
+  artist_pick_track_id: Nullable<OpaqueID>
   blocknumber: number
   balance: string
   associated_wallets_balance: string


### PR DESCRIPTION
### Description
Follow-up to https://github.com/AudiusProject/audius-client/pull/2795 -- all DNs are encoding artist pick track ids now, remove logic handling non-encoded ids.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Change artist pick and query via API

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

