### PR TITLE
[PAY-1150] Disable scrolling when chat reaction popup is active

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -510,6 +510,7 @@ export const ChatScreen = () => {
                   ListHeaderComponent={
                     canSendMessage ? null : <ChatUnavailable chatId={chatId} />
                   }
+                  scrollEnabled={!shouldShowPopup}
                 />
               </View>
             )}


### PR DESCRIPTION
### Description
Partially solves a bug where while pressing and holding on a chat message, after the reactions popup appears, the user can still scroll vertically on the underlying flatlist, as well as swipe left to navigate back on the navigator. This commit disables scrolling when the popup is active. Unfortunately the user can still swipe left, and if time a scroll gesture right at the end of the longpress there will still be an offset between the popup and original chat message.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

