### PR TITLE
[PAY-1195] Mobile chat screen unavailable states

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -193,14 +193,20 @@ export const getCanCreateChat = createSelector(
     getBlockees,
     getBlockers,
     getChatPermissions,
-    (_: CommonState, { userId }: { userId: Maybe<ID> }) => userId
+    (_: CommonState, { userId }: { userId: Maybe<ID> }) => userId,
+    (state: CommonState, { userId }: { userId: Maybe<ID> }) => {
+      if (!userId) return null
+      const usersMap = getUsers(state, { ids: [userId] })
+      return usersMap[userId]
+    }
   ],
   (
     currentUserId,
     blockees,
     blockers,
     chatPermissions,
-    userId
+    userId,
+    user
   ): { canCreateChat: boolean; callToAction: ChatPermissionAction } => {
     if (!currentUserId) {
       return {
@@ -230,6 +236,11 @@ export const getCanCreateChat = createSelector(
       } else if (
         userPermissions.permits === ChatPermission.NONE ||
         blockers.includes(userId)
+      ) {
+        action = ChatPermissionAction.NONE
+      } else if (
+        userPermissions.permits === ChatPermission.FOLLOWEES &&
+        !user?.does_current_user_follow
       ) {
         action = ChatPermissionAction.NONE
       } else if (blockees.includes(userId)) {

--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -193,7 +193,6 @@ export const getCanCreateChat = createSelector(
     getBlockees,
     getBlockers,
     getChatPermissions,
-    (_: CommonState, { userId }: { userId: Maybe<ID> }) => userId,
     (state: CommonState, { userId }: { userId: Maybe<ID> }) => {
       if (!userId) return null
       const usersMap = getUsers(state, { ids: [userId] })
@@ -205,7 +204,6 @@ export const getCanCreateChat = createSelector(
     blockees,
     blockers,
     chatPermissions,
-    userId,
     user
   ): { canCreateChat: boolean; callToAction: ChatPermissionAction } => {
     if (!currentUserId) {
@@ -214,16 +212,16 @@ export const getCanCreateChat = createSelector(
         callToAction: ChatPermissionAction.SIGN_UP
       }
     }
-    if (!userId) {
+    if (!user) {
       return {
         canCreateChat: false,
         callToAction: ChatPermissionAction.NONE
       }
     }
 
-    const userPermissions = chatPermissions[userId]
-    const isBlockee = blockees.includes(userId)
-    const isBlocker = blockers.includes(userId)
+    const userPermissions = chatPermissions[user.user_id]
+    const isBlockee = blockees.includes(user.user_id)
+    const isBlocker = blockers.includes(user.user_id)
     const canCreateChat =
       !isBlockee &&
       !isBlocker &&
@@ -235,7 +233,7 @@ export const getCanCreateChat = createSelector(
         action = ChatPermissionAction.WAIT
       } else if (
         userPermissions.permits === ChatPermission.NONE ||
-        blockers.includes(userId)
+        blockers.includes(user.user_id)
       ) {
         action = ChatPermissionAction.NONE
       } else if (
@@ -243,7 +241,7 @@ export const getCanCreateChat = createSelector(
         !user?.does_current_user_follow
       ) {
         action = ChatPermissionAction.NONE
-      } else if (blockees.includes(userId)) {
+      } else if (blockees.includes(user.user_id)) {
         action = ChatPermissionAction.UNBLOCK
       } else if (userPermissions.permits === ChatPermission.TIPPERS) {
         action = ChatPermissionAction.TIP

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -519,6 +519,12 @@ const slice = createSlice({
       const { chatId } = action.payload
       chatsAdapter.removeOne(state.chats, chatId)
       chatMessagesAdapter.removeAll(state.messages[chatId])
+    },
+    fetchChatRecheckPermissions: (
+      _state,
+      _action: PayloadAction<{ chatId: string }>
+    ) => {
+      // triggers saga
     }
   }
 })

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -293,9 +293,9 @@ const slice = createSlice({
       const { messageId } = action.payload
       delete state.optimisticReactions[messageId]
     },
-    fetchChatRecheckPermissions: (
+    fetchChatIfNecessary: (
       _state,
-      _action: PayloadAction<{ chatId: string }>
+      _action: PayloadAction<{ chatId: string; bustCache?: boolean }>
     ) => {
       // triggers saga
     },

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -293,6 +293,12 @@ const slice = createSlice({
       const { messageId } = action.payload
       delete state.optimisticReactions[messageId]
     },
+    fetchChatRecheckPermissions: (
+      _state,
+      _action: PayloadAction<{ chatId: string }>
+    ) => {
+      // triggers saga
+    },
     fetchChatSucceeded: (state, action: PayloadAction<{ chat: UserChat }>) => {
       const { chat } = action.payload
       if (dayjs(chat.cleared_history_at).isAfter(chat.last_message_at)) {
@@ -519,12 +525,6 @@ const slice = createSlice({
       const { chatId } = action.payload
       chatsAdapter.removeOne(state.chats, chatId)
       chatMessagesAdapter.removeAll(state.messages[chatId])
-    },
-    fetchChatRecheckPermissions: (
-      _state,
-      _action: PayloadAction<{ chatId: string }>
-    ) => {
-      // triggers saga
     }
   }
 })

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -62,7 +62,7 @@ const {
   fetchBlockers,
   fetchBlockees,
   fetchPermissions,
-  fetchChatRecheckPermissions
+  fetchChatIfNecessary
 } = chatActions
 const { getUserId } = accountSelectors
 const { getHasTrack } = playerSelectors
@@ -255,7 +255,7 @@ export const ChatScreen = () => {
       dispatch(fetchPermissions({ userIds: [otherUser.user_id] }))
     }
     if (chatId) {
-      dispatch(fetchChatRecheckPermissions({ chatId }))
+      dispatch(fetchChatIfNecessary({ chatId, bustCache: true }))
     }
   }, [chatId, dispatch, otherUser.user_id])
 
@@ -522,7 +522,7 @@ export const ChatScreen = () => {
                 <ChatTextInput chatId={chatId} />
               </View>
             ) : (
-              <ChatUnavailable user={otherUser} chatId={chatId} />
+              <ChatUnavailable chatId={chatId} />
             )}
           </KeyboardAvoidingView>
         </View>

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -452,7 +452,7 @@ export const ChatScreen = () => {
       <ScreenContent>
         {/* Everything inside the portal displays on top of all other screen contents. */}
         <Portal hostName='ChatReactionsPortal'>
-          {shouldShowPopup && popupMessage ? (
+          {canSendMessage && shouldShowPopup && popupMessage ? (
             <ReactionPopup
               chatId={chatId}
               messageTop={messageTop.current}

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -42,6 +42,7 @@ import type { AppTabScreenParamList } from '../app-screen'
 
 import { ChatMessageListItem } from './ChatMessageListItem'
 import { ChatTextInput } from './ChatTextInput'
+import { ChatUnavailable } from './ChatUnavailable'
 import { EmptyChatMessages } from './EmptyChatMessages'
 import { ReactionPopup } from './ReactionPopup'
 
@@ -51,11 +52,18 @@ const {
   getChat,
   getChatMessageById,
   getChatMessageByIndex,
-  getReactionsPopupMessageId
+  getReactionsPopupMessageId,
+  getCanSendMessage
 } = chatSelectors
-
-const { fetchMoreMessages, markChatAsRead, setReactionsPopupMessageId } =
-  chatActions
+const {
+  fetchMoreMessages,
+  markChatAsRead,
+  setReactionsPopupMessageId,
+  fetchBlockers,
+  fetchBlockees,
+  fetchPermissions,
+  fetchChatRecheckPermissions
+} = chatActions
 const { getUserId } = accountSelectors
 const { getHasTrack } = playerSelectors
 
@@ -212,6 +220,9 @@ export const ChatScreen = () => {
   const popupMessage = useSelector((state) =>
     getChatMessageById(state, chatId ?? '', popupMessageId ?? '')
   )
+  const { canSendMessage } = useSelector((state) =>
+    getCanSendMessage(state, { userId: otherUser.user_id, chatId })
+  )
 
   // A ref so that the unread separator doesn't disappear immediately when the chat is marked as read
   // Using a ref instead of state here to prevent unwanted flickers.
@@ -235,6 +246,18 @@ export const ChatScreen = () => {
       chatFrozenRef.current = chat
     }
   }, [chatId, chat])
+
+  // Fetch all permissions, blockers/blockees, and recheck_permissions flag
+  useEffect(() => {
+    dispatch(fetchBlockees())
+    dispatch(fetchBlockers())
+    if (otherUser.user_id) {
+      dispatch(fetchPermissions({ userIds: [otherUser.user_id] }))
+    }
+    if (chatId) {
+      dispatch(fetchChatRecheckPermissions({ chatId }))
+    }
+  }, [chatId, dispatch, otherUser.user_id])
 
   // Find earliest unread message to display unread tag correctly
   const earliestUnreadIndex = useMemo(
@@ -488,15 +511,19 @@ export const ChatScreen = () => {
               </View>
             )}
 
-            <View
-              style={styles.composeView}
-              onLayout={measureChatContainerBottom}
-              ref={composeRef}
-              pointerEvents={'box-none'}
-            >
-              <View style={styles.whiteBackground} />
-              <ChatTextInput chatId={chatId} />
-            </View>
+            {canSendMessage ? (
+              <View
+                style={styles.composeView}
+                onLayout={measureChatContainerBottom}
+                ref={composeRef}
+                pointerEvents={'box-none'}
+              >
+                <View style={styles.whiteBackground} />
+                <ChatTextInput chatId={chatId} />
+              </View>
+            ) : (
+              <ChatUnavailable user={otherUser} chatId={chatId} />
+            )}
           </KeyboardAvoidingView>
         </View>
       </ScreenContent>

--- a/packages/mobile/src/screens/chat-screen/ChatUnavailable.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUnavailable.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useMemo } from 'react'
+
+import type { User } from '@audius/common'
+import { chatSelectors, ChatPermissionAction } from '@audius/common'
+import { View, Text } from 'react-native'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { UserBadges } from 'app/components/user-badges'
+import { useNavigation } from 'app/hooks/useNavigation'
+import { setVisibility } from 'app/store/drawers/slice'
+import { makeStyles } from 'app/styles'
+
+const { getCanSendMessage } = chatSelectors
+
+const messages = {
+  noAction: 'You can no longer send messages to asdf asdf asdf adsf asdf ',
+  tip1: 'You must send ',
+  tip2: ' a tip before you can send them messages.',
+  blockee: 'You cannot send messages to users you have blocked. ',
+  learnMore: 'Learn More.',
+  unblockUser: 'Unblock User.'
+}
+
+const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    paddingBottom: spacing(19),
+    paddingHorizontal: spacing(6)
+  },
+  unavailableText: {
+    textAlign: 'center',
+    fontSize: typography.fontSize.medium,
+    lineHeight: typography.fontSize.medium * 1.3,
+    color: palette.neutral
+  },
+  link: {
+    color: palette.secondary
+  }
+}))
+
+type ChatUnavailableProps = {
+  user: User
+  chatId: string
+}
+
+export const ChatUnavailable = ({ user, chatId }: ChatUnavailableProps) => {
+  const styles = useStyles()
+  const dispatch = useDispatch()
+  const navigation = useNavigation()
+  const { callToAction } = useSelector((state) =>
+    getCanSendMessage(state, { userId: user.user_id, chatId })
+  )
+
+  // TODO: link to blog
+  const handleLearnMorePress = useCallback(() => {}, [])
+
+  const handleUnblockPress = useCallback(() => {
+    dispatch(
+      setVisibility({
+        drawer: 'BlockMessages',
+        visible: true,
+        data: { userId: user.user_id }
+      })
+    )
+  }, [dispatch, user])
+
+  const mapActionToProps = useMemo(() => {
+    return {
+      [ChatPermissionAction.NONE]: () => (
+        <>
+          <Text style={styles.unavailableText}>
+            {messages.noAction}
+            <UserBadges
+              user={user}
+              as={Text}
+              nameStyle={styles.unavailableText}
+            />
+            <Text
+              style={[styles.unavailableText, styles.link]}
+              onPress={handleLearnMorePress}
+            >
+              {messages.learnMore}
+            </Text>
+          </Text>
+        </>
+      ),
+      [ChatPermissionAction.TIP]: () => (
+        <>
+          <Text style={styles.unavailableText}>
+            {messages.tip1}
+            <Text
+              onPress={() =>
+                navigation.navigate('Profile', { id: user.user_id })
+              }
+            >
+              <UserBadges
+                user={user}
+                as={Text}
+                nameStyle={[styles.unavailableText, styles.link]}
+              />
+            </Text>
+            {messages.tip2}
+          </Text>
+        </>
+      ),
+      [ChatPermissionAction.UNBLOCK]: () => (
+        <>
+          <Text style={styles.unavailableText}>
+            {messages.blockee}
+            <Text
+              style={[styles.unavailableText, styles.link]}
+              onPress={handleUnblockPress}
+            >
+              {messages.unblockUser}
+            </Text>
+          </Text>
+        </>
+      ),
+      [ChatPermissionAction.WAIT]: () => null
+    }
+  }, [
+    handleLearnMorePress,
+    handleUnblockPress,
+    navigation,
+    styles.link,
+    styles.unavailableText,
+    user
+  ])
+
+  return <View style={styles.root}>{mapActionToProps[callToAction]()}</View>
+}


### PR DESCRIPTION
### Description
Adds a message at the bottom of the chat screen when current user is not allowed to send messages to another user. Replaces the textinput. Also disables reactions.

Also added a saga to re-fetch a chat and update it if the recheck permissions flag was changed. This is helpful for if the user loses permissions mid-session. Not sure if strictly necessary, maybe it's ok to just let the user continue to message and only show the `ChatUnavailable` state on next app load.

Either way we should probably handle error states for sent messages.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local ios stage
![simulator_screenshot_5628657F-0756-47E8-A26E-65ACA7DD14E5](https://github.com/AudiusProject/audius-client/assets/3893871/0483b650-01cb-40c9-bc87-85393fc39431)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

