### PR TITLE
[C-2699] Fix collection action button sizes

### DIFF
--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -27,6 +27,10 @@
   height: var(--unit-12);
 }
 
+.button.medium .textLabel {
+  font-size: var(--font-l);
+}
+
 .button.small {
   height: var(--unit-8);
 }
@@ -51,10 +55,6 @@
 }
 
 .button .icon.left {
-  margin-right: var(--unit-3);
-}
-
-.button.small .icon.left {
   margin-right: var(--unit-2);
 }
 
@@ -63,7 +63,7 @@
 }
 
 .button .icon.right {
-  margin-left: var(--unit-3);
+  margin-left: var(--unit-2);
 }
 
 .button .icon.right.noText {

--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -27,10 +27,6 @@
   height: var(--unit-12);
 }
 
-.button.medium .textLabel {
-  font-size: var(--font-l);
-}
-
 .button.small {
   height: var(--unit-8);
 }
@@ -55,6 +51,10 @@
 }
 
 .button .icon.left {
+  margin-right: var(--unit-3);
+}
+
+.button.small .icon.left {
   margin-right: var(--unit-2);
 }
 
@@ -63,7 +63,7 @@
 }
 
 .button .icon.right {
-  margin-left: var(--unit-2);
+  margin-left: var(--unit-3);
 }
 
 .button .icon.right.noText {

--- a/packages/web/src/components/collection/desktop/CollectionActionButton.tsx
+++ b/packages/web/src/components/collection/desktop/CollectionActionButton.tsx
@@ -1,0 +1,15 @@
+import { Button, ButtonProps } from '@audius/stems'
+
+import styles from './CollectionHeader.module.css'
+
+type CollectionActionButtonProps = ButtonProps
+
+export const CollectionActionButton = (props: CollectionActionButtonProps) => {
+  return (
+    <Button
+      textClassName={styles.collectionButtonText}
+      iconClassName={styles.collectionButtonIcon}
+      {...props}
+    />
+  )
+}

--- a/packages/web/src/components/collection/desktop/CollectionHeader.module.css
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.module.css
@@ -189,10 +189,6 @@
   fill: var(--neutral-light-4);
 }
 
-.buttonFormatting {
-  padding: 0 16px;
-}
-
 .buttonTextFormatting {
   text-transform: uppercase;
 }

--- a/packages/web/src/components/collection/desktop/CollectionHeader.module.css
+++ b/packages/web/src/components/collection/desktop/CollectionHeader.module.css
@@ -189,10 +189,6 @@
   fill: var(--neutral-light-4);
 }
 
-.buttonTextFormatting {
-  text-transform: uppercase;
-}
-
 .hide {
   opacity: 0;
 }
@@ -242,4 +238,13 @@
 
 .spinner g path {
   stroke: var(--white);
+}
+
+.collectionButtonText {
+  font-size: var(--font-l) !important;
+  text-transform: uppercase;
+}
+
+.collectionButtonIcon {
+  margin-right: var(--unit-2) !important;
 }

--- a/packages/web/src/components/collection/desktop/EditButton.tsx
+++ b/packages/web/src/components/collection/desktop/EditButton.tsx
@@ -1,11 +1,11 @@
 import { useCallback } from 'react'
 
-import { Button, ButtonProps, ButtonType, IconPencil } from '@audius/stems'
+import { ButtonProps, ButtonType, IconPencil } from '@audius/stems'
 import { useDispatch } from 'react-redux'
 
 import { open as openEditCollectionModal } from 'store/application/ui/editPlaylistModal/slice'
 
