### PR TITLE
[PAY-1258] Add toast when chat messages are copied

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -11,6 +11,7 @@ import { View, Dimensions, Pressable, Animated } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { usePopupAnimation } from 'app/hooks/usePopupAnimation'
+import { useToast } from 'app/hooks/useToast'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { zIndex } from 'app/utils/zIndex'
@@ -26,6 +27,10 @@ import {
 
 const { getUserId } = accountSelectors
 const { setMessageReaction } = chatActions
+
+const messages = {
+  messageCopied: 'Message copied to clipboard'
+}
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   dimBackground: {
@@ -118,6 +123,8 @@ export const ReactionPopup = ({
   const styles = useStyles()
   const dispatch = useDispatch()
   const userId = useSelector(getUserId)
+  const { toast } = useToast()
+
   const userIdEncoded = encodeHashId(userId)
   const selectedReaction = message.reactions?.find(
     (r) => r.user_id === userIdEncoded
@@ -151,15 +158,27 @@ export const ReactionPopup = ({
     [userId, handleClosePopup, dispatch, chatId, userIdEncoded]
   )
 
-  const handleCopyPress = useCallback(
-    (message: string) => {
-      Clipboard.setString(message)
-      handleClosePopup()
+  const { message: messageText } = message
+  const handleCopyPress = useCallback(() => {
+    Clipboard.setString(messageText)
+    handleClosePopup()
+    toast({ content: messages.messageCopied, type: 'info' })
+  }, [messageText, handleClosePopup, toast])
+
+  const handleReactionChanged = useCallback(
+    (reaction) => {
+      if (reaction) {
+        handleReactionSelected(message, reaction)
+      }
     },
-    [handleClosePopup]
+    [message, handleReactionSelected]
   )
 
-  return shouldShowPopup ? (
+  if (!shouldShowPopup) {
+    return null
+  }
+
+  return (
     <>
       <Animated.View
         style={[
@@ -203,7 +222,7 @@ export const ReactionPopup = ({
           messageTop={messageTop}
           containerTop={containerTop}
           messageHeight={messageHeight}
-          onPress={() => handleCopyPress(message.message)}
+          onPress={handleCopyPress}
         />
         <Animated.View
           style={[
@@ -226,11 +245,7 @@ export const ReactionPopup = ({
         >
           <ReactionList
             selectedReaction={selectedReaction as ReactionTypes}
-            onChange={(reaction) => {
-              if (reaction) {
-                handleReactionSelected(message, reaction)
-              }
-            }}
+            onChange={handleReactionChanged}
             isVisible={shouldShowPopup}
             scale={1.6}
             style={{
@@ -240,5 +255,5 @@ export const ReactionPopup = ({
         </Animated.View>
       </View>
     </>
-  ) : null
+  )
 }

--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -158,12 +158,11 @@ export const ReactionPopup = ({
     [userId, handleClosePopup, dispatch, chatId, userIdEncoded]
   )
 
-  const { message: messageText } = message
   const handleCopyPress = useCallback(() => {
-    Clipboard.setString(messageText)
+    Clipboard.setString(message.message)
     handleClosePopup()
     toast({ content: messages.messageCopied, type: 'info' })
-  }, [messageText, handleClosePopup, toast])
+  }, [message.message, handleClosePopup, toast])
 
   const handleReactionChanged = useCallback(
     (reaction) => {


### PR DESCRIPTION
### Description
Adds some logic to show a toast when a user copies a chat message. Also cleaned up a couple of callbacks which were redefined every render unnecessarily

![Kapture 2023-05-24 at 15 23 11](https://github.com/AudiusProject/audius-client/assets/1815175/d19c39a8-6336-445c-b064-eeee8742f40c)

### Dragons
N/A

### How Has This Been Tested?
Manual testing on physical ios device and simulator

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

