### PR TITLE
[plat-1085] persist track and collection is_hidden when saving or rep…

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -994,7 +994,7 @@ export const audiusBackend = ({
 
   async function repostTrack(
     trackId: ID,
-    metadata?: { is_repost_of_repost: boolean }
+    metadata?: { is_repost_of_repost: boolean; is_hidden: boolean }
   ) {
     try {
       return await audiusLibs.EntityManager.repostTrack(
@@ -1018,7 +1018,7 @@ export const audiusBackend = ({
 
   async function repostCollection(
     playlistId: ID,
-    metadata?: { is_repost_of_repost: boolean }
+    metadata?: { is_repost_of_repost: boolean; is_hidden: boolean }
   ) {
     try {
       return audiusLibs.EntityManager.repostPlaylist(
@@ -1684,7 +1684,7 @@ export const audiusBackend = ({
   // Favoriting a track
   async function saveTrack(
     trackId: ID,
-    metadata?: { is_save_of_repost: boolean }
+    metadata?: { is_save_of_repost: boolean; is_hidden: boolean }
   ) {
     try {
       return await audiusLibs.EntityManager.saveTrack(
@@ -1713,7 +1713,7 @@ export const audiusBackend = ({
   // Favorite a playlist
   async function saveCollection(
     playlistId: ID,
-    metadata?: { is_save_of_repost: boolean }
+    metadata?: { is_save_of_repost: boolean; is_hidden: boolean }
   ) {
     try {
       return await audiusLibs.EntityManager.savePlaylist(

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -87,8 +87,11 @@ export function* repostCollectionAsync(
     ? // If we're on the feed, and someone i follow has
       // reposted the content i am reposting,
       // is_repost_of_repost is true
-      { is_repost_of_repost: collection.followee_reposts.length !== 0 }
-    : { is_repost_of_repost: false }
+      {
+        is_hidden: collection.is_private,
+        is_repost_of_repost: collection.followee_reposts.length !== 0
+      }
+    : { is_hidden: collection.is_private, is_repost_of_repost: false }
 
   yield* call(
     confirmRepostCollection,
@@ -115,7 +118,7 @@ export function* confirmRepostCollection(
   ownerId: ID,
   collectionId: ID,
   user: User,
-  metadata: { is_repost_of_repost: boolean }
+  metadata: { is_repost_of_repost: boolean; is_hidden: boolean }
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(
@@ -349,8 +352,11 @@ export function* saveCollectionAsync(
   const saveMetadata = action.isFeed
     ? // If we're on the feed, and the content
       // being saved is a repost
-      { is_save_of_repost: collection.followee_reposts.length !== 0 }
-    : { is_save_of_repost: false }
+      {
+        is_hidden: collection.is_private,
+        is_save_of_repost: collection.followee_reposts.length !== 0
+      }
+    : { is_hidden: collection.is_private, is_save_of_repost: false }
   yield* call(
     confirmSaveCollection,
     collection.playlist_owner_id,
@@ -401,7 +407,7 @@ export function* saveCollectionAsync(
 export function* confirmSaveCollection(
   ownerId: ID,
   collectionId: ID,
-  metadata?: { is_save_of_repost: boolean }
+  metadata?: { is_save_of_repost: boolean; is_hidden: boolean }
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(

--- a/packages/web/src/common/store/social/tracks/sagas.ts
+++ b/packages/web/src/common/store/social/tracks/sagas.ts
@@ -77,8 +77,11 @@ export function* repostTrackAsync(
     ? // If we're on the feed, and someone i follow has
       // reposted the content i am reposting,
       // is_repost_of_repost is true
-      { is_repost_of_repost: track.followee_reposts.length !== 0 }
-    : { is_repost_of_repost: false }
+      {
+        is_hidden: track.is_unlisted,
+        is_repost_of_repost: track.followee_reposts.length !== 0
+      }
+    : { is_hidden: track.is_unlisted, is_repost_of_repost: false }
   yield* call(confirmRepostTrack, action.trackId, user, repostMetadata)
 
   const eagerlyUpdatedMetadata: Partial<Track> = {
@@ -152,7 +155,7 @@ export function* repostTrackAsync(
 export function* confirmRepostTrack(
   trackId: ID,
   user: User,
-  metadata?: { is_repost_of_repost: boolean }
+  metadata?: { is_repost_of_repost: boolean; is_hidden: boolean }
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(
@@ -356,8 +359,11 @@ export function* saveTrackAsync(
   const saveMetadata = action.isFeed
     ? // If we're on the feed, and the content
       // being saved is a repost
-      { is_save_of_repost: track.followee_reposts.length !== 0 }
-    : { is_save_of_repost: false }
+      {
+        is_hidden: track.is_unlisted,
+        is_save_of_repost: track.followee_reposts.length !== 0
+      }
+    : { is_hidden: track.is_unlisted, is_save_of_repost: false }
   yield* call(confirmSaveTrack, action.trackId, user, saveMetadata)
 
   const eagerlyUpdatedMetadata: Partial<Track> = {
@@ -423,7 +429,7 @@ export function* saveTrackAsync(
 export function* confirmSaveTrack(
   trackId: ID,
   user: User,
-  metadata?: { is_save_of_repost: boolean }
+  metadata?: { is_save_of_repost: boolean; is_hidden: boolean }
 ) {
   const audiusBackendInstance = yield* getContext('audiusBackendInstance')
   yield* put(


### PR DESCRIPTION

### Description
passes whether a track or collection is private/unlisted when saving or reposting. as of right now, users can favorite and repost unlisted tracks via the play bar, which should not be allowed. we want to stop transactions where users are favoriting or reposting unlisted items so passing this metadata lets entity manager decide whether to continue the transaction.

follows a very similar pattern to is repost of repost

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

going to test locally and then e2e against stage 
### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

