### PR TITLE
[plat-1085] disable fav and repost on hidden tracks in play bar

### DIFF
--- a/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
+++ b/packages/mobile/src/components/now-playing-drawer/PlayBar.tsx
@@ -111,7 +111,9 @@ export const PlayBar = (props: PlayBarProps) => {
   const renderFavoriteButton = () => {
     return (
       <FavoriteButton
-        isDisabled={currentUser?.user_id === track?.owner_id}
+        isDisabled={
+          currentUser?.user_id === track?.owner_id || track?.is_unlisted
+        }
         onPress={onPressFavoriteButton}
         isActive={track?.has_current_user_saved ?? false}
         wrapperStyle={styles.icon}

--- a/packages/web/src/components/play-bar/desktop/PlayBar.js
+++ b/packages/web/src/components/play-bar/desktop/PlayBar.js
@@ -472,7 +472,7 @@ class PlayBar extends Component {
                     aria-label={repostText}
                     onClick={() => this.onToggleRepost(reposted, trackId)}
                     isActive={reposted}
-                    isDisabled={isFavoriteAndRepostDisabled}
+                    isDisabled={isFavoriteAndRepostDisabled || isTrackUnlisted}
                     isDarkMode={shouldShowDark(theme)}
                     isMatrixMode={matrix}
                   />
@@ -489,7 +489,7 @@ class PlayBar extends Component {
               >
                 <span>
                   <FavoriteButton
-                    isDisabled={isFavoriteAndRepostDisabled}
+                    isDisabled={isFavoriteAndRepostDisabled || isTrackUnlisted}
                     isMatrixMode={matrix}
                     isActive={favorited}
                     isDarkMode={shouldShowDark(theme)}

--- a/packages/web/src/components/play-bar/mobile/PlayBar.tsx
+++ b/packages/web/src/components/play-bar/mobile/PlayBar.tsx
@@ -139,6 +139,7 @@ const PlayBar = ({
         <TrackingBar percentComplete={percentComplete} />
         <div className={styles.controls}>
           <FavoriteButton
+            isDisabled={track?.is_unlisted}
             onClick={toggleFavorite}
             isDarkMode={isDarkMode()}
             isMatrixMode={isMatrix()}


### PR DESCRIPTION
### Description
Disable favorite and repost buttons in the play bar for hidden tracks. they should not be able to be liked/favorited, and there is no ui button for it on the page, but there is a way to do so via the play bar currently. this diff disables the buttons in the play bar

This change is only for tracks since you can't even view private playlists via links as of right now.

### Dragons

### How Has This Been Tested?

tested via ui, will attach video


https://github.com/AudiusProject/audius-client/assets/109105561/5556dfd4-8f29-4344-b4a5-3483c8eb8610


