### PR TITLE
[C-2770] Fix issue where playlist library can disappear

### DIFF
--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -85,8 +85,7 @@ const unwrapEntry = (entry: { metadata: any }) => {
 const forceUpdateKeys = new Set([
   'field_visibility',
   'followee_reposts',
-  'followee_saves',
-  'playlist_library'
+  'followee_saves'
 ])
 
 // Customize lodash recursive merge to never merge
@@ -98,6 +97,12 @@ export const mergeCustomizer = (objValue: any, srcValue: any, key: string) => {
   }
   if (key === 'is_verified') {
     return srcValue || objValue
+  }
+
+  // Not every user request provides playlist_library,
+  // so always prefer it's existence, starting with latest
+  if (key === 'playlist_library') {
+    return objValue ?? srcValue
   }
 
   // Delete is unidirectional (after marked deleted, future updates are not reflected)

--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -102,7 +102,7 @@ export const mergeCustomizer = (objValue: any, srcValue: any, key: string) => {
   // Not every user request provides playlist_library,
   // so always prefer it's existence, starting with latest
   if (key === 'playlist_library') {
-    return objValue ?? srcValue
+    return objValue || srcValue
   }
 
   // Delete is unidirectional (after marked deleted, future updates are not reflected)


### PR DESCRIPTION
### Description

Fixes issue where user's playlist library can disappear from left-nav. This has to do with the api not always returning a user's playlist_library, which actually makes sense for all users other that the active user. The fix for now is to just always keep a user's playlist_library on their user object if we ever get it back.
