### PR TITLE
[PAY-1220] Fix chat receive bug

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -25,13 +25,15 @@ type UserChatWithMessagesStatus = UserChat & {
   messagesSummary?: TypedCommsResponse<ChatMessage>['summary']
 }
 
+type ChatID = string
+
 type ChatState = {
   chats: EntityState<UserChatWithMessagesStatus> & {
     status: Status
     summary?: TypedCommsResponse<UserChat>['summary']
   }
   messages: Record<
-    string,
+    ChatID,
     EntityState<ChatMessageWithExtras> & {
       status?: Status
       summary?: TypedCommsResponse<ChatMessage>['summary']
@@ -362,6 +364,14 @@ const slice = createSlice({
     ) => {
       // triggers saga to get chat if not exists
       const { chatId, message, status } = action.payload
+
+      // If no chatId, don't add the message
+      // and abort early, relying on the saga
+      // to fetch the chat
+      if (!(chatId in state.messages)) {
+        console.info('addMessage: no chatId')
+        return
+      }
 
       const existingMessage = getMessage(
         state.messages[chatId],

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -369,7 +369,6 @@ const slice = createSlice({
       // and abort early, relying on the saga
       // to fetch the chat
       if (!(chatId in state.messages)) {
-        console.info('addMessage: no chatId')
         return
       }
 


### PR DESCRIPTION
### Description

**Bug:** receiving a new chat in an active session causes a crash because we try to use the ChatID of a chat that doesn't yet exist to index into the `messages` object.

**Fix**:
- First, in the `addMessage` flow exit early if we don't know about the chat yet.
- Fix additional bug in the `fetchChatIfNeeded` flow to fetch chat users so that the `ChatListItem` renders


Also adds a misc type cleanup

### Dragons

None

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Web/stage

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