-import styles from './CollectionHeader.module.css'
+import { CollectionActionButton } from './CollectionActionButton'
 
 const messages = {
   edit: 'Edit'
@@ -25,8 +25,7 @@ export const EditButton = (props: EditButtonProps) => {
   )
 
   return (
-    <Button
-      textClassName={styles.buttonTextFormatting}
+    <CollectionActionButton
       type={ButtonType.COMMON}
       text={messages.edit}
       leftIcon={<IconPencil />}

--- a/packages/web/src/components/collection/desktop/EditButton.tsx
+++ b/packages/web/src/components/collection/desktop/EditButton.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react'
 
 import { Button, ButtonProps, ButtonType, IconPencil } from '@audius/stems'
-import cn from 'classnames'
 import { useDispatch } from 'react-redux'
 
 import { open as openEditCollectionModal } from 'store/application/ui/editPlaylistModal/slice'
@@ -27,7 +26,6 @@ export const EditButton = (props: EditButtonProps) => {
 
   return (
     <Button
-      className={cn(styles.buttonFormatting)}
       textClassName={styles.buttonTextFormatting}
       type={ButtonType.COMMON}
       text={messages.edit}

--- a/packages/web/src/components/collection/desktop/FavoriteButton.tsx
+++ b/packages/web/src/components/collection/desktop/FavoriteButton.tsx
@@ -11,7 +11,6 @@ import {
   FavoriteSource
 } from '@audius/common'
 import { Button, ButtonProps, ButtonType, IconHeart } from '@audius/stems'
-import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Tooltip } from 'components/tooltip'
@@ -83,7 +82,6 @@ export const FavoriteButton = (props: FavoriteButtonProps) => {
       text={isSaved ? messages.unfavorite : messages.favorite}
     >
       <Button
-        className={cn(styles.buttonFormatting)}
         textClassName={styles.buttonTextFormatting}
         type={type ?? (isSaved ? ButtonType.SECONDARY : ButtonType.COMMON)}
         text={isSaved ? messages.favorited : messages.favorite}

--- a/packages/web/src/components/collection/desktop/FavoriteButton.tsx
+++ b/packages/web/src/components/collection/desktop/FavoriteButton.tsx
@@ -10,12 +10,12 @@ import {
   collectionsSocialActions,
   FavoriteSource
 } from '@audius/common'
-import { Button, ButtonProps, ButtonType, IconHeart } from '@audius/stems'
+import { ButtonProps, ButtonType, IconHeart } from '@audius/stems'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Tooltip } from 'components/tooltip'
 
-import styles from './CollectionHeader.module.css'
+import { CollectionActionButton } from './CollectionActionButton'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
 
 const { getCollection } = collectionPageSelectors
@@ -81,8 +81,7 @@ export const FavoriteButton = (props: FavoriteButtonProps) => {
       disabled={isOwner || saveCount === 0}
       text={isSaved ? messages.unfavorite : messages.favorite}
     >
-      <Button
-        textClassName={styles.buttonTextFormatting}
+      <CollectionActionButton
         type={type ?? (isSaved ? ButtonType.SECONDARY : ButtonType.COMMON)}
         text={isSaved ? messages.favorited : messages.favorite}
         leftIcon={<IconHeart />}

--- a/packages/web/src/components/collection/desktop/OverflowMenuButton.tsx
+++ b/packages/web/src/components/collection/desktop/OverflowMenuButton.tsx
@@ -9,7 +9,6 @@ import {
   usersSocialActions
 } from '@audius/common'
 import { Button, ButtonType, IconKebabHorizontal } from '@audius/stems'
-import cn from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 
 import Menu from 'components/menu/Menu'
@@ -83,7 +82,6 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
       {(ref, triggerPopup) => (
         <Button
           ref={ref}
-          className={cn(styles.buttonFormatting)}
           leftIcon={<IconKebabHorizontal />}
           onClick={triggerPopup}
           text={null}

--- a/packages/web/src/components/collection/desktop/PlayButton.tsx
+++ b/packages/web/src/components/collection/desktop/PlayButton.tsx
@@ -1,8 +1,8 @@
 import { MouseEventHandler } from 'react'
 
-import { Button, ButtonType, IconPause, IconPlay } from '@audius/stems'
+import { ButtonType, IconPause, IconPlay } from '@audius/stems'
 
-import styles from './CollectionHeader.module.css'
+import { CollectionActionButton } from './CollectionActionButton'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
 
 const messages = {
@@ -19,9 +19,7 @@ export const PlayButton = (props: PlayButtonProps) => {
   const { onPlay, playing: isPlaying } = props
 
   return (
-    <Button
-      className={styles.playAllButton}
-      textClassName={styles.buttonTextFormatting}
+    <CollectionActionButton
       type={ButtonType.PRIMARY_ALT}
       text={isPlaying ? messages.pause : messages.play}
       leftIcon={isPlaying ? <IconPause /> : <IconPlay />}

--- a/packages/web/src/components/collection/desktop/PlayButton.tsx
+++ b/packages/web/src/components/collection/desktop/PlayButton.tsx
@@ -1,7 +1,6 @@
 import { MouseEventHandler } from 'react'
 
 import { Button, ButtonType, IconPause, IconPlay } from '@audius/stems'
-import cn from 'classnames'
 
 import styles from './CollectionHeader.module.css'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
@@ -21,16 +20,13 @@ export const PlayButton = (props: PlayButtonProps) => {
 
   return (
     <Button
-      className={cn(styles.playAllButton, {
-        [styles.buttonFormatting]: isPlaying
-      })}
+      className={styles.playAllButton}
       textClassName={styles.buttonTextFormatting}
       type={ButtonType.PRIMARY_ALT}
       text={isPlaying ? messages.pause : messages.play}
       leftIcon={isPlaying ? <IconPause /> : <IconPlay />}
       onClick={onPlay}
       widthToHideText={BUTTON_COLLAPSE_WIDTHS.first}
-      minWidth={132}
     />
   )
 }

--- a/packages/web/src/components/collection/desktop/PublishButton.tsx
+++ b/packages/web/src/components/collection/desktop/PublishButton.tsx
@@ -4,7 +4,6 @@ import {
   CommonState
 } from '@audius/common'
 import { Button, ButtonProps, ButtonType, IconRocket } from '@audius/stems'
-import cn from 'classnames'
 import { useSelector } from 'react-redux'
 import { useToggle } from 'react-use'
 
@@ -39,7 +38,6 @@ export const PublishButton = (props: PublishButtonProps) => {
 
   const publishButtonElement = (
     <Button
-      className={cn(styles.buttonFormatting)}
       textClassName={styles.buttonTextFormatting}
       type={_is_publishing ? ButtonType.DISABLED : ButtonType.COMMON}
       text={

--- a/packages/web/src/components/collection/desktop/PublishButton.tsx
+++ b/packages/web/src/components/collection/desktop/PublishButton.tsx
@@ -3,13 +3,14 @@ import {
   collectionPageSelectors,
   CommonState
 } from '@audius/common'
-import { Button, ButtonProps, ButtonType, IconRocket } from '@audius/stems'
+import { ButtonProps, ButtonType, IconRocket } from '@audius/stems'
 import { useSelector } from 'react-redux'
 import { useToggle } from 'react-use'
 
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import { Tooltip } from 'components/tooltip'
 
+import { CollectionActionButton } from './CollectionActionButton'
 import styles from './CollectionHeader.module.css'
 import { PublishConfirmationModal } from './PublishConfirmationModal'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
@@ -37,8 +38,7 @@ export const PublishButton = (props: PublishButtonProps) => {
   const isDisabled = track_count === 0
 
   const publishButtonElement = (
-    <Button
-      textClassName={styles.buttonTextFormatting}
+    <CollectionActionButton
       type={_is_publishing ? ButtonType.DISABLED : ButtonType.COMMON}
       text={
         _is_publishing ? (

--- a/packages/web/src/components/collection/desktop/RepostButton.tsx
+++ b/packages/web/src/components/collection/desktop/RepostButton.tsx
@@ -8,12 +8,12 @@ import {
   collectionsSocialActions,
   RepostSource
 } from '@audius/common'
-import { Button, ButtonProps, ButtonType, IconRepost } from '@audius/stems'
+import { ButtonProps, ButtonType, IconRepost } from '@audius/stems'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { Tooltip } from 'components/tooltip'
 
-import styles from './CollectionHeader.module.css'
+import { CollectionActionButton } from './CollectionActionButton'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
 
 const { getCollection } = collectionPageSelectors
@@ -50,12 +50,11 @@ export const RepostButton = (props: RepostButtonProps) => {
     <Tooltip
       text={has_current_user_reposted ? messages.unrepost : messages.repost}
     >
-      <Button
+      <CollectionActionButton
         type={
           type ??
           (has_current_user_reposted ? ButtonType.SECONDARY : ButtonType.COMMON)
         }
-        textClassName={styles.buttonTextFormatting}
         text={has_current_user_reposted ? messages.reposted : messages.repost}
         leftIcon={<IconRepost />}
         onClick={handleRepost}

--- a/packages/web/src/components/collection/desktop/RepostButton.tsx
+++ b/packages/web/src/components/collection/desktop/RepostButton.tsx
@@ -55,7 +55,6 @@ export const RepostButton = (props: RepostButtonProps) => {
           type ??
           (has_current_user_reposted ? ButtonType.SECONDARY : ButtonType.COMMON)
         }
-        className={styles.buttonFormatting}
         textClassName={styles.buttonTextFormatting}
         text={has_current_user_reposted ? messages.reposted : messages.repost}
         leftIcon={<IconRepost />}

--- a/packages/web/src/components/collection/desktop/ShareButton.tsx
+++ b/packages/web/src/components/collection/desktop/ShareButton.tsx
@@ -7,7 +7,6 @@ import {
   SmartCollectionVariant
 } from '@audius/common'
 import { Button, ButtonProps, ButtonType, IconShare } from '@audius/stems'
-import cn from 'classnames'
 import { useDispatch } from 'react-redux'
 
 import styles from './CollectionHeader.module.css'
@@ -55,7 +54,6 @@ export const ShareButton = (props: ShareButtonProps) => {
 
   return (
     <Button
-      className={cn(styles.buttonFormatting)}
       textClassName={styles.buttonTextFormatting}
       type={type ?? ButtonType.COMMON}
       text={messages.share}

--- a/packages/web/src/components/collection/desktop/ShareButton.tsx
+++ b/packages/web/src/components/collection/desktop/ShareButton.tsx
@@ -6,10 +6,10 @@ import {
   ShareSource,
   SmartCollectionVariant
 } from '@audius/common'
-import { Button, ButtonProps, ButtonType, IconShare } from '@audius/stems'
+import { ButtonProps, ButtonType, IconShare } from '@audius/stems'
 import { useDispatch } from 'react-redux'
 
-import styles from './CollectionHeader.module.css'
+import { CollectionActionButton } from './CollectionActionButton'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
 
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
@@ -53,8 +53,7 @@ export const ShareButton = (props: ShareButtonProps) => {
   }, [dispatch, collectionId, userId])
 
   return (
-    <Button
-      textClassName={styles.buttonTextFormatting}
+    <CollectionActionButton
       type={type ?? ButtonType.COMMON}
       text={messages.share}
       leftIcon={<IconShare />}


### PR DESCRIPTION
### Description

Fixes issue where favorites button had a different size than the rest of the collection action buttons. The issue actually had to do with the way "medium" sized button styles worked, where secondary font-size was larger than other button variant sizes. This fix adds consistency to button sizes across the board, reducing the need for hard-coded styles