### PR TITLE
[PAY-1361] Fix reactions button hit area

### DIFF
--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.module.css
@@ -68,68 +68,82 @@
   margin-bottom: var(--unit-4);
 }
 
-.reactionsButton {
-  display: flex;
-  opacity: 0;
+/* Reactions positioning */
+
+.reactionsContainer {
+  bottom: -24px;
+  position: absolute;
   flex-direction: row-reverse;
   align-items: center;
   justify-content: center;
-  position: absolute;
+  display: flex;
   cursor: pointer;
-  bottom: -24px;
-  /* transform looks better if it only eases-out */
-  transition: opacity var(--quick), transform 0.07s ease-out;
-  transform: scale(0.5);
 }
 
-.reactionsButton:not(.hasReaction) {
-  background-color: var(--white);
-  border: 1px solid var(--neutral-light-6);
-  width: var(--unit-8);
-  height: var(--unit-8);
+.reactionsContainer:not(.hasReaction) {
   bottom: -16px;
-  border-radius: 50%;
 }
 
-.root.isAuthor .reactionsButton {
+.root.isAuthor .reactionsContainer {
   left: -16px;
 }
-.root:not(.isAuthor) .reactionsButton {
+.root:not(.isAuthor) .reactionsContainer {
   right: -16px;
   direction: rtl;
 }
 
-.root.isAuthor .reactionsButton.hasReaction {
+.root.isAuthor .reactionsContainer.hasReaction {
   left: -24px;
 }
 
-.root:not(.isAuthor) .reactionsButton.hasReaction {
+.root:not(.isAuthor) .reactionsContainer.hasReaction {
   right: -24px;
 }
 
+/* Styling of reaction button inside the reactions container */
+
+.reactionsButton {
+  display: flex;
+  width: 100px;
+  height: 100px;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  /* transform looks better if it only eases-out */
+  transition: opacity var(--quick), transform 0.07s ease-out;
+}
+
+.reactionsContainer:not(.hasReaction) .reactionsButton {
+  background-color: var(--white);
+  border: 1px solid var(--neutral-light-6);
+  width: var(--unit-8);
+  height: var(--unit-8);
+  border-radius: 50%;
+}
+
 .bubble:hover .reactionsButton,
-.reactionsButton.isOpened,
-.reactionsButton.hasReaction {
+.reactionsContainer.isOpened .reactionsButton,
+.reactionsContainer.hasReaction .reactionsButton {
   transform: scale(1, 1);
   opacity: 1;
 }
 
-.reactionsButton:not(.hasReaction) path {
+.reactionsContainer:not(.hasReaction) path {
   width: var(--unit-6);
   height: var(--unit-6);
   fill: var(--secondary);
   transition: fill var(--quick);
 }
 
-.reactionsButton:not(.hasReaction):hover {
+.reactionsContainer:not(.hasReaction):hover .reactionsButton {
   transform: scale(1.1);
 }
 
-.reactionsButton:not(.hasReaction):hover path {
+.reactionsContainer:not(.hasReaction):hover .reactionsButton path {
   fill: var(--secondary-dark-2);
 }
 
-.reactionsButton:not(.hasReaction):active {
+.reactionsContainer:not(.hasReaction):active .reactionsButton {
   transform: scale(0.6);
 }
 

--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
@@ -127,12 +127,12 @@ export const ChatMessageListItem = (props: ChatMessageListItemProps) => {
 
     return (
       <div
-        ref={reactionButtonRef}
-        className={cn(styles.reactionsButton, {
+        className={cn(styles.reactionsContainer, {
           [styles.isOpened]: isReactionPopupVisible,
           [styles.hasReaction]:
             message.reactions && message.reactions.length > 0
         })}
+        ref={reactionButtonRef}
         onClick={handleOpenReactionPopupButtonClicked}
       >
         {message.reactions?.length > 0 ? (
@@ -153,7 +153,9 @@ export const ChatMessageListItem = (props: ChatMessageListItemProps) => {
             )
           })
         ) : (
-          <IconPlus className={styles.addReactionIcon} />
+          <div className={cn(styles.reactionsButton)}>
+            <IconPlus className={styles.addReactionIcon} />
+          </div>
         )}
       </div>
     )

--- a/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
+++ b/packages/web/src/pages/chat-page/components/ChatMessageListItem.tsx
@@ -127,12 +127,12 @@ export const ChatMessageListItem = (props: ChatMessageListItemProps) => {
 
     return (
       <div
+        ref={reactionButtonRef}
         className={cn(styles.reactionsContainer, {
           [styles.isOpened]: isReactionPopupVisible,
           [styles.hasReaction]:
             message.reactions && message.reactions.length > 0
         })}
-        ref={reactionButtonRef}
         onClick={handleOpenReactionPopupButtonClicked}
       >
         {message.reactions?.length > 0 ? (


### PR DESCRIPTION
### Description

Fixes issue where the edges of the reactions button wouldn't be clickable. This was caused by my `:active` scaling animation scaling the button instead of the content inside the button, causing the `onClick` to fail to fire. The fix is to animate/scale content inside the button instead of the button itself. 

Would attach video but airplane wifi; play around on demo to see!

### Dragons

CSS diff looks scary but it works

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

