### PR TITLE
[C-2747] Fix track title layout with offline + ai attribution

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -139,6 +139,12 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     justifyContent: 'center',
     paddingHorizontal: spacing(4)
   },
+  headerRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
   headerText: {
     marginTop: spacing(4),
     marginBottom: spacing(4),
@@ -458,12 +464,14 @@ export const TrackScreenDetailsTile = ({
       </View>
     ) : (
       <View style={styles.headerContainer}>
-        <TrackDownloadStatusIndicator
-          style={styles.downloadStatusIndicator}
-          size={20}
-          trackId={track_id}
-        />
-        {renderHeaderText()}
+        <View style={styles.headerRow}>
+          <TrackDownloadStatusIndicator
+            style={styles.downloadStatusIndicator}
+            size={20}
+            trackId={track_id}
+          />
+          {renderHeaderText()}
+        </View>
         {renderAiHeader()}
       </View>
     )


### PR DESCRIPTION
### Description

Some AI attribution changes broke the flex layout for track title and offline indicator

Before:
<img width="240" src="https://github.com/AudiusProject/audius-client/assets/2358254/8c6cc406-09f6-4ea2-9a54-26ed7e973a23">

After:
<img width="292" alt="Screenshot 2023-06-08 at 1 13 44 PM" src="https://github.com/AudiusProject/audius-client/assets/2358254/06cc5e53-cf44-4e34-bd3e-6b4d6a075abf">
<img width="292" alt="Screenshot 2023-06-08 at 1 13 28 PM" src="https://github.com/AudiusProject/audius-client/assets/2358254/68a55db4-8d79-4359-8810-56a73d365af5">
