### PR TITLE
[PAY-1463] Fix d to set discovery node

### DIFF
--- a/packages/common/src/services/local-storage/LocalStorage.ts
+++ b/packages/common/src/services/local-storage/LocalStorage.ts
@@ -7,8 +7,6 @@ import { Nullable } from '../../utils'
 
 // TODO: the following should come from @audius/libs/dist/core when
 // discoveryProvider/constants is migrated to typescript.
-const DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-node-timestamp'
-
 const AUDIUS_ACCOUNT_KEY = '@audius/account'
 const AUDIUS_ACCOUNT_USER_KEY = '@audius/audius-user'
 
@@ -116,10 +114,4 @@ export class LocalStorage {
 
   getCurrentUserExists = async () =>
     this.getValue(CURRENT_USER_EXISTS_LOCAL_STORAGE_KEY)
-
-  async getCachedDiscoveryProvider() {
-    return await this.getJSONValue<CachedDiscoveryProviderType>(
-      DISCOVERY_PROVIDER_TIMESTAMP
-    )
-  }
 }

--- a/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
+++ b/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
@@ -21,11 +21,7 @@ const getCachedDiscoveryNode = () => {
       const cachedDiscoveryNodeTimestamp = JSON.parse(
         cached
       ) as CachedDiscoveryNodeTimestamp
-      if (
-        cachedDiscoveryNodeTimestamp &&
-        cachedDiscoveryNodeTimestamp.timestamp &&
-        cachedDiscoveryNodeTimestamp.timestamp >
-          new Date().getTime() - CACHE_TTL
+      if (cachedDiscoveryNodeTimestamp?.timestamp > new Date().getTime() - CACHE_TTL
       ) {
         const cachedDiscoveryNode =
           cachedDiscoveryNodeTimestamp.endpoint ?? undefined

--- a/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
+++ b/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
@@ -21,7 +21,10 @@ const getCachedDiscoveryNode = () => {
       const cachedDiscoveryNodeTimestamp = JSON.parse(
         cached
       ) as CachedDiscoveryNodeTimestamp
-      if (cachedDiscoveryNodeTimestamp?.timestamp > new Date().getTime() - CACHE_TTL
+      if (
+        cachedDiscoveryNodeTimestamp?.timestamp &&
+        cachedDiscoveryNodeTimestamp.timestamp >
+          new Date().getTime() - CACHE_TTL
       ) {
         const cachedDiscoveryNode =
           cachedDiscoveryNodeTimestamp.endpoint ?? undefined

--- a/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
+++ b/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
@@ -3,7 +3,64 @@ import { DiscoveryNodeSelectorService } from '@audius/common'
 import { env } from '../env'
 import { remoteConfigInstance } from '../remote-config/remote-config-instance'
 
+const DISCOVERY_PROVIDER_TIMESTAMP = '@audius/libs:discovery-node-timestamp'
+const CACHE_TTL = 24 * 60 * 1000 // 24 hours
+
+type CachedDiscoveryNodeTimestamp =
+  | {
+      endpoint?: string
+      timestamp?: number
+    }
+  | null
+  | undefined
+
+const cached = localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP)
+let cachedDiscoveryNode
+if (cached) {
+  try {
+    const cachedDiscoveryNodeTimestamp = JSON.parse(
+      cached
+    ) as CachedDiscoveryNodeTimestamp
+    if (
+      cachedDiscoveryNodeTimestamp &&
+      cachedDiscoveryNodeTimestamp.timestamp &&
+      cachedDiscoveryNodeTimestamp.timestamp > new Date().getTime() - CACHE_TTL
+    ) {
+      cachedDiscoveryNode = cachedDiscoveryNodeTimestamp.endpoint ?? undefined
+      console.debug(
+        '[discovery-node-selector-service] Using cached discovery node',
+        cachedDiscoveryNode
+      )
+    } else {
+      console.debug(
+        '[discovery-node-selector-service] Cached discovery node expired',
+        cachedDiscoveryNodeTimestamp
+      )
+    }
+  } catch (e) {
+    console.error(
+      "[discovery-node-selector-service] Couldn't parse cached discovery node",
+      e
+    )
+  }
+}
+
 export const discoveryNodeSelectorService = new DiscoveryNodeSelectorService({
   env,
-  remoteConfigInstance
+  remoteConfigInstance,
+  initialSelectedNode: cachedDiscoveryNode,
+  onChange: (endpoint) => {
+    const newTimestamp: CachedDiscoveryNodeTimestamp = {
+      endpoint,
+      timestamp: new Date().getTime()
+    }
+    console.debug(
+      '[discovery-node-selector-service] Updating cached discovery provider',
+      newTimestamp
+    )
+    localStorage.setItem(
+      DISCOVERY_PROVIDER_TIMESTAMP,
+      JSON.stringify(newTimestamp)
+    )
+  }
 })

--- a/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
+++ b/packages/web/src/services/audius-sdk/discoveryNodeSelector.ts
@@ -14,53 +14,59 @@ type CachedDiscoveryNodeTimestamp =
   | null
   | undefined
 
-const cached = localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP)
-let cachedDiscoveryNode
-if (cached) {
-  try {
-    const cachedDiscoveryNodeTimestamp = JSON.parse(
-      cached
-    ) as CachedDiscoveryNodeTimestamp
-    if (
-      cachedDiscoveryNodeTimestamp &&
-      cachedDiscoveryNodeTimestamp.timestamp &&
-      cachedDiscoveryNodeTimestamp.timestamp > new Date().getTime() - CACHE_TTL
-    ) {
-      cachedDiscoveryNode = cachedDiscoveryNodeTimestamp.endpoint ?? undefined
-      console.debug(
-        '[discovery-node-selector-service] Using cached discovery node',
-        cachedDiscoveryNode
-      )
-    } else {
-      console.debug(
-        '[discovery-node-selector-service] Cached discovery node expired',
-        cachedDiscoveryNodeTimestamp
+const getCachedDiscoveryNode = () => {
+  const cached = localStorage.getItem(DISCOVERY_PROVIDER_TIMESTAMP)
+  if (cached) {
+    try {
+      const cachedDiscoveryNodeTimestamp = JSON.parse(
+        cached
+      ) as CachedDiscoveryNodeTimestamp
+      if (
+        cachedDiscoveryNodeTimestamp &&
+        cachedDiscoveryNodeTimestamp.timestamp &&
+        cachedDiscoveryNodeTimestamp.timestamp >
+          new Date().getTime() - CACHE_TTL
+      ) {
+        const cachedDiscoveryNode =
+          cachedDiscoveryNodeTimestamp.endpoint ?? undefined
+        console.debug(
+          '[discovery-node-selector-service] Using cached discovery node',
+          cachedDiscoveryNode
+        )
+        return cachedDiscoveryNode
+      } else {
+        console.debug(
+          '[discovery-node-selector-service] Cached discovery node expired',
+          cachedDiscoveryNodeTimestamp
+        )
+      }
+    } catch (e) {
+      console.error(
+        "[discovery-node-selector-service] Couldn't parse cached discovery node",
+        e
       )
     }
-  } catch (e) {
-    console.error(
-      "[discovery-node-selector-service] Couldn't parse cached discovery node",
-      e
-    )
   }
+}
+
+const updateCachedDiscoveryNode = (endpoint: string) => {
+  const newTimestamp: CachedDiscoveryNodeTimestamp = {
+    endpoint,
+    timestamp: new Date().getTime()
+  }
+  console.debug(
+    '[discovery-node-selector-service] Updating cached discovery provider',
+    newTimestamp
+  )
+  localStorage.setItem(
+    DISCOVERY_PROVIDER_TIMESTAMP,
+    JSON.stringify(newTimestamp)
+  )
 }
 
 export const discoveryNodeSelectorService = new DiscoveryNodeSelectorService({
   env,
   remoteConfigInstance,
-  initialSelectedNode: cachedDiscoveryNode,
-  onChange: (endpoint) => {
-    const newTimestamp: CachedDiscoveryNodeTimestamp = {
-      endpoint,
-      timestamp: new Date().getTime()
-    }
-    console.debug(
-      '[discovery-node-selector-service] Updating cached discovery provider',
-      newTimestamp
-    )
-    localStorage.setItem(
-      DISCOVERY_PROVIDER_TIMESTAMP,
-      JSON.stringify(newTimestamp)
-    )
-  }
+  initialSelectedNode: getCachedDiscoveryNode(),
+  onChange: updateCachedDiscoveryNode
 })


### PR DESCRIPTION
### Description

Fix the "d" dialog that changes discovery node by adding back the code that reads and sets the local storage cache for discovery node.

Web only.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

