### PR TITLE
[PAY-1386] DMs: Mark chat as read on client when new message from self comes through websocket

### DIFF
--- a/packages/common/src/store/pages/chat/selectors.ts
+++ b/packages/common/src/store/pages/chat/selectors.ts
@@ -124,6 +124,7 @@ export const getHasUnreadMessages = (state: CommonState) => {
   if (getUnreadMessagesCount(state) > 0) {
     return true
   }
+  // This really shouldn't be necessary since the above should be kept in sync
   const chats = getChats(state)
   for (const chat of chats) {
     if (chat.unread_message_count > 0) {


### PR DESCRIPTION
### Description

Small change to allow us to know a chat is read by seeing our own message through a web socket

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

