### PR TITLE
[PAY-1394] DMs: Show global unread indicator if there's unread messages in a loaded chat

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -120,8 +120,18 @@ export const getUnreadMessagesCount = (state: CommonState) => {
   return state.pages.chat.unreadMessagesCount
 }
 
-export const getHasUnreadMessages = (state: CommonState) =>
-  getUnreadMessagesCount(state) > 0
+export const getHasUnreadMessages = (state: CommonState) => {
+  if (getUnreadMessagesCount(state) > 0) {
+    return true
+  }
+  const chats = getChats(state)
+  for (const chat of chats) {
+    if (chat.unread_message_count > 0) {
+      return true
+    }
+  }
+  return false
+}
 
 export const getOtherChatUsersFromChat = (
   state: CommonState,


### PR DESCRIPTION
### Description

Small change to show the global unread indicator if any of the loaded chats have unread messages (since the global unread message count doesn't increase when sent a new message)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Doesn't fix the plethora of other unread optimistic problems, but a small win

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

