### PR TITLE
[PAY-1370] Fix reaction touch targets

### DIFF
--- a/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
@@ -80,12 +80,10 @@ export const ReactionList = (props: ReactionListProps) => {
 
       // based on the current x0 and moveX, determine which reaction the
       // user is interacting with.
-      const currentReaction = positionEntries.find(
-        ([reaction, { x, width }]) => {
-          const currentPosition = (moveX || x0) - xOffset.current
-          return currentPosition > x && currentPosition <= x + width
-        }
-      )
+      const currentReaction = positionEntries.find(([, { x, width }]) => {
+        const currentPosition = (moveX || x0) - xOffset.current
+        return currentPosition > x && currentPosition <= x + width
+      })
 
       if (currentReaction) {
         const [reactionType] = currentReaction

--- a/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
+++ b/packages/mobile/src/screens/notifications-screen/Reaction/ReactionList.tsx
@@ -78,8 +78,8 @@ export const ReactionList = (props: ReactionListProps) => {
         positions.current
       ) as PositionEntries
 
-      // based on the current x0 and moveX, determine which reaction the
-      // user is interacting with.
+      // Based on the current x0 and moveX, determine which reaction the user
+      // is interacting with. Offset by the distance from the left edge of screen.
       const currentReaction = positionEntries.find(([, { x, width }]) => {
         const currentPosition = (moveX || x0) - xOffset.current
         return currentPosition > x && currentPosition <= x + width


### PR DESCRIPTION
### Description
For some reason (maybe after RN upgrade) the gesture position values were being measured in reference to the leftmost edge of the screen, but the x and width measurements in the reaction list were measured in reference to the parent view. Needed to incorporate the x offset from the parent to the screen into the gestures.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage - tested on both notification screen and reactions popup.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

