### PR TITLE
[PAY-1247] Cap height of chat textinput on mobile

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useState } from 'react'
 
-import { chatActions } from '@audius/common'
+import { chatActions, playerSelectors } from '@audius/common'
 import { Platform } from 'react-native'
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import IconSend from 'app/assets/images/iconSend.svg'
 import { TextInput } from 'app/components/core'
@@ -11,6 +11,7 @@ import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 
 const { sendMessage } = chatActions
+const { getHasTrack } = playerSelectors
 
 const ICON_BLUR = 0.5
 const ICON_FOCUS = 1
@@ -22,7 +23,7 @@ const messages = {
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   composeTextContainer: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     backgroundColor: palette.neutralLight10,
     paddingLeft: spacing(4),
     borderRadius: spacing(1)
@@ -48,6 +49,7 @@ export const ChatTextInput = ({ chatId }: ChatTextInputProps) => {
   const dispatch = useDispatch()
 
   const [inputMessage, setInputMessage] = useState('')
+  const hasCurrentlyPlayingTrack = useSelector(getHasTrack)
 
   const handleSubmit = useCallback(
     (message) => {
@@ -76,7 +78,8 @@ export const ChatTextInput = ({ chatId }: ChatTextInputProps) => {
         root: styles.composeTextContainer,
         input: [
           styles.composeTextInput,
-          Platform.OS === 'ios' ? { paddingBottom: spacing(1) } : null
+          Platform.OS === 'ios' ? { paddingBottom: spacing(1) } : null,
+          { maxHeight: hasCurrentlyPlayingTrack ? spacing(70) : spacing(80) }
         ]
       }}
       onChangeText={(text) => {


### PR DESCRIPTION
### Description
Set a max height for the chat text input. Maintains a consistent height regardless of whether now playing drawer is visible or not.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local ios stage

<img width="435" alt="Screenshot 2023-05-26 at 3 59 52 PM" src="https://github.com/AudiusProject/audius-client/assets/3893871/63ee6867-4b31-46c0-a0d1-39f4c5069ba0">
<img width="448" alt="Screenshot 2023-05-26 at 3 58 02 PM" src="https://github.com/AudiusProject/audius-client/assets/3893871/8e7fae8f-0f19-4cfa-a6ff-f07cf73ed19e">


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

