### PR TITLE
[PAY-1465] Auto-nav to chat only when permitted

### DIFF
--- a/packages/mobile/src/components/block-messages-drawer/BlockMessagesDrawer.tsx
+++ b/packages/mobile/src/components/block-messages-drawer/BlockMessagesDrawer.tsx
@@ -16,7 +16,7 @@ import { spacing } from 'app/styles/spacing'
 import { useColor } from 'app/utils/theme'
 
 const { getUser } = cacheUsersSelectors
-const { getDoesBlockUser } = chatSelectors
+const { getDoesBlockUser, getCanCreateChat } = chatSelectors
 const { blockUser, unblockUser, createChat } = chatActions
 
 const BLOCK_MESSAGES_MODAL_NAME = 'BlockMessages'
@@ -112,11 +112,14 @@ export const BlockMessagesDrawer = () => {
   const user = useSelector((state) => getUser(state, { id: userId }))
   // Assuming blockees have already been fetched in ProfileActionsDrawer.
   const doesBlockUser = useSelector((state) => getDoesBlockUser(state, userId))
+  const { canCreateChat } = useSelector((state) =>
+    getCanCreateChat(state, { userId })
+  )
 
   const handleConfirmPress = useCallback(() => {
     if (doesBlockUser) {
       dispatch(unblockUser({ userId }))
-      if (shouldOpenChat) {
+      if (shouldOpenChat && canCreateChat) {
         dispatch(createChat({ userIds: [userId] }))
       }
     } else {
@@ -128,7 +131,7 @@ export const BlockMessagesDrawer = () => {
         visible: false
       })
     )
-  }, [dispatch, doesBlockUser, shouldOpenChat, userId])
+  }, [canCreateChat, dispatch, doesBlockUser, shouldOpenChat, userId])
 
   const handleCancelPress = useCallback(() => {
     dispatch(

--- a/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
+++ b/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
@@ -155,7 +155,7 @@ export const InboxUnavailableDrawer = () => {
     getData<'InboxUnavailable'>(state)
   )
   const user = useSelector((state) => getUser(state, { id: userId }))
-  const { callToAction } = useSelector((state) =>
+  const { canCreateChat, callToAction } = useSelector((state) =>
     getCanCreateChat(state, { userId })
   )
 
@@ -170,11 +170,11 @@ export const InboxUnavailableDrawer = () => {
 
   const handleUnblockPress = useCallback(() => {
     dispatch(unblockUser({ userId }))
-    if (shouldOpenChat) {
+    if (shouldOpenChat && canCreateChat) {
       dispatch(createChat({ userIds: [userId] }))
     }
     closeDrawer()
-  }, [dispatch, userId, shouldOpenChat, closeDrawer])
+  }, [dispatch, userId, shouldOpenChat, canCreateChat, closeDrawer])
 
   const handleLearnMorePress = useCallback(() => {
     // TODO: Link to blog


### PR DESCRIPTION
### Description
Previously we added a feature where if the user unblocks someone from the create chat list screen, they would automatically be taken to the chat. This is a problem if the user is actually not permitted for a different reason.
Say if A is tip-gated, then B blocks A. If B unblocks A, the drawer will immediately attempt to create a chat and nav to it. Instead it should just close the drawer and stay on the same screen, at which point A will be marked as tip-gated instead.
Solution is to re-check permissions before creating the chat.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

https://github.com/AudiusProject/audius-client/assets/3893871/e86eb0f1-f3c1-4be1-b599-7340b69087d1


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

