### PR TITLE
[INF-417] Generate sourcemaps when running web:prod

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,7 +10,7 @@
     "start": "craco --max-old-space-size=12288 start",
     "start:dev": "npm run write-sha && npm run publish-scripts && env-cmd ./.env/.env.git env-cmd --no-override ./.env/.env.dev npm start",
     "start:stage": "npm run write-sha && npm run publish-scripts && env-cmd ./.env/.env.git env-cmd --no-override ./.env/.env.stage npm start",
-    "start:prod": "npm run write-sha && npm run publish-scripts && env-cmd ./.env/.env.git env-cmd --no-override ./.env/.env.prod npm start",
+    "start:prod": "npm run write-sha && npm run publish-scripts && env-cmd ./.env/.env.git env-cmd --no-override ./.env/.env.prod env-cmd ./.env/.env.source-maps npm start",
     "prebuild": "npm run publish-scripts",
     "build": "craco --max-old-space-size=12288 build && cp package.json build/package.json",
     "build:dev": "npm run write-sha && env-cmd ./.env/.env.git env-cmd ./.env/.env.dev npm run build && rm -rf build-development && mv build build-development",


### PR DESCRIPTION
### Description

Noticed that sourcemaps were working fine when running web:dev. Turns out we have sourcemap generation via the `build:prod-source-maps` command. All we needed was the same env var when running `start:prod`

### Dragons

We expose source maps in prod anyway so this should be safe. It may slow down `start:prod` slightly

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

