### PR TITLE
[PAY-1309] Use proper tracking of hasMore for chats list

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -28,6 +28,9 @@ export const getChatsStatus = (state: CommonState) =>
 export const getChatsSummary = (state: CommonState) =>
   state.pages.chat.chats.summary
 
+export const getHasMoreChats = (state: CommonState) =>
+  state.pages.chat.chats.hasMore
+
 export const getOptimisticReads = (state: CommonState) =>
   state.pages.chat.optimisticChatRead
 

--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -31,6 +31,7 @@ type ChatID = string
 type ChatState = {
   chats: EntityState<UserChatWithMessagesStatus> & {
     status: Status
+    hasMore: boolean
     summary?: TypedCommsResponse<UserChat>['summary']
   }
   messages: Record<
@@ -108,6 +109,7 @@ const recalculatePreviousMessageHasTail = (
 
 const initialState: ChatState = {
   chats: {
+    hasMore: true,
     status: Status.IDLE,
     ...chatsAdapter.getInitialState()
   },
@@ -158,8 +160,11 @@ const slice = createSlice({
       state,
       action: PayloadAction<TypedCommsResponse<UserChat[]>>
     ) => {
+      const { summary } = action.payload
       state.chats.status = Status.SUCCESS
-      state.chats.summary = action.payload.summary
+      state.chats.summary = summary
+      state.chats.hasMore =
+        summary?.prev_count !== undefined && summary.prev_count > 0
       for (const chat of action.payload.data) {
         if (!(chat.chat_id in state.messages)) {
           state.messages[chat.chat_id] = chatMessagesAdapter.getInitialState()

--- a/packages/mobile/src/screens/chat-screen/ChatListScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatListScreen.tsx
@@ -17,7 +17,7 @@ import { ChatListItem } from './ChatListItem'
 import { ChatListItemSkeleton } from './ChatListItemSkeleton'
 import { HeaderShadow } from './HeaderShadow'
 
-const { getChats, getChatsStatus } = chatSelectors
+const { getChats, getChatsStatus, getHasMoreChats } = chatSelectors
 const { fetchMoreMessages, fetchMoreChats } = chatActions
 
 const CHATS_MESSAGES_PREFETCH_LIMIT = 10
@@ -106,6 +106,7 @@ export const ChatListScreen = () => {
   const chats = useSelector(getChats)
   const chatsStatus = useSelector(getChatsStatus)
 
+  const hasMore = useSelector(getHasMoreChats)
   // If this is the first fetch, we want to show the fade-out loading skeleton
   // On subsequent loads, we want to show a skeleton in each incoming chat row.
   const isLoadingFirstTime =
@@ -132,9 +133,9 @@ export const ChatListScreen = () => {
   }, [chats, dispatch])
 
   const handleLoadMore = useCallback(() => {
-    if (chatsStatus === Status.LOADING) return
+    if (chatsStatus === Status.LOADING || !hasMore) return
     dispatch(fetchMoreChats())
-  }, [chatsStatus, dispatch])
+  }, [hasMore, chatsStatus, dispatch])
 
   return (
     <Screen

--- a/packages/web/src/pages/chat-page/components/ChatList.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatList.tsx
@@ -17,7 +17,7 @@ import styles from './ChatList.module.css'
 import { ChatListItem } from './ChatListItem'
 import { SkeletonChatListItem } from './SkeletonChatListItem'
 
-const { getChats, getChatsStatus, getChatsSummary } = chatSelectors
+const { getChats, getChatsStatus, getHasMoreChats } = chatSelectors
 const { fetchMoreChats } = chatActions
 
 const messages = {
@@ -36,7 +36,7 @@ export const ChatList = (props: ChatListProps) => {
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
   const chats = useSelector(getChats)
   const status = useSelector(getChatsStatus)
-  const summary = useSelector(getChatsSummary)
+  const hasMore = useSelector(getHasMoreChats)
 
   const handleLoadMoreChats = useCallback(() => {
     dispatch(fetchMoreChats())
@@ -54,10 +54,7 @@ export const ChatList = (props: ChatListProps) => {
         pageStart={0}
         initialLoad={true}
         loadMore={handleLoadMoreChats}
-        hasMore={
-          status === Status.IDLE ||
-          (summary?.prev_count !== undefined && summary?.prev_count > 0)
-        }
+        hasMore={hasMore}
         useWindow={false}
         loader={
           <LoadingSpinner key={'loading-spinner'} className={styles.spinner} />


### PR DESCRIPTION
### Description
This fixes the rapid flashing issue on accounts which have no open conversations yet. The cause was bad logic around when to fetch more chats. I added state and logic to track `hasMore` in the slice based on the existing logic in the web `ChatsList` component and updated both web and mobile to use the same logic by reading from the slice.

### Dragons
N/A

### How Has This Been Tested?
Tested on web and physical devices against staging

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

