### PR TITLE
[C-2700][C-2701] upload redesign feature flag and placeholder page

### DIFF
--- a/packages/common/src/services/remote-config/feature-flags.ts
+++ b/packages/common/src/services/remote-config/feature-flags.ts
@@ -49,7 +49,8 @@ export enum FeatureFlags {
   PLAYLIST_UPDATES_POST_QA = 'playlist_updates_post_qa',
   AI_ATTRIBUTION = 'ai_attribution',
   WRITE_METADATA_THROUGH_CHAIN = 'write_metadata_through_chain',
-  DEVELOPER_APPS_PAGE = 'developer_apps_page'
+  DEVELOPER_APPS_PAGE = 'developer_apps_page',
+  UPLOAD_REDESIGN_ENABLED = 'upload_redesign_enabled'
 }
 
 type FlagDefaults = Record<FeatureFlags, boolean>
@@ -114,5 +115,6 @@ export const flagDefaults: FlagDefaults = {
   [FeatureFlags.PLAYLIST_UPDATES_POST_QA]: false,
   [FeatureFlags.AI_ATTRIBUTION]: false,
   [FeatureFlags.WRITE_METADATA_THROUGH_CHAIN]: false,
-  [FeatureFlags.DEVELOPER_APPS_PAGE]: false
+  [FeatureFlags.DEVELOPER_APPS_PAGE]: false,
+  [FeatureFlags.UPLOAD_REDESIGN_ENABLED]: false
 }

--- a/packages/web/src/pages/upload-page/UploadPage.tsx
+++ b/packages/web/src/pages/upload-page/UploadPage.tsx
@@ -1,0 +1,20 @@
+import { FeatureFlags } from '@audius/common'
+
+import { useFlag } from 'hooks/useRemoteConfig'
+
+import UploadPageLegacy from './UploadPageLegacy'
+import UploadPageNew from './UploadPageNew'
+
+export const UploadPage = (props: any) => {
+  const { isEnabled: isRedesignEnabled } = useFlag(
+    FeatureFlags.UPLOAD_REDESIGN_ENABLED
+  )
+
+  return isRedesignEnabled ? (
+    <UploadPageNew {...props} />
+  ) : (
+    <UploadPageLegacy {...props} />
+  )
+}
+
+export default UploadPage

--- a/packages/web/src/pages/upload-page/UploadPageLegacy.js
+++ b/packages/web/src/pages/upload-page/UploadPageLegacy.js
@@ -39,7 +39,7 @@ const Pages = Object.freeze({
 
 const SHOW_FIRST_UPLOAD_MODAL_DELAY = 3000
 
-const UploadPage = (props) => {
+const UploadPageLegacy = (props) => {
   const { children, page } = props
 
   return (
@@ -451,7 +451,7 @@ class Upload extends Component {
         contentClassName={styles.upload}
         header={header}
       >
-        <UploadPage page={page}>{currentPage}</UploadPage>
+        <UploadPageLegacy page={page}>{currentPage}</UploadPageLegacy>
       </Page>
     )
   }

--- a/packages/web/src/pages/upload-page/UploadPageNew.module.css
+++ b/packages/web/src/pages/upload-page/UploadPageNew.module.css
@@ -1,0 +1,9 @@
+.upload {
+  text-align: left;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/web/src/pages/upload-page/UploadPageNew.tsx
+++ b/packages/web/src/pages/upload-page/UploadPageNew.tsx
@@ -1,0 +1,25 @@
+import { UploadType } from '@audius/common'
+
+import Header from 'components/header/desktop/Header'
+import Page from 'components/page/Page'
+
+import styles from './UploadPage.module.css'
+
+type UploadPageProps = {
+  uploadType: UploadType
+}
+
+export const UploadPageNew = (props: UploadPageProps) => {
+  return (
+    <Page
+      title='Upload'
+      description='Upload and publish audio content to the Audius platform'
+      contentClassName={styles.upload}
+      header={<Header primary={'Upload'} />}
+    >
+      This is the new upload page
+    </Page>
+  )
+}
+
+export default UploadPageNew


### PR DESCRIPTION
### Description

- Add feature flag `UPLOAD_REDESIGN_ENABLED` (also added in optimizely)
- UploadPage -> UploadPageLegacy
- Added UploadPageNew
- Switch between the two based on flag

### How Has This Been Tested?

Local web. Upload still works with the flag off.

### Feature Flags ###

`UPLOAD_REDESIGN_ENABLED` - if true, use the new redesigned upload flow
