### PR TITLE
Add overflow menu options for track list items on mobile

### DIFF
--- a/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
+++ b/packages/mobile/src/components/overflow-menu-drawer/TrackOverflowMenuDrawer.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react'
 
 import type { ID, OverflowActionCallbacks, CommonState } from '@audius/common'
 import {
+  shareModalUIActions,
   playbackPositionActions,
   FavoriteSource,
   FollowSource,
@@ -25,11 +26,12 @@ import { AppTabNavigationContext } from 'app/screens/app-screen'
 import { setVisibility } from 'app/store/drawers/slice'
 
 const { getUserId } = accountSelectors
+const { requestOpen: requestOpenShareModal } = shareModalUIActions
 const { getMobileOverflowModal } = mobileOverflowMenuUISelectors
 const { requestOpen: openAddToPlaylistModal } = addToPlaylistUIActions
 const { followUser, unfollowUser } = usersSocialActions
 const { setTrackPosition, clearTrackPosition } = playbackPositionActions
-const { repostTrack, undoRepostTrack, saveTrack, unsaveTrack, shareTrack } =
+const { repostTrack, undoRepostTrack, saveTrack, unsaveTrack } =
   tracksSocialActions
 const { getUser } = cacheUsersSelectors
 const { getTrack } = cacheTracksSelectors
@@ -79,7 +81,13 @@ const TrackOverflowMenuDrawer = ({ render }: Props) => {
     [OverflowAction.UNFAVORITE]: () =>
       dispatch(unsaveTrack(id, FavoriteSource.OVERFLOW)),
     [OverflowAction.SHARE]: () =>
-      dispatch(shareTrack(id, ShareSource.OVERFLOW)),
+      dispatch(
+        requestOpenShareModal({
+          type: 'track',
+          trackId: id,
+          source: ShareSource.OVERFLOW
+        })
+      ),
     [OverflowAction.ADD_TO_PLAYLIST]: () =>
       dispatch(openAddToPlaylistModal(id, title, is_unlisted)),
     [OverflowAction.VIEW_TRACK_PAGE]: () => {

--- a/packages/mobile/src/components/track-list/TrackListItem.tsx
+++ b/packages/mobile/src/components/track-list/TrackListItem.tsx
@@ -207,10 +207,12 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
 
   const {
     has_current_user_saved,
+    has_current_user_reposted,
     is_delete,
     is_unlisted,
     title,
     track_id,
+    owner_id,
     is_premium: isPremium
   } = track
   const { is_deactivated, name } = user
@@ -264,6 +266,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
   )
 
   const currentUserId = useSelector(getUserId)
+  const isOwner = currentUserId === owner_id
 
   const isLongFormContent =
     track.genre === Genre.PODCASTS || track.genre === Genre.AUDIOBOOKS
@@ -273,6 +276,17 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
 
   const handleOpenOverflowMenu = useCallback(() => {
     const overflowActions = [
+      OverflowAction.SHARE,
+      !isOwner
+        ? has_current_user_saved
+          ? OverflowAction.UNFAVORITE
+          : OverflowAction.FAVORITE
+        : null,
+      !isOwner
+        ? has_current_user_reposted
+          ? OverflowAction.UNREPOST
+          : OverflowAction.REPOST
+        : null,
       !isGatedContentEnabled || !isPremium
         ? OverflowAction.ADD_TO_PLAYLIST
         : null,
@@ -284,6 +298,7 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
           ? OverflowAction.MARK_AS_UNPLAYED
           : OverflowAction.MARK_AS_PLAYED
         : null,
+      isOwner ? OverflowAction.EDIT_TRACK : null,
       OverflowAction.VIEW_ARTIST_PAGE
     ].filter(removeNullable)
 
@@ -295,12 +310,15 @@ const TrackListItemComponent = (props: TrackListItemComponentProps) => {
       })
     )
   }, [
-    dispatch,
+    isOwner,
+    has_current_user_reposted,
+    has_current_user_saved,
+    isGatedContentEnabled,
+    isPremium,
     isNewPodcastControlsEnabled,
     isLongFormContent,
     playbackPositionInfo?.status,
-    isGatedContentEnabled,
-    isPremium,
+    dispatch,
     track_id
   ])
 


### PR DESCRIPTION
### Description
* Add overflow menu options to track list items on mobile to match the designs
* Fix the share option to open the share drawer properly

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

