### PR TITLE
[PAY-1276] Mobile chats change color on press

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -121,6 +121,20 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     marginBottom: spacing(2)
   }
 }))
+const useGetTailColor = (
+  isAuthor: boolean,
+  isPressed: boolean,
+  isLinkPreviewOnly
+) => {
+  const styles = useStyles()
+  return isPressed
+    ? isAuthor && !isLinkPreviewOnly
+      ? styles.pressedIsAuthor.backgroundColor
+      : styles.pressed.backgroundColor
+    : isAuthor && !isLinkPreviewOnly
+    ? styles.isAuthor.backgroundColor
+    : styles.bubble.backgroundColor
+}
 
 type ChatReactionProps = {
   reaction: ChatMessageReaction
@@ -157,15 +171,18 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
     itemsRef
   } = props
   const styles = useStyles()
-
   const userId = useSelector(getUserId)
   const senderUserId = decodeHashId(message.sender_user_id)
   const isAuthor = senderUserId === userId
+  const [isPressed, setIsPressed] = useState(false)
+  const links = find(message.message)
+  const link = links.filter((link) => link.type === 'url' && link.isLink)[0]
+  const isLinkPreviewOnly = link && link.value === message.message
+  const tailColor = useGetTailColor(isAuthor, isPressed, isLinkPreviewOnly)
   const isUnderneathPopup =
     useSelector((state) =>
       isIdEqualToReactionsPopupMessageId(state, message.message_id)
     ) && !isPopup
-  const [isPressed, setIsPressed] = useState(false)
 
   const handlePressIn = useCallback(() => {
     setIsPressed(true)
@@ -180,10 +197,6 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
       onLongPress?.(message.message_id)
     }
   }, [message.message_id, message.status, onLongPress])
-
-  const links = find(message.message)
-  const link = links.filter((link) => link.type === 'url' && link.isLink)[0]
-  const isLinkPreviewOnly = link && link.value === message.message
 
   return (
     <>
@@ -252,15 +265,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
               </View>
               {message.hasTail ? (
                 <ChatTail
-                  fill={
-                    isPressed
-                      ? isAuthor && !isLinkPreviewOnly
-                        ? styles.pressedIsAuthor.backgroundColor
-                        : styles.pressed.backgroundColor
-                      : isAuthor && !isLinkPreviewOnly
-                      ? styles.isAuthor.backgroundColor
-                      : styles.bubble.backgroundColor
-                  }
+                  fill={tailColor}
                   style={[
                     styles.tail,
                     isAuthor ? styles.tailIsAuthor : styles.tailOtherUser

--- a/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
+++ b/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
@@ -17,6 +17,9 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   rootIsLinkPreviewOnly: {
     borderRadius: spacing(3)
   },
+  pressed: {
+    backgroundColor: palette.neutralLight10
+  },
   thumbnail: {
     display: 'flex',
     alignItems: 'center',
@@ -68,7 +71,10 @@ type LinkPreviewProps = {
   messageId: string
   href: string
   isLinkPreviewOnly: boolean
+  isPressed: boolean
   onLongPress: (event: GestureResponderEvent) => void
+  onPressIn: (event: GestureResponderEvent) => void
+  onPressOut: (event: GestureResponderEvent) => void
 }
 
 export const LinkPreview = ({
@@ -76,7 +82,10 @@ export const LinkPreview = ({
   messageId,
   href,
   isLinkPreviewOnly,
-  onLongPress
+  isPressed = false,
+  onLongPress,
+  onPressIn,
+  onPressOut
 }: LinkPreviewProps) => {
   const styles = useStyles()
   const metadata = useLinkUnfurlMetadata(chatId, messageId, href)
@@ -91,10 +100,13 @@ export const LinkPreview = ({
       url={href}
       delayLongPress={REACTION_LONGPRESS_DELAY}
       onLongPress={onLongPress}
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
     >
       <View
         style={[
           styles.root,
+          isPressed ? styles.pressed : null,
           isLinkPreviewOnly ? styles.rootIsLinkPreviewOnly : null
         ]}
       >
@@ -109,10 +121,17 @@ export const LinkPreview = ({
                 />
               </View>
             ) : null}
-            <View style={styles.domainContainer}>
+            <View
+              style={[
+                styles.domainContainer,
+                isPressed ? styles.pressed : null
+              ]}
+            >
               <Text style={styles.domain}>{domain}</Text>
             </View>
-            <View style={styles.textContainer}>
+            <View
+              style={[styles.textContainer, isPressed ? styles.pressed : null]}
+            >
               {metadata.title ? (
                 <Text style={styles.title}>{metadata.title}</Text>
               ) : null}


### PR DESCRIPTION
### Description
Mobile chats change color on press

### Dragons

When the reaction popup appears, the chat message in the popup will not have the press colors. I don't think it's possible to pass the touch event to the newly created chat message component. And it won't register a `handlePressOut` for that reason.

### How Has This Been Tested?

Local ios stage

Uploading Simulator Screen Recording - iPhone 14 Pro - 2023-05-26 at 17.32.55.mp4…



### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

