### PR TITLE
[C-2647] Use entire cache to denormalize data

### DIFF
--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -32,6 +32,7 @@ import {
   QueryHookResults
 } from './types'
 import { capitalize, getKeyFromFetchArgs, selectCommonEntityMap } from './utils'
+import { useProxySelector } from 'hooks/useProxySelector'
 const { addEntries } = cacheActions
 
 export const createApi = <
@@ -204,10 +205,13 @@ const buildEndpointHooks = <
       }
 
     // Rehydrate local nonNormalizedData using entities from global normalized cache
-    let cachedData: Data = useSelector((state: CommonState) => {
-      const entityMap = selectCommonEntityMap(state, endpoint.options.kind)
-      return denormalize(nonNormalizedData, apiResponseSchema, entityMap)
-    }, isEqual)
+    let cachedData: Data = useProxySelector(
+      (state: CommonState) => {
+        const entityMap = selectCommonEntityMap(state, endpoint.options.kind)
+        return denormalize(nonNormalizedData, apiResponseSchema, entityMap)
+      },
+      [nonNormalizedData, apiResponseSchema, endpoint.options.kind]
+    )
 
     const context = useContext(AudiusQueryContext)
     useEffect(() => {

--- a/packages/common/src/audius-query/createApi.ts
+++ b/packages/common/src/audius-query/createApi.ts
@@ -5,6 +5,7 @@ import { isEqual } from 'lodash'
 import { denormalize, normalize } from 'normalizr'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { useProxySelector } from 'hooks/useProxySelector'
 import { Kind } from 'models/Kind'
 import { Status } from 'models/Status'
 import { getCollection } from 'store/cache/collections/selectors'
@@ -32,7 +33,6 @@ import {
   QueryHookResults
 } from './types'
 import { capitalize, getKeyFromFetchArgs, selectCommonEntityMap } from './utils'
-import { useProxySelector } from 'hooks/useProxySelector'
 const { addEntries } = cacheActions
 
 export const createApi = <

--- a/packages/common/src/audius-query/types.ts
+++ b/packages/common/src/audius-query/types.ts
@@ -53,9 +53,6 @@ export type EntityMap = {
       }
     | undefined
 }
-export type StrippedEntityMap = {
-  [x: string]: string[] | undefined
-}
 
 type FetchBaseAction = {
   fetchArgs: any
@@ -69,7 +66,6 @@ export type FetchErrorAction = PayloadAction<
 export type FetchSucceededAction = PayloadAction<
   FetchBaseAction & {
     nonNormalizedData: any
-    strippedEntityMap: StrippedEntityMap
   }
 >
 
@@ -82,7 +78,6 @@ export type PerEndpointState<NormalizedData> = {
 export type PerKeyState<NormalizedData> = {
   status: Status
   nonNormalizedData?: NormalizedData
-  strippedEntityMap?: StrippedEntityMap
   errorMessage?: string
 }
 

--- a/packages/common/src/audius-query/utils.ts
+++ b/packages/common/src/audius-query/utils.ts
@@ -18,12 +18,14 @@ export const selectCommonEntityMap = (
   kind?: Kind
 ): EntityMap | null => {
   const entityMap: EntityMap = {
-    users: cacheSelectors.getAllEntries(state, { kind: Kind.USERS })
+    [Kind.USERS]: cacheSelectors.getAllEntries(state, { kind: Kind.USERS })
   }
   if (kind === Kind.USERS) return entityMap
-  entityMap.tracks = cacheSelectors.getAllEntries(state, { kind: Kind.TRACKS })
+  entityMap[Kind.TRACKS] = cacheSelectors.getAllEntries(state, {
+    kind: Kind.TRACKS
+  })
   if (kind === Kind.TRACKS) return entityMap
-  entityMap.collections = cacheSelectors.getAllEntries(state, {
+  entityMap[Kind.COLLECTIONS] = cacheSelectors.getAllEntries(state, {
     kind: Kind.COLLECTIONS
   })
   return entityMap

--- a/packages/common/src/audius-query/utils.ts
+++ b/packages/common/src/audius-query/utils.ts
@@ -1,11 +1,9 @@
-import { mapValues, zipObject } from 'lodash'
-
 import { Kind } from 'models/Kind'
 import { CommonState } from 'store/reducers'
 
 import * as cacheSelectors from '../store/cache/selectors'
 
-import { EntityMap, StrippedEntityMap } from './types'
+import { EntityMap } from './types'
 
 export function capitalize(str: string) {
   return str.replace(str[0], str[0].toUpperCase())
@@ -15,39 +13,18 @@ export const getKeyFromFetchArgs = (fetchArgs: any) => {
   return JSON.stringify(fetchArgs)
 }
 
-export const stripEntityMap = (entities: EntityMap): StrippedEntityMap => {
-  return mapValues(
-    entities,
-    (entityType) => entityType && Object.keys(entityType)
-  )
-}
-
-export const selectRehydrateEntityMap = (
+export const selectCommonEntityMap = (
   state: CommonState,
-  strippedEntityMap: StrippedEntityMap
+  kind?: Kind
 ): EntityMap | null => {
-  try {
-    return mapValues(
-      strippedEntityMap,
-      (entityIds, kind) =>
-        entityIds &&
-        zipObject(
-          entityIds,
-          entityIds.map((entityId) => {
-            const cachedEntity = cacheSelectors.getEntry(state, {
-              kind: Kind[kind as keyof typeof Kind],
-              id: parseInt(entityId)
-            })
-            // Reject and return null if not all entities are populated
-            if (!cachedEntity) throw new Error('missing entity')
-            return cachedEntity
-          })
-        )
-    )
-  } catch (e) {
-    if ((e as Error).message !== 'missing entity') {
-      throw e
-    }
-    return null
+  const entityMap: EntityMap = {
+    users: cacheSelectors.getAllEntries(state, { kind: Kind.USERS })
   }
+  if (kind === Kind.USERS) return entityMap
+  entityMap.tracks = cacheSelectors.getAllEntries(state, { kind: Kind.TRACKS })
+  if (kind === Kind.TRACKS) return entityMap
+  entityMap.collections = cacheSelectors.getAllEntries(state, {
+    kind: Kind.COLLECTIONS
+  })
+  return entityMap
 }


### PR DESCRIPTION
### Description

Select the full cache from store to rehydrate entities in `audius-query`

Fixes issue where we didn't know what entities to use to replace normalized id references data on cache hit.

### Dragons

Selecting the whole cache may cause extra renders, but we're doing this already. UseProxySelector will hopefully avoid the worst of it