### PR TITLE
[PAY-1535] Refresh chat messages on render and pull to refresh on chats list

### DIFF
--- a/packages/common/src/store/pages/chat/sagas.ts
+++ b/packages/common/src/store/pages/chat/sagas.ts
@@ -37,9 +37,11 @@ const {
   fetchUnreadMessagesCountFailed,
   goToChat,
   fetchChatIfNecessary,
+  fetchLatestChats,
   fetchMoreChats,
   fetchMoreChatsSucceeded,
   fetchMoreChatsFailed,
+  fetchLatestMessages,
   fetchMoreMessages,
   fetchMoreMessagesSucceeded,
   fetchMoreMessagesFailed,
@@ -74,6 +76,9 @@ const {
   getOtherChatUsers
 } = chatSelectors
 const { toast } = toastActions
+
+const CHAT_PAGE_SIZE = 30
+const MESSAGES_PAGE_SIZE = 50
 
 /**
  * Helper to dispatch actions for fetching chat users
@@ -111,6 +116,49 @@ function* doFetchUnreadMessagesCount() {
   }
 }
 
+/**
+ * Gets all chats fresher than what we currently have
+ */
+function* doFetchLatestChats() {
+  try {
+    const audiusSdk = yield* getContext('audiusSdk')
+    const sdk = yield* call(audiusSdk)
+    const summary = yield* select(getChatsSummary)
+    let before: string | undefined
+    let hasMoreChats = true
+    let data: UserChat[] = []
+    let firstResponse: TypedCommsResponse<UserChat[]> | undefined
+    while (hasMoreChats) {
+      const response = yield* call([sdk.chats, sdk.chats.getAll], {
+        before,
+        after: summary?.next_cursor,
+        limit: CHAT_PAGE_SIZE
+      })
+      hasMoreChats = response.data.length > 0
+      before = summary?.prev_cursor
+      data = data.concat(response.data)
+      if (!firstResponse) {
+        firstResponse = response
+      }
+    }
+    yield* fetchUsersForChats(data)
+    yield* put(
+      fetchMoreChatsSucceeded({
+        ...firstResponse,
+        data
+      })
+    )
+  } catch (e) {
+    console.error('fetchLatestChatsFailed', e)
+    yield* put(fetchMoreChatsFailed())
+    const reportToSentry = yield* getContext('reportToSentry')
+    reportToSentry({
+      level: ErrorLevel.Error,
+      error: e as Error
+    })
+  }
+}
+
 function* doFetchMoreChats() {
   try {
     const audiusSdk = yield* getContext('audiusSdk')
@@ -119,7 +167,7 @@ function* doFetchMoreChats() {
     const before = summary?.prev_cursor
     const response = yield* call([sdk.chats, sdk.chats.getAll], {
       before,
-      limit: 30
+      limit: CHAT_PAGE_SIZE
     })
     yield* fetchUsersForChats(response.data)
     yield* put(fetchMoreChatsSucceeded(response))
@@ -134,6 +182,75 @@ function* doFetchMoreChats() {
   }
 }
 
+/**
+ * Gets all messages newer than what we currently have
+ */
+function* doFetchLatestMessages(
+  action: ReturnType<typeof fetchLatestMessages>
+) {
+  const { chatId } = action.payload
+  try {
+    const audiusSdk = yield* getContext('audiusSdk')
+    const sdk = yield* call(audiusSdk)
+
+    // Update the chat too to keep everything in sync
+    yield* call(doFetchChat, { chatId })
+    const chat = yield* select((state) => getChat(state, chatId))
+    const after = chat?.messagesSummary?.next_cursor
+
+    let hasMoreUnread = true
+    let data: ChatMessage[] = []
+    let before: string | undefined
+    let firstResponse: TypedCommsResponse<ChatMessage[]> | undefined
+    while (hasMoreUnread) {
+      // This will get all messages sent after what we currently got, starting at the most recent,
+      // and batching by MESSAGE_PAGE_SIZE. Sends one extra request to get the 0 response but oh well
+      const response = yield* call([sdk.chats, sdk.chats.getMessages], {
+        chatId,
+        before,
+        after: chat?.messagesSummary?.next_cursor,
+        limit: MESSAGES_PAGE_SIZE
+      })
+      data = data.concat(response.data)
+      hasMoreUnread =
+        // If we have no more messages with our after filter, we're done
+        (!!after && response.data.length > 0) ||
+        // If we don't have an after filter, eg on first messages load, then go until we get all the unreads
+        (!after &&
+          !!chat?.unread_message_count &&
+          chat.unread_message_count >
+            (response.summary?.next_count ?? 0) + data.length)
+      before = response.summary?.prev_cursor
+      if (!firstResponse) {
+        firstResponse = response
+      }
+    }
+    yield* put(
+      fetchMoreMessagesSucceeded({
+        chatId,
+        response: {
+          ...firstResponse,
+          data
+        }
+      })
+    )
+  } catch (e) {
+    console.error('fetchLatestChatMessagesFailed', e)
+    yield* put(fetchMoreMessagesFailed({ chatId }))
+    const reportToSentry = yield* getContext('reportToSentry')
+    reportToSentry({
+      level: ErrorLevel.Error,
+      error: e as Error,
+      additionalInfo: {
+        chatId
+      }
+    })
+  }
+}
+
+/**
+ * Get older messages than what we currently have for a chat
+ */
 function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
   const { chatId } = action.payload
   try {
@@ -150,20 +267,20 @@ function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
     let hasMoreUnread = true
     let data: ChatMessage[] = []
     while (hasMoreUnread) {
-      const limit = 10
-      const response = yield* call([sdk.chats, sdk.chats!.getMessages], {
+      const response = yield* call([sdk.chats, sdk.chats.getMessages], {
         chatId,
         before,
-        limit
+        limit: MESSAGES_PAGE_SIZE
       })
       // Only save the last response summary. Pagination is one-way
       lastResponse = response
       data = data.concat(response.data)
       // If the unread count is greater than the previous fetched messages (next_cursor)
-      // plus this batch (limit), we should keep fetching
+      // plus this batch, we should keep fetching
       hasMoreUnread =
         !!chat?.unread_message_count &&
-        chat.unread_message_count > (response.summary?.next_count ?? 0) + limit
+        chat.unread_message_count >
+          (response.summary?.next_count ?? 0) + data.length
       before = response.summary?.prev_cursor
     }
     if (!lastResponse) {
@@ -179,7 +296,7 @@ function* doFetchMoreMessages(action: ReturnType<typeof fetchMoreMessages>) {
       })
     )
   } catch (e) {
-    console.error('fetchNewChatMessagesFailed', e)
+    console.error('fetchMoreChatMessagesFailed', e)
     yield* put(fetchMoreMessagesFailed({ chatId }))
     const reportToSentry = yield* getContext('reportToSentry')
     reportToSentry({
@@ -631,11 +748,19 @@ function* watchSendMessage() {
   yield takeEvery(sendMessage, doSendMessage)
 }
 
-function* watchFetchChats() {
+function* watchFetchLatestChats() {
+  yield takeLatest(fetchLatestChats, doFetchLatestChats)
+}
+
+function* watchFetchMoreChats() {
   yield takeLatest(fetchMoreChats, doFetchMoreChats)
 }
 
-function* watchFetchChatMessages() {
+function* watchFetchLatestMessages() {
+  yield takeEvery(fetchLatestMessages, doFetchLatestMessages)
+}
+
+function* watchFetchMoreMessages() {
   yield takeEvery(fetchMoreMessages, doFetchMoreMessages)
 }
 
@@ -683,8 +808,10 @@ export const sagas = () => {
   return [
     watchFetchUnreadMessagesCount,
     watchFetchChatIfNecessary,
-    watchFetchChats,
-    watchFetchChatMessages,
+    watchFetchLatestChats,
+    watchFetchMoreChats,
+    watchFetchLatestMessages,
+    watchFetchMoreMessages,
     watchSetMessageReaction,
     watchCreateChat,
     watchMarkChatAsRead,

--- a/packages/mobile/src/screens/chat-screen/ChatListScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatListScreen.tsx
@@ -19,7 +19,7 @@ import { ChatListItemSkeleton } from './ChatListItemSkeleton'
 import { HeaderShadow } from './HeaderShadow'
 
 const { getChats, getChatsStatus, getHasMoreChats } = chatSelectors
-const { fetchMoreMessages, fetchMoreChats } = chatActions
+const { fetchMoreMessages, fetchLatestChats, fetchMoreChats } = chatActions
 
 const CHATS_MESSAGES_PREFETCH_LIMIT = 10
 
@@ -120,6 +120,15 @@ export const ChatListScreen = () => {
     </TouchableOpacity>
   )
 
+  const handleLoadMore = useCallback(() => {
+    if (chatsStatus === Status.LOADING || !hasMore) return
+    dispatch(fetchMoreChats())
+  }, [hasMore, chatsStatus, dispatch])
+
+  const refresh = useCallback(() => {
+    dispatch(fetchLatestChats())
+  }, [dispatch])
+
   // Prefetch messages for initial loaded chats
   useEffect(() => {
     if (
@@ -134,10 +143,9 @@ export const ChatListScreen = () => {
     }
   }, [chats, dispatch])
 
-  const handleLoadMore = useCallback(() => {
-    if (chatsStatus === Status.LOADING || !hasMore) return
-    dispatch(fetchMoreChats())
-  }, [hasMore, chatsStatus, dispatch])
+  useEffect(() => {
+    refresh()
+  }, [refresh])
 
   return (
     <Screen
@@ -162,6 +170,8 @@ export const ChatListScreen = () => {
               ))
           ) : (
             <FlatList
+              refreshing={chatsStatus === 'REFRESHING'}
+              onRefresh={refresh}
               data={nonEmptyChats}
               contentContainerStyle={styles.listContainer}
               renderItem={({ item }) => <ChatListItem chatId={item.chat_id} />}

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -78,6 +78,7 @@ const {
   getReactionsPopupMessageId
 } = chatSelectors
 const {
+  fetchLatestMessages,
   fetchMoreMessages,
   markChatAsRead,
   setReactionsPopupMessageId,
@@ -254,16 +255,12 @@ export const ChatScreen = () => {
   // The chat/chatId selectors will trigger the rerenders necessary.
   const chatFrozenRef = useRef(chat)
 
-  // Initial fetch, but only if messages weren't fetched on app load
+  // Refresh messages on first render
   useEffect(() => {
-    if (
-      chatId &&
-      (chat?.messagesStatus ?? Status.IDLE) === Status.IDLE &&
-      chatMessages.length === 0
-    ) {
-      dispatch(fetchMoreMessages({ chatId }))
+    if (chatId) {
+      dispatch(fetchLatestMessages({ chatId }))
     }
-  }, [dispatch, chatId, chat, chatMessages.length])
+  }, [dispatch, chatId])
 
   useEffect(() => {
     // Update chatFrozenRef when entering a new chat screen.


### PR DESCRIPTION
### Description

Would appreciate more eyes and testing on this, it's rather large.

- On rendering a chat screen:
  - If it's the first load:
    - Get batches of messages until we have all the unread messages
  - Otherwise
    - Get all messages newer than what we have
- Adds pull to refresh on the chat list screen
- Updates reducer logic to take the earliest prev_cursor and latest next_cursor in both fetchMessages and fetchChats
- Updates messages batch size to 50 from 10

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Known issue: Going into a chat that has new messages before a chat has been refreshed to acknowledge an unread count won't show the inline indicator of the unread count. This is because we cache the unread state on loading the chat screen prior to refreshing and finding those new messages.

Cursors: I think things should work roughly the same. I do want to be extra extra careful about the `hasMoreUnread` flag in the sagas, because an infinite loop would be devastating.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

Tested on iOS Sim by turning off websockets manually in code.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

