### PR TITLE
[C-2702] Remove initialSelectedNode from disc-node selector

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -79,7 +79,7 @@ import {
   Nullable,
   removeNullable
 } from '../../utils'
-import type { DiscoveryNodeSelectorInstance } from '../discovery-node-selector'
+import type { DiscoveryNodeSelectorService } from '../discovery-node-selector'
 
 import { MonitoringCallbacks } from './types'
 
@@ -226,7 +226,7 @@ type AudiusBackendParams = {
   ethProviderUrls: Maybe<string[]>
   ethRegistryAddress: Maybe<string>
   ethTokenAddress: Maybe<string>
-  discoveryNodeSelectorInstance: DiscoveryNodeSelectorInstance
+  discoveryNodeSelectorService: DiscoveryNodeSelectorService
   getFeatureEnabled: (
     flag: FeatureFlags,
     fallbackFlag?: FeatureFlags
@@ -283,7 +283,7 @@ export const audiusBackend = ({
   ethProviderUrls,
   ethRegistryAddress,
   ethTokenAddress,
-  discoveryNodeSelectorInstance,
+  discoveryNodeSelectorService,
   getFeatureEnabled,
   getHostUrl,
   getLibs,
@@ -738,15 +738,7 @@ export const audiusBackend = ({
     let discoveryNodeSelector: Maybe<DiscoveryNodeSelector>
 
     if (useSdkDiscoveryNodeSelector) {
-      discoveryNodeSelector =
-        await discoveryNodeSelectorInstance.getDiscoveryNodeSelector()
-
-      const initialSelectedNode =
-        await discoveryNodeSelectorInstance.initialSelectedNode
-
-      if (initialSelectedNode) {
-        discoveryProviderSelectionCallback(initialSelectedNode.endpoint, [])
-      }
+      discoveryNodeSelector = await discoveryNodeSelectorService.getInstance()
 
       discoveryNodeSelector.addEventListener('change', (endpoint) => {
         discoveryProviderSelectionCallback(endpoint, [])

--- a/packages/common/src/services/discovery-node-selector/DiscoveryNodeSelectorService.ts
+++ b/packages/common/src/services/discovery-node-selector/DiscoveryNodeSelectorService.ts
@@ -6,7 +6,6 @@ import {
 } from '@audius/sdk'
 
 import { Env } from '../env'
-import type { CachedDiscoveryProviderType } from '../local-storage'
 import {
   BooleanKeys,
   IntKeys,
@@ -17,21 +16,18 @@ import {
 type DiscoveryNodeSelectorConfig = {
   env: Env
   remoteConfigInstance: RemoteConfigInstance
-  initialSelectedNode: Promise<CachedDiscoveryProviderType | null>
 }
 
-export class DiscoveryNodeSelectorInstance {
+export class DiscoveryNodeSelectorService {
   private env: Env
   private remoteConfigInstance: RemoteConfigInstance
   private discoveryNodeSelectorPromise: Promise<DiscoveryNodeSelector> | null
-  public initialSelectedNode: Promise<CachedDiscoveryProviderType | null>
 
   constructor(config: DiscoveryNodeSelectorConfig) {
-    const { env, remoteConfigInstance, initialSelectedNode } = config
+    const { env, remoteConfigInstance } = config
     this.env = env
     this.remoteConfigInstance = remoteConfigInstance
     this.discoveryNodeSelectorPromise = null
-    this.initialSelectedNode = initialSelectedNode
   }
 
   private async makeDiscoveryNodeSelector() {
@@ -63,14 +59,11 @@ export class DiscoveryNodeSelectorInstance {
     const requestTimeout =
       getRemoteVar(IntKeys.DISCOVERY_PROVIDER_SELECTION_TIMEOUT_MS) ?? undefined
 
-    const initialSelectedNode = await this.initialSelectedNode
-
     return new DiscoveryNodeSelector({
       healthCheckThresholds,
       blocklist,
       requestTimeout,
-      bootstrapServices: discoveryNodes,
-      initialSelectedNode: initialSelectedNode?.endpoint
+      bootstrapServices: discoveryNodes
     })
   }
 
@@ -87,7 +80,7 @@ export class DiscoveryNodeSelectorInstance {
     return null
   }
 
-  public async getDiscoveryNodeSelector() {
+  public async getInstance() {
     if (!this.discoveryNodeSelectorPromise) {
       this.discoveryNodeSelectorPromise = this.makeDiscoveryNodeSelector()
     }

--- a/packages/common/src/services/discovery-node-selector/index.ts
+++ b/packages/common/src/services/discovery-node-selector/index.ts
@@ -1,1 +1,1 @@
-export * from './DiscoveryNodeSelectorInstance'
+export * from './DiscoveryNodeSelectorService'

--- a/packages/mobile/src/services/audius-backend-instance.ts
+++ b/packages/mobile/src/services/audius-backend-instance.ts
@@ -8,7 +8,7 @@ import { track } from 'app/services/analytics'
 import { reportToSentry } from 'app/utils/reportToSentry'
 
 import { createPrivateKey } from './createPrivateKey'
-import { discoveryNodeSelectorInstance } from './discovery-node-selector'
+import { discoveryNodeSelectorService } from './discovery-node-selector'
 import { withEagerOption } from './eagerLoadUtils'
 import { env } from './env'
 import {
@@ -31,7 +31,7 @@ export const audiusBackendInstance = audiusBackend({
   ethProviderUrls: (Config.ETH_PROVIDER_URL || '').split(','),
   ethRegistryAddress: Config.ETH_REGISTRY_ADDRESS,
   ethTokenAddress: Config.ETH_TOKEN_ADDRESS,
-  discoveryNodeSelectorInstance,
+  discoveryNodeSelectorService,
   getFeatureEnabled,
   getHostUrl: () => {
     return `${Config.PUBLIC_PROTOCOL}//${Config.PUBLIC_HOSTNAME}`

--- a/packages/mobile/src/services/audius-sdk.ts
+++ b/packages/mobile/src/services/audius-sdk.ts
@@ -5,7 +5,7 @@ import { sdk } from '@audius/sdk'
 import { keccak_256 } from '@noble/hashes/sha3'
 import * as secp from '@noble/secp256k1'
 
-import { discoveryNodeSelectorInstance } from './discovery-node-selector'
+import { discoveryNodeSelectorService } from './discovery-node-selector'
 import { audiusLibs, waitForLibsInit } from './libs'
 
 let inProgress = false
@@ -19,8 +19,7 @@ const initSdk = async () => {
   const audiusSdk = sdk({
     appName: 'audius-mobile-client',
     services: {
-      discoveryNodeSelector:
-        await discoveryNodeSelectorInstance.getDiscoveryNodeSelector(),
+      discoveryNodeSelector: await discoveryNodeSelectorService.getInstance(),
       auth: {
         sign: async (data: string) => {
           await waitForLibsInit()

--- a/packages/mobile/src/services/discovery-node-selector.ts
+++ b/packages/mobile/src/services/discovery-node-selector.ts
@@ -1,11 +1,9 @@
-import { DiscoveryNodeSelectorInstance } from '@audius/common'
+import { DiscoveryNodeSelectorService } from '@audius/common'
 
 import { env } from './env'
-import { localStorage } from './local-storage'
 import { remoteConfigInstance } from './remote-config/remote-config-instance'
 
-export const discoveryNodeSelectorInstance = new DiscoveryNodeSelectorInstance({
+export const discoveryNodeSelectorService = new DiscoveryNodeSelectorService({
   env,
-  remoteConfigInstance,
-  initialSelectedNode: localStorage.getCachedDiscoveryProvider()
+  remoteConfigInstance
 })

--- a/packages/web/src/services/audius-backend/audius-backend-instance.ts
+++ b/packages/web/src/services/audius-backend/audius-backend-instance.ts
@@ -7,7 +7,7 @@ import {
   waitForLibsInit,
   withEagerOption
 } from 'services/audius-backend/eagerLoadUtils'
-import { discoveryNodeSelectorInstance } from 'services/discovery-node-selector'
+import { discoveryNodeSelectorService } from 'services/discovery-node-selector'
 import { getFeatureEnabled } from 'services/remote-config/featureFlagHelpers'
 import { remoteConfigInstance } from 'services/remote-config/remote-config-instance'
 import { monitoringCallbacks } from 'services/serviceMonitoring'
@@ -38,7 +38,7 @@ export const audiusBackendInstance = audiusBackend({
   getFeatureEnabled,
   getHostUrl: () => window.location.origin,
   getLibs: () => getLibs(remoteConfigInstance),
-  discoveryNodeSelectorInstance,
+  discoveryNodeSelectorService,
   getWeb3Config: async (
     libs,
     registryAddress,

--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -4,7 +4,7 @@ import * as secp from '@noble/secp256k1'
 import { signTypedData } from 'eth-sig-util'
 
 import { waitForLibsInit } from 'services/audius-backend/eagerLoadUtils'
-import { discoveryNodeSelectorInstance } from 'services/discovery-node-selector'
+import { discoveryNodeSelectorService } from 'services/discovery-node-selector'
 import { entityManagerInstance } from 'services/entity-manager'
 
 declare global {
@@ -22,8 +22,7 @@ const initSdk = async () => {
   const audiusSdk = sdk({
     appName: 'audius-client',
     services: {
-      discoveryNodeSelector:
-        await discoveryNodeSelectorInstance.getDiscoveryNodeSelector(),
+      discoveryNodeSelector: await discoveryNodeSelectorService.getInstance(),
       entityManager: entityManagerInstance,
       auth: {
         sign: async (data) => {

--- a/packages/web/src/services/discovery-node-selector.ts
+++ b/packages/web/src/services/discovery-node-selector.ts
@@ -1,12 +1,9 @@
-import { DiscoveryNodeSelectorInstance } from '@audius/common'
-
-import { localStorage } from 'services/local-storage'
+import { DiscoveryNodeSelectorService } from '@audius/common'
 
 import { env } from './env'
 import { remoteConfigInstance } from './remote-config/remote-config-instance'
 
-export const discoveryNodeSelectorInstance = new DiscoveryNodeSelectorInstance({
+export const discoveryNodeSelectorService = new DiscoveryNodeSelectorService({
   env,
-  remoteConfigInstance,
-  initialSelectedNode: localStorage.getCachedDiscoveryProvider()
+  remoteConfigInstance
 })


### PR DESCRIPTION
### Description

Removes the initialSelectedNode from discovery-node-selector to prevent issues where users get stuck on a node that may be unhealthy.
