### PR TITLE
[CON-742] Make users and track actions v2 for v2 users/tracks even when feature flags are disabled

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -1047,13 +1047,11 @@ export const audiusBackend = ({
     metadata: TrackMetadata,
     onProgress: (loaded: number, total: number) => void
   ) {
-    const storageV2SignupEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_SIGNUP
-    )
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
-    if (storageV2SignupEnabled || storageV2UploadEnabled) {
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
+    if (storageV2UploadEnabled) {
       try {
         const { trackId, updatedMetadata, txReceipt } =
           await audiusLibs.Track.uploadTrackV2AndWriteToChain(
@@ -1092,9 +1090,10 @@ export const audiusBackend = ({
     metadata: TrackMetadata,
     onProgress: (loaded: number, total: number) => void
   ) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     if (storageV2UploadEnabled) {
       const updatedMetadata = await audiusLibs.Track.uploadTrackV2(
         trackFile,
@@ -1139,9 +1138,10 @@ export const audiusBackend = ({
       metadata: TrackMetadata
     }[]
   ) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     if (storageV2UploadEnabled) {
       return await audiusLibs.Track.addTracksToChainV2(
         uploadedTracks.map((t) => t.metadata)
@@ -1152,9 +1152,10 @@ export const audiusBackend = ({
   }
 
   async function uploadImage(file: File) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     if (storageV2UploadEnabled) {
       return await audiusLibs.creatorNode.uploadTrackCoverArtV2(file, () => {})
     } else {
@@ -1164,14 +1165,16 @@ export const audiusBackend = ({
 
   async function updateTrack(
     _trackId: ID,
-    metadata: TrackMetadata & { artwork: { file: File } }
+    metadata: TrackMetadata & { artwork: { file: File } },
+    isStorageV2Track = false
   ) {
     const cleanedMetadata = schemas.newTrackMetadata(metadata, true)
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
 
-    if (storageV2UploadEnabled) {
+    if (storageV2UploadEnabled || isStorageV2Track) {
       if (metadata.artwork) {
         const resp = await audiusLibs.creatorNode.uploadTrackCoverArtV2(
           metadata.artwork.file,
@@ -1293,9 +1296,10 @@ export const audiusBackend = ({
       newMetadata.associated_sol_wallets ||
       associatedWallets?.associated_sol_wallets
 
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     try {
       if (newMetadata.updatedProfilePicture) {
         if (storageV2UploadEnabled) {
@@ -1465,9 +1469,10 @@ export const audiusBackend = ({
         track: trackId,
         metadata_time: currentBlock.timestamp
       }))
-      const storageV2UploadEnabled = await getFeatureEnabled(
-        FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-      )
+      const storageV2UploadEnabled =
+        (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+        (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+        audiusLibs.Account.getCurrentUser()?.is_storage_v2
       const response = await audiusLibs.EntityManager.createPlaylist(
         {
           ...metadata,
@@ -1490,9 +1495,10 @@ export const audiusBackend = ({
   }
 
   async function updatePlaylist(metadata: Collection) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     try {
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
@@ -1508,9 +1514,10 @@ export const audiusBackend = ({
   }
 
   async function orderPlaylist(playlist: any) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     try {
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
@@ -1525,9 +1532,10 @@ export const audiusBackend = ({
   }
 
   async function publishPlaylist(playlist: Collection) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     try {
       playlist.is_private = false
       const { blockHash, blockNumber } =
@@ -1546,9 +1554,10 @@ export const audiusBackend = ({
   }
 
   async function addPlaylistTrack(playlist: Collection) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     try {
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(
@@ -1563,9 +1572,10 @@ export const audiusBackend = ({
   }
 
   async function deletePlaylistTrack(playlist: Collection) {
-    const storageV2UploadEnabled = await getFeatureEnabled(
-      FeatureFlags.STORAGE_V2_TRACK_UPLOAD
-    )
+    const storageV2UploadEnabled =
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_TRACK_UPLOAD)) ||
+      (await getFeatureEnabled(FeatureFlags.STORAGE_V2_SIGNUP)) ||
+      audiusLibs.Account.getCurrentUser()?.is_storage_v2
     try {
       const { blockHash, blockNumber } =
         await audiusLibs.EntityManager.updatePlaylist(

--- a/packages/web/src/common/store/cache/tracks/sagas.js
+++ b/packages/web/src/common/store/cache/tracks/sagas.js
@@ -166,7 +166,12 @@ function* confirmEditTrack(
         const { blockHash, blockNumber } = yield call(
           audiusBackendInstance.updateTrack,
           trackId,
-          { ...formFields }
+          { ...formFields },
+          currentTrack?.track_cid &&
+            !(
+              currentTrack.track_cid?.trim().length === 46 &&
+              currentTrack.track_cid.trim().startsWith('Qm')
+            )
         )
 
         const confirmed = yield call(confirmTransaction, blockHash, blockNumber)


### PR DESCRIPTION
### Description

Makes it safe to flip v2 tracks back to disabled after flipping to enabled. Otherwise updating v2 tracks would fail because it would try the old flow (which is what I saw for my prod v2 track on mobile where I didn't have the feature flag enabled - the app crashed and sentry confirmed it was trying to use the v1 edit-track flow).

This is also important for users who signup as v2 but don't get the feature flag for v2 uploads (due to feature flag flakiness we've run into before).

### Dragons

### How Has This Been Tested?
- Uploaded a v2 track to staging and confirmed that editing it works even with setting the feature flag to false (previously broken - caused heavy load screen)
- Tested the inverse (upload a v1 track with the track upload feature flag set to true and then to false)

### How will this change be monitored?

### Feature Flags ###
Same upload flag: `storage_v2_track_upload`

