### PR TITLE
Hotfix: Fix stems downloads on mobile web

### DIFF
--- a/packages/web/patches/react-lottie+1.2.3.patch
+++ b/packages/web/patches/react-lottie+1.2.3.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/react-lottie/dist/index.js b/node_modules/react-lottie/dist/index.js
+index b9015a6..397e63f 100644
+--- a/node_modules/react-lottie/dist/index.js
++++ b/node_modules/react-lottie/dist/index.js
+@@ -94,12 +94,13 @@ var Lottie = function (_React$Component) {
+ 
+       this.anim = _lottieWeb2.default.loadAnimation(this.options);
+       this.registerEvents(eventListeners);
++      this.unmounted = false
+     }
+   }, {
+     key: 'componentWillUpdate',
+     value: function componentWillUpdate(nextProps /* , nextState */) {
+       /* Recreate the animation handle if the data is changed */
+-      if (this.options.animationData !== nextProps.options.animationData) {
++      if (this.options.animationData !== nextProps.options.animationData && !this.unmounted) {
+         this.deRegisterEvents(this.props.eventListeners);
+         this.destroy();
+         this.options = (0, _extends3.default)({}, this.options, nextProps.options);
+@@ -129,6 +130,7 @@ var Lottie = function (_React$Component) {
+       this.destroy();
+       this.options.animationData = null;
+       this.anim = null;
++      this.unmounted = true
+     }
+   }, {
+     key: 'setSpeed',

--- a/packages/web/patches/react-lottie+1.2.3.patch
+++ b/packages/web/patches/react-lottie+1.2.3.patch
@@ -1,27 +1,17 @@
 diff --git a/node_modules/react-lottie/dist/index.js b/node_modules/react-lottie/dist/index.js
-index b9015a6..397e63f 100644
+index b9015a6..8d37a73 100644
 --- a/node_modules/react-lottie/dist/index.js
 +++ b/node_modules/react-lottie/dist/index.js
-@@ -94,12 +94,13 @@ var Lottie = function (_React$Component) {
- 
-       this.anim = _lottieWeb2.default.loadAnimation(this.options);
-       this.registerEvents(eventListeners);
-+      this.unmounted = false
-     }
-   }, {
-     key: 'componentWillUpdate',
+@@ -100,8 +100,10 @@ var Lottie = function (_React$Component) {
      value: function componentWillUpdate(nextProps /* , nextState */) {
        /* Recreate the animation handle if the data is changed */
--      if (this.options.animationData !== nextProps.options.animationData) {
-+      if (this.options.animationData !== nextProps.options.animationData && !this.unmounted) {
-         this.deRegisterEvents(this.props.eventListeners);
-         this.destroy();
+       if (this.options.animationData !== nextProps.options.animationData) {
+-        this.deRegisterEvents(this.props.eventListeners);
+-        this.destroy();
++        if (this.anim !== null) {
++          this.deRegisterEvents(this.props.eventListeners);
++          this.destroy();
++        }
          this.options = (0, _extends3.default)({}, this.options, nextProps.options);
-@@ -129,6 +130,7 @@ var Lottie = function (_React$Component) {
-       this.destroy();
-       this.options.animationData = null;
-       this.anim = null;
-+      this.unmounted = true
-     }
-   }, {
-     key: 'setSpeed',
+         this.anim = _lottieWeb2.default.loadAnimation(this.options);
+         this.registerEvents(nextProps.eventListeners);

--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -126,7 +126,8 @@ class TrackPageProvider extends Component<
     // Go to 404 if the track id isn't parsed correctly or if should redirect
     if (!params || (params.trackId && shouldRedirectTrack(params.trackId))) {
       console.log('not found 1')
-      this.props.goToRoute(NOT_FOUND_PAGE)
+      if (this.props.pathname !== '/signup')
+        this.props.goToRoute(NOT_FOUND_PAGE)
       return
     }
 


### PR DESCRIPTION
### Description

- Never go to the 404 page from `TrackProvider` if we're actually trying to go to `/signup`, which happens on mobile web
- Patch Lottie to prevent accessing `this.anim` when `this.anim` is null

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

