### PR TITLE
[C-2635] Fix offline playback; broken signature fetch

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -579,7 +579,9 @@ export const Audio = () => {
       ? queueTracks.slice(refUids.length)
       : queueTracks
 
-    const queryParamsMap = await handleGatedQueryParams(newQueueTracks)
+    const queryParamsMap = isReachable
+      ? await handleGatedQueryParams(newQueueTracks)
+      : null
 
     const newTrackData = newQueueTracks.map((track) => {
       if (!track) {
@@ -596,7 +598,7 @@ export const Audio = () => {
         const audioFilePath = getLocalAudioPath(trackId)
         url = `file://${audioFilePath}`
       } else {
-        const queryParams = queryParamsMap[track.track_id]
+        const queryParams = queryParamsMap?.[track.track_id]
         if (queryParams) {
           url = apiClient.makeUrl(
             `/tracks/${encodeHashId(track.track_id)}/stream`,


### PR DESCRIPTION
### Description

Fetching signatures for gated content was breaking offline playback. The queueing of tracks would fail because the audiusBackend fetch failed.

Shoutouts @dylanjeffers for pairing help