### PR TITLE
Fix mobile textinput borders + labels

### DIFF
--- a/packages/mobile/src/components/core/TextInput.tsx
+++ b/packages/mobile/src/components/core/TextInput.tsx
@@ -272,7 +272,10 @@ export const TextInput = forwardRef<RNTextInput, TextInputProps>(
             {
               borderColor: borderFocusAnimation.current.interpolate({
                 inputRange: [0, 1],
-                outputRange: [neutralLight7, secondary].map(convertHexToRGBA)
+                outputRange: [
+                  convertHexToRGBA(neutralLight7),
+                  convertHexToRGBA(secondary)
+                ]
               })
             }
           ]}
@@ -292,9 +295,10 @@ export const TextInput = forwardRef<RNTextInput, TextInputProps>(
                     fontSize: labelAnimation.current,
                     color: labelAnimation.current.interpolate({
                       inputRange: [16, 18],
-                      outputRange: [neutralLight4, neutral].map(
-                        convertHexToRGBA
-                      )
+                      outputRange: [
+                        convertHexToRGBA(neutralLight4),
+                        convertHexToRGBA(neutral)
+                      ]
                     })
                   }
                 ]}


### PR DESCRIPTION
### Description
Bug was that `map` passes index as 2nd arg, so the first color in the list was getting opacity 0. We didn't hit this before because `opacity` in `convertHexToRGBA` was actually not being used, we always set it to `1` regardless of the `opacity` arg.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage:
![Simulator Screen Shot - iPhone 14 Pro - 2023-06-14 at 17 13 44](https://github.com/AudiusProject/audius-client/assets/3893871/663b16e4-c2e3-4a7f-9ad8-bdb8a43fa26e)


Confirmed send button opacity still works on android:
![Screenshot_1686777153](https://github.com/AudiusProject/audius-client/assets/3893871/6411c5bb-2c0c-4de5-83bd-c18a65112904)
a41b2df0-1dce-4028-9def-5aa73af550fc)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

