### PR TITLE
[PAY-1390] fix inverted condition for computing track count

### DIFF
--- a/packages/mobile/src/components/collection-list/CollectionCard.tsx
+++ b/packages/mobile/src/components/collection-list/CollectionCard.tsx
@@ -87,7 +87,7 @@ const useTrackCountWithOfflineOverride = (collection: Collection | null) => {
     if (!collection) {
       return 0
     }
-    if (!isReachable) {
+    if (isReachable) {
       return collection.playlist_contents.track_ids.length
     }
     const trackIds =


### PR DESCRIPTION
### Description
I made a mistake in merging main into my last PR for infinite loading and swapped the track count condition. This caused us to show the offline track count when online and vice versa.

### Dragons
N/A

### How Has This Been Tested?
Locally on physical device

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

