### PR TITLE
Retry CodePush installs if they failed the first time C-2659

### DIFF
--- a/packages/mobile/src/app/useSyncCodepush.ts
+++ b/packages/mobile/src/app/useSyncCodepush.ts
@@ -15,8 +15,12 @@ export const useSyncCodepush = () => {
     codePush.sync(
       {
         installMode: codePush.InstallMode.ON_NEXT_RESTART,
-        mandatoryInstallMode: codePush.InstallMode.ON_NEXT_RESTART
+        mandatoryInstallMode: codePush.InstallMode.ON_NEXT_RESTART,
         // ^ We'll manually show the mandatory update UI and prompt the user to restart the app.
+        rollbackRetryOptions: {
+          delayInHours: 0.5,
+          maxRetryAttempts: 5
+        }
       },
       (newStatus) => {
         console.log('New CodePush Status: ', newStatus)


### PR DESCRIPTION
### Description
Attempt to reinstall CodePush updates that failed to install the first time (for unknown reasons)
Will try up to 5 times
Android has a 20-30% CodePush rollback rate consistently, will see if this helps

From CodePush docs:
```
rollbackRetryOptions (RollbackRetryOptions) - The rollback retry mechanism allows the application to attempt to reinstall an update that was previously rolled back (with the restrictions specified in the options). It is an "options" object used to determine whether a rollback retry should occur, and if so, what settings to use for the rollback retry. This defaults to null, which has the effect of disabling the retry mechanism. Setting this to any truthy value will enable the retry mechanism with the default settings, and passing an object to this parameter allows enabling the rollback retry as well as overriding one or more of the default values.

The following list represents the available options and their defaults:

delayInHours (Number) - Specifies the minimum time in hours that the app will wait after the latest rollback before attempting to reinstall the same rolled-back package. Defaults to 24.

maxRetryAttempts (Number) - Specifies the maximum number of retry attempts that the app can make before it stops trying. Cannot be less than 1. Defaults to 1.
```

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

