### PR TITLE
[PAY-1455] Optimize reactions perf (maybe)

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -629,6 +629,8 @@ export const ChatScreen = () => {
                     ) : null
                   }
                   scrollEnabled={popupMessageId == null}
+                  removeClippedSubviews
+                  windowSize={5}
                 />
               </View>
             )}


### PR DESCRIPTION
### Description

Changes two props on our flatlist:
- `removeClippedSubviews` - this detaches out of screen views from the main UI thread
- Set `windowSize = 5`. `windowSize` determines how many viewports (half above, half below) are still rendered invisibly before the views are culled. The default is 21, which is very high!

https://reactnative.dev/docs/optimizing-flatlist-configuration#windowsize

Anecdotally this seems to help chats with many reactions on iOS simulator, but need to test this on device more thoroughly to see if it actually does anything (or introduces any scary bugs).

I went down another rabbit hole earlier trying to have the reactions only render when the parent view itself is onscreen; this is actually quite easy with `onViewableItemsChanged` https://reactnative.dev/docs/flatlist#onviewableitemschanged , but it resulted in reactions popcorning in when scrolling through a chat. So trying the easy thing first with these props.

### Dragons

- Apparently `removeClippedSubviews` may introduce bugs. Need to test this on device more.
- `windowSize` may be too low and cause use to show blank sections of the list if you scroll too fast.

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

