### PR TITLE
[PAY-1498][PAY-1477] Misc mobile DMs UI Fixes

### DIFF
--- a/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
+++ b/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
@@ -100,12 +100,15 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   }
 }))
 
-const DrawerContent = () => {
+type DrawerContentProps = {
+  data: ReturnType<typeof useDrawer<'InboxUnavailable'>>['data']
+}
+
+const DrawerContent = ({ data }: DrawerContentProps) => {
   const styles = useStyles()
   const dispatch = useDispatch()
   const navigation = useNavigation()
 
-  const { data } = useDrawer('InboxUnavailable')
   const { userId, shouldOpenChat } = data
   const user = useSelector((state) => getUser(state, { id: userId }))
   const { canCreateChat, callToAction } = useSelector((state) =>
@@ -233,6 +236,11 @@ export const InboxUnavailableDrawer = () => {
   const styles = useStyles()
   const neutralLight2 = useColor('neutralLight2')
 
+  // Select data outside of drawer and use it to conditionally render content,
+  // preventing a race condition with the store clearly before drawer
+  // is dismissed
+  const { data } = useDrawer('InboxUnavailable')
+
   return (
     <NativeDrawer drawerName={INBOX_UNAVAILABLE_MODAL_NAME}>
       <View style={styles.drawer}>
@@ -241,7 +249,7 @@ export const InboxUnavailableDrawer = () => {
           <Text style={styles.title}>{messages.title}</Text>
         </View>
         <View style={styles.border} />
-        <DrawerContent />
+        {data ? <DrawerContent data={data} /> : null}
       </View>
     </NativeDrawer>
   )

--- a/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
+++ b/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
@@ -237,7 +237,7 @@ export const InboxUnavailableDrawer = () => {
   const neutralLight2 = useColor('neutralLight2')
 
   // Select data outside of drawer and use it to conditionally render content,
-  // preventing a race condition with the store clearly before drawer
+  // preventing a race condition with the store clears before drawer
   // is dismissed
   const { data } = useDrawer('InboxUnavailable')
 

--- a/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
+++ b/packages/mobile/src/components/inbox-unavailable-drawer/InboxUnavailableDrawer.tsx
@@ -91,12 +91,8 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
     height: spacing(12)
   },
   buttonText: {
-    color: palette.neutral,
     fontSize: typography.fontSize.large,
     fontFamily: typography.fontByWeight.bold
-  },
-  buttonTextWhite: {
-    color: palette.white
   },
   border: {
     borderBottomWidth: 1,
@@ -194,7 +190,7 @@ const DrawerContent = () => {
             iconPosition='left'
             styles={{
               root: styles.button,
-              text: [styles.buttonText, styles.buttonTextWhite]
+              text: styles.buttonText
             }}
             fullWidth
           />
@@ -211,7 +207,7 @@ const DrawerContent = () => {
             variant={'primary'}
             styles={{
               root: styles.button,
-              text: [styles.buttonText, styles.buttonTextWhite]
+              text: styles.buttonText
             }}
             fullWidth
           />


### PR DESCRIPTION
### Description

- Fixes onPress colors for `InboxUnavailableDrawer` by default button text colors
- Fixes crash on slowly dragging to dismiss said drawer
<img width="548" alt="Screen Shot 2023-06-20 at 7 33 52 PM" src="https://github.com/AudiusProject/audius-client/assets/6780028/42a7d39e-aa39-4f44-9600-a130243eb1e0">
<img width="550" alt="Screen Shot 2023-06-20 at 7 35 17 PM" src="https://github.com/AudiusProject/audius-client/assets/6780028/cbd494de-667a-43bf-ad94-c890b55aadac">



### Dragons

Not sure if there was a reason we were specifically styling the text color versus just falling back on the variant.


*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

