### PR TITLE
Remove content node cid query route

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1419,15 +1419,9 @@ export const audiusBackend = ({
    * @returns Object The associated wallets mapping of address to nested signature
    */
   async function fetchUserAssociatedEthWallets(user: User) {
-    const gateways = getCreatorNodeIPFSGateways(user.creator_node_endpoint)
     const cid = user?.metadata_multihash ?? null
     if (cid) {
-      const metadata = await fetchCID(
-        cid,
-        gateways,
-        /* cache */ false,
-        /* asUrl */ false
-      )
+      const metadata = await fetchCID(cid, /* cache */ false, /* asUrl */ false)
       if (metadata?.associated_wallets) {
         return metadata.associated_wallets
       }
@@ -1441,15 +1435,9 @@ export const audiusBackend = ({
    * @returns Object The associated wallets mapping of address to nested signature
    */
   async function fetchUserAssociatedSolWallets(user: User) {
-    const gateways = getCreatorNodeIPFSGateways(user.creator_node_endpoint)
     const cid = user?.metadata_multihash ?? null
     if (cid) {
-      const metadata = await fetchCID(
-        cid,
-        gateways,
-        /* cache */ false,
-        /* asUrl */ false
-      )
+      const metadata = await fetchCID(cid, /* cache */ false, /* asUrl */ false)
       if (metadata?.associated_sol_wallets) {
         return metadata.associated_sol_wallets
       }
@@ -1463,15 +1451,9 @@ export const audiusBackend = ({
    * @returns Object The associated wallets mapping of address to nested signature
    */
   async function fetchUserAssociatedWallets(user: User) {
-    const gateways = getCreatorNodeIPFSGateways(user.creator_node_endpoint)
     const cid = user?.metadata_multihash ?? null
     if (cid) {
-      const metadata = await fetchCID(
-        cid,
-        gateways,
-        /* cache */ false,
-        /* asUrl */ false
-      )
+      const metadata = await fetchCID(cid, /* cache */ false, /* asUrl */ false)
       return {
         associated_sol_wallets: metadata?.associated_sol_wallets ?? null,
         associated_wallets: metadata?.associated_wallets ?? null

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -439,16 +439,14 @@ export const audiusBackend = ({
 
     try {
       const res = await audiusLibs.File.fetchCIDFromDiscovery(cid, responseType)
-      if (res?.data) {
-        if (asUrl) {
-          const url = nativeMobile
-            ? res.config.url
-            : URL.createObjectURL(res.data)
-          if (cache) CIDCache.add(cid, url)
-          return url
-        }
-        return res.data
+      if (asUrl) {
+        const url = nativeMobile
+          ? res.config.url
+          : URL.createObjectURL(res.data)
+        if (cache) CIDCache.add(cid, url)
+        return url
       }
+      return res?.data ?? null
     } catch (e) {
       const message = getErrorMessage(e)
       if (message === 'Unauthorized') {

--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -430,62 +430,25 @@ export const audiusBackend = ({
     })
   }
 
-  async function fetchCID(
-    cid: CID,
-    creatorNodeGateways = [] as string[],
-    cache = true,
-    asUrl = true,
-    trackId: Nullable<ID> = null
-  ) {
+  async function fetchCID(cid: CID, cache = true, asUrl = true) {
     await waitForLibsInit()
 
     // If requesting a url (we mean a blob url for the file),
     // otherwise, default to JSON
     const responseType = asUrl ? 'blob' : 'json'
 
-    // TODO read only from discovery after CID metadata migration
-    const getMetadataFromDiscoveryEnabled =
-      (await getFeatureEnabled(
-        FeatureFlags.GET_METADATA_FROM_DISCOVERY_ENABLED
-      )) ?? false
-    if (getMetadataFromDiscoveryEnabled) {
-      try {
-        const res = await audiusLibs.File.fetchCIDFromDiscovery(
-          cid,
-          responseType
-        )
-        if (res?.data) {
-          if (asUrl) {
-            const url = nativeMobile
-              ? res.config.url
-              : URL.createObjectURL(res.data)
-            if (cache) CIDCache.add(cid, url)
-            return url
-          }
-          return res.data
-        }
-      } catch (e) {
-        console.error(e)
-      }
-      // If failed to find metadata in discovery, try with content nodes
-    }
-
     try {
-      const res = await audiusLibs.File.fetchCID(
-        cid,
-        creatorNodeGateways,
-        () => {},
-        responseType,
-        trackId
-      )
-      if (asUrl) {
-        const url = nativeMobile
-          ? res.config.url
-          : URL.createObjectURL(res.data)
-        if (cache) CIDCache.add(cid, url)
-        return url
+      const res = await audiusLibs.File.fetchCIDFromDiscovery(cid, responseType)
+      if (res?.data) {
+        if (asUrl) {
+          const url = nativeMobile
+            ? res.config.url
+            : URL.createObjectURL(res.data)
+          if (cache) CIDCache.add(cid, url)
+          return url
+        }
+        return res.data
       }
-      return res?.data ?? null
     } catch (e) {
       const message = getErrorMessage(e)
       if (message === 'Unauthorized') {

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -105,7 +105,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.TRENDING_UNDERGROUND_NOTIFICATIONS]: false,
   [FeatureFlags.TASTEMAKER_NOTIFICATIONS]: false,
   [FeatureFlags.SDK_DISCOVERY_NODE_SELECTOR]: false,
-  [FeatureFlags.GET_METADATA_FROM_DISCOVERY_ENABLED]: false,
   [FeatureFlags.RELATED_ARTISTS_ON_PROFILE_ENABLED]: false,
   [FeatureFlags.PROXY_WORMHOLE]: false,
   [FeatureFlags.STORAGE_V2_TRACK_UPLOAD]: false,

--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -40,7 +40,6 @@ export enum FeatureFlags {
   TRENDING_UNDERGROUND_NOTIFICATIONS = 'trending_underground_notifications',
   TASTEMAKER_NOTIFICATIONS = 'tastemaker_notifications',
   SDK_DISCOVERY_NODE_SELECTOR = 'sdk_discovery_node_selector_2',
-  GET_METADATA_FROM_DISCOVERY_ENABLED = 'get_metadata_from_discovery_enabled',
   RELATED_ARTISTS_ON_PROFILE_ENABLED = 'related_artists_on_profile_enabled',
   PROXY_WORMHOLE = 'proxy_wormhole',
   STORAGE_V2_TRACK_UPLOAD = 'storage_v2_track_upload',


### PR DESCRIPTION
### Description
All metadata has been backfilled to discovery and is currently written to discovery. Remove legacy route.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
Make sure client can query metadata throughout app (viewing profile, other profiles, updating, etc.)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###
Removes `get_metadata_from_discovery_enabled` flag
