### PR TITLE
[C-2646] Add idListArgKey for lists of entities; add fetchArgs types

### DIFF
--- a/packages/common/src/api/collection.ts
+++ b/packages/common/src/api/collection.ts
@@ -1,11 +1,14 @@
-import { Kind } from 'models'
+import { ID, Kind } from 'models'
 import { createApi } from 'src/audius-query/createApi'
 
 const collectionApi = createApi({
   reducerPath: 'collectionApi',
   endpoints: {
     getPlaylistById: {
-      fetch: async ({ playlistId, currentUserId }, { apiClient }) => {
+      fetch: async (
+        { playlistId, currentUserId }: { playlistId: ID; currentUserId: ID },
+        { apiClient }
+      ) => {
         return (
           await apiClient.getPlaylist({
             playlistId,
@@ -21,7 +24,10 @@ const collectionApi = createApi({
     },
     // Note: Please do not use this endpoint yet as it depends on further changes on the DN side.
     getPlaylistByPermalink: {
-      fetch: async ({ permalink, currentUserId }, { apiClient }) => {
+      fetch: async (
+        { permalink, currentUserId }: { permalink: string; currentUserId: ID },
+        { apiClient }
+      ) => {
         return (
           await apiClient.getPlaylistByPermalink({
             permalink,

--- a/packages/common/src/api/relatedArtists.ts
+++ b/packages/common/src/api/relatedArtists.ts
@@ -1,10 +1,11 @@
+import { ID } from 'models/Identifiers'
 import { createApi } from 'src/audius-query/createApi'
 
 const relatedArtistsApi = createApi({
   reducerPath: 'relatedArtistsApi',
   endpoints: {
     getRelatedArtists: {
-      fetch: async ({ artistId }, { apiClient }) =>
+      fetch: async ({ artistId }: { artistId: ID }, { apiClient }) =>
         await apiClient.getRelatedArtists({
           userId: artistId,
           limit: 50

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -1,4 +1,4 @@
-import { Kind } from 'models'
+import { ID, Kind } from 'models'
 import { createApi } from 'src/audius-query/createApi'
 import { parseTrackRouteFromPermalink } from 'utils/stringUtils'
 
@@ -6,7 +6,7 @@ const trackApi = createApi({
   reducerPath: 'trackApi',
   endpoints: {
     getTrackById: {
-      fetch: async ({ id }, { apiClient }) => {
+      fetch: async ({ id }: { id: ID }, { apiClient }) => {
         return await apiClient.getTrack({ id })
       },
       options: {
@@ -16,7 +16,10 @@ const trackApi = createApi({
       }
     },
     getTrackByPermalink: {
-      fetch: async ({ permalink, currentUserId }, { apiClient }) => {
+      fetch: async (
+        { permalink, currentUserId }: { permalink: string; currentUserId: ID },
+        { apiClient }
+      ) => {
         const { handle, slug } = parseTrackRouteFromPermalink(permalink)
         return await apiClient.getTrackByHandleAndSlug({
           handle,
@@ -31,7 +34,10 @@ const trackApi = createApi({
       }
     },
     getTracksByIds: {
-      fetch: async ({ ids, currentUserId }, { apiClient }) => {
+      fetch: async (
+        { ids, currentUserId }: { ids: ID[]; currentUserId: ID },
+        { apiClient }
+      ) => {
         return await apiClient.getTracks({ ids, currentUserId })
       },
       options: {

--- a/packages/common/src/api/track.ts
+++ b/packages/common/src/api/track.ts
@@ -35,7 +35,7 @@ const trackApi = createApi({
         return await apiClient.getTracks({ ids, currentUserId })
       },
       options: {
-        idArgKey: 'ids',
+        idListArgKey: 'ids',
         kind: Kind.TRACKS,
         schemaKey: 'tracks'
       }

--- a/packages/common/src/api/user.ts
+++ b/packages/common/src/api/user.ts
@@ -1,11 +1,14 @@
-import { Kind } from 'models'
+import { ID, Kind } from 'models'
 import { createApi } from 'src/audius-query/createApi'
 
 const userApi = createApi({
   reducerPath: 'userApi',
   endpoints: {
     getUserById: {
-      fetch: async ({ id, currentUserId }, { apiClient }) => {
+      fetch: async (
+        { id, currentUserId }: { id: ID; currentUserId: ID },
+        { apiClient }
+      ) => {
         const apiUser = await apiClient.getUser({ userId: id, currentUserId })
         return apiUser?.[0]
       },

--- a/packages/common/src/audius-query/README.md
+++ b/packages/common/src/audius-query/README.md
@@ -71,7 +71,7 @@
 
       _Note: A schema key is required, though any unreserved key can be used if the data does not contain any of the entities stored in the entity cache (i.e. any of the `Kinds` from [Kind.ts](/packages/common/src/models/Kind.ts))_
 
-    - **`kind`** - in combination with either `idArgKey`, or `permalinkArgKey`, allows local cache hits for single entities. If an entity with the matching `kind` and the `id` or `permalink` exists in cache, we will return that instead of calling the fetch function. See [enable single entity cache hits](#enable-single-entity-cache-hits) below
+    - **`kind`** - in combination with either `idArgKey` or `permalinkArgKey`, allows local cache hits for single entities. If an entity with the matching `kind` and the `id` or `permalink` exists in cache, we will return that instead of calling the fetch function. See [enable single entity cache hits](#enable-single-entity-cache-hits) below
       - **`idArgKey`** - `fetchArgs[idArgKey]` must contain the id of the entity
       - **`permalinkArgKey`** - `fetchArgs[permalinkArgKey]` must contain the permalink of the entity
       - **`idListArgKey`** - works like `idArgKey` but for endpoints that return a list entities

--- a/packages/common/src/audius-query/README.md
+++ b/packages/common/src/audius-query/README.md
@@ -71,9 +71,10 @@
 
       _Note: A schema key is required, though any unreserved key can be used if the data does not contain any of the entities stored in the entity cache (i.e. any of the `Kinds` from [Kind.ts](/packages/common/src/models/Kind.ts))_
 
-    - **`kind`** - in combination with either `idArgKey` or `permalinkArgKey`, allows local cache hits for single entities. If an entity with the matching `kind` and the `id` or `permalink` exists in cache, we will return that instead of calling the fetch function. See [enable single entity cache hits](#enable-single-entity-cache-hits) below
+    - **`kind`** - in combination with either `idArgKey`, or `permalinkArgKey`, allows local cache hits for single entities. If an entity with the matching `kind` and the `id` or `permalink` exists in cache, we will return that instead of calling the fetch function. See [enable single entity cache hits](#enable-single-entity-cache-hits) below
       - **`idArgKey`** - `fetchArgs[idArgKey]` must contain the id of the entity
       - **`permalinkArgKey`** - `fetchArgs[permalinkArgKey]` must contain the permalink of the entity
+      - **`idListArgKey`** - works like `idArgKey` but for endpoints that return a list entities
 
 1.  Export hooks
 

--- a/packages/common/src/audius-query/types.ts
+++ b/packages/common/src/audius-query/types.ts
@@ -36,6 +36,7 @@ export type SliceConfig = CreateSliceOptions<any, any, any>
 
 type EndpointOptions = {
   idArgKey?: string
+  idListArgKey?: string
   permalinkArgKey?: string
   schemaKey: string
   kind?: Kind

--- a/packages/web/src/components/related-artists/RelatedArtists.tsx
+++ b/packages/web/src/components/related-artists/RelatedArtists.tsx
@@ -38,7 +38,10 @@ export const RelatedArtists = () => {
 
   const artistId = profile?.user_id
 
-  const { data: relatedArtists } = useGetRelatedArtists({ artistId })
+  const { data: relatedArtists } = useGetRelatedArtists(
+    { artistId: artistId! },
+    { disabled: !artistId }
+  )
 
   const handleClick = useCallback(() => {
     if (profile) {

--- a/packages/web/src/pages/chat-page/components/ChatMessagePlaylist.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessagePlaylist.tsx
@@ -44,9 +44,9 @@ export const ChatMessagePlaylist = ({
   const { data: playlist, status } = useGetPlaylistById(
     {
       playlistId,
-      currentUserId
+      currentUserId: currentUserId!
     },
-    { disabled: !playlistId }
+    { disabled: !playlistId || !currentUserId }
   )
   const collection = playlist
     ? {
@@ -62,9 +62,9 @@ export const ChatMessagePlaylist = ({
   const { data: tracks } = useGetTracksByIds(
     {
       ids: trackIds,
-      currentUserId
+      currentUserId: currentUserId!
     },
-    { disabled: !trackIds.length }
+    { disabled: !trackIds.length || !currentUserId }
   )
   const playlistTracks = tracks ?? []
 

--- a/packages/web/src/pages/chat-page/components/ChatMessageTrack.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageTrack.tsx
@@ -41,10 +41,10 @@ export const ChatMessageTrack = ({ link, isAuthor }: ChatMessageTrackProps) => {
 
   const { data: track, status } = useGetTrackByPermalink(
     {
-      permalink,
-      currentUserId
+      permalink: permalink!,
+      currentUserId: currentUserId!
     },
-    { disabled: !permalink }
+    { disabled: !permalink || !currentUserId }
   )
 
   const uid = useMemo(() => {


### PR DESCRIPTION
### Description

Adds `idListArgKey` which allows cache hit for lists of entities if all entities are already present in the cache.
Also added argument types to the existing api endpoint fetch functions so the hooks can typecheck the fetchArgs.

Future work:
- Selective fetching so we can hit some of the entities from cache and fetch the rest

