### PR TITLE
[PAY-1421] Fix android reaction offsets

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -173,15 +173,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   }
 }))
 
-const measureView = (
-  viewRef: RefObject<View>,
-  measurementRef: MutableRefObject<number>
-) => {
-  viewRef.current?.measureInWindow((x, y, width, height) => {
-    measurementRef.current = y
-  })
-}
-
 type ContainerLayoutStatus = {
   top: number
   bottom: number
@@ -439,19 +430,13 @@ export const ChatScreen = () => {
       }
       // Measure position of selected message to create a copy of it on top
       // of the dimmed background inside the portal.
-      const { messageY, messageH } = await new Promise<{
-        messageY: number
-        messageH: number
-      }>((resolve) => {
-        messageRef.measureInWindow((x, y, width, height) => {
-          resolve({ messageY: y, messageH: height })
-        })
+      messageRef.measure((x, y, width, height, pageX, pageY) => {
+        // Need to subtract spacing(2) to account for padding in message View.
+        messageTop.current = pageY - spacing(2)
+        messageHeight.current = height
+        dispatch(setReactionsPopupMessageId({ messageId: id }))
+        light()
       })
-      // Need to subtract spacing(2) to account for padding in message View.
-      messageTop.current = messageY - spacing(2)
-      messageHeight.current = messageH
-      dispatch(setReactionsPopupMessageId({ messageId: id }))
-      light()
     },
     [canSendMessage, dispatch]
   )
@@ -501,8 +486,16 @@ export const ChatScreen = () => {
   )
 
   const measureChatContainerBottom = useCallback(() => {
-    measureView(composeRef, chatContainerBottom)
-  }, [])
+    composeRef.current?.measure((x, y, width, height, pageX, pageY) => {
+      chatContainerBottom.current = pageY
+    })
+  }, [composeRef, chatContainerBottom])
+
+  const measureChatContainerTop = useCallback(() => {
+    chatContainerRef.current?.measure((x, y, width, height, pageX, pageY) => {
+      chatContainerTop.current = pageY
+    })
+  }, [chatContainerRef, chatContainerTop])
 
   const handleOnContentSizeChanged = useCallback(
     (contentWidth, contentHeight) => {
@@ -567,14 +560,7 @@ export const ChatScreen = () => {
             />
           ) : null}
         </Portal>
-        <View
-          ref={chatContainerRef}
-          onLayout={() => {
-            chatContainerRef.current?.measureInWindow((x, y, width, height) => {
-              chatContainerTop.current = y
-            })
-          }}
-        >
+        <View ref={chatContainerRef} onLayout={measureChatContainerTop}>
           <KeyboardAvoidingView
             keyboardShowingOffset={
               hasCurrentlyPlayingTrack ? PLAY_BAR_HEIGHT : 0

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -428,6 +428,7 @@ export const ChatScreen = () => {
       if (!canSendMessage) {
         return
       }
+
       // Measure position of selected message to create a copy of it on top
       // of the dimmed background inside the portal.
       messageRef.measure((x, y, width, height, pageX, pageY) => {
@@ -489,13 +490,13 @@ export const ChatScreen = () => {
     composeRef.current?.measure((x, y, width, height, pageX, pageY) => {
       chatContainerBottom.current = pageY
     })
-  }, [composeRef, chatContainerBottom])
+  }, [])
 
   const measureChatContainerTop = useCallback(() => {
     chatContainerRef.current?.measure((x, y, width, height, pageX, pageY) => {
       chatContainerTop.current = pageY
     })
-  }, [chatContainerRef, chatContainerTop])
+  }, [])
 
   const handleOnContentSizeChanged = useCallback(
     (contentWidth, contentHeight) => {

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -1,4 +1,3 @@
-import type { MutableRefObject, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import type { ChatMessageWithExtras } from '@audius/common'

--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -21,7 +21,6 @@ import { ReactionList } from '../notifications-screen/Reaction'
 import { ChatMessageListItem } from './ChatMessageListItem'
 import { CopyMessagesButton } from './CopyMessagesButton'
 import {
-  REACTION_ANDROID_OFFSET,
   REACTION_CONTAINER_HEIGHT,
   REACTION_CONTAINER_TOP_OFFSET
 } from './constants'
@@ -109,13 +108,11 @@ type ReactionPopupProps = {
   onClose: () => void
 }
 
-const addAndroidOffset = (value: number) => value + REACTION_ANDROID_OFFSET
-
 export const ReactionPopup = ({
   chatId,
-  containerTop: containerTopProp,
-  containerBottom: containerBottomProp,
-  messageTop: messageTopProp,
+  containerTop,
+  containerBottom,
+  messageTop,
   messageHeight,
   isAuthor,
   message,
@@ -131,18 +128,6 @@ export const ReactionPopup = ({
   const selectedReaction = message.reactions?.find(
     (r) => r.user_id === userIdEncoded
   )?.reaction
-  const messageTop =
-    Platform.OS === 'android'
-      ? addAndroidOffset(messageTopProp)
-      : messageTopProp
-  const containerBottom =
-    Platform.OS === 'android'
-      ? addAndroidOffset(containerBottomProp)
-      : containerBottomProp
-  const containerTop =
-    Platform.OS === 'android'
-      ? addAndroidOffset(containerTopProp)
-      : containerTopProp
 
   const handleClose = useCallback(() => {
     // If the user selected a new reaction, dispatch with that reaction before closing

--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@audius/common'
 import { chatActions, encodeHashId, accountSelectors } from '@audius/common'
 import Clipboard from '@react-native-clipboard/clipboard'
-import { Dimensions, Pressable, Animated, Platform } from 'react-native'
+import { Dimensions, Pressable, Animated } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { usePopupAnimation } from 'app/hooks/usePopupAnimation'
@@ -45,6 +45,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     display: 'flex',
     zIndex: zIndex.CHAT_REACTIONS_POPUP_CLOSE_PRESSABLES,
     overflow: 'hidden'
+    // backgroundColor: 'red',
+    // opacity: 0.5
   },
   outerPressable: {
     position: 'absolute',

--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -45,8 +45,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     display: 'flex',
     zIndex: zIndex.CHAT_REACTIONS_POPUP_CLOSE_PRESSABLES,
     overflow: 'hidden'
-    // backgroundColor: 'red',
-    // opacity: 0.5
   },
   outerPressable: {
     position: 'absolute',


### PR DESCRIPTION
### Description

The real fix here was to switch to using `measure` and `pageY` everywhere. God knows why this is different on iOS vs Android. 

Made few cosmetic changes as well; removed the `measureView` abstraction, and the promise wrapping the message ref measurement.

Video of me not knowing how to use the Android emulator 😆:


https://github.com/AudiusProject/audius-client/assets/6780028/3186d262-4521-42b3-81f8-4232a9d1307e

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

