### PR TITLE
[PAY-1222] Fix unread messages count

### DIFF
--- a/packages/common/src/store/pages/chat/middleware.ts
+++ b/packages/common/src/store/pages/chat/middleware.ts
@@ -7,13 +7,8 @@ import { encodeHashId } from 'utils/hashIds'
 
 import { actions as chatActions } from './slice'
 
-const {
-  connect,
-  disconnect,
-  addMessage,
-  incrementUnreadCount,
-  setMessageReactionSucceeded
-} = chatActions
+const { connect, disconnect, addMessage, setMessageReactionSucceeded } =
+  chatActions
 
 export const chatMiddleware =
   (audiusSdk: () => Promise<AudiusSdk>): Middleware =>
@@ -34,13 +29,17 @@ export const chatMiddleware =
             console.debug('[chats] WebSocket opened. Listening for chats...')
           }
           messageListener = ({ chatId, message }) => {
-            store.dispatch(
-              addMessage({ chatId, message, status: Status.SUCCESS })
-            )
             const currentUserId = getUserId(store.getState())
-            if (message.sender_user_id !== encodeHashId(currentUserId)) {
-              store.dispatch(incrementUnreadCount({ chatId }))
-            }
+            const isSelfMessage =
+              message.sender_user_id === encodeHashId(currentUserId)
+            store.dispatch(
+              addMessage({
+                chatId,
+                message,
+                status: Status.SUCCESS,
+                isSelfMessage
+              })
+            )
           }
           reactionListener = ({ chatId, messageId, reaction }) => {
             store.dispatch(

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -245,9 +245,11 @@ function* doMarkChatAsRead(action: ReturnType<typeof markChatAsRead>) {
     const audiusSdk = yield* getContext('audiusSdk')
     const sdk = yield* call(audiusSdk)
     const chat = yield* select((state) => getChat(state, chatId))
-    if (!chat || !dayjs(chat?.last_read_at).isAfter(chat?.last_message_at)) {
+    if (!chat || dayjs(chat?.last_read_at).isBefore(chat?.last_message_at)) {
       yield* call([sdk.chats, sdk.chats.read], { chatId })
       yield* put(markChatAsReadSucceeded({ chatId }))
+    } else {
+      yield* put(markChatAsReadFailed({ chatId }))
     }
   } catch (e) {
     console.error('markChatAsReadFailed', e)

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -278,7 +278,8 @@ function* doSendMessage(action: ReturnType<typeof sendMessage>) {
           reactions: [],
           created_at: dayjs().toISOString()
         },
-        status: Status.LOADING
+        status: Status.LOADING,
+        isSelfMessage: true
       })
     )
 

--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -249,6 +249,8 @@ function* doMarkChatAsRead(action: ReturnType<typeof markChatAsRead>) {
       yield* call([sdk.chats, sdk.chats.read], { chatId })
       yield* put(markChatAsReadSucceeded({ chatId }))
     } else {
+      // Mark the write as 'failed' in this case (just means we already marked this as read somehow)
+      // to delete the optimistic read status
       yield* put(markChatAsReadFailed({ chatId }))
     }
   } catch (e) {

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -359,11 +359,12 @@ const slice = createSlice({
       action: PayloadAction<{
         chatId: string
         message: ChatMessage
+        isSelfMessage: boolean
         status?: Status
       }>
     ) => {
       // triggers saga to get chat if not exists
-      const { chatId, message, status } = action.payload
+      const { chatId, message, status, isSelfMessage } = action.payload
 
       // If no chatId, don't add the message
       // and abort early, relying on the saga
@@ -372,50 +373,52 @@ const slice = createSlice({
         return
       }
 
+      // Return early if we've seen this message
       const existingMessage = getMessage(
         state.messages[chatId],
         message.message_id
       )
-      if (!existingMessage) {
-        chatMessagesAdapter.addOne(state.messages[chatId], {
-          ...message,
-          hasTail: true,
-          status: status ?? Status.IDLE
-        })
-        chatsAdapter.updateOne(state.chats, {
-          id: chatId,
-          changes: {
-            last_message: message.message,
-            last_message_at: message.created_at,
-            // If a new message comes through, we don't need to recheck permissions anymore
-            recheck_permissions: false
-          }
-        })
-        recalculatePreviousMessageHasTail(state.messages[chatId], 0)
-      }
-    },
-    incrementUnreadCount: (
-      state,
-      action: PayloadAction<{ chatId: string }>
-    ) => {
-      const { chatId } = action.payload
-      // If we're actively reading, this will immediately get marked as read.
-      // Ignore the unread bump to prevent flicker
-      if (state.activeChatId !== chatId) {
-        const existingChat = getChat(state, chatId)
-        const optimisticRead = state.optimisticChatRead[chatId]
-        const existingUnreadCount = optimisticRead
-          ? optimisticRead.unread_message_count
-          : existingChat?.unread_message_count ?? 0
-        chatsAdapter.updateOne(state.chats, {
-          id: chatId,
-          changes: { unread_message_count: existingUnreadCount + 1 }
-        })
-      }
-      if (state.optimisticUnreadMessagesCount) {
-        state.optimisticUnreadMessagesCount += 1
-      } else {
-        state.optimisticUnreadMessagesCount = state.unreadMessagesCount + 1
+      if (existingMessage) return
+
+      // Add the message
+      chatMessagesAdapter.addOne(state.messages[chatId], {
+        ...message,
+        hasTail: true,
+        status: status ?? Status.IDLE
+      })
+      chatsAdapter.updateOne(state.chats, {
+        id: chatId,
+        changes: {
+          last_message: message.message,
+          last_message_at: message.created_at,
+          // If a new message comes through, we don't need to recheck permissions anymore
+          recheck_permissions: false
+        }
+      })
+
+      // Recalculate tails
+      recalculatePreviousMessageHasTail(state.messages[chatId], 0)
+
+      // Handle unread counts
+
+      if (!isSelfMessage) {
+        // If we're actively reading, this will immediately get marked as read.
+        // Ignore the unread bump to prevent flicker
+        if (state.activeChatId !== chatId) {
+          const existingChat = getChat(state, chatId)
+          const optimisticRead = state.optimisticChatRead[chatId]
+          const existingUnreadCount = optimisticRead
+            ? optimisticRead.unread_message_count
+            : existingChat?.unread_message_count ?? 0
+          chatsAdapter.updateOne(state.chats, {
+            id: chatId,
+            changes: { unread_message_count: existingUnreadCount + 1 }
+          })
+        }
+
+        // Web or mobile: update optimistic unread count
+        state.optimisticUnreadMessagesCount =
+          (state.optimisticUnreadMessagesCount ?? state.unreadMessagesCount) + 1
       }
     },
     /**

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -400,7 +400,6 @@ const slice = createSlice({
       recalculatePreviousMessageHasTail(state.messages[chatId], 0)
 
       // Handle unread counts
-
       if (!isSelfMessage) {
         // If we're actively reading, this will immediately get marked as read.
         // Ignore the unread bump to prevent flicker

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -78,8 +78,9 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
 
     // On first load, mark chat as read
     useEffect(() => {
-      if (!chatId) return
-      dispatch(markChatAsRead({ chatId }))
+      if (chatId) {
+        dispatch(markChatAsRead({ chatId }))
+      }
     }, [chatId, dispatch])
 
     // A ref so that the unread separator doesn't disappear immediately when the chat is marked as read

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -76,6 +76,12 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
 
     const ref = useRef<HTMLDivElement>(null)
 
+    // On first load, mark chat as read
+    useEffect(() => {
+      if (!chatId) return
+      dispatch(markChatAsRead({ chatId }))
+    }, [chatId, dispatch])
+
     // A ref so that the unread separator doesn't disappear immediately when the chat is marked as read
     // Using a ref instead of state here to prevent unwanted flickers.
     // The chat/chatId selectors will trigger the rerenders necessary.

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.tsx
@@ -48,7 +48,7 @@ type ChatMessageListProps = ComponentPropsWithoutRef<'div'> & {
 }
 
 const SCROLL_TOP_THRESHOLD = 800
-const SCROLL_BOTTOM_THRESHOLD = 32
+const SCROLL_BOTTOM_THRESHOLD = 80
 const THROTTLE_DURATION_MS = 500
 
 const isScrolledNearBottom = (element: HTMLElement) => {
@@ -98,7 +98,7 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         if (!chatId) return
 
         // Handle case where scrolled to bottom
-        if (isScrolledNearBottom(e.currentTarget)) {
+        if (isScrolledNearBottom(e.target as HTMLDivElement)) {
           // Mark chat as read when the user reaches the bottom (saga handles no-op if already read)
           dispatch(markChatAsRead({ chatId }))
           dispatch(setActiveChat({ chatId }))
@@ -114,7 +114,7 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
               chat?.messagesStatus,
               chat?.messagesSummary?.prev_count
             ) &&
-            isScrolledNearTop(e.currentTarget)
+            isScrolledNearTop(e.target as HTMLDivElement)
           ) {
             // Fetch more messages when user reaches the top
             dispatch(fetchMoreMessages({ chatId }))
@@ -132,7 +132,7 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       () =>
         throttle(scrollHandler, THROTTLE_DURATION_MS, {
           leading: true,
-          trailing: false
+          trailing: true
         }),
       [scrollHandler]
     )


### PR DESCRIPTION
### Description

Fixes multiple bugs here. 

**Bugs:**
- Retransmitted messages would get double counted. Fix this by losing the `incrementUnreadCount` action entirely and performing the increment in the `addMessage` reducer.
- If scrolled up in a chat, own messages would be counted because the chat would be considered inactive. Now explicitly check for own messages.
- Fixed issues with scroll handler: need to throttle on leading and trailing edge (otherwise it might not fire on scrolling down to bottom of the screen), which necessitated a change to event.target instead of event.currentTarget, bc the latter may no longer existed when the throttled scrollhandler runs
- Fixed issue where chats wouldn't be immediately marked as read when going to a new chat page because we relied on the scroll handler to fire at least once; fix is to mark as read in a useEffect on load. 
- Adjusted scroll bottom threshold to something more permissive.

### Dragons

Need to test more on mobile.

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Web
*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

