### PR TITLE
Finish implementation of typography CSS module

### DIFF
--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -294,7 +294,7 @@ const TrackTile = ({
             <div
               className={cn(
                 typeStyles.labelXSmall,
-                typeStyles.labelLight,
+                typeStyles.labelWeak,
                 styles.headerRow
               )}
             >
@@ -320,7 +320,7 @@ const TrackTile = ({
           <div
             className={cn(
               typeStyles.titleMedium,
-              typeStyles.titleLight,
+              typeStyles.titleWeak,
               styles.creatorRow
             )}
           >

--- a/packages/web/src/components/typography/typography.module.css
+++ b/packages/web/src/components/typography/typography.module.css
@@ -17,91 +17,169 @@
  ```
 */
 
-/* Title Styles */
-.titleLarge {
-  font-size: var(--font-l);
+/* Display Styles */
+
+/* 96 / 120 */
+.diplayXLarge {
+  font-size: var(--unit-24);
+  font-weight: var(--font-bold);
+  line-height: calc(var(--unit) * 30);
+}
+/* 72 / 88 */
+.displayLarge {
+  font-size: var(--unit-18);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-22);
+}
+/* 56 / 68 */
+.displayMedium {
+  font-size: var(--unit-14);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-17);
+}
+/* 42 / 52 */
+.displaySmall {
+  font-size: calc(var(--unit) * 10.5);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-13);
+}
+.displayStrong {
+  font-weight: var(--font-heavy);
+}
+
+/* Heading Styles */
+
+/* 36 / 40 */
+.headingXLarge {
+  font-size: var(--unit-9);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-10);
+}
+/* 28 / 32 */
+.headingLarge {
+  font-size: var(--unit-7);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-8);
+}
+/* 24 / 32 */
+.headingMedium {
+  font-size: var(--unit-6);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-8);
+}
+/* 20 / 24 */
+.headingSmall {
+  font-size: var(--unit-5);
   font-weight: var(--font-bold);
   line-height: var(--unit-6);
 }
+.headingStrong {
+  font-weight: var(--font-heavy);
+}
+
+/* Title Styles */
+
+/* 18 / 24 */
+.titleLarge {
+  font-size: calc(var(--unit) * 4.5);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-6);
+}
+/* 16 / 20 */
 .titleMedium {
-  font-size: var(--font-m);
+  font-size: var(--unit-4);
   font-weight: var(--font-bold);
   line-height: var(--unit-5);
 }
+/* 14 / 16 */
 .titleSmall {
-  font-size: var(--font-s);
+  font-size: calc(var(--unit) * 3.5);
   font-weight: var(--font-bold);
   line-height: var(--unit-4);
 }
+/* 12 / 16 */
 .titleXSmall {
-  font-size: var(--font-xs);
+  font-size: var(--unit-3);
   font-weight: var(--font-bold);
   line-height: var(--unit-4);
 }
-
-.titleLight {
+.titleWeak {
   font-weight: var(--font-demi-bold);
 }
 .titleStrong {
   font-weight: var(--font-heavy);
 }
 
-/* Body Styles */
-.bodyLarge {
-  font-size: var(--font-l);
-  font-weight: var(--font-medium);
-  line-height: var(--unit-6);
-}
-.bodyMedium {
-  font-size: var(--font-m);
-  font-weight: var(--font-medium);
-  line-height: var(--unit-5);
-}
-.bodySmall {
-  font-size: var(--font-s);
-  font-weight: var(--font-medium);
-  line-height: var(--unit-5);
-}
-.bodyXSmall {
-  font-size: var(--font-xs);
-  font-weight: var(--font-medium);
-  line-height: var(--unit-5);
-}
-
-.bodyStrong {
-  font-weight: var(--font-demi-bold);
-}
-
 /* Label Styles */
 
+/* 20 / 24 */
 .labelXLarge {
-  font-size: var(--font-xl);
+  font-size: var(--unit-5);
   font-weight: var(--font-bold);
+  letter-spacing: 0.5px;
   line-height: var(--unit-6);
 }
+/* 16 / 16 */
 .labelLarge {
-  font-size: var(--font-m);
+  font-size: var(--unit-4);
   font-weight: var(--font-bold);
+  letter-spacing: 0.5px;
   line-height: var(--unit-4);
 }
+/* 14 / 16 */
 .labelMedium {
-  font-size: var(--font-s);
+  font-size: calc(var(--unit) * 3.5);
   font-weight: var(--font-bold);
+  letter-spacing: 0.5px;
   line-height: var(--unit-4);
 }
+/* 12 /12 */
 .labelSmall {
-  font-size: var(--font-xs);
+  font-size: var(--unit-3);
   font-weight: var(--font-bold);
+  letter-spacing: 0.5px;
   line-height: var(--unit-3);
 }
+/* 10 / 12 */
 .labelXSmall {
-  font-size: var(--font-2xs);
+  font-size: calc(var(--unit) * 2.5);
   font-weight: var(--font-bold);
+  letter-spacing: 0.5px;
   line-height: var(--unit-3);
 }
-.labelLight {
+.labelWeak {
   font-weight: var(--font-medium);
 }
 .labelStrong {
   font-weight: var(--font-heavy);
+}
+
+/* Body Styles */
+
+/* 18 / 24 */
+.bodyLarge {
+  font-size: calc(var(--unit) * 4.5);
+  font-weight: var(--font-medium);
+  line-height: var(--unit-6);
+}
+/* 16 / 20 */
+.bodyMedium {
+  font-size: var(--unit-4);
+  font-weight: var(--font-medium);
+  line-height: var(--unit-5);
+}
+/* 14 / 20 */
+.bodySmall {
+  font-size: calc(var(--unit) * 3.5);
+  font-weight: var(--font-medium);
+  line-height: var(--unit-5);
+}
+/* 12 / 20 */
+.bodyXSmall {
+  font-size: var(--unit-3);
+  font-weight: var(--font-medium);
+  line-height: var(--unit-5);
+}
+.bodyStrong {
+  font-weight: var(--font-demi-bold);
 }


### PR DESCRIPTION
### Description
This adds the remaining typography styles from the [Figma designs](https://www.figma.com/file/IFhreiwgRdt5kecYQPFjyO/Typography%3A-Base-%5BSTEM%5D?type=design&node-id=933-421&mode=dev). These should now be ready to use in web code whenever a design uses a named typography style.

I also added some comments at the top of the file to explain how the classes map to our typography system and show some examples for usage.

Between my last PR and this one, the `light` variant was changed to `weak`, so I updated the two places that variant was used for title and label font styles.

### Dragons
N/A

### How Has This Been Tested?
Verified locally

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

