### PR TITLE
[PAY-1423] Fix empty chat message box with currently playing track

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -166,6 +166,10 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   loadingSpinner: {
     height: spacing(10),
     width: spacing(10)
+  },
+  emptyContainer: {
+    display: 'flex',
+    flexGrow: 1
   }
 }))
 
@@ -574,7 +578,9 @@ export const ChatScreen = () => {
             }
             style={[
               styles.keyboardAvoiding,
-              hasCurrentlyPlayingTrack ? { bottom: PLAY_BAR_HEIGHT } : null
+              hasCurrentlyPlayingTrack
+                ? { bottom: PLAY_BAR_HEIGHT, marginTop: PLAY_BAR_HEIGHT }
+                : null
             ]}
             onKeyboardHide={measureChatContainerBottom}
           >
@@ -601,7 +607,16 @@ export const ChatScreen = () => {
                   maintainVisibleContentPosition={
                     maintainVisibleContentPosition
                   }
-                  ListEmptyComponent={<EmptyChatMessages />}
+                  ListEmptyComponent={
+                    // Wrap the EmptyChatMessages in a view here rather than within the component
+                    // For some reason, this prevents this inversion bug:
+                    // https://github.com/facebook/react-native/issues/21196
+                    // This is better than doing a rotation transform because when the react bug is fixed,
+                    // our workaround won't re-introduce the bug!
+                    <View style={styles.emptyContainer}>
+                      <EmptyChatMessages />
+                    </View>
+                  }
                   ListHeaderComponent={
                     canSendMessage ? null : <ChatUnavailable chatId={chatId} />
                   }

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -579,7 +579,7 @@ export const ChatScreen = () => {
             style={[
               styles.keyboardAvoiding,
               hasCurrentlyPlayingTrack
-                ? { bottom: PLAY_BAR_HEIGHT, marginTop: PLAY_BAR_HEIGHT }
+                ? { bottom: PLAY_BAR_HEIGHT, paddingTop: PLAY_BAR_HEIGHT }
                 : null
             ]}
             onKeyboardHide={measureChatContainerBottom}

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -105,8 +105,9 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     flexShrink: 1
   },
   listContentContainer: {
-    paddingHorizontal: spacing(6),
-    display: 'flex'
+    display: 'flex',
+    flexGrow: 1,
+    paddingHorizontal: spacing(6)
   },
   profileTitle: {
     display: 'flex',
@@ -577,10 +578,6 @@ export const ChatScreen = () => {
             ]}
             onKeyboardHide={measureChatContainerBottom}
           >
-            {chat?.messagesStatus === Status.SUCCESS &&
-            chatMessages?.length === 0 ? (
-              <EmptyChatMessages />
-            ) : null}
             {isLoading ? (
               <View style={styles.loadingSpinnerContainer}>
                 <LoadingSpinner style={styles.loadingSpinner} />
@@ -604,6 +601,7 @@ export const ChatScreen = () => {
                   maintainVisibleContentPosition={
                     maintainVisibleContentPosition
                   }
+                  ListEmptyComponent={<EmptyChatMessages />}
                   ListHeaderComponent={
                     canSendMessage ? null : <ChatUnavailable chatId={chatId} />
                   }

--- a/packages/mobile/src/screens/chat-screen/EmptyChatMessages.tsx
+++ b/packages/mobile/src/screens/chat-screen/EmptyChatMessages.tsx
@@ -1,11 +1,7 @@
-import { playerSelectors } from '@audius/common'
 import { View, Text, Image } from 'react-native'
-import { useSelector } from 'react-redux'
 
 import WavingHand from 'app/assets/images/emojis/waving-hand-sign.png'
 import { makeStyles } from 'app/styles'
-import { spacing } from 'app/styles/spacing'
-const { getHasTrack } = playerSelectors
 
 const messages = {
   newMessage: 'New Message',
@@ -14,14 +10,8 @@ const messages = {
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
-  outerContainer: {
-    display: 'flex',
-    flexGrow: 1,
-    justifyContent: 'flex-end',
-    paddingBottom: spacing(8)
-  },
-  emptyContainer: {
-    marginHorizontal: spacing(6),
+  root: {
+    marginTop: spacing(8),
     padding: spacing(6),
     display: 'flex',
     flexDirection: 'row',
@@ -29,10 +19,9 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     backgroundColor: palette.white,
     borderColor: palette.neutralLight7,
     borderWidth: 1,
-    borderRadius: spacing(2),
-    transform: [{ rotateY: '180deg' }, { rotateZ: '180deg' }]
+    borderRadius: spacing(2)
   },
-  emptyTextContainer: {
+  textContainer: {
     display: 'flex',
     flexDirection: 'column',
     marginHorizontal: spacing(6)
@@ -41,13 +30,13 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     height: spacing(16),
     width: spacing(16)
   },
-  emptyTitle: {
+  title: {
     fontSize: typography.fontSize.xxl,
     color: palette.neutral,
     fontFamily: typography.fontByWeight.bold,
     lineHeight: typography.fontSize.xxl * 1.3
   },
-  emptyText: {
+  text: {
     marginTop: spacing(2),
     marginRight: spacing(6),
     fontSize: typography.fontSize.large,
@@ -58,20 +47,12 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
 
 export const EmptyChatMessages = () => {
   const styles = useStyles()
-  const hasCurrentlyPlayingTrack = useSelector(getHasTrack)
   return (
-    <View
-      style={[
-        styles.outerContainer,
-        hasCurrentlyPlayingTrack ? { paddingBottom: spacing(19.5) } : null
-      ]}
-    >
-      <View style={styles.emptyContainer}>
-        <Image style={styles.wavingHand} source={WavingHand} />
-        <View style={styles.emptyTextContainer}>
-          <Text style={styles.emptyTitle}>{messages.sayHello}</Text>
-          <Text style={styles.emptyText}>{messages.firstImpressions}</Text>
-        </View>
+    <View style={styles.root}>
+      <Image style={styles.wavingHand} source={WavingHand} />
+      <View style={styles.textContainer}>
+        <Text style={styles.title}>{messages.sayHello}</Text>
+        <Text style={styles.text}>{messages.firstImpressions}</Text>
       </View>
     </View>
   )

--- a/packages/mobile/src/screens/chat-screen/EmptyChatMessages.tsx
+++ b/packages/mobile/src/screens/chat-screen/EmptyChatMessages.tsx
@@ -1,7 +1,11 @@
+import { playerSelectors } from '@audius/common'
 import { View, Text, Image } from 'react-native'
+import { useSelector } from 'react-redux'
 
 import WavingHand from 'app/assets/images/emojis/waving-hand-sign.png'
 import { makeStyles } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
+const { getHasTrack } = playerSelectors
 
 const messages = {
   newMessage: 'New Message',
@@ -10,8 +14,13 @@ const messages = {
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
+  outerContainer: {
+    display: 'flex',
+    flexGrow: 1,
+    justifyContent: 'flex-end',
+    paddingBottom: spacing(8)
+  },
   emptyContainer: {
-    marginTop: spacing(8),
     marginHorizontal: spacing(6),
     padding: spacing(6),
     display: 'flex',
@@ -20,7 +29,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     backgroundColor: palette.white,
     borderColor: palette.neutralLight7,
     borderWidth: 1,
-    borderRadius: spacing(2)
+    borderRadius: spacing(2),
+    transform: [{ rotateY: '180deg' }, { rotateZ: '180deg' }]
   },
   emptyTextContainer: {
     display: 'flex',
@@ -48,12 +58,20 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
 
 export const EmptyChatMessages = () => {
   const styles = useStyles()
+  const hasCurrentlyPlayingTrack = useSelector(getHasTrack)
   return (
-    <View style={styles.emptyContainer}>
-      <Image style={styles.wavingHand} source={WavingHand} />
-      <View style={styles.emptyTextContainer}>
-        <Text style={styles.emptyTitle}>{messages.sayHello}</Text>
-        <Text style={styles.emptyText}>{messages.firstImpressions}</Text>
+    <View
+      style={[
+        styles.outerContainer,
+        hasCurrentlyPlayingTrack ? { paddingBottom: spacing(19.5) } : null
+      ]}
+    >
+      <View style={styles.emptyContainer}>
+        <Image style={styles.wavingHand} source={WavingHand} />
+        <View style={styles.emptyTextContainer}>
+          <Text style={styles.emptyTitle}>{messages.sayHello}</Text>
+          <Text style={styles.emptyText}>{messages.firstImpressions}</Text>
+        </View>
       </View>
     </View>
   )


### PR DESCRIPTION
### Description
Change the empty chat message box to be an actual `ListEmptyComponent` of the flatlist which necessitated mirror-flipping it, and also add extra padding when currently playing track drawer is visible.

Keep in mind everything is flipped because the parent flatlist is inverted.

### Dragons

Feel like there's a clever css way to do this but couldn't figure it out.

### How Has This Been Tested?

Local ios stage
![Simulator Screen Shot - iPhone 14 Pro - 2023-06-09 at 00 31 26](https://github.com/AudiusProject/audius-client/assets/3893871/f8815501-dd22-41c7-8a60-69e8accc982a)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

