### PR TITLE
[PAY-1483] Patch RN to fix textinput multiline onchange not firing

### DIFF
--- a/packages/mobile/patches/README.md
+++ b/packages/mobile/patches/README.md
@@ -21,3 +21,5 @@ Patch to support full screen swipe gestures in native stack. and navigation draw
 ## react-native+0.71.8.patch
 
 Patch to prevent a freezing issue on some Android 13 devices when using an inverted FlatList with a lot of text or any animations. See https://github.com/facebook/react-native/issues/35350 and https://github.com/facebook/react-native/issues/30034
+
+Patch to fix an issue with TextInput not sending onChange events on the first character entered, when multiline is set to true. See https://github.com/facebook/react-native/issues/37784

--- a/packages/mobile/patches/react-native+0.71.8.patch
+++ b/packages/mobile/patches/react-native+0.71.8.patch
@@ -40,6 +40,35 @@ index e948a85..0814a98 100644
    horizontallyInverted: {
      transform: [{scaleX: -1}],
    },
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+index 1c8f8e0..0542362 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+@@ -256,21 +256,21 @@ - (BOOL)textView:(__unused UITextView *)textView shouldChangeTextInRange:(NSRang
+ 
+ - (void)textViewDidChange:(__unused UITextView *)textView
+ {
+-  if (_ignoreNextTextInputCall) {
++  if (_ignoreNextTextInputCall && [_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+     _ignoreNextTextInputCall = NO;
+     return;
+   }
++  _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;
+   _textDidChangeIsComing = NO;
+   [_backedTextInputView.textInputDelegate textInputDidChange];
+ }
+ 
+ - (void)textViewDidChangeSelection:(__unused UITextView *)textView
+ {
+-  if (_lastStringStateWasUpdatedWith && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
++  if (![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+     [self textViewDidChange:_backedTextInputView];
+     _ignoreNextTextInputCall = YES;
+   }
+-  _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;
+   [self textViewProbablyDidChangeSelection];
+ }
+ 
 diff --git a/node_modules/react-native/scripts/.packager.env b/node_modules/react-native/scripts/.packager.env
 new file mode 100644
 index 0000000..361f5fb


### PR DESCRIPTION
### Description
Discovered an RN bug with TextInput where `multiline` was set to true - `onChange` would not fire for the first character entered into the textinput.

See https://github.com/facebook/react-native/issues/37784.

### Dragons

The patch reverts a commit that is to fix a different issue: https://github.com/facebook/react-native/issues/36494
Tested the repro steps in that issue and didn't notice anything broken.

### How Has This Been Tested?

Local ios stage

https://github.com/AudiusProject/audius-client/assets/3893871/163a15f5-beb0-4213-bd11-430a31b8223e


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

