### PR TITLE
[PAY-1255] [PAY-1245] DMs: Add confirmation modals

### DIFF
--- a/packages/stems/src/assets/styles/colors.css
+++ b/packages/stems/src/assets/styles/colors.css
@@ -48,7 +48,7 @@ root {
   --white: #ffffff;
 
   --accent-red: #d0021b;
-  --accent-red-dark-1: #aa0115;
+  --accent-red-dark-1: #bb0218;
   --accent-red-light-1: #d51b32;
 
   --accent-green: #0ba400;
@@ -109,7 +109,7 @@ root {
   --static-white: #ffffff;
 
   --static-accent-red: #d0021b;
-  --static-accent-red-dark-1: #aa0115;
+  --static-accent-red-dark-1: #bb0218;
   --static-accent-red-light-1: #d51b32;
 
   --static-accent-green: #0ba400;

--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -453,3 +453,44 @@
 .textButton:hover .icon path {
   fill: var(--secondary);
 }
+
+/** Destructive buttons **/
+.destructive {
+  background: transparent;
+  border: 1px solid var(--accent-red);
+  border-radius: var(--unit-1);
+}
+
+.destructive .textLabel {
+  font-size: var(--font-m);
+  font-weight: var(--font-bold);
+  color: var(--accent-red);
+}
+
+.destructive .icon path {
+  fill: var(--accent-red);
+}
+
+/** destructive hover **/
+.destructive.includeHoverAnimations:hover:enabled {
+  transform: var(--grow);
+  background-color: var(--accent-red);
+}
+
+.destructive.includeHoverAnimations:active:enabled {
+  transform: perspective(1px) scale3d(0.99, 0.99, 0.99);
+  background-color: var(--accent-red-dark-1);
+}
+
+.destructive.includeHoverAnimations:hover:enabled .textLabel {
+  color: white;
+}
+
+.destructive.includeHoverAnimations:hover:enabled .icon path {
+  fill: var(--static-white);
+}
+
+/** destructive disabled **/
+.destructive:disabled {
+  opacity: 0.45;
+}

--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -462,7 +462,7 @@
 }
 
 .destructive .textLabel {
-  font-size: var(--font-m);
+  font-size: var(--font-l);
   font-weight: var(--font-bold);
   color: var(--accent-red);
 }

--- a/packages/stems/src/components/Button/Button.stories.tsx
+++ b/packages/stems/src/components/Button/Button.stories.tsx
@@ -60,3 +60,7 @@ White.args = { type: Type.WHITE }
 // Text
 export const Text = Template.bind({})
 Text.args = { type: Type.TEXT }
+
+// Destructive
+export const Destructive = Template.bind({})
+Destructive.args = { type: Type.DESTRUCTIVE }

--- a/packages/stems/src/components/Button/Button.tsx
+++ b/packages/stems/src/components/Button/Button.tsx
@@ -23,7 +23,8 @@ const TYPE_STYLE_MAP = {
   [Type.DISABLED]: styles.disabled,
   [Type.GLASS]: styles.glass,
   [Type.WHITE]: styles.white,
-  [Type.TEXT]: styles.textButton
+  [Type.TEXT]: styles.textButton,
+  [Type.DESTRUCTIVE]: styles.destructive
 }
 
 /**

--- a/packages/stems/src/components/Button/types.ts
+++ b/packages/stems/src/components/Button/types.ts
@@ -10,7 +10,8 @@ export enum Type {
   DISABLED = 'disabled',
   GLASS = 'glass',
   WHITE = 'white',
-  TEXT = 'text'
+  TEXT = 'text',
+  DESTRUCTIVE = 'destructive'
 }
 
 export enum Size {

--- a/packages/stems/src/components/Modal/types.ts
+++ b/packages/stems/src/components/Modal/types.ts
@@ -1,5 +1,4 @@
 import { HTMLAttributes, ReactNode } from 'react'
-import * as React from 'react'
 
 import { ScrollbarProps } from 'components/Scrollbar'
 
@@ -44,7 +43,7 @@ export type ModalProps = {
   /**
    * @deprecated in favor of composability - use ModalHeader sub-component instead.
    */
-  title?: React.ReactNode
+  title?: ReactNode
   /**
    * @deprecated in favor of composability - use ModalHeader sub-component instead.
    */
@@ -128,16 +127,16 @@ export type ModalHeaderProps = HTMLAttributes<HTMLDivElement> & {
   dismissButtonClassName?: string
   showDismissButton?: boolean
   onClose?: () => void
-  children: React.ReactNode
+  children: ReactNode
 }
 
-export type ModalTitleProps = HTMLAttributes<HTMLDivElement> & {
+export type ModalTitleProps = Omit<HTMLAttributes<HTMLDivElement>, 'title'> & {
   subtitleClassName?: string
-  icon?: React.ReactNode
+  icon?: ReactNode
   iconClassName?: string
-  title: React.ReactNode
+  title: ReactNode
   titleClassName?: string
-  subtitle?: React.ReactNode
+  subtitle?: ReactNode
   titleId?: string
   subtitleId?: string
 }

--- a/packages/web/src/assets/styles/colors.css
+++ b/packages/web/src/assets/styles/colors.css
@@ -46,7 +46,7 @@
   --accent-blue: #1ba1f1;
 
   --accent-red: #d0021b;
-  --accent-red-dark-1: #aa0115;
+  --accent-red-dark-1: #bb0218;
   --accent-red-light-1: #d51b32;
 
   --accent-green: #0ba400;
@@ -222,7 +222,7 @@
   --static-white: #ffffff;
 
   --static-accent-red: #d0021b;
-  --static-accent-red-dark-1: #aa0115;
+  --static-accent-red-dark-1: #bb0218;
   --static-accent-red-light-1: #d51b32;
 
   --static-accent-green: #0ba400;

--- a/packages/web/src/components/help-callout/HelpCallout.module.css
+++ b/packages/web/src/components/help-callout/HelpCallout.module.css
@@ -8,7 +8,8 @@
   border-radius: var(--unit-2);
 }
 
-.icon {
+.icon,
+.icon svg {
   width: var(--unit-6);
   height: var(--unit-6);
 }

--- a/packages/web/src/components/help-callout/HelpCallout.tsx
+++ b/packages/web/src/components/help-callout/HelpCallout.tsx
@@ -7,15 +7,17 @@ import { ReactComponent as IconQuestionCircle } from 'assets/img/iconQuestionCir
 import styles from './HelpCallout.module.css'
 
 export const HelpCallout = ({
+  icon = <IconQuestionCircle />,
   content,
   className
 }: {
+  icon?: ReactNode
   content: ReactNode
   className?: string
 }) => {
   return (
     <div className={cn(styles.root, className)}>
-      <IconQuestionCircle className={styles.icon} />
+      <div className={styles.icon}>{icon}</div>
       <div className={styles.content}>{content}</div>
     </div>
   )

--- a/packages/web/src/pages/chat-page/components/BlockUserConfirmationModal.module.css
+++ b/packages/web/src/pages/chat-page/components/BlockUserConfirmationModal.module.css
@@ -1,0 +1,26 @@
+.root {
+  max-width: 488px;
+}
+
+.icon path {
+  fill: var(--neutral-light-2);
+}
+
+.button {
+  flex: 1;
+}
+
+.content > div {
+  line-height: 150%;
+  font-weight: var(--font-medium);
+  font-size: var(--font-l);
+  display: flex;
+  flex-direction: column;
+  gap: var(--unit-4);
+}
+
+.footer {
+  display: flex;
+  gap: var(--unit-4);
+  padding: 0 var(--unit-6) var(--unit-6) var(--unit-6);
+}

--- a/packages/web/src/pages/chat-page/components/BlockUserConfirmationModal.tsx
+++ b/packages/web/src/pages/chat-page/components/BlockUserConfirmationModal.tsx
@@ -1,0 +1,84 @@
+import { useCallback } from 'react'
+
+import { User, chatActions } from '@audius/common'
+import {
+  Button,
+  ButtonType,
+  IconBlockMessages,
+  IconInfo,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from '@audius/stems'
+import { useDispatch } from 'react-redux'
+
+import { HelpCallout } from 'components/help-callout/HelpCallout'
+import { UserNameAndBadges } from 'components/user-name-and-badges/UserNameAndBadges'
+
+import styles from './BlockUserConfirmationModal.module.css'
+
+const { blockUser } = chatActions
+
+const messages = {
+  title: 'Are you sure?',
+  confirm: 'Confirm',
+  cancel: 'Cancel',
+  content: (user: User) => (
+    <>
+      Are you sure you want to block <UserNameAndBadges user={user} /> from
+      sending messages to your inbox?
+    </>
+  ),
+  callout:
+    'This will not affect their ability to view your profile or interact with your content.'
+}
+
+type BlockUserConfirmationModalProps = {
+  isVisible: boolean
+  onClose: () => void
+  user: User
+}
+
+export const BlockUserConfirmationModal = ({
+  isVisible,
+  onClose,
+  user
+}: BlockUserConfirmationModalProps) => {
+  const dispatch = useDispatch()
+  const handleConfirmClicked = useCallback(() => {
+    dispatch(blockUser({ userId: user.user_id }))
+    onClose()
+  }, [dispatch, onClose, user])
+
+  return (
+    <Modal bodyClassName={styles.root} isOpen={isVisible} onClose={onClose}>
+      <ModalHeader>
+        <ModalTitle
+          title={messages.title}
+          icon={<IconBlockMessages />}
+          iconClassName={styles.icon}
+        />
+      </ModalHeader>
+      <ModalContent className={styles.content}>
+        <div>{messages.content(user)}</div>
+        <HelpCallout icon={<IconInfo />} content={messages.callout} />
+      </ModalContent>
+      <ModalFooter className={styles.footer}>
+        <Button
+          className={styles.button}
+          type={ButtonType.COMMON_ALT}
+          text={messages.cancel}
+          onClick={onClose}
+        />
+        <Button
+          className={styles.button}
+          type={ButtonType.PRIMARY_ALT}
+          text={messages.confirm}
+          onClick={handleConfirmClicked}
+        />
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/packages/web/src/pages/chat-page/components/BlockUserConfirmationModal.tsx
+++ b/packages/web/src/pages/chat-page/components/BlockUserConfirmationModal.tsx
@@ -23,7 +23,7 @@ const { blockUser } = chatActions
 
 const messages = {
   title: 'Are you sure?',
-  confirm: 'Confirm',
+  confirm: 'Block User',
   cancel: 'Cancel',
   content: (user: User) => (
     <>
@@ -68,13 +68,13 @@ export const BlockUserConfirmationModal = ({
       <ModalFooter className={styles.footer}>
         <Button
           className={styles.button}
-          type={ButtonType.COMMON_ALT}
+          type={ButtonType.PRIMARY}
           text={messages.cancel}
           onClick={onClose}
         />
         <Button
           className={styles.button}
-          type={ButtonType.PRIMARY_ALT}
+          type={ButtonType.DESTRUCTIVE}
           text={messages.confirm}
           onClick={handleConfirmClicked}
         />

--- a/packages/web/src/pages/chat-page/components/ChatHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatHeader.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback } from 'react'
+import { forwardRef, useCallback, useState } from 'react'
 
 import {
   useProxySelector,
@@ -23,8 +23,11 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useModalState } from 'common/hooks/useModalState'
 import { profilePage } from 'utils/route'
 
+import { BlockUserConfirmationModal } from './BlockUserConfirmationModal'
 import styles from './ChatHeader.module.css'
 import { ChatUser } from './ChatUser'
+import { DeleteChatConfirmationModal } from './DeleteChatConfirmationModal'
+import { UnblockUserConfirmationModal } from './UnblockUserConfirmationModal'
 
 const messages = {
   header: 'Messages',
@@ -38,7 +41,6 @@ const messages = {
 }
 
 const { getOtherChatUsers, getBlockees } = chatSelectors
-const { blockUser, unblockUser, deleteChat } = chatActions
 
 type ChatHeaderProps = { currentChatId?: string }
 
@@ -47,6 +49,12 @@ export const ChatHeader = forwardRef<HTMLDivElement, ChatHeaderProps>(
     const dispatch = useDispatch()
     const [, setCreateChatVisible] = useModalState('CreateChat')
     const [, setInboxSettingsVisible] = useModalState('InboxSettings')
+    const [isUnblockUserModalVisible, setIsUnblockUserModalVisible] =
+      useState(false)
+    const [isBlockUserModalVisible, setIsBlockUserModalVisible] =
+      useState(false)
+    const [isDeleteChatModalVisible, setIsDeleteChatModalVisible] =
+      useState(false)
     const users = useProxySelector(
       (state) => getOtherChatUsers(state, currentChatId),
       [currentChatId]
@@ -64,22 +72,20 @@ export const ChatHeader = forwardRef<HTMLDivElement, ChatHeaderProps>(
     }, [setInboxSettingsVisible])
 
     const handleUnblockClicked = useCallback(() => {
-      dispatch(unblockUser({ userId: user.user_id }))
-    }, [dispatch, user])
+      setIsUnblockUserModalVisible(true)
+    }, [setIsUnblockUserModalVisible])
 
     const handleBlockClicked = useCallback(() => {
-      dispatch(blockUser({ userId: user.user_id }))
-    }, [dispatch, user])
+      setIsBlockUserModalVisible(true)
+    }, [setIsBlockUserModalVisible])
 
     const handleVisitClicked = useCallback(() => {
       dispatch(pushRoute(profilePage(user.handle)))
     }, [dispatch, user])
 
     const handleDeleteClicked = useCallback(() => {
-      if (currentChatId) {
-        dispatch(deleteChat({ chatId: currentChatId }))
-      }
-    }, [dispatch, currentChatId])
+      setIsDeleteChatModalVisible(true)
+    }, [setIsDeleteChatModalVisible])
 
     const overflowItems = [
       isBlocked
@@ -138,6 +144,21 @@ export const ChatHeader = forwardRef<HTMLDivElement, ChatHeaderProps>(
                     onClick={trigger}
                   />
                 )}
+              />
+              <UnblockUserConfirmationModal
+                user={user}
+                isVisible={isUnblockUserModalVisible}
+                onClose={() => setIsUnblockUserModalVisible(false)}
+              />
+              <BlockUserConfirmationModal
+                user={user}
+                isVisible={isBlockUserModalVisible}
+                onClose={() => setIsBlockUserModalVisible(false)}
+              />
+              <DeleteChatConfirmationModal
+                chatId={currentChatId}
+                isVisible={isDeleteChatModalVisible}
+                onClose={() => setIsDeleteChatModalVisible(false)}
               />
             </div>
           ) : null}

--- a/packages/web/src/pages/chat-page/components/ChatHeader.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatHeader.tsx
@@ -1,11 +1,6 @@
 import { forwardRef, useCallback, useState } from 'react'
 
-import {
-  useProxySelector,
-  chatSelectors,
-  chatActions,
-  User
-} from '@audius/common'
+import { useProxySelector, chatSelectors, User } from '@audius/common'
 import {
   IconButton,
   IconCompose,

--- a/packages/web/src/pages/chat-page/components/DeleteChatConfirmationModal.module.css
+++ b/packages/web/src/pages/chat-page/components/DeleteChatConfirmationModal.module.css
@@ -1,0 +1,23 @@
+.root {
+  max-width: 488px;
+}
+
+.icon path {
+  fill: var(--neutral-light-2);
+}
+
+.button {
+  flex: 1;
+}
+
+.content {
+  line-height: 150%;
+  font-weight: var(--font-medium);
+  font-size: var(--font-l);
+}
+
+.footer {
+  display: flex;
+  gap: var(--unit-4);
+  padding: 0 var(--unit-6) var(--unit-6) var(--unit-6);
+}

--- a/packages/web/src/pages/chat-page/components/DeleteChatConfirmationModal.tsx
+++ b/packages/web/src/pages/chat-page/components/DeleteChatConfirmationModal.tsx
@@ -1,0 +1,71 @@
+import { useCallback } from 'react'
+
+import { chatActions } from '@audius/common'
+import {
+  Button,
+  ButtonType,
+  IconTrash,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from '@audius/stems'
+import { useDispatch } from 'react-redux'
+
+import styles from './DeleteChatConfirmationModal.module.css'
+
+const { deleteChat } = chatActions
+
+const messages = {
+  title: 'Are you sure?',
+  content: 'Are you sure you want to delete this chat?',
+  confirm: 'Confirm',
+  cancel: 'Cancel'
+}
+
+type ConfirmationModalProps = {
+  isVisible: boolean
+  onClose: () => void
+  chatId?: string
+}
+
+export const DeleteChatConfirmationModal = ({
+  isVisible,
+  onClose,
+  chatId
+}: ConfirmationModalProps) => {
+  const dispatch = useDispatch()
+  const handleConfirmClicked = useCallback(() => {
+    if (chatId) {
+      dispatch(deleteChat({ chatId }))
+    }
+    onClose()
+  }, [dispatch, onClose, chatId])
+  return (
+    <Modal bodyClassName={styles.root} isOpen={isVisible} onClose={onClose}>
+      <ModalHeader>
+        <ModalTitle
+          title={messages.title}
+          icon={<IconTrash />}
+          iconClassName={styles.icon}
+        />
+      </ModalHeader>
+      <ModalContent className={styles.content}>{messages.content}</ModalContent>
+      <ModalFooter className={styles.footer}>
+        <Button
+          className={styles.button}
+          type={ButtonType.COMMON_ALT}
+          text={messages.cancel}
+          onClick={onClose}
+        />
+        <Button
+          className={styles.button}
+          type={ButtonType.PRIMARY_ALT}
+          text={messages.confirm}
+          onClick={handleConfirmClicked}
+        />
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/packages/web/src/pages/chat-page/components/UnblockUserConfirmationModal.module.css
+++ b/packages/web/src/pages/chat-page/components/UnblockUserConfirmationModal.module.css
@@ -1,0 +1,23 @@
+.root {
+  max-width: 488px;
+}
+
+.icon path {
+  fill: var(--neutral-light-2);
+}
+
+.button {
+  flex: 1;
+}
+
+.content {
+  line-height: 150%;
+  font-weight: var(--font-medium);
+  font-size: var(--font-l);
+}
+
+.footer {
+  display: flex;
+  gap: var(--unit-4);
+  padding: 0 var(--unit-6) var(--unit-6) var(--unit-6);
+}

--- a/packages/web/src/pages/chat-page/components/UnblockUserConfirmationModal.tsx
+++ b/packages/web/src/pages/chat-page/components/UnblockUserConfirmationModal.tsx
@@ -1,0 +1,79 @@
+import { useCallback } from 'react'
+
+import { User, chatActions } from '@audius/common'
+import {
+  Button,
+  ButtonType,
+  IconUnblockMessages,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from '@audius/stems'
+import { useDispatch } from 'react-redux'
+
+import { UserNameAndBadges } from 'components/user-name-and-badges/UserNameAndBadges'
+
+import styles from './UnblockUserConfirmationModal.module.css'
+
+const { unblockUser } = chatActions
+
+const messages = {
+  title: 'Are you sure?',
+  confirm: 'Confirm',
+  cancel: 'Cancel',
+  content: (user: User) => (
+    <>
+      Are you sure you want to unblock <UserNameAndBadges user={user} /> and
+      allow them to send messages to your inbox?
+    </>
+  )
+}
+
+type UnblockUserConfirmationModalProps = {
+  isVisible: boolean
+  onClose: () => void
+  user: User
+}
+
+export const UnblockUserConfirmationModal = ({
+  isVisible,
+  onClose,
+  user
+}: UnblockUserConfirmationModalProps) => {
+  const dispatch = useDispatch()
+  const handleConfirmClicked = useCallback(() => {
+    dispatch(unblockUser({ userId: user.user_id }))
+    onClose()
+  }, [dispatch, onClose, user])
+
+  return (
+    <Modal bodyClassName={styles.root} isOpen={isVisible} onClose={onClose}>
+      <ModalHeader>
+        <ModalTitle
+          title={messages.title}
+          icon={<IconUnblockMessages />}
+          iconClassName={styles.icon}
+        />
+      </ModalHeader>
+      <ModalContent className={styles.content}>
+        {messages.content(user)}
+      </ModalContent>
+      <ModalFooter className={styles.footer}>
+        <Button
+          className={styles.button}
+          type={ButtonType.COMMON_ALT}
+          text={messages.cancel}
+          onClick={onClose}
+        />
+        <Button
+          className={styles.button}
+          type={ButtonType.PRIMARY_ALT}
+          text={messages.confirm}
+          onClick={handleConfirmClicked}
+        />
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/packages/web/src/utils/theme/dark.ts
+++ b/packages/web/src/utils/theme/dark.ts
@@ -33,6 +33,8 @@ const theme = {
   '--white': '#32334D',
   '--darkmode-static-white': 'var(--static-white)',
 
+  '--accent-red-dark-1': '#C43047',
+
   '--page-header-gradient-color-1': '#7652CC',
   '--page-header-gradient-color-2': '#B05CE6',
 

--- a/packages/web/src/utils/theme/default.ts
+++ b/packages/web/src/utils/theme/default.ts
@@ -34,7 +34,7 @@ const theme = {
   '--darkmode-static-white': 'var(--white)',
 
   '--accent-red': '#D0021B',
-  '--accent-red-dark-1': '#AA0115',
+  '--accent-red-dark-1': '#BB0218',
   '--accent-red-light-1': '#D51B32',
 
   '--accent-green': '#0BA400',


### PR DESCRIPTION
### Description

Adds confirmation modals to blocking, unblocking, and delete chats.

Opted not to make a general "ConfirmationModal" after realizing how much of the modal was being redefined via props, and considering how much of it changes from modal to modal (like button types etc).

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

- Doesn't have any error handling
- Doesn't wait for success
- Delete Chat copy to be finalized still
- Destructive button type didn't exist yet, adding now
- Updates all `--accent-red-dark-1` to new values per Julian's request

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Locally, vs Stage, blocking and unblocking stage users

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

