### PR TITLE
[PAY-1468] Fix mobile chats copy message button

### DIFF
--- a/packages/mobile/src/screens/chat-screen/CopyMessagesButton.tsx
+++ b/packages/mobile/src/screens/chat-screen/CopyMessagesButton.tsx
@@ -1,12 +1,9 @@
-import { useState } from 'react'
-
-import { Text, Pressable, View } from 'react-native'
+import { Text, TouchableOpacity } from 'react-native'
 
 import IconCopy from 'app/assets/images/iconCopy2.svg'
 import { makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
-import { zIndex } from 'app/utils/zIndex'
 
 const messages = {
   copy: 'Copy Message'
@@ -15,18 +12,9 @@ const messages = {
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   copyPressableContainer: {
     position: 'absolute',
-    dipslay: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing(1.5),
-    zIndex: zIndex.CHAT_REACTIONS_POPUP_CONTENT
-  },
-  copyAnimatedContainer: {
-    dipslay: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing(1.5),
-    zIndex: zIndex.CHAT_REACTIONS_POPUP_CONTENT
+    gap: spacing(1.5)
   },
   copyText: {
     fontSize: typography.fontSize.xs,
@@ -51,14 +39,11 @@ export const CopyMessagesButton = ({
   onPress
 }: CopyMessagesButtonProps) => {
   const styles = useStyles()
-  const { white } = useThemeColors()
-  const [isPressed, setIsPressed] = useState(false)
+  const { staticWhite } = useThemeColors()
 
   return (
-    <Pressable
+    <TouchableOpacity
       onPress={onPress}
-      onPressIn={() => setIsPressed(true)}
-      onPressOut={() => setIsPressed(false)}
       style={[
         styles.copyPressableContainer,
         {
@@ -68,12 +53,8 @@ export const CopyMessagesButton = ({
         }
       ]}
     >
-      <View
-        style={[styles.copyAnimatedContainer, { opacity: isPressed ? 0.5 : 1 }]}
-      >
-        <IconCopy fill={white} height={12} width={12} />
-        <Text style={styles.copyText}>{messages.copy}</Text>
-      </View>
-    </Pressable>
+      <IconCopy fill={staticWhite} height={12} width={12} />
+      <Text style={styles.copyText}>{messages.copy}</Text>
+    </TouchableOpacity>
   )
 }

--- a/packages/mobile/src/screens/chat-screen/CopyMessagesButton.tsx
+++ b/packages/mobile/src/screens/chat-screen/CopyMessagesButton.tsx
@@ -10,7 +10,7 @@ const messages = {
 }
 
 const useStyles = makeStyles(({ spacing, palette, typography }) => ({
-  copyPressableContainer: {
+  root: {
     position: 'absolute',
     flexDirection: 'row',
     alignItems: 'center',
@@ -45,7 +45,7 @@ export const CopyMessagesButton = ({
     <TouchableOpacity
       onPress={onPress}
       style={[
-        styles.copyPressableContainer,
+        styles.root,
         {
           top: messageTop - containerTop + messageHeight + spacing(5),
           right: isAuthor ? spacing(6) : undefined,

--- a/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
+++ b/packages/mobile/src/screens/chat-screen/ReactionPopup.tsx
@@ -42,7 +42,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   },
   popupContainer: {
     position: 'absolute',
-    display: 'flex',
     zIndex: zIndex.CHAT_REACTIONS_POPUP_CLOSE_PRESSABLES,
     overflow: 'hidden'
   },
@@ -75,25 +74,8 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
   emoji: {
     height: spacing(17)
   },
-  copyPressableContainer: {
-    position: 'absolute',
-    dipslay: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing(1.5),
+  copyContainer: {
     zIndex: zIndex.CHAT_REACTIONS_POPUP_CONTENT
-  },
-  copyAnimatedContainer: {
-    dipslay: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing(1.5),
-    zIndex: zIndex.CHAT_REACTIONS_POPUP_CONTENT
-  },
-  copyText: {
-    fontSize: typography.fontSize.xs,
-    fontFamily: typography.fontByWeight.bold,
-    color: palette.white
   }
 }))
 
@@ -217,7 +199,9 @@ export const ReactionPopup = ({
           ]}
           handleClosePopup={handleClosePopup}
         />
-        <Animated.View style={{ opacity: otherOpacityAnim }}>
+        <Animated.View
+          style={[styles.copyContainer, { opacity: otherOpacityAnim }]}
+        >
           <CopyMessagesButton
             isAuthor={isAuthor}
             messageTop={messageTop}


### PR DESCRIPTION
### Description
The fix was to add zIndex to the correct parent View.

Bonus - use `staticWhite` so copy message button is always white in other themes.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

https://github.com/AudiusProject/audius-client/assets/3893871/9bf099d7-2816-43a6-ac15-070e178c36d6


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

