### PR TITLE
Fetch chats on app foreground

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -1,3 +1,4 @@
+import type { Dispatch } from 'react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import type { ChatMessageWithExtras } from '@audius/common'
@@ -19,6 +20,7 @@ import { useKeyboard } from '@react-native-community/hooks'
 import { useFocusEffect } from '@react-navigation/native'
 import type { FlatListProps, LayoutChangeEvent } from 'react-native'
 import {
+  AppState,
   FlatList,
   Keyboard,
   Platform,
@@ -201,6 +203,40 @@ const getNewMessageToastThreshold = (
     : NEW_MESSAGE_TOAST_SCROLL_THRESHOLD
 }
 
+// Gets latest messages on both initial render and when app state changes
+const useGetLatestMessages = (
+  chatId: string,
+  dispatch: ReturnType<typeof useDispatch>
+) => {
+  const fetchLatestMessagesCallback = useCallback(() => {
+    if (chatId) {
+      dispatch(fetchLatestMessages({ chatId }))
+    }
+  }, [dispatch, chatId])
+
+  // Refresh messages on first render
+  useEffect(() => {
+    console.debug('Fetching latest messages on first render')
+    fetchLatestMessagesCallback()
+  }, [fetchLatestMessagesCallback])
+
+  // Also listen to app state changes to refresh messages,
+  // in case this page was previously in the background
+  useEffect(() => {
+    const handle = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        console.debug(
+          'App came back from background onto chat page, fetching latest messages'
+        )
+        fetchLatestMessagesCallback()
+      }
+    })
+
+    // Remove listener on unmount
+    return () => handle.remove()
+  })
+}
+
 export const ChatScreen = () => {
   const styles = useStyles()
   const palette = useThemePalette()
@@ -255,12 +291,7 @@ export const ChatScreen = () => {
   // The chat/chatId selectors will trigger the rerenders necessary.
   const chatFrozenRef = useRef(chat)
 
-  // Refresh messages on first render
-  useEffect(() => {
-    if (chatId) {
-      dispatch(fetchLatestMessages({ chatId }))
-    }
-  }, [dispatch, chatId])
+  useGetLatestMessages(chatId, dispatch)
 
   useEffect(() => {
     // Update chatFrozenRef when entering a new chat screen.

--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -1,4 +1,3 @@
-import type { Dispatch } from 'react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 
 import type { ChatMessageWithExtras } from '@audius/common'


### PR DESCRIPTION
### Description

There was a bug where our nice new `fetchLatestMessages` action/saga wouldn't fire if we backgrounded the app on a chat page and then foregrounded it onto the same chat page, because we wouldn't remount the component + trigger the useEffect that dispatches the action.

This change also listens to app state to trigger fetching new messages.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

On device, turned off websockets, looked at logs. 

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

