### PR TITLE
Update legacy playlist screens to use legacy inputs

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -41,7 +41,7 @@ import {
 import { AiGeneratedTracksScreen } from '../ai-generated-tracks-screen'
 import { AppDrawerContext } from '../app-drawer-screen'
 import { AudioScreen } from '../audio-screen'
-import { EditPlaylistScreen } from '../edit-playlist-screen/EditPlaylistScreen'
+import { EditPlaylistScreen } from '../edit-playlist-screen/LegacyEditPlaylistScreen'
 import { EditProfileScreen } from '../edit-profile-screen'
 import {
   AboutScreen,

--- a/packages/mobile/src/screens/edit-playlist-screen/CreatePlaylistScreen.tsx
+++ b/packages/mobile/src/screens/edit-playlist-screen/CreatePlaylistScreen.tsx
@@ -10,9 +10,9 @@ import { useDispatch } from 'react-redux'
 import { FormScreen } from 'app/components/form-screen'
 import { useToast } from 'app/hooks/useToast'
 
-import { PlaylistDescriptionInput } from './PlaylistDescriptionInput'
-import { PlaylistImageInput } from './PlaylistImageInput'
-import { PlaylistNameInput } from './PlaylistNameInput'
+import { PlaylistDescriptionInput } from './LegacyPlaylistDescriptionInput'
+import { PlaylistImageInput } from './LegacyPlaylistImageInput'
+import { PlaylistNameInput } from './LegacyPlaylistNameInput'
 const { createPlaylist } = cacheCollectionsActions
 
 const messages = {

--- a/packages/mobile/src/screens/edit-playlist-screen/LegacyEditPlaylistScreen.tsx
+++ b/packages/mobile/src/screens/edit-playlist-screen/LegacyEditPlaylistScreen.tsx
@@ -19,9 +19,9 @@ import { TrackList } from 'app/components/track-list'
 import { isImageUriSource } from 'app/hooks/useContentNodeImage'
 import { makeStyles } from 'app/styles'
 
-import { PlaylistDescriptionInput } from './PlaylistDescriptionInput'
-import { PlaylistImageInput } from './PlaylistImageInput'
-import { PlaylistNameInput } from './PlaylistNameInput'
+import { PlaylistDescriptionInput } from './LegacyPlaylistDescriptionInput'
+import { PlaylistImageInput } from './LegacyPlaylistImageInput'
+import { PlaylistNameInput } from './LegacyPlaylistNameInput'
 const { getMetadata, getTracks } = createPlaylistModalUISelectors
 const { editPlaylist, orderPlaylist, removeTrackFromPlaylist } =
   cacheCollectionsActions

--- a/packages/mobile/src/screens/edit-playlist-screen/LegacyPlaylistImageInput.tsx
+++ b/packages/mobile/src/screens/edit-playlist-screen/LegacyPlaylistImageInput.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native'
 import { FormImageInput } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 
-import { RandomImageInput } from './RandomImageButton'
+import { RandomImageInput } from './LegacyRandomImageButton'
 
 const name = 'artwork'
 


### PR DESCRIPTION
### Description
* Update legacy screens to display legacy inputs
* Update app tab screen to render legacy edit playlist screen

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

