### PR TITLE
[PAY-1308] Use all messages for tracking latest received

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -325,31 +325,31 @@ export const ChatScreen = () => {
     }
   }, [earliestUnreadIndex, chatMessages])
 
-  const newestReceivedMessageId = useMemo(() => {
-    const idx = chatMessages.findIndex(
-      (chat) => chat.sender_user_id !== userIdEncoded
-    )
-    return idx >= 0 ? chatMessages[idx].message_id : null
-  }, [chatMessages, userIdEncoded])
+  const newestMessage = chatMessages.length > 0 ? chatMessages[0] : null
 
   // If most recent message changes and we are scrolled up, fire a toast
   useEffect(() => {
-    if (
-      newestReceivedMessageId &&
-      newestReceivedMessageId !== newestMessageId.current
-    ) {
-      newestMessageId.current = newestReceivedMessageId
+    if (newestMessage && newestMessage.message_id !== newestMessageId.current) {
+      newestMessageId.current = newestMessage.message_id
+      // Only fire toasts for received messages, which we can only compute if
+      // we have a valid userId
+      const isReceivedMessage =
+        userIdEncoded && newestMessage.sender_user_id !== userIdEncoded
       if (
+        isReceivedMessage &&
         scrollPosition.current >
-        getNewMessageToastThreshold({
-          bottom: chatContainerBottom.current,
-          top: chatContainerTop.current
-        })
+          getNewMessageToastThreshold({
+            bottom: chatContainerBottom.current,
+            top: chatContainerTop.current
+          })
       ) {
-        toast({ content: messages.newMessageReceived, type: 'info' })
+        toast({
+          content: messages.newMessageReceived,
+          type: 'info'
+        })
       }
     }
-  }, [newestReceivedMessageId, newestMessageId, scrollPosition, toast])
+  }, [newestMessage, newestMessageId, scrollPosition, userIdEncoded, toast])
 
   const handleScrollToIndexFailed = useCallback<
     ChatListEventHandler<'onScrollToIndexFailed'>

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -219,7 +219,7 @@ export const ChatScreen = () => {
   const chatContainerTop = useRef(0)
   const chatContainerBottom = useRef(0)
   const scrollPosition = useRef(0)
-  const newestMessageId = useRef('')
+  const latestMessageId = useRef('')
   const flatListInnerHeight = useRef(0)
 
   const hasCurrentlyPlayingTrack = useSelector(getHasTrack)
@@ -325,16 +325,16 @@ export const ChatScreen = () => {
     }
   }, [earliestUnreadIndex, chatMessages])
 
-  const newestMessage = chatMessages.length > 0 ? chatMessages[0] : null
+  const latestMessage = chatMessages.length > 0 ? chatMessages[0] : null
 
   // If most recent message changes and we are scrolled up, fire a toast
   useEffect(() => {
-    if (newestMessage && newestMessage.message_id !== newestMessageId.current) {
-      newestMessageId.current = newestMessage.message_id
+    if (latestMessage && latestMessage.message_id !== latestMessageId.current) {
+      latestMessageId.current = latestMessage.message_id
       // Only fire toasts for received messages, which we can only compute if
       // we have a valid userId
       const isReceivedMessage =
-        userIdEncoded && newestMessage.sender_user_id !== userIdEncoded
+        userIdEncoded && latestMessage.sender_user_id !== userIdEncoded
       if (
         isReceivedMessage &&
         scrollPosition.current >
@@ -349,7 +349,7 @@ export const ChatScreen = () => {
         })
       }
     }
-  }, [newestMessage, newestMessageId, scrollPosition, userIdEncoded, toast])
+  }, [latestMessage, latestMessageId, scrollPosition, userIdEncoded, toast])
 
   const handleScrollToIndexFailed = useCallback<
     ChatListEventHandler<'onScrollToIndexFailed'>


### PR DESCRIPTION
### Description
The logic I had before was well-intentioned (find the first message that isn't from the current user). But it has a flaw when the first page of messages are all from the current user and you have to scroll up to see the first "received" message.
I changed the logic to just run the effect whenever the most recent message changes, and only do the toast logic when the most recent message is from the other user.

### Dragons
N/A

### How Has This Been Tested?
Tested locally on physical devices

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

