### PR TITLE
[PAY-1391] ensure all collections are fetched before attempting to download

### DIFF
--- a/packages/common/src/store/saved-collections/selectors.ts
+++ b/packages/common/src/store/saved-collections/selectors.ts
@@ -10,6 +10,7 @@ import { CommonState } from '../commonStore'
 import { CollectionType } from './types'
 
 const getAccountCollections = (state: CommonState) => state.account.collections
+
 export const getSavedCollectionsState = (
   state: CommonState,
   type: CollectionType

--- a/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
@@ -3,6 +3,7 @@ import {
   getContext,
   savedPageSelectors
 } from '@audius/common'
+import { fetchAllAccountCollections } from 'common/store/saved-collections/sagas'
 import moment from 'moment'
 import { takeEvery, select, call, put } from 'typed-redux-saga'
 
@@ -78,6 +79,9 @@ function* downloadAllFavorites() {
   }
 
   // Add favorited collections and their tracks
+  // AccountCollections don't include track lists, so retrieve all the collections
+  // first
+  yield* call(fetchAllAccountCollections)
   const favoritedCollections = yield* select(getAccountCollections)
 
   for (const favoritedCollection of favoritedCollections) {

--- a/packages/web/src/common/store/saved-collections/sagas.ts
+++ b/packages/web/src/common/store/saved-collections/sagas.ts
@@ -29,6 +29,10 @@ function* fetchCollectionsAsync({ ids, type }: FetchCollectionsConfig) {
   )
 }
 
+/** Will create and wait on parallel effects to fetch full details for all saved albums and
+ * playlists. Note: Only use this if you really need full details (such as track
+ * lists) for all collections, as it may potentially fetch a lot of data.
+ */
 export function* fetchAllAccountCollections() {
   yield waitForRead()
 

--- a/packages/web/src/common/store/saved-collections/sagas.ts
+++ b/packages/web/src/common/store/saved-collections/sagas.ts
@@ -1,12 +1,23 @@
-import { savedCollectionsActions, waitForRead } from '@audius/common'
-import { call, put, takeEvery } from 'typed-redux-saga'
+import {
+  CollectionType,
+  ID,
+  savedCollectionsActions,
+  savedCollectionsSelectors,
+  waitForRead
+} from '@audius/common'
+import { all, call, select, put, takeEvery } from 'typed-redux-saga'
 
 import { retrieveCollections } from '../cache/collections/utils'
 
 const { fetchCollections, fetchCollectionsSucceeded } = savedCollectionsActions
+const { getAccountAlbums, getAccountPlaylists } = savedCollectionsSelectors
 
-function* fetchCollectionsAsync(action: ReturnType<typeof fetchCollections>) {
-  const { type, ids } = action.payload
+type FetchCollectionsConfig = {
+  type: CollectionType
+  ids: ID[]
+}
+
+function* fetchCollectionsAsync({ ids, type }: FetchCollectionsConfig) {
   yield waitForRead()
 
   yield* call(retrieveCollections, ids)
@@ -18,8 +29,31 @@ function* fetchCollectionsAsync(action: ReturnType<typeof fetchCollections>) {
   )
 }
 
+export function* fetchAllAccountCollections() {
+  yield waitForRead()
+
+  const { data: playlists } = yield* select(getAccountPlaylists)
+  const { data: albums } = yield* select(getAccountAlbums)
+
+  yield* all([
+    call(fetchCollectionsAsync, {
+      ids: albums.map(({ id }) => id),
+      type: 'albums'
+    }),
+    call(fetchCollectionsAsync, {
+      ids: playlists.map(({ id }) => id),
+      type: 'playlists'
+    })
+  ])
+}
+
 function* watchFetchCollections() {
-  yield takeEvery(fetchCollections.type, fetchCollectionsAsync)
+  yield* takeEvery(
+    fetchCollections.type,
+    function* (action: ReturnType<typeof fetchCollections>) {
+      yield* fetchCollectionsAsync(action.payload)
+    }
+  )
 }
 
 export default function sagas() {


### PR DESCRIPTION
### Description
The original logic in `requestDownloadAllFavorites` assumed that all collections were fetched before running. This was true because we would load everything when `FavoritesScreen` mounted. However, now that we are fetching full collection details in pages, the selector used for the "download all" flow will only include items that have already been fetched as part of viewing the Albums or Playlists tabs.

To fix this, I added a helper saga that will fetch all account collections and we will wait on that before starting the download process.

Note: I chose to implement it as parallel fetches of albums/playlists so that we reuse the same sagas/actions that power the favorites screen. The result is that if you open the favorites screen and toggle download all, the albums and playlists tabs will subsequently already have all of their data loaded.

### Dragons
N/A

### How Has This Been Tested?
Tested locally on physical device

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

