### PR TITLE
DMs: Fix deletions not causing perms rechecks

### DIFF
--- a/packages/common/src/store/pages/chat/slice.ts
+++ b/packages/common/src/store/pages/chat/slice.ts
@@ -301,7 +301,7 @@ const slice = createSlice({
     },
     fetchChatIfNecessary: (
       _state,
-      _action: PayloadAction<{ chatId: string; bustCache?: boolean }>
+      _action: PayloadAction<{ chatId: string }>
     ) => {
       // triggers saga
     },


### PR DESCRIPTION
### Description

- Refactors the "bustCache" param an instead separates out a new fn
- Fetch chat on message failure to get `recheck_permissions` flag in case chat was deleted

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

