### PR TITLE
[PAY-1362] Mobile press chat message closes reaction popup

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -175,6 +175,7 @@ type ChatMessageListItemProps = {
   isPopup: boolean
   style?: StyleProp<ViewStyle>
   onLongPress?: (id: string) => void
+  handleClosePopup?: () => void
   itemsRef?: any
 }
 
@@ -187,6 +188,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
     isPopup = false,
     style: styleProp,
     onLongPress,
+    handleClosePopup,
     itemsRef
   } = props
   const styles = useStyles()
@@ -253,8 +255,8 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
           <Pressable
             onLongPress={handleLongPress}
             delayLongPress={REACTION_LONGPRESS_DELAY}
-            onPressIn={handlePressIn}
-            onPressOut={handlePressOut}
+            onPressIn={isPopup ? handleClosePopup : handlePressIn}
+            onPressOut={isPopup ? handleClosePopup : handlePressOut}
           >
             <View style={styles.shadow}>
               <View style={styles.shadow2}>

--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -211,6 +211,7 @@ export const ReactionPopup = ({
               left: !isAuthor ? spacing(6) : undefined
             }
           ]}
+          handleClosePopup={handleClosePopup}
         />
         <CopyMessagesButton
           isAuthor={isAuthor}


### PR DESCRIPTION
### Description
When reaction popup is open, pressing on the message closes it.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

