### PR TITLE
Add mobile hidden track playlist logic

### DIFF
--- a/packages/common/src/store/cache/collections/selectors.ts
+++ b/packages/common/src/store/cache/collections/selectors.ts
@@ -69,6 +69,32 @@ export const getCollectionsByUid = (state: CommonState) => {
   }, {} as { [uid: string]: Collection | null })
 }
 
+const getCollectionTracks = (state: CommonState, { id }: { id?: ID }) => {
+  const collection = getCollection(state, { id })
+  const collectionTrackIds = collection?.playlist_contents.track_ids.map(
+    (track_id) => track_id.track // track === actual track id, oof
+  )
+  return getTracks(state, { ids: collectionTrackIds })
+}
+
+export const getIsCollectionEmpty = (
+  state: CommonState,
+  { id }: { id?: ID }
+) => {
+  const collectionTracks = getCollectionTracks(state, { id })
+
+  return Object.values(collectionTracks).length === 0
+}
+
+export const getCollecitonHasHiddenTracks = (
+  state: CommonState,
+  { id }: { id?: ID }
+) => {
+  const collectionTracks = getCollectionTracks(state, { id })
+
+  return Object.values(collectionTracks)?.some((track) => track.is_unlisted)
+}
+
 export const getStatuses = (state: CommonState, props: { ids: ID[] }) => {
   const statuses: { [id: number]: Status } = {}
   props.ids.forEach((id) => {

--- a/packages/common/src/store/ui/add-to-playlist/actions.ts
+++ b/packages/common/src/store/ui/add-to-playlist/actions.ts
@@ -8,10 +8,18 @@ export const CLOSE = 'ADD_TO_PLAYLIST/CLOSE'
 
 export const requestOpen = createCustomAction(
   REQUEST_OPEN,
-  (trackId: ID, trackTitle: string) => ({ trackId, trackTitle })
+  (trackId: ID, trackTitle: string, isUnlisted?: boolean) => ({
+    trackId,
+    trackTitle,
+    isUnlisted
+  })
 )
 export const open = createCustomAction(
   OPEN,
-  (trackId: ID, trackTitle: string) => ({ trackId, trackTitle })
+  (trackId: ID, trackTitle: string, isUnlisted?: boolean) => ({
+    trackId,
+    trackTitle,
+    isUnlisted
+  })
 )
 export const close = createCustomAction(CLOSE, () => {})

--- a/packages/common/src/store/ui/add-to-playlist/reducer.ts
+++ b/packages/common/src/store/ui/add-to-playlist/reducer.ts
@@ -9,12 +9,14 @@ type AddToPlaylistActions = ActionType<typeof actions>
 export type AddToPlaylistState = {
   trackId: ID | null
   trackTitle: string | null
+  isUnlisted: boolean
 }
 
 const initialState = {
   isOpen: false,
   trackId: null,
-  trackTitle: null
+  trackTitle: null,
+  isUnlisted: false
 }
 
 const reducer = createReducer<AddToPlaylistState, AddToPlaylistActions>(
@@ -24,14 +26,16 @@ const reducer = createReducer<AddToPlaylistState, AddToPlaylistActions>(
       return {
         ...state,
         trackId: action.trackId,
-        trackTitle: action.trackTitle
+        trackTitle: action.trackTitle,
+        isUnlisted: action.isUnlisted ?? false
       }
     },
     [actions.CLOSE](state, _action) {
       return {
         ...state,
         trackId: null,
-        trackTitle: null
+        trackTitle: null,
+        isUnlisted: false
       }
     }
   }

--- a/packages/common/src/store/ui/add-to-playlist/selectors.ts
+++ b/packages/common/src/store/ui/add-to-playlist/selectors.ts
@@ -5,3 +5,5 @@ const getBaseState = (state: CommonState) => state.ui.addToPlaylist
 export const getTrackId = (state: CommonState) => getBaseState(state).trackId
 export const getTrackTitle = (state: CommonState) =>
   getBaseState(state).trackTitle
+export const getTrackIsUnlisted = (state: CommonState) =>
+  getBaseState(state).isUnlisted

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -181,6 +181,7 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
  * The details shown at the top of the Track Screen and Collection Screen
  */
 export const DetailsTile = ({
+  collectionId,
   coSign,
   description,
   descriptionLinkPressSource,
@@ -393,6 +394,7 @@ export const DetailsTile = ({
               hideShare={hideShare}
               isOwner={isOwner}
               isPlaylist={isPlaylist}
+              collectionId={collectionId}
               isPublished={isPublished}
               onPressEdit={onPressEdit}
               onPressOverflow={onPressOverflow}

--- a/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileActionButtons.tsx
@@ -1,5 +1,7 @@
-import { FeatureFlags } from '@audius/common'
+import type { CommonState, ID } from '@audius/common'
+import { FeatureFlags, cacheCollectionsSelectors } from '@audius/common'
 import { View } from 'react-native'
+import { useSelector } from 'react-redux'
 
 import IconKebabHorizontal from 'app/assets/images/iconKebabHorizontal.svg'
 import IconPencil from 'app/assets/images/iconPencil.svg'
@@ -13,12 +15,18 @@ import { flexRowCentered, makeStyles } from 'app/styles'
 import type { GestureResponderHandler } from 'app/types/gesture'
 import { useThemeColors } from 'app/utils/theme'
 
-// const messages = {
-//   publishButtonDisabledContent: 'You must add at least 1 track.',
-//   shareButtonDisabledContent: 'You can’t share an empty playlist.'
-// }
+const { getCollecitonHasHiddenTracks, getIsCollectionEmpty } =
+  cacheCollectionsSelectors
+
+const messages = {
+  publishButtonEmptyDisabledContent: 'You must add at least 1 track.',
+  publishButtonHiddenDisabledContent:
+    'You cannot make a playlist with hidden tracks public.',
+  shareButtonDisabledContent: 'You can’t share an empty playlist.'
+}
 
 type DetailsTileActionButtonsProps = {
+  collectionId?: ID
   hasReposted: boolean
   hasSaved: boolean
   isOwner: boolean
@@ -59,7 +67,7 @@ const useStyles = makeStyles(({ palette }) => ({
     marginHorizontal: 16
   },
 
-  editButton: {
+  editButtonIcon: {
     width: 27
   }
 }))
@@ -68,6 +76,7 @@ const useStyles = makeStyles(({ palette }) => ({
  * The action buttons on track and playlist screens
  */
 export const DetailsTileActionButtons = ({
+  collectionId,
   hasReposted,
   hasSaved,
   isPlaylist,
@@ -88,6 +97,12 @@ export const DetailsTileActionButtons = ({
   const { neutralLight2 } = useThemeColors()
   const { isEnabled: isPlaylistUpdatesEnabled } = useFeatureFlag(
     FeatureFlags.PLAYLIST_UPDATES_PRE_QA
+  )
+  const isCollectionEmpty = useSelector((state: CommonState) =>
+    getIsCollectionEmpty(state, { id: collectionId })
+  )
+  const collectionHasHiddenTracks = useSelector((state: CommonState) =>
+    getCollecitonHasHiddenTracks(state, { id: collectionId })
   )
 
   const repostButton = (
@@ -112,10 +127,8 @@ export const DetailsTileActionButtons = ({
     <IconButton
       fill={neutralLight2}
       icon={IconShare}
-      isDisabled={!isPublished}
-      // TODO: Add isDisabled based on if playlist is publishable logic
-      // Needs to check for hidden tracks and things like that
-      // disabledPressToastContent={messages.shareButtonDisabledContent}
+      isDisabled={isCollectionEmpty}
+      disabledPressToastContent={messages.shareButtonDisabledContent}
       onPress={onPressShare}
       styles={{ icon: [styles.actionButton, { height: 24, width: 24 }] }}
     />
@@ -135,7 +148,7 @@ export const DetailsTileActionButtons = ({
       fill={neutralLight2}
       icon={IconPencil}
       onPress={onPressEdit}
-      styles={{ icon: [styles.actionButton, styles.editButton] }}
+      styles={{ icon: [styles.actionButton, styles.editButtonIcon] }}
     />
   )
 
@@ -143,10 +156,12 @@ export const DetailsTileActionButtons = ({
     <IconButton
       fill={neutralLight2}
       icon={IconRocket}
-      // TODO: Add isDisabled based on if playlist is publishable logic
-      // Needs to check for hidden tracks and things like that
-      // isDisabled
-      // disabledPressToastContent={messages.publishButtonDisabledContent}
+      isDisabled={isCollectionEmpty || collectionHasHiddenTracks}
+      disabledPressToastContent={
+        collectionHasHiddenTracks
+          ? messages.publishButtonHiddenDisabledContent
+          : messages.publishButtonEmptyDisabledContent
+      }
       onPress={onPressPublish}
       styles={{ icon: styles.actionButton }}
     />

--- a/packages/mobile/src/components/details-tile/types.ts
+++ b/packages/mobile/src/components/details-tile/types.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import type { Track, User, SearchTrack, SearchUser } from '@audius/common'
+import type { Track, User, SearchTrack, SearchUser, ID } from '@audius/common'
 import type { TextStyle } from 'react-native'
 
 import type { GestureResponderHandler } from 'app/types/gesture'
@@ -16,6 +16,9 @@ export type DetailsTileDetail = {
 }
 
 export type DetailsTileProps = {
+  /** Id of the collection */
+  collectionId?: ID
+
   /** Cosign information */
   coSign?: Track['_co_sign']
 

--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -62,7 +62,7 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
   if (!track || !user) {
     return null
   }
-  const { owner_id, title } = track
+  const { owner_id, title, is_unlisted } = track
   const { handle } = user
 
   if (!id || !owner_id || !handle || !title) {
@@ -81,7 +81,7 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
     [OverflowAction.SHARE]: () =>
       dispatch(shareTrack(id, ShareSource.OVERFLOW)),
     [OverflowAction.ADD_TO_PLAYLIST]: () =>
-      dispatch(openAddToPlaylistModal(id, title)),
+      dispatch(openAddToPlaylistModal(id, title, is_unlisted)),
     [OverflowAction.VIEW_TRACK_PAGE]: () => {
       closeNowPlayingDrawer()
       navigation?.push('Track', { id })

--- a/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
+++ b/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
@@ -23,7 +23,6 @@ import IconTwitterBird from 'app/assets/images/iconTwitterBird.svg'
 import { useFeatureFlag } from 'app/hooks/useRemoteConfig'
 import { useToast } from 'app/hooks/useToast'
 import { makeStyles } from 'app/styles'
-import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
 
 import ActionDrawer from '../action-drawer'
@@ -43,14 +42,17 @@ const { getAccountUser } = accountSelectors
 
 export const shareToastTimeout = 1500
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ spacing }) => ({
+  titleContainer: {
+    paddingBottom: spacing(4)
+  },
   title: {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    paddingTop: 8,
-    paddingBottom: 16
+    paddingTop: spacing(2),
+    paddingBottom: spacing(4)
   },
   titleText: {
     textTransform: 'uppercase'
@@ -58,12 +60,16 @@ const useStyles = makeStyles(() => ({
   titleIcon: {
     marginRight: spacing(3)
   },
+  titleHelperText: {
+    paddingHorizontal: spacing(4),
+    textAlign: 'center'
+  },
   row: {
     flexDirection: 'row',
     justifyContent: 'flex-start',
     alignItems: 'center',
-    paddingVertical: 12,
-    paddingHorizontal: 24
+    paddingVertical: spacing(3),
+    paddingHorizontal: spacing(6)
   },
   viewShot: {
     position: 'absolute',
@@ -257,21 +263,28 @@ export const ShareDrawer = () => {
         modalName='Share'
         rows={getRows()}
         renderTitle={() => (
-          <View style={styles.title}>
-            <IconShare
-              style={styles.titleIcon}
-              fill={neutralLight2}
-              height={18}
-              width={20}
-            />
-            <Text
-              weight='heavy'
-              color='neutralLight2'
-              fontSize='xl'
-              style={styles.titleText}
-            >
-              {messages.modalTitle(shareType)}
-            </Text>
+          <View style={styles.titleContainer}>
+            <View style={styles.title}>
+              <IconShare
+                style={styles.titleIcon}
+                fill={neutralLight2}
+                height={18}
+                width={20}
+              />
+              <Text
+                weight='heavy'
+                color='neutralLight2'
+                fontSize='xl'
+                style={styles.titleText}
+              >
+                {messages.modalTitle(shareType)}
+              </Text>
+            </View>
+            {shareType === 'playlist' ? (
+              <Text style={styles.titleHelperText} fontSize={'large'}>
+                {messages.playlistShareHelperText}
+              </Text>
+            ) : null}
           </View>
         )}
         styles={{ row: styles.row }}

--- a/packages/mobile/src/components/share-drawer/messages.ts
+++ b/packages/mobile/src/components/share-drawer/messages.ts
@@ -10,6 +10,8 @@ const shareTypeMap: Record<ShareType, string> = {
 
 export const messages = {
   modalTitle: (asset: ShareType) => `Share ${shareTypeMap[asset]}`,
+  playlistShareHelperText:
+    'Spread the word! Share your playlist with friends and fans! Hidden playlists will be visible to anyone on the internet with the link.',
   twitter: 'Share to Twitter',
   instagramStory: 'Share to Instagram Story',
   snapchat: 'Share to Snapchat',

--- a/packages/mobile/src/components/track-list/TrackArtwork.tsx
+++ b/packages/mobile/src/components/track-list/TrackArtwork.tsx
@@ -2,14 +2,17 @@ import type { Track } from '@audius/common'
 import { SquareSizes } from '@audius/common'
 import { View } from 'react-native'
 
+import IconHidden from 'app/assets/images/iconHidden.svg'
 import IconPause from 'app/assets/images/pbIconPauseAlt.svg'
 import IconPlay from 'app/assets/images/pbIconPlayAlt.svg'
 import { TrackImage } from 'app/components/image/TrackImage'
 import { makeStyles } from 'app/styles'
+import { useThemeColors } from 'app/utils/theme'
 
 type TrackArtworkProps = {
   track: Track
   isActive?: boolean
+  isUnlisted?: boolean
   isPlaying: boolean
 }
 
@@ -31,8 +34,9 @@ const useStyles = makeStyles(({ spacing }) => ({
 }))
 
 export const TrackArtwork = (props: TrackArtworkProps) => {
-  const { isPlaying, isActive, track } = props
+  const { isPlaying, isActive, track, isUnlisted } = props
   const styles = useStyles()
+  const { staticWhite } = useThemeColors()
 
   const ActiveIcon = isPlaying ? IconPause : IconPlay
 
@@ -42,6 +46,11 @@ export const TrackArtwork = (props: TrackArtworkProps) => {
       size={SquareSizes.SIZE_150_BY_150}
       style={styles.image}
     >
+      {isUnlisted && !isActive ? (
+        <View style={styles.artworkIcon}>
+          <IconHidden fill={staticWhite} />
+        </View>
+      ) : null}
       {isActive ? (
         <View style={styles.artworkIcon}>
           <ActiveIcon />

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -215,7 +215,8 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   } = track
   const { is_deactivated, name } = user
 
-  const isDeleted = is_delete || !!is_deactivated || is_unlisted
+  const isDeleted = is_delete || !!is_deactivated
+  const isUnlisted = is_unlisted
 
   const { isUserAccessTBD, doesUserHaveAccess } = usePremiumContentAccess(track)
   const isLocked = !isUserAccessTBD && !doesUserHaveAccess
@@ -305,7 +306,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
 
   const handlePressSave = (e: NativeSyntheticEvent<NativeTouchEvent>) => {
     e.stopPropagation()
-    const isNotAvailable = isDeleted && !has_current_user_saved
+    const isNotAvailable = (isDeleted || isUnlisted) && !has_current_user_saved
     if (!isNotAvailable && onSave) {
       onSave(has_current_user_saved, track_id)
     }
@@ -353,6 +354,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
               track={track as Track}
               isActive={isActive}
               isPlaying={isPlaying}
+              isUnlisted={isUnlisted}
             />
           ) : isActive && !isDeleted && !isLocked ? (
             <View style={styles.playButtonContainer}>

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -100,7 +100,11 @@ type CollectionScreenDetailsTileProps = {
   collectionId: number | SmartCollectionVariant
 } & Omit<
   DetailsTileProps,
-  'descriptionLinkPressSource' | 'details' | 'headerText' | 'onPressPlay'
+  | 'descriptionLinkPressSource'
+  | 'details'
+  | 'headerText'
+  | 'onPressPlay'
+  | 'collectionId'
 >
 
 const recordPlay = (id: Maybe<number>, play = true) => {
@@ -203,7 +207,6 @@ export const CollectionScreenDetailsTile = ({
   const renderTrackList = useCallback(() => {
     return (
       <TrackList
-        hideArt
         showDivider
         showSkeleton={isLineupLoading}
         togglePlay={handlePressTrackListItemPlay}
@@ -227,6 +230,7 @@ export const CollectionScreenDetailsTile = ({
   return (
     <DetailsTile
       {...detailsTileProps}
+      collectionId={typeof collectionId === 'number' ? collectionId : undefined}
       description={description}
       descriptionLinkPressSource='collection page'
       details={details}

--- a/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/EditTrackForm.tsx
@@ -44,7 +44,6 @@ const GATED_CONTENT_UPLOAD_PROMPT_DRAWER_SEEN_KEY =
 
 const useStyles = makeStyles(({ spacing }) => ({
   backButton: {
-    transform: [{ rotate: '180deg' }],
     marginLeft: -6
   },
   tile: {

--- a/packages/mobile/src/screens/edit-track-screen/components/FormScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/FormScreen.tsx
@@ -1,12 +1,10 @@
 import type { ReactElement, ReactNode } from 'react'
 
 import { View } from 'react-native'
-import { useSelector } from 'react-redux'
 
 import type { ScreenProps } from 'app/components/core'
 import { ScreenContent, Button, Screen } from 'app/components/core'
 import { useNavigation } from 'app/hooks/useNavigation'
-import { getIsKeyboardOpen } from 'app/store/keyboard/selectors'
 import { makeStyles } from 'app/styles'
 
 const messages = {
@@ -34,7 +32,6 @@ export const FormScreen = (props: FormScreenProps) => {
   const { children, bottomSection, style: styleProp, ...other } = props
   const styles = useStyles()
   const navigation = useNavigation()
-  const isKeyboardOpen = useSelector(getIsKeyboardOpen)
 
   const defaultBottomSection = (
     <Button
@@ -50,11 +47,9 @@ export const FormScreen = (props: FormScreenProps) => {
     <Screen variant='secondary' style={[styles.root, styleProp]} {...other}>
       <ScreenContent>
         {children}
-        {isKeyboardOpen ? null : (
-          <View style={styles.bottomSection}>
-            {bottomSection ?? defaultBottomSection}
-          </View>
-        )}
+        <View style={styles.bottomSection}>
+          {bottomSection ?? defaultBottomSection}
+        </View>
       </ScreenContent>
     </Screen>
   )

--- a/packages/web/src/common/store/add-to-playlist/sagas.ts
+++ b/packages/web/src/common/store/add-to-playlist/sagas.ts
@@ -11,7 +11,7 @@ const fetchSavedPlaylists = accountActions.fetchSavedPlaylists
 
 function* handleRequestOpen(action: ReturnType<typeof actions.requestOpen>) {
   yield put(fetchSavedPlaylists())
-  yield put(actions.open(action.trackId, action.trackTitle))
+  yield put(actions.open(action.trackId, action.trackTitle, action.isUnlisted))
   yield put(setVisibility({ modal: 'AddToPlaylist', visible: true }))
 }
 


### PR DESCRIPTION
### Description
* Update share drawer for playlists to warn the user of sharing private playlists
* Update add to playlist drawer for hidden tracks to disable public playlists
* Add hidden icon for hidden tracks in playlist track list
* Update disable logic for action buttons for playlists

<img width="503" alt="Screenshot 2023-06-02 at 5 14 28 PM" src="https://github.com/AudiusProject/audius-client/assets/23732287/715a5fe0-aeb3-42da-8919-6f07dcff380a">
<img width="479" alt="Screenshot 2023-06-02 at 5 14 43 PM" src="https://github.com/AudiusProject/audius-client/assets/23732287/802391a9-6628-460d-9197-fdef52ffef6e">
<img width="508" alt="Screenshot 2023-06-02 at 5 13 58 PM" src="https://github.com/AudiusProject/audius-client/assets/23732287/4f9b292f-037d-4d6d-9914-d3af606084a7">

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

