### PR TITLE
[C-1873, C-2551, C-2552, C-2553] Add hidden track logic for playlists on web

### DIFF
--- a/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.module.css
+++ b/packages/web/src/components/add-to-playlist/desktop/AddToPlaylistModal.module.css
@@ -26,7 +26,6 @@
 }
 
 .list {
-  cursor: pointer;
   user-select: none;
   font-size: var(--font-xs);
   background-color: var(--white);
@@ -42,7 +41,12 @@
   color: var(--neutral);
 }
 
-.listItem:hover {
+.listItem.disabled .playlistName,
+.listItem.disabled .imageWrapper {
+  opacity: 0.5;
+}
+
+.listItem:not(.disabled):hover {
   cursor: pointer;
   color: var(--white);
   background: var(--secondary);

--- a/packages/web/src/components/collection/desktop/PublishButton.tsx
+++ b/packages/web/src/components/collection/desktop/PublishButton.tsx
@@ -1,4 +1,5 @@
 import {
+  cacheCollectionsSelectors,
   Collection,
   collectionPageSelectors,
   CommonState
@@ -16,11 +17,14 @@ import { PublishConfirmationModal } from './PublishConfirmationModal'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
 
 const { getCollection } = collectionPageSelectors
+const { getCollecitonHasHiddenTracks } = cacheCollectionsSelectors
 
 const messages = {
   publish: 'Make Public',
   publishing: 'Making Public',
-  emptyPlaylistTooltipText: 'You must add at least 1 song.'
+  emptyPlaylistTooltipText: 'You must add at least 1 song.',
+  hiddenTracksTooltipText:
+    'You cannot make a playlist with hidden tracks public.'
 }
 
 type PublishButtonProps = Partial<ButtonProps> & {
@@ -32,10 +36,13 @@ export const PublishButton = (props: PublishButtonProps) => {
   const { _is_publishing, track_count } = useSelector((state: CommonState) =>
     getCollection(state, { id: collectionId })
   ) as Collection
+  const hasHiddenTracks = useSelector((state: CommonState) =>
+    getCollecitonHasHiddenTracks(state, { id: collectionId })
+  )
 
   const [isConfirming, toggleIsConfirming] = useToggle(false)
 
-  const isDisabled = track_count === 0
+  const isDisabled = track_count === 0 || hasHiddenTracks
 
   const publishButtonElement = (
     <CollectionActionButton
@@ -63,9 +70,15 @@ export const PublishButton = (props: PublishButtonProps) => {
 
   return (
     <>
-      {track_count === 0 ? (
-        <Tooltip text={messages.emptyPlaylistTooltipText}>
-          <div>{publishButtonElement}</div>
+      {track_count === 0 || hasHiddenTracks ? (
+        <Tooltip
+          text={
+            hasHiddenTracks
+              ? messages.hiddenTracksTooltipText
+              : messages.emptyPlaylistTooltipText
+          }
+        >
+          <span>{publishButtonElement}</span>
         </Tooltip>
       ) : (
         publishButtonElement

--- a/packages/web/src/components/collection/desktop/ShareButton.tsx
+++ b/packages/web/src/components/collection/desktop/ShareButton.tsx
@@ -9,13 +9,16 @@ import {
 import { ButtonProps, ButtonType, IconShare } from '@audius/stems'
 import { useDispatch } from 'react-redux'
 
+import { Tooltip } from 'components/tooltip'
+
 import { CollectionActionButton } from './CollectionActionButton'
 import { BUTTON_COLLAPSE_WIDTHS } from './utils'
 
 const { requestOpen: requestOpenShareModal } = shareModalUIActions
 
 const messages = {
-  share: 'Share'
+  share: 'Share',
+  emptyPlaylistTooltipText: 'You can’t share an empty playlist.'
 }
 
 type ShareButtonProps = Partial<ButtonProps> & {
@@ -52,7 +55,7 @@ export const ShareButton = (props: ShareButtonProps) => {
     }
   }, [dispatch, collectionId, userId])
 
-  return (
+  const shareButtonElement = (
     <CollectionActionButton
       type={type ?? ButtonType.COMMON}
       text={messages.share}
@@ -61,5 +64,13 @@ export const ShareButton = (props: ShareButtonProps) => {
       onClick={handleShare}
       {...other}
     />
+  )
+
+  return other.disabled ? (
+    <Tooltip text={messages.emptyPlaylistTooltipText}>
+      <span>{shareButtonElement}</span>
+    </Tooltip>
+  ) : (
+    shareButtonElement
   )
 }

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -79,6 +79,7 @@ export type OwnProps = {
   isOwner: boolean
   isOwnerDeactivated?: boolean
   isReposted: boolean
+  isUnlisted?: boolean
   trackId: ID
   trackTitle: string
   genre: Genre
@@ -122,6 +123,7 @@ const TrackMenu = (props: TrackMenuProps) => {
       isOwner,
       isOwnerDeactivated,
       isReposted,
+      isUnlisted,
       openAddToPlaylistModal,
       openEditTrackModal,
       openEmbedModal,
@@ -173,7 +175,7 @@ const TrackMenu = (props: TrackMenuProps) => {
     const addToPlaylistMenuItem = {
       text: messages.addToPlaylist,
       onClick: () => {
-        openAddToPlaylistModal(trackId, trackTitle)
+        openAddToPlaylistModal(trackId, trackTitle, isUnlisted ?? false)
       }
     }
 
@@ -313,8 +315,8 @@ function mapDispatchToProps(dispatch: Dispatch) {
     setArtistPick: (trackId: ID) =>
       dispatch(showSetAsArtistPickConfirmation(trackId)),
     unsetArtistPick: () => dispatch(showSetAsArtistPickConfirmation()),
-    openAddToPlaylistModal: (trackId: ID, title: string) =>
-      dispatch(openAddToPlaylist(trackId, title)),
+    openAddToPlaylistModal: (trackId: ID, title: string, isUnlisted: boolean) =>
+      dispatch(openAddToPlaylist(trackId, title, isUnlisted)),
     openEditTrackModal: (trackId: ID) =>
       dispatch(editTrackModalActions.open(trackId)),
     openEmbedModal: (trackId: ID) =>

--- a/packages/web/src/components/share-modal/components/ShareDialog.module.css
+++ b/packages/web/src/components/share-modal/components/ShareDialog.module.css
@@ -41,7 +41,9 @@
 
 .description {
   margin-bottom: var(--unit-6);
-  font-weight: var(--font-demi-bold);
+  font-weight: var(--font-medium);
+  font-size: var(--font-l);
+  line-height: 1.5;
 }
 
 .actionList {

--- a/packages/web/src/components/share-modal/components/ShareDialog.tsx
+++ b/packages/web/src/components/share-modal/components/ShareDialog.tsx
@@ -71,7 +71,9 @@ export const ShareDialog = ({
       <ModalContent>
         <div className={styles.modalContent}>
           <p className={styles.description}>
-            Spread the word! Share with your friends and fans!
+            {shareType === 'playlist'
+              ? messages.playlistShareDescription
+              : messages.shareDescription}
           </p>
           <ul className={styles.actionList}>
             <ShareActionListItem

--- a/packages/web/src/components/share-modal/messages.ts
+++ b/packages/web/src/components/share-modal/messages.ts
@@ -24,5 +24,8 @@ export const messages = {
     `Check out ${playlistName} by ${handle} @AudiusProject #Audius`,
   // TODO: See if you can display my when the account user is the user
   audioNftPlaylistShareText: (name: string) =>
-    `Check out ${name} Audio NFTs in a playlist @AudiusProject #Audius`
+    `Check out ${name} Audio NFTs in a playlist @AudiusProject #Audius`,
+  shareDescription: 'Spread the word! Share with your friends and fans!',
+  playlistShareDescription:
+    'Spread the word! Share your playlist with friends and fans! Hidden playlists will be visible to anyone on the internet with the link.'
 }

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -211,6 +211,7 @@ const ConnectedTrackTile = ({
       isFavorited,
       isOwner,
       isReposted,
+      isUnlisted,
       trackId,
       trackTitle: title,
       genre: genre as Genre,

--- a/packages/web/src/components/tracks-table/TracksTable.module.css
+++ b/packages/web/src/components/tracks-table/TracksTable.module.css
@@ -39,9 +39,11 @@
   display: inline-flex;
   gap: 16px;
 }
+
 .trackActionsContainer .tableActionButton {
   opacity: 0;
 }
+
 .trackActionsContainer .placeholderButton {
   width: 14px;
 }
@@ -51,10 +53,28 @@
 }
 
 .tablePlayButton {
+  position: absolute;
   opacity: 0;
+  transition: opacity 0.07s ease-out;
 }
+
 .tablePlayButton.active {
   opacity: 1;
+}
+
+.hiddenIcon {
+  position: absolute;
+  opacity: 1;
+  transition: opacity 0.07s ease-out;
+}
+
+.hiddenIcon.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.hiddenIcon path {
+  fill: var(--neutral-light-4);
 }
 
 .tableRow:hover .tablePlayButton,
@@ -62,18 +82,29 @@
   opacity: 1;
 }
 
+.tableRow:hover .hiddenIcon {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .tableRow.disabled {
   cursor: default;
   color: var(--neutral-light-4);
   background-color: var(--neutral-light-9);
 }
+
 .tableRow.disabled:hover {
   box-shadow: none;
   background-color: var(--neutral-light-9);
 }
+
 .tableRow.disabled:hover .tablePlayButton {
   opacity: 0;
   pointer-events: none;
+}
+
+.tableRow.disabled:hover .hiddenIcon {
+  opacity: 1;
 }
 
 .tableRow.lockedRow {

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -7,7 +7,7 @@ import {
   usePremiumContentAccessMap,
   UserTrack
 } from '@audius/common'
-import { IconLock } from '@audius/stems'
+import { IconHidden, IconLock } from '@audius/stems'
 import cn from 'classnames'
 import moment from 'moment'
 import { Cell, Row } from 'react-table'
@@ -158,13 +158,23 @@ export const TracksTable = ({
     (cellInfo: TrackCell) => {
       const index = cellInfo.row.index
       const active = index === playingIndex
+      const track = cellInfo.row.original
+      const isTrackUnlisted = track.is_unlisted
+
       return (
-        <TablePlayButton
-          className={cn(styles.tablePlayButton, { [styles.active]: active })}
-          paused={!playing}
-          playing={active}
-          hideDefault={false}
-        />
+        <>
+          <TablePlayButton
+            className={cn(styles.tablePlayButton, { [styles.active]: active })}
+            paused={!playing}
+            playing={active}
+            hideDefault={false}
+          />
+          {isTrackUnlisted ? (
+            <IconHidden
+              className={cn(styles.hiddenIcon, { [styles.hidden]: active })}
+            />
+          ) : null}
+        </>
       )
     },
     [playing, playingIndex]


### PR DESCRIPTION
### Description
* Update share modal for playlists to warn the user of sharing private playlists
* Update add to playlist modal for hidden tracks to disable public playlists
* Add hidden icon for hidden tracks in playlist tracks table
* Update disable logic for action buttons for playlists based on emptiness and if they contain hidden tracks

<img width="1165" alt="Screenshot 2023-06-07 at 12 17 15 PM" src="https://github.com/AudiusProject/audius-client/assets/23732287/edb62954-6df2-434c-b87f-e44f4ecef293">
<img width="544" alt="Screenshot 2023-06-07 at 12 17 29 PM" src="https://github.com/AudiusProject/audius-client/assets/23732287/9ffb62dd-ad0f-491f-b1ff-84028ade3349">

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

