### PR TITLE
Mobile chats recalculate container bottom on keyboard shown

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -592,6 +592,7 @@ export const ChatScreen = () => {
               getKeyboardAvoidingPlaybarAwareStyle()
             ]}
             onKeyboardHide={measureChatContainerBottom}
+            onKeyboardShow={measureChatContainerBottom}
           >
             {isLoading ? (
               <View style={styles.loadingSpinnerContainer}>


### PR DESCRIPTION
### Description
The bug: with keyboard open, if the user longpresses a message and opens the reaction popup, the message will display over the textinput below it.
![Simulator Screenshot - iPhone 14 Pro - 2023-06-23 at 16 17 21](https://github.com/AudiusProject/audius-client/assets/3893871/c304252e-3278-4ab8-9cbd-5a91006417b8)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

![Simulator Screenshot - iPhone 14 Pro - 2023-06-23 at 16 17 34](https://github.com/AudiusProject/audius-client/assets/3893871/d397a4e1-7756-4c38-8f45-9e608a0b8d73)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

