### PR TITLE
Fix unread count incorrect on mobile chats

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -22,12 +22,6 @@ const {
   selectIds: getChatMessageIds
 } = chatMessagesAdapter.getSelectors()
 
-/**
- * Gets a single chat (without optimistic read status)
- */
-export const getChat = selectChatById
-
-// Selectors for UserChat (all chats for a user)
 export const getChatsStatus = (state: CommonState) =>
   state.pages.chat.chats.status
 
@@ -45,6 +39,16 @@ export const getBlockees = (state: CommonState) => state.pages.chat.blockees
 export const getBlockers = (state: CommonState) => state.pages.chat.blockers
 
 const getChatPermissions = (state: CommonState) => state.pages.chat.permissions
+
+// Gets a chat and its optimistic read status
+export const getChat = (state: CommonState, chatId: string) => {
+  const chat = selectChatById(state, chatId)
+  if (!chat) return undefined
+  return {
+    ...chat,
+    ...state.pages.chat.optimisticChatRead[chatId]
+  }
+}
 
 /**
  * Gets all chats and their optimistic read status

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -212,7 +212,6 @@ export const ChatScreen = () => {
   const chatMessages = useSelector((state) =>
     getChatMessages(state, chatId ?? '')
   )
-  const unreadCount = chat?.unread_message_count ?? 0
   const isLoading =
     (chat?.messagesStatus ?? Status.LOADING) === Status.LOADING &&
     chatMessages?.length === 0
@@ -260,9 +259,6 @@ export const ChatScreen = () => {
     dispatch(fetchBlockers())
     if (otherUser.user_id) {
       dispatch(fetchPermissions({ userIds: [otherUser.user_id] }))
-    }
-    if (chatId) {
-      dispatch(fetchChatIfNecessary({ chatId, bustCache: true }))
     }
   }, [chatId, dispatch, otherUser.user_id])
 
@@ -389,11 +385,16 @@ export const ChatScreen = () => {
           isPopup={false}
           onLongPress={handleMessagePress}
         />
-        {item.message_id === earliestUnreadMessageId ? (
+        {item.message_id === earliestUnreadMessageId &&
+        chatFrozenRef.current?.unread_message_count ? (
           <View style={styles.unreadTagContainer}>
             <View style={styles.unreadSeparator} />
             <Text style={styles.unreadTag}>
-              {unreadCount} {pluralize(messages.newMessage, unreadCount > 1)}
+              {chatFrozenRef.current?.unread_message_count}{' '}
+              {pluralize(
+                messages.newMessage,
+                chatFrozenRef.current?.unread_message_count > 1
+              )}
             </Text>
             <View style={styles.unreadSeparator} />
           </View>
@@ -406,8 +407,7 @@ export const ChatScreen = () => {
       chatId,
       styles.unreadSeparator,
       styles.unreadTag,
-      styles.unreadTagContainer,
-      unreadCount
+      styles.unreadTagContainer
     ]
   )
 


### PR DESCRIPTION
### Description
Unread counts were sometimes incorrect due to
- getChats selector not including optimistic reads.
- Needed to use ChatFrozenRef to get the unread count to avoid optimistic unread count.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

