### PR TITLE
[PAY-1399] Fix Android chat send button color

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -82,8 +82,8 @@ export const ChatTextInput = ({
             ? pressed
               ? primaryDark2
               : primary
-            : // Setting opacity directly affects the opacity of the icon on
-              // Android, this workaround keeps the icon always white.
+            : // Setting opacity style affects both the background and icon
+              // on Android, this workaround keeps the icon always white.
               convertHexToRGBA(primary, 50)
         }
       ]}

--- a/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatTextInput.tsx
@@ -8,13 +8,11 @@ import IconSend from 'app/assets/images/iconSend.svg'
 import { TextInput } from 'app/components/core'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
+import { convertHexToRGBA } from 'app/utils/convertHexToRGBA'
 import { useThemeColors } from 'app/utils/theme'
 
 const { sendMessage } = chatActions
 const { getHasTrack } = playerSelectors
-
-const ICON_BLUR = 0.5
-const ICON_FOCUS = 1
 
 const messages = {
   startNewMessage: ' Start a New Message'
@@ -80,15 +78,23 @@ export const ChatTextInput = ({
       style={({ pressed }) => [
         styles.iconCircle,
         {
-          backgroundColor: pressed && hasLength ? primaryDark2 : primary,
-          opacity: hasLength ? ICON_FOCUS : ICON_BLUR
+          backgroundColor: hasLength
+            ? pressed
+              ? primaryDark2
+              : primary
+            : // Setting opacity directly affects the opacity of the icon on
+              // Android, this workaround keeps the icon always white.
+              convertHexToRGBA(primary, 50)
         }
       ]}
     >
       <IconSend
+        style={{ opacity: 1 }}
         width={styles.icon.width}
         height={styles.icon.height}
         fill={styles.icon.fill}
+        color={styles.icon.fill}
+        opacity={1}
       />
     </Pressable>
   )

--- a/packages/mobile/src/utils/convertHexToRGBA.ts
+++ b/packages/mobile/src/utils/convertHexToRGBA.ts
@@ -14,5 +14,5 @@ export const convertHexToRGBA = (hexCode, opacity = 1) => {
     opacity = opacity / 100
   }
 
-  return `rgba(${r},${g},${b},${1})`
+  return `rgba(${r},${g},${b},${opacity})`
 }


### PR DESCRIPTION
### Description
Workaround to keep Android send icon always white.

### Dragons

Changed logic in `convertHexToRGBA` but I believe it was a bug.

### How Has This Been Tested?

Before:
![Screenshot_1686614620](https://github.com/AudiusProject/audius-client/assets/3893871/0da507d9-9346-47b2-bca0-2ac4a7c078bf)

After:
![Screenshot_1686614605](https://github.com/AudiusProject/audius-client/assets/3893871/bdf4bd3d-b34f-4d6c-bd34-e5d74aef35c0)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

