### PR TITLE
[PAY-1448] End the race between SDK and Libs, once and for all

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -694,6 +694,7 @@ export const audiusBackend = ({
       discoveryNodeSelector = await discoveryNodeSelectorService.getInstance()
 
       discoveryNodeSelector.addEventListener('change', (endpoint) => {
+        console.debug('[AudiusBackend] DiscoveryNodeSelector changed', endpoint)
         discoveryProviderSelectionCallback(endpoint, [])
       })
     }

--- a/packages/common/src/store/pages/chat/middleware.ts
+++ b/packages/common/src/store/pages/chat/middleware.ts
@@ -21,7 +21,6 @@ export const chatMiddleware =
     let hasConnected = false
     return (next) => (action) => {
       if (connect.match(action) && !hasConnected) {
-        console.debug('[chats] Listening...')
         hasConnected = true
         const fn = async () => {
           const sdk = await audiusSdk()
@@ -58,6 +57,7 @@ export const chatMiddleware =
           sdk.chats.addEventListener('message', messageListener)
           sdk.chats.addEventListener('reaction', reactionListener)
           sdk.chats.addEventListener('close', closeListener)
+          console.debug('[chats] Listening...')
           return sdk.chats.listen()
         }
         fn()

--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -67,6 +67,13 @@ const initSdk = async () => {
       }
     }
   })
+  // We wait for libs here because AudiusBackend needs to register a listener that
+  // will let AudiusAPIClient know that libs has loaded, and without it AudiusAPIClient
+  // retries failed requests ad nauseum with no delays or backoffs and won't ever get
+  // the signal that libs is loaded. It sucks. But the easiest thing to do right now...
+  console.debug('[audiusSdk] Waiting for libs init...')
+  await waitForLibsInit()
+  console.debug('[audiusSdk] Libs initted, SDK initted.')
   window.audiusSdk = audiusSdk
   inProgress = false
   window.dispatchEvent(new CustomEvent(SDK_LOADED_EVENT_NAME))


### PR DESCRIPTION
### Description

tl;dr - let's just wait for libs to init before doing anything with SDK, even if SDK is fully functional on its own

#### The Bug

Occasionally, the user would get into a state where they'd be infinitely requesting the same "bad" request to the same DN. Oftentimes, this would be on page load as we'd try to fetch reactions for a notification that hasn't been reacted to yet. Other times, I was able to trigger it by opening the tip modal for someone I hadn't tipped yet. These are expected "failed" requests (404s in this case) as we expect those to not exist sometimes. So why was there an infinite request happening?

What's more, we had seen this bug before and _thought_ we had fixed it!

#### The root cause

In `AudiusAPIClient` we had this branch of code that makes a request using the eager discovery provider, and on failure, it waits for libs to initialize before retrying:
https://github.com/AudiusProject/audius-client/blob/ee1b6c3329adf59f4c880149fa18830b50bc1587/packages/common/src/services/audius-api-client/AudiusAPIClient.ts#L1916-L1929

This implies something flips `initializationState.type` from manual to something else, which we find here:
https://github.com/AudiusProject/audius-client/blob/ee1b6c3329adf59f4c880149fa18830b50bc1587/packages/common/src/services/audius-api-client/AudiusAPIClient.ts#L1833-L1847

The way `AudiusAPIClient` determines libs is initialized is whether or not libs has selected a discovery node. In SDK, that means registering an event handler for the `'change'` event, which happens in `AudiusBackend` here:

https://github.com/AudiusProject/audius-client/blob/0dff4a1a93f2221e66c2f0cff4b548a2af368c1e/packages/common/src/services/audius-backend/AudiusBackend.ts#L693-L700

But what was happening is that by the time the `AudiusBackend` init was called and its event handler added, the `'change'` event had already been fired!

The change here was that we made DMs (chats) start listening to the websocket on initial page load. This meant that _right away_ the SDK was getting loaded, which _also_ requires the `DiscoveryNodeSelectorService`, and then the `sdk.chat.listen()` command would run which would select a discovery node, and sometimes all of that would happen before we even init `AudiusBackend`.

Well there's a couple options we have to deal with that:
1. We could put a flag in SDK to indicate that the `DiscoveryNodeSelector` has a selected discovery node.
2. We could simply have SDK wait for libs
3. We could do a ton of work to finally tear out the cruft that is AudiusBackend/AudiusAPIClient and start committing to a whole new system of glorious SDK adoption

As much as I want 3, and as easy a fix 1 could be, I opted to do 2 since it's even easier and keeps SDK clean, and since 3 is the ultimate goal anyway

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

This will make connecting the websocket a wee bit slower?

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

I tested thoroughly locally against stage web using Chrome, I even intentionally delayed initialization of `AudiusBackend` to get a 100% repro and then confirmed the fix

To reproduce the original bug, check out code prior to this and add a delay [here](https://github.com/AudiusProject/audius-client/blob/0dff4a1a93f2221e66c2f0cff4b548a2af368c1e/packages/common/src/services/audius-backend/AudiusBackend.ts#L694-L695)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

