### PR TITLE
Wait for libs to init before initting SDK

### DIFF
--- a/packages/web/src/services/audius-sdk/audiusSdk.ts
+++ b/packages/web/src/services/audius-sdk/audiusSdk.ts
@@ -19,6 +19,13 @@ const SDK_LOADED_EVENT_NAME = 'AUDIUS_SDK_LOADED'
 
 const initSdk = async () => {
   inProgress = true
+  // We wait for libs here because AudiusBackend needs to register a listener that
+  // will let AudiusAPIClient know that libs has loaded, and without it AudiusAPIClient
+  // retries failed requests ad nauseum with no delays or backoffs and won't ever get
+  // the signal that libs is loaded. It sucks. But the easiest thing to do right now...
+  console.debug('[audiusSdk] Waiting for libs init...')
+  await waitForLibsInit()
+  console.debug('[audiusSdk] Libs initted, initializing SDK...')
   const discoveryNodeSelector = await discoveryNodeSelectorService.getInstance()
   const audiusSdk = sdk({
     appName: 'audius-client',
@@ -67,13 +74,7 @@ const initSdk = async () => {
       }
     }
   })
-  // We wait for libs here because AudiusBackend needs to register a listener that
-  // will let AudiusAPIClient know that libs has loaded, and without it AudiusAPIClient
-  // retries failed requests ad nauseum with no delays or backoffs and won't ever get
-  // the signal that libs is loaded. It sucks. But the easiest thing to do right now...
-  console.debug('[audiusSdk] Waiting for libs init...')
-  await waitForLibsInit()
-  console.debug('[audiusSdk] Libs initted, SDK initted.')
+  console.debug('[audiusSdk] SDK initted.')
   window.audiusSdk = audiusSdk
   inProgress = false
   window.dispatchEvent(new CustomEvent(SDK_LOADED_EVENT_NAME))


### PR DESCRIPTION
### Description

SDK internally calls DN.select() here now : https://github.com/AudiusProject/audius-protocol/blob/f1a02996172e91f8880abbbe3c3588b08f5fa7dd/libs/src/sdk/services/StorageNodeSelector/StorageNodeSelector.ts#LL40C4-L40C4

so we have to wait for handlers

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

