### PR TITLE
[C-2787] Reregister device-token on app startup

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -64,7 +64,8 @@ import {
   Entity,
   Achievement,
   Notification,
-  IdentityNotification
+  IdentityNotification,
+  PushNotifications
 } from '../../store'
 import { CIDCache } from '../../store/cache/CIDCache'
 import {
@@ -2812,9 +2813,10 @@ export const audiusBackend = ({
         }
       })
         .then((res) => res.json())
-        .then((res) => res.settings)
+        .then((res: { settings: PushNotifications }) => res.settings)
     } catch (e) {
       console.error(e)
+      return null
     }
   }
 

--- a/packages/mobile/src/components/image/FastImage.tsx
+++ b/packages/mobile/src/components/image/FastImage.tsx
@@ -15,12 +15,13 @@ export type ImageProps = Omit<FastImageProps, 'source'>
 export const FastImage = (props: FastImageProps) => {
   const { source, priority, ...other } = props
 
-  const imageSource =
-    typeof source === 'number'
-      ? source
-      : Array.isArray(source)
-      ? { uri: source[0].uri, priority }
-      : { uri: source.uri, priority }
+  const imageSource = !source
+    ? source
+    : typeof source === 'number'
+    ? source
+    : Array.isArray(source)
+    ? { uri: source[0].uri, priority }
+    : { uri: source.uri, priority }
 
   return <RNFastImage source={imageSource} {...other} />
 }

--- a/packages/mobile/src/store/settings/sagas.ts
+++ b/packages/mobile/src/store/settings/sagas.ts
@@ -26,6 +26,20 @@ export function* deregisterPushNotifications() {
   yield* call(audiusBackendInstance.deregisterDeviceToken, token)
 }
 
+/*
+ * Runs once at startup and re-registers the device-token in case it changes
+ */
+function* reregisterDeviceToken() {
+  const audiusBackend = yield* getContext('audiusBackendInstance')
+  const hasPermission = yield* call([PushNotifications, 'hasPermission'])
+  console.log({ hasPermission })
+  if (hasPermission) {
+    const { token, os } = yield* call([PushNotifications, 'getToken'])
+    console.log({ token, os })
+    yield* call(audiusBackend.registerDeviceToken, token, os)
+  }
+}
+
 function* enablePushNotifications() {
   yield* call([PushNotifications, 'requestPermission'])
   const { token, os } = yield* call([PushNotifications, 'getToken'])
@@ -71,9 +85,9 @@ function* watchGetPushNotificationSettings() {
   yield* takeEvery(actions.GET_PUSH_NOTIFICATION_SETTINGS, function* () {
     yield* call(waitForRead)
     try {
-      const settings = (yield* call(
+      const settings = yield* call(
         audiusBackendInstance.getPushNotificationSettings
-      )) as TPushNotifications
+      )
       let pushNotificationSettings = mapValues(
         initialState.pushNotifications,
         function (_val: boolean) {
@@ -157,6 +171,7 @@ function* watchRequestPushNotificationPermissions() {
 export default function sagas() {
   return [
     ...commonSettingsSagas(),
+    reregisterDeviceToken,
     watchGetPushNotificationSettings,
     watchUpdatePushNotificationSettings,
     watchRequestPushNotificationPermissions

--- a/packages/mobile/src/store/settings/sagas.ts
+++ b/packages/mobile/src/store/settings/sagas.ts
@@ -32,10 +32,8 @@ export function* deregisterPushNotifications() {
 function* reregisterDeviceToken() {
   const audiusBackend = yield* getContext('audiusBackendInstance')
   const hasPermission = yield* call([PushNotifications, 'hasPermission'])
-  console.log({ hasPermission })
   if (hasPermission) {
     const { token, os } = yield* call([PushNotifications, 'getToken'])
-    console.log({ token, os })
     yield* call(audiusBackend.registerDeviceToken, token, os)
   }
 }


### PR DESCRIPTION
### Description

At app startup, reregister device token if notification permissions are enabled. This will prevent cases where a device id changes causing users to not receive notifications.
- Also improves some typing
- Also fixes issue with fast-image, there are some obscure cases where uri is undefined leading to app-ending bug