### PR TITLE
[PAY-1412] Reset player state on app load

### DIFF
--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { accountSelectors, chatActions, Status } from '@audius/common'
+import {
+  accountSelectors,
+  chatActions,
+  playerActions,
+  Status
+} from '@audius/common'
 import type { NavigatorScreenParams } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { getHasCompletedAccount } from 'common/store/pages/signon/selectors'
@@ -24,6 +29,7 @@ import { StatusBar } from './StatusBar'
 const { getAccountStatus } = accountSelectors
 const { fetchMoreChats, fetchUnreadMessagesCount, connect, disconnect } =
   chatActions
+const { reset } = playerActions
 
 export type RootScreenParamList = {
   HomeStack: NavigatorScreenParams<{
@@ -76,6 +82,14 @@ export const RootScreen = ({
       dispatch(disconnect())
     }
   }, [dispatch, isLoaded, accountStatus])
+
+  // Reset the player when the app is loaded for the first time. Fixes an issue
+  // where after a crash, the player would persist the previous state. PAY-1412.
+  useEffect(() => {
+    if (isLoaded) {
+      dispatch(playerActions.reset({ shouldAutoplay: false }))
+    }
+  }, [isLoaded, dispatch])
 
   const handleSplashScreenDismissed = useCallback(() => {
     setIsSplashScreenDismissed(true)

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -67,9 +67,12 @@ export const RootScreen = ({
       !isLoaded &&
       (accountStatus === Status.SUCCESS || accountStatus === Status.ERROR)
     ) {
+      // Reset the player when the app is loaded for the first time. Fixes an issue
+      // where after a crash, the player would persist the previous state. PAY-1412.
+      dispatch(reset({ shouldAutoplay: false }))
       setIsLoaded(true)
     }
-  }, [accountStatus, setIsLoaded, isLoaded])
+  }, [accountStatus, setIsLoaded, isLoaded, dispatch])
 
   // Connect to chats websockets and prefetch chats
   useEffect(() => {
@@ -82,14 +85,6 @@ export const RootScreen = ({
       dispatch(disconnect())
     }
   }, [dispatch, isLoaded, accountStatus])
-
-  // Reset the player when the app is loaded for the first time. Fixes an issue
-  // where after a crash, the player would persist the previous state. PAY-1412.
-  useEffect(() => {
-    if (isLoaded) {
-      dispatch(reset({ shouldAutoplay: false }))
-    }
-  }, [isLoaded, dispatch])
 
   const handleSplashScreenDismissed = useCallback(() => {
     setIsSplashScreenDismissed(true)

--- a/packages/mobile/src/screens/root-screen/RootScreen.tsx
+++ b/packages/mobile/src/screens/root-screen/RootScreen.tsx
@@ -87,7 +87,7 @@ export const RootScreen = ({
   // where after a crash, the player would persist the previous state. PAY-1412.
   useEffect(() => {
     if (isLoaded) {
-      dispatch(playerActions.reset({ shouldAutoplay: false }))
+      dispatch(reset({ shouldAutoplay: false }))
     }
   }, [isLoaded, dispatch])
 


### PR DESCRIPTION
### Description
Hard to repro this bug but I think this should fix it. The theory is that after a crash, the player state from before the crash was persisted, which caused `getHasTrack` player selector to erroneously report `true`.

Would like to get this in for the QA and see if we get any repros of the bug.

### Dragons

Adding stuff to root screen!

### How Has This Been Tested?

Hard to prove this makes the bug go away, but I did confirm this action only runs once on startup and that normal app behavior is unaffected.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

