### PR TITLE
Force mobile build again

### DIFF
--- a/packages/mobile/ios/fastlane/Fastfile
+++ b/packages/mobile/ios/fastlane/Fastfile
@@ -116,40 +116,9 @@ platform :ios do
       puts "ENVFILE: #{ENV['ENVFILE']}"
     end
 
-    # Version number (e.g. 1.0.100) will be incremented by a patch version
-    # from the currently live version in the app store. If a higher version number
-    # is specified in Info.plist, that one will be used
-
-    currentReleasedVersionNumberString = options[:current_released_version] ? (options[:current_released_version].to_s) : (get_app_store_version_number(
-      bundle_id: 'co.audius.audiusmusic'
-    ))
-
-    currentReleasedVersionNumber = options[:current_released_version] ? (options[:current_released_version]) : (Gem::Version.new currentReleasedVersionNumberString)
-
     plistVersionNumber = options[:plist_version] ? (options[:plist_version]) : (Gem::Version.new get_version_number_from_plist(
       scheme: scheme
     ))
-
-    # If the version specified in project is greater than
-    # the previous version number, there is no need to modify version number in the project
-    if plistVersionNumber <= currentReleasedVersionNumber
-      # Increment the patch version
-      # This is necessary because the same version number cannot be used twice on the app store
-      patchRegex = /\d+.\d+.(\d+)/
-      previousPatch = currentReleasedVersionNumberString[patchRegex, 1]
-      currentReleasedVersionNumberString[patchRegex, 1] = (previousPatch.to_i + 1).to_s
-      plistVersionNumber = currentReleasedVersionNumberString
-
-      increment_version_number_in_plist(
-        version_number: plistVersionNumber,
-        scheme: scheme
-      )
-
-      increment_version_number_in_xcodeproj(
-        version_number: plistVersionNumber,
-        scheme: scheme
-      )
-    end
 
     # Increment build
 
@@ -227,7 +196,7 @@ platform :ios do
       codepushDeployment = CODEPUSH_RC_DEPLOYMENT
     end
     currentReleasedVersionNumber, plistVersionNumber = get_version(scheme: scheme)
-    isVersionIncremented = plistVersionNumber > currentReleasedVersionNumber
+    isVersionIncremented = true # REVERT!!!
     packageJson = File.open "../../package.json"
     packageJsonData = JSON.load packageJson
     if !isVersionIncremented


### PR DESCRIPTION
### Description
Accidentally released 1.1.67 intstead of 1.1.66 due to some old code in the fastlane file that doesn't even have to be there any more :')

Expired 1.1.67 and going to force release 1.1.66 using this, then revert. Double checked the android file to make sure the same issue won't happen there as well.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

