### PR TITLE
[PAY-1177]  Fix double reaction click animation

### DIFF
--- a/packages/web/src/components/notification/Notification/components/Reaction/Reaction.tsx
+++ b/packages/web/src/components/notification/Notification/components/Reaction/Reaction.tsx
@@ -20,6 +20,7 @@ export type ReactionProps = {
   width?: number
   height?: number
   title?: string
+  disableClickAnimation?: boolean
 }
 
 export const Reaction = (props: ReactionProps) => {
@@ -31,7 +32,8 @@ export const Reaction = (props: ReactionProps) => {
     onClick,
     width = 86,
     height = 86,
-    title
+    title,
+    disableClickAnimation = false
   } = props
   const [isInteracting, setInteracting] = useState(false)
   const [isClicked, setIsClicked] = useState(false)
@@ -79,7 +81,7 @@ export const Reaction = (props: ReactionProps) => {
         [styles.active]: isActive === true,
         [styles.inactive]: isActive === false,
         [styles.responsive]: isResponsive,
-        [styles.clicked]: isClicked
+        [styles.clicked]: !disableClickAnimation && isClicked
       })}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}

--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
@@ -128,6 +128,7 @@ export const ChatMessageListItem = (props: ChatMessageListItemProps) => {
                 width={48}
                 height={48}
                 title={reactionUsers[decodeHashId(reaction.user_id)!]?.name}
+                disableClickAnimation
               />
             )
           })


### PR DESCRIPTION
### Description

Old:

https://github.com/AudiusProject/audius-client/assets/6780028/1d035414-ee9e-45ab-94b0-530700ded035

New:

https://github.com/AudiusProject/audius-client/assets/6780028/75dff7a0-2c19-48f7-a81a-8505e8841756

The issue that the normal reaction click animation was playing, which looks bad when the reaction is shrunk down. This solution is a bit of compromise (removing the active click animation entirely), but matches messenger + iMessage behavior.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

