### PR TITLE
[pay-1311] Reset chat state on sign out

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -17,6 +17,7 @@ import {
 import dayjs from 'dayjs'
 
 import { ID, Status, ChatMessageWithExtras } from 'models'
+import { signOut } from 'store/sign-out/slice'
 import { hasTail } from 'utils/chatUtils'
 import { encodeHashId } from 'utils/hashIds'
 
@@ -547,6 +548,11 @@ const slice = createSlice({
       const { chatId } = action.payload
       chatsAdapter.removeOne(state.chats, chatId)
       chatMessagesAdapter.removeAll(state.messages[chatId])
+    }
+  },
+  extraReducers: {
+    [signOut.type]: () => {
+      return initialState
     }
   }
 })


### PR DESCRIPTION
### Description
Since our chat state reducers and sagas are all based on the current signed-in user and don't support multiple user chat states, we should reset it on sign out. This isn't an issue for web, as the page is refreshed after sign out and we lose all redux state.

### Dragons
N/A

### How Has This Been Tested?
Tested on physical device against staging

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

