### PR TITLE
Fix entity button widths

### DIFF
--- a/packages/web/src/components/collection/desktop/utils.ts
+++ b/packages/web/src/components/collection/desktop/utils.ts
@@ -1,6 +1,6 @@
 export const BUTTON_COLLAPSE_WIDTHS = {
-  first: 1148,
-  second: 1184,
-  third: 1274,
-  fourth: 1374
+  first: 1095,
+  second: 1190,
+  third: 1286,
+  fourth: 1386
 }

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -1,6 +1,6 @@
 .giantTrackTile {
   width: 100%;
-  max-width: 960px;
+  max-width: 1080px;
   border-radius: 12px;
   overflow: hidden;
   background-color: var(--white);


### PR DESCRIPTION
### Description

Fixes issue where track-page action buttons get cut off when a user has favorited and/or reposted it.
Also improves distances where the buttons collapse