### PR TITLE
[PAY-1426] DMs: Simplify unfurl styles for mobile, fix border radius shadow

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatMessageListItem.tsx
@@ -49,7 +49,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   bubble: {
     marginTop: spacing(2),
     backgroundColor: palette.white,
-    borderRadius: spacing(3)
+    borderRadius: spacing(3),
+    overflow: 'hidden'
   },
   isAuthor: {
     backgroundColor: palette.secondaryLight2
@@ -133,7 +134,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   },
   unfurl: {
     width: Dimensions.get('window').width - 48,
-    minHeight: 72
+    minHeight: 72,
+    borderRadius: 0 // Undoes border radius from track/collection tiles
   }
 }))
 
@@ -236,18 +238,12 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
   const { secondaryDark1, neutralLight7 } = useThemeColors()
 
   const borderBottomColor = isAuthor ? secondaryDark1 : neutralLight7
-  const borderBottomWidth = hideMessage
-    ? 0
-    : isCollection || isTrack
-    ? undefined
-    : 1
-  const borderBottomRadius = hideMessage ? undefined : 0
+  const borderBottomWidth =
+    hideMessage || isCollection || isTrack ? undefined : 1
   const unfurlStyles = {
     ...styles.unfurl,
     borderBottomColor,
-    borderBottomWidth,
-    borderBottomLeftRadius: borderBottomRadius,
-    borderBottomRightRadius: borderBottomRadius
+    borderBottomWidth
   }
 
   return (
@@ -309,7 +305,6 @@ export const ChatMessageListItem = memo(function ChatMessageListItem(
                       chatId={chatId}
                       messageId={message.message_id}
                       href={link.href}
-                      hideMessage={hideMessage}
                       onLongPress={handleLongPress}
                       onPressIn={handlePressIn}
                       onPressOut={handlePressOut}

--- a/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
+++ b/packages/mobile/src/screens/chat-screen/LinkPreview.tsx
@@ -11,13 +11,7 @@ import { REACTION_LONGPRESS_DELAY } from './constants'
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   root: {
-    backgroundColor: palette.white,
-    borderTopLeftRadius: spacing(3),
-    borderTopRightRadius: spacing(3),
-    overflow: 'hidden'
-  },
-  rootIsLinkPreviewOnly: {
-    borderRadius: spacing(3)
+    backgroundColor: palette.white
   },
   pressed: {
     backgroundColor: palette.neutralLight10
@@ -73,7 +67,6 @@ type LinkPreviewProps = {
   chatId: string
   messageId: string
   href: string
-  hideMessage: boolean
   isPressed: boolean
   onLongPress: (event: GestureResponderEvent) => void
   onPressIn: (event: GestureResponderEvent) => void
@@ -87,7 +80,6 @@ export const LinkPreview = ({
   chatId,
   messageId,
   href,
-  hideMessage,
   isPressed = false,
   onLongPress,
   onPressIn,
@@ -118,14 +110,7 @@ export const LinkPreview = ({
       onPressIn={onPressIn}
       onPressOut={onPressOut}
     >
-      <View
-        style={[
-          styles.root,
-          isPressed ? styles.pressed : null,
-          hideMessage ? styles.rootIsLinkPreviewOnly : null,
-          style
-        ]}
-      >
+      <View style={[styles.root, isPressed ? styles.pressed : null, style]}>
         {description || title ? (
           <>
             {image ? (


### PR DESCRIPTION
### Description

- Simplifies the DM bubble on mobile (mirroring #3554 ) by adding `overflow: hidden` to the main bubble and leaving it in charge of all border radiuses. Notably, this does not result in the same halo effect that occurs on web, so I didn't opt to do the same wrapper/background color strategy

Before:
![image](https://github.com/AudiusProject/audius-client/assets/3690498/b20d8503-257d-43cf-88f7-b985c3947abb)

After:
![image](https://github.com/AudiusProject/audius-client/assets/3690498/666394d7-2f63-43a9-be32-ef3a4c799bc5)


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

