### PR TITLE
Mobile ChatMessageListItem uses message id + selector

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -212,7 +212,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   const tailColor = useGetTailColor(isAuthor, isPressed, hideMessage)
   const isUnderneathPopup =
     useSelector((state) =>
-      isIdEqualToReactionsPopupMessageId(state, message?.message_id ?? '')
+      isIdEqualToReactionsPopupMessageId(state, messageId)
     ) && !isPopup
 
   const handlePressIn = useCallback(() => {
@@ -224,10 +224,10 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   }, [setIsPressed])
 
   const handleLongPress = useCallback(() => {
-    if (message && message.status !== Status.ERROR) {
-      onLongPress?.(message.message_id)
+    if (message?.status !== Status.ERROR) {
+      onLongPress?.(messageId)
     }
-  }, [message, onLongPress])
+  }, [message?.status, messageId, onLongPress])
 
   const onLinkPreviewEmpty = useCallback(() => {
     if (linkValue) {
@@ -279,9 +279,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
                       : null
                   ]}
                   ref={
-                    itemsRef
-                      ? (el) => (itemsRef.current[message.message_id] = el)
-                      : null
+                    itemsRef ? (el) => (itemsRef.current[messageId] = el) : null
                   }
                 >
                   {isPlaylistUrl(linkValue) ? (
@@ -304,7 +302,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
                     <LinkPreview
                       key={`${link.value}-${link.start}-${link.end}`}
                       chatId={chatId}
-                      messageId={message.message_id}
+                      messageId={messageId}
                       href={link.href}
                       hideMessage={hideMessage}
                       onLongPress={handleLongPress}
@@ -321,7 +319,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
                   ) : null}
                   {!hideMessage ? (
                     <Hyperlink
-                      text={message.message}
+                      text={messageId}
                       styles={{
                         root: [
                           styles.message,
@@ -373,7 +371,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
           </Pressable>
         </View>
         {isAuthor && message.status === Status.ERROR ? (
-          <ResendMessageButton messageId={message.message_id} chatId={chatId} />
+          <ResendMessageButton messageId={messageId} chatId={chatId} />
         ) : null}
         {message.hasTail ? (
           <>

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -224,7 +224,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   }, [setIsPressed])
 
   const handleLongPress = useCallback(() => {
-    if ((message?.status ?? Status.IDLE) !== Status.ERROR && message) {
+    if (message && message.status !== Status.ERROR) {
       onLongPress?.(message.message_id)
     }
   }, [message, onLongPress])

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -224,7 +224,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   }, [setIsPressed])
 
   const handleLongPress = useCallback(() => {
-    if (message && message.status !== Status.ERROR && ) {
+    if (message && message.status !== Status.ERROR) {
       onLongPress?.(message.message_id)
     }
   }, [message, onLongPress])

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useState } from 'react'
 
-import type { ReactionTypes, ChatMessageWithExtras } from '@audius/common'
+import type { ReactionTypes } from '@audius/common'
 import {
   Status,
   accountSelectors,

--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -224,7 +224,7 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   }, [setIsPressed])
 
   const handleLongPress = useCallback(() => {
-    if (message && message.status !== Status.ERROR) {
+    if (message && message.status !== Status.ERROR && ) {
       onLongPress?.(message.message_id)
     }
   }, [message, onLongPress])
@@ -246,10 +246,6 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
       ? { ...styles.unfurl, ...styles.unfurlAuthor }
       : { ...styles.unfurl, ...styles.unfurlOtherUser }
     : styles.unfurl
-
-  console.log(
-    `REED message: ${JSON.stringify(message?.reactions)} isPopup: ${isPopup}`
-  )
 
   return message ? (
     <>

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -462,7 +462,7 @@ export const ChatScreen = () => {
     ({ item }) => (
       <>
         <ChatMessageListItem
-          message={item}
+          messageId={item.message_id}
           chatId={chatId}
           itemsRef={itemsRef}
           isPopup={false}

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -448,7 +448,7 @@ export const ChatScreen = () => {
       dispatch(setReactionsPopupMessageId({ messageId: id }))
       light()
     },
-    [dispatch]
+    [canSendMessage, dispatch]
   )
 
   const topBarRight = (

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -429,6 +429,9 @@ export const ChatScreen = () => {
       if (messageRef === null || messageRef === undefined) {
         return
       }
+      if (!canSendMessage) {
+        return
+      }
       // Measure position of selected message to create a copy of it on top
       // of the dimmed background inside the portal.
       const { messageY, messageH } = await new Promise<{

--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -220,7 +220,7 @@ export const ReactionPopup = ({
         <Pressable style={styles.innerPressable} onPress={handleClosePopup} />
         <ChatMessageListItem
           chatId={chatId}
-          message={message}
+          messageId={message.message_id}
           isPopup={true}
           style={[
             styles.popupChatMessage,


### PR DESCRIPTION
### Description
Was doing this as part of investigation for PAY-1422. Ultimately couldn't repro the bug but this is probably a better pattern to follow anyway.
Bonus: prevent user from setting reaction when not permitted.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

