### PR TITLE
[PAY-1365] Disable fullscreen gestures on mobile chat screen

### DIFF
--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -332,6 +332,7 @@ export const AppTabScreen = ({ baseScreen, Stack }: AppTabScreenProps) => {
             // @ts-ignore hard to correctly type navigation params (PAY-1141)
             params?.chatId
           }
+          options={{ fullScreenGestureEnabled: false }}
         />
       </Stack.Group>
     </Stack.Navigator>


### PR DESCRIPTION
### Description
After much investigation with @dylanjeffers and @schottra we were unable to come up with the perfect solution. Current thinking is that if we were able to get the stack navigator gesture handler to cede handling the pan gesture via `onResponderTerminateRequest` then this might work. Would have to patch rngh to do this.

For now the best we could come up with is disabling full screen swipe left gestures on the ChatScreen entirely. User will still be able to swipe left from the leftmost edge of the screen.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

