### PR TITLE
[C-2644] Fix issue where new playlist drag-drop not persisting

### DIFF
--- a/packages/common/src/store/playlist-library/helpers.ts
+++ b/packages/common/src/store/playlist-library/helpers.ts
@@ -404,7 +404,7 @@ export const removePlaylistLibraryDuplicates = (
 export const reorderPlaylistLibrary = (
   library: PlaylistLibrary | PlaylistLibraryFolder,
   draggingId: PlaylistLibraryID,
-  droppingId: ID | SmartCollectionVariant | string,
+  droppingId: PlaylistLibraryID,
   draggingKind = 'library-playlist',
   reorderBeforeTarget = false
 ) => {

--- a/packages/web/src/common/store/cache/collections/commonSagas.js
+++ b/packages/web/src/common/store/cache/collections/commonSagas.js
@@ -33,6 +33,10 @@ import { fetchUsers } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
+import {
+  addPlaylistsNotInLibrary,
+  removePlaylistFromLibrary
+} from 'common/store/playlist-library/sagas'
 import { waitForWrite } from 'utils/sagaHelpers'
 
 import { createPlaylistSaga } from './createPlaylistSaga'
@@ -909,6 +913,8 @@ function* confirmDeletePlaylist(userId, playlistId) {
           )
         ])
 
+        yield call(removePlaylistFromLibrary, playlistId)
+
         const { blockHash, blockNumber, error } = yield call(
           audiusBackendInstance.deletePlaylist,
           playlistId
@@ -951,6 +957,7 @@ function* confirmDeletePlaylist(userId, playlistId) {
             })
           )
         ])
+        yield call(addPlaylistsNotInLibrary)
         yield put(
           collectionActions.deletePlaylistFailed(
             message,

--- a/packages/web/src/common/store/playlist-library/watchAddToFolderSaga.ts
+++ b/packages/web/src/common/store/playlist-library/watchAddToFolderSaga.ts
@@ -4,7 +4,10 @@ import {
   playlistLibraryActions,
   playlistLibraryHelpers,
   AddToFolderAction,
-  toastActions
+  toastActions,
+  CommonState,
+  collectionsSocialActions,
+  FavoriteSource
 } from '@audius/common'
 import { takeEvery, select, put } from 'typed-redux-saga'
 
@@ -14,6 +17,7 @@ const { toast } = toastActions
 const { getPlaylistLibrary } = accountSelectors
 const { addPlaylistToFolder, findInPlaylistLibrary } = playlistLibraryHelpers
 const { update, addToFolder } = playlistLibraryActions
+const { saveCollection } = collectionsSocialActions
 
 const messages = {
   playlistMovedToFolderToast: (folderName: string) =>
@@ -35,6 +39,13 @@ function* addToFolderWorker(action: AddToFolderAction) {
     draggingId,
     folder.id
   )
+
+  const isNewAddition = yield* select(
+    (state: CommonState) => !!state.account.collections[draggingId as number]
+  )
+  if (!isNewAddition) {
+    yield* put(saveCollection(draggingId as number, FavoriteSource.NAVIGATOR))
+  }
 
   // Show a toast if playlist dragged from outside of library was already in the library so it simply got moved to the target folder.
   if (

--- a/packages/web/src/common/store/playlist-library/watchReorderLibrarySaga.ts
+++ b/packages/web/src/common/store/playlist-library/watchReorderLibrarySaga.ts
@@ -1,7 +1,10 @@
 import {
+  CommonState,
+  FavoriteSource,
   Name,
   ReorderAction,
   accountSelectors,
+  collectionsSocialActions,
   playlistLibraryActions,
   playlistLibraryHelpers
 } from '@audius/common'
@@ -12,6 +15,7 @@ import { make } from '../analytics/actions'
 const { getPlaylistLibrary } = accountSelectors
 const { reorderPlaylistLibrary, isInsideFolder } = playlistLibraryHelpers
 const { update, reorder } = playlistLibraryActions
+const { saveCollection } = collectionsSocialActions
 
 export function* watchReorderLibrarySaga() {
   yield* takeEvery(reorder.type, reorderLibrarySagaWorker)
@@ -37,6 +41,13 @@ function* reorderLibrarySagaWorker(action: ReorderAction) {
       kind: draggingKind
     })
   )
+
+  const isNewAddition = yield* select(
+    (state: CommonState) => !!state.account.collections[draggingId as number]
+  )
+  if (!isNewAddition) {
+    yield* put(saveCollection(draggingId as number, FavoriteSource.NAVIGATOR))
+  }
 
   const isDroppingIntoFolder = isInsideFolder(playlistLibrary, droppingId)
   const isIdInFolderBeforeReorder = isInsideFolder(playlistLibrary, draggingId)

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -26,6 +26,10 @@ import { adjustUserField } from 'common/store/cache/users/sagas'
 import * as confirmerActions from 'common/store/confirmer/actions'
 import { confirmTransaction } from 'common/store/confirmer/sagas'
 import * as signOnActions from 'common/store/pages/signon/actions'
+import {
+  addPlaylistsNotInLibrary,
+  removePlaylistFromLibrary
+} from 'common/store/playlist-library/sagas'
 import { albumPage, audioNftPlaylistPage, playlistPage } from 'utils/route'
 import { waitForWrite } from 'utils/sagaHelpers'
 
@@ -377,6 +381,9 @@ export function* saveCollectionAsync(
       user: { id: user.user_id, handle: user.handle }
     })
   )
+
+  yield* call(addPlaylistsNotInLibrary)
+
   yield* put(
     cacheActions.update(Kind.COLLECTIONS, [
       {
@@ -500,6 +507,8 @@ export function* unsaveCollectionAsync(
   yield* put(
     accountActions.removeAccountPlaylist({ collectionId: action.collectionId })
   )
+
+  yield* call(removePlaylistFromLibrary, action.collectionId)
   yield* put(
     cacheActions.update(Kind.COLLECTIONS, [
       {

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.module.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   line-height: normal;
-  overflow: hidden;
+  width: 100%;
 }
 
 .level1 {

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.module.css
@@ -9,6 +9,8 @@
   display: flex;
   align-items: center;
   line-height: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .level1 {

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.module.css
@@ -10,7 +10,6 @@
   align-items: center;
   line-height: normal;
   overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .level1 {

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistUpdateDot.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistUpdateDot.module.css
@@ -1,6 +1,6 @@
 .root {
   position: absolute;
-  left: calc(var(--unit-8) - var(--unit-3));
+  left: calc(var(--unit-3) * -1);
 }
 
 .tooltip :global(.ant-tooltip-arrow) {


### PR DESCRIPTION
### Description

Fixes issue where drag-dropping new (unfavorited) playlists into the left nav wouldnt appear. Also fixes case of drag-dropping to specific sections in the left nav, including inside folders
- Refactors playlist-library saga to use `typed-redux-saga` which caught a few type bugs.
- Small styling fix with overflowing text. Now that we wrap everything in a span, we also need to text wrap it.
