### PR TITLE
[PAY-1435] Navigate to chat after unblocking user on mobile

### DIFF
--- a/packages/mobile/src/components/block-messages-drawer/BlockMessagesDrawer.tsx
+++ b/packages/mobile/src/components/block-messages-drawer/BlockMessagesDrawer.tsx
@@ -17,7 +17,7 @@ import { useColor } from 'app/utils/theme'
 
 const { getUser } = cacheUsersSelectors
 const { getDoesBlockUser } = chatSelectors
-const { blockUser, unblockUser } = chatActions
+const { blockUser, unblockUser, createChat } = chatActions
 
 const BLOCK_MESSAGES_MODAL_NAME = 'BlockMessages'
 
@@ -106,7 +106,7 @@ export const BlockMessagesDrawer = () => {
   const neutralLight2 = useColor('neutralLight2')
   const neutral = useColor('neutral')
   const dispatch = useDispatch()
-  const { userId } = useSelector((state: AppState) =>
+  const { userId, navigateToChat } = useSelector((state: AppState) =>
     getData<'BlockMessages'>(state)
   )
   const user = useSelector((state) => getUser(state, { id: userId }))
@@ -116,6 +116,9 @@ export const BlockMessagesDrawer = () => {
   const handleConfirmPress = useCallback(() => {
     if (doesBlockUser) {
       dispatch(unblockUser({ userId }))
+      if (navigateToChat) {
+        dispatch(createChat({ userIds: [userId] }))
+      }
     } else {
       dispatch(blockUser({ userId }))
     }
@@ -125,7 +128,7 @@ export const BlockMessagesDrawer = () => {
         visible: false
       })
     )
-  }, [dispatch, doesBlockUser, userId])
+  }, [dispatch, doesBlockUser, navigateToChat, userId])
 
   const handleCancelPress = useCallback(() => {
     dispatch(

--- a/packages/mobile/src/components/block-messages-drawer/BlockMessagesDrawer.tsx
+++ b/packages/mobile/src/components/block-messages-drawer/BlockMessagesDrawer.tsx
@@ -106,7 +106,7 @@ export const BlockMessagesDrawer = () => {
   const neutralLight2 = useColor('neutralLight2')
   const neutral = useColor('neutral')
   const dispatch = useDispatch()
-  const { userId, navigateToChat } = useSelector((state: AppState) =>
+  const { userId, shouldOpenChat } = useSelector((state: AppState) =>
     getData<'BlockMessages'>(state)
   )
   const user = useSelector((state) => getUser(state, { id: userId }))
@@ -116,7 +116,7 @@ export const BlockMessagesDrawer = () => {
   const handleConfirmPress = useCallback(() => {
     if (doesBlockUser) {
       dispatch(unblockUser({ userId }))
-      if (navigateToChat) {
+      if (shouldOpenChat) {
         dispatch(createChat({ userIds: [userId] }))
       }
     } else {
@@ -128,7 +128,7 @@ export const BlockMessagesDrawer = () => {
         visible: false
       })
     )
-  }, [dispatch, doesBlockUser, navigateToChat, userId])
+  }, [dispatch, doesBlockUser, shouldOpenChat, userId])
 
   const handleCancelPress = useCallback(() => {
     dispatch(

--- a/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
+++ b/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
@@ -24,7 +24,7 @@ import { useColor } from 'app/utils/theme'
 
 import { UserBadges } from '../user-badges'
 
-const { unblockUser } = chatActions
+const { unblockUser, createChat } = chatActions
 const { getCanCreateChat } = chatSelectors
 const { getUser } = cacheUsersSelectors
 const { beginTip } = tippingActions
@@ -151,7 +151,9 @@ export const InboxUnavailableDrawer = () => {
   const styles = useStyles()
   const neutralLight2 = useColor('neutralLight2')
 
-  const { userId } = useSelector((state) => getData<'InboxUnavailable'>(state))
+  const { userId, navigateToChat } = useSelector((state) =>
+    getData<'InboxUnavailable'>(state)
+  )
   const user = useSelector((state) => getUser(state, { id: userId }))
   const { callToAction } = useSelector((state) =>
     getCanCreateChat(state, { userId })
@@ -168,8 +170,11 @@ export const InboxUnavailableDrawer = () => {
 
   const handleUnblockPress = useCallback(() => {
     dispatch(unblockUser({ userId }))
+    if (navigateToChat) {
+      dispatch(createChat({ userIds: [userId] }))
+    }
     closeDrawer()
-  }, [dispatch, userId, closeDrawer])
+  }, [dispatch, userId, navigateToChat, closeDrawer])
 
   const handleLearnMorePress = useCallback(() => {
     // TODO: Link to blog

--- a/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
+++ b/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
@@ -151,7 +151,7 @@ export const InboxUnavailableDrawer = () => {
   const styles = useStyles()
   const neutralLight2 = useColor('neutralLight2')
 
-  const { userId, navigateToChat } = useSelector((state) =>
+  const { userId, shouldOpenChat } = useSelector((state) =>
     getData<'InboxUnavailable'>(state)
   )
   const user = useSelector((state) => getUser(state, { id: userId }))
@@ -170,11 +170,11 @@ export const InboxUnavailableDrawer = () => {
 
   const handleUnblockPress = useCallback(() => {
     dispatch(unblockUser({ userId }))
-    if (navigateToChat) {
+    if (shouldOpenChat) {
       dispatch(createChat({ userIds: [userId] }))
     }
     closeDrawer()
-  }, [dispatch, userId, navigateToChat, closeDrawer])
+  }, [dispatch, userId, shouldOpenChat, closeDrawer])
 
   const handleLearnMorePress = useCallback(() => {
     // TODO: Link to blog

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -177,7 +177,7 @@ export const ChatUserListItem = ({ userId }: ChatUserListItemProps) => {
         setVisibility({
           drawer: 'InboxUnavailable',
           visible: true,
-          data: { userId: user.user_id, navigateToChat: true }
+          data: { userId: user.user_id, shouldOpenChat: true }
         })
       )
     }

--- a/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatUserListItem.tsx
@@ -177,7 +177,7 @@ export const ChatUserListItem = ({ userId }: ChatUserListItemProps) => {
         setVisibility({
           drawer: 'InboxUnavailable',
           visible: true,
-          data: { userId: user.user_id }
+          data: { userId: user.user_id, navigateToChat: true }
         })
       )
     }

--- a/packages/mobile/src/screens/profile-screen/MessageLockedButton.tsx
+++ b/packages/mobile/src/screens/profile-screen/MessageLockedButton.tsx
@@ -38,7 +38,7 @@ export const MessageLockedButton = (props: MessageLockedButtonProps) => {
       setVisibility({
         drawer: 'InboxUnavailable',
         visible: true,
-        data: { userId }
+        data: { userId, navigateToChat: true }
       })
     )
   }, [dispatch, userId])

--- a/packages/mobile/src/screens/profile-screen/MessageLockedButton.tsx
+++ b/packages/mobile/src/screens/profile-screen/MessageLockedButton.tsx
@@ -38,7 +38,7 @@ export const MessageLockedButton = (props: MessageLockedButtonProps) => {
       setVisibility({
         drawer: 'InboxUnavailable',
         visible: true,
-        data: { userId, navigateToChat: true }
+        data: { userId, shouldOpenChat: true }
       })
     )
   }, [dispatch, userId])

--- a/packages/mobile/src/store/drawers/slice.ts
+++ b/packages/mobile/src/store/drawers/slice.ts
@@ -56,10 +56,10 @@ export type DrawerData = {
   ChatActions: { userId: number; chatId: string }
   CreateChatActions: { userId: number }
   ProfileActions: undefined
-  BlockMessages: { userId: number; navigateToChat: boolean }
+  BlockMessages: { userId: number; shouldOpenChat: boolean }
   DeleteChat: { chatId: string }
   SupportersInfo: undefined
-  InboxUnavailable: { userId: number; navigateToChat: boolean }
+  InboxUnavailable: { userId: number; shouldOpenChat: boolean }
 }
 
 export type DrawersState = { [drawer in Drawer]: boolean | 'closing' } & {

--- a/packages/mobile/src/store/drawers/slice.ts
+++ b/packages/mobile/src/store/drawers/slice.ts
@@ -56,10 +56,10 @@ export type DrawerData = {
   ChatActions: { userId: number; chatId: string }
   CreateChatActions: { userId: number }
   ProfileActions: undefined
-  BlockMessages: { userId: number }
+  BlockMessages: { userId: number; navigateToChat: boolean }
   DeleteChat: { chatId: string }
   SupportersInfo: undefined
-  InboxUnavailable: { userId: number }
+  InboxUnavailable: { userId: number; navigateToChat: boolean }
 }
 
 export type DrawersState = { [drawer in Drawer]: boolean | 'closing' } & {


### PR DESCRIPTION
### Description
Adds a boolean flag to allow certain drawers to navigate to a chat after the user unblocks the selected user they want to chat with.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

local ios  stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

