### PR TITLE
[C-2587] Fix playlist update tooltip

### DIFF
--- a/packages/mobile/src/components/suggested-tracks/SuggestedTracks.tsx
+++ b/packages/mobile/src/components/suggested-tracks/SuggestedTracks.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 import type { UserTrackMetadata } from '@audius/common'
 import { SquareSizes, useGetSuggestedTracks } from '@audius/common'
 import { View } from 'react-native'
@@ -114,13 +116,10 @@ export const SuggestedTracks = () => {
       <View>
         <Divider />
         {suggestedTracks?.map((suggestedTrack) => (
-          <>
-            <SuggestedTrack
-              key={suggestedTrack.track_id}
-              track={suggestedTrack}
-            />
+          <Fragment key={suggestedTrack.track_id}>
+            <SuggestedTrack track={suggestedTrack} />
             <Divider />
-          </>
+          </Fragment>
         ))}
       </View>
       <TextButton

--- a/packages/web/src/components/collection/desktop/EditButton.tsx
+++ b/packages/web/src/components/collection/desktop/EditButton.tsx
@@ -16,7 +16,7 @@ type EditButtonProps = Partial<ButtonProps> & {
 }
 
 export const EditButton = (props: EditButtonProps) => {
-  const { collectionId } = props
+  const { collectionId, ...other } = props
   const dispatch = useDispatch()
 
   const handleEdit = useCallback(
@@ -30,7 +30,7 @@ export const EditButton = (props: EditButtonProps) => {
       text={messages.edit}
       leftIcon={<IconPencil />}
       onClick={handleEdit}
-      {...props}
+      {...other}
     />
   )
 }

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistUpdateDot.module.css
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistUpdateDot.module.css
@@ -2,7 +2,3 @@
   position: absolute;
   left: calc(var(--unit-3) * -1);
 }
-
-.tooltip :global(.ant-tooltip-arrow) {
-  left: var(--unit-6);
-}

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistUpdateDot.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/PlaylistUpdateDot.tsx
@@ -8,11 +8,9 @@ const messages = { recentlyUpdatedTooltip: 'Recently Updated' }
 export const PlaylistUpdateDot = () => {
   return (
     <Tooltip
-      className={styles.tooltip}
-      shouldWrapContent={true}
-      shouldDismissOnClick={false}
       mouseEnterDelay={0.1}
       text={messages.recentlyUpdatedTooltip}
+      placement='right'
     >
       <UpdateDot className={styles.root} />
     </Tooltip>

--- a/packages/web/src/pages/collection-page/components/desktop/SuggestedTracks.tsx
+++ b/packages/web/src/pages/collection-page/components/desktop/SuggestedTracks.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 import {
   SquareSizes,
   Status,
@@ -67,12 +69,12 @@ export const SuggestedTracks = () => {
           <LoadingSpinner className={styles.loading} />
         ) : null}
         {suggestedTracks?.map((suggestedTrack) => (
-          <>
-            <li key={suggestedTrack.track_id}>
+          <Fragment key={suggestedTrack.track_id}>
+            <li>
               <SuggestedTrack track={suggestedTrack} />
             </li>
             {divider}
-          </>
+          </Fragment>
         ))}
         {divider}
       </ul>


### PR DESCRIPTION
### Description

Fixes issue where playlist update tooltip get's in it's own way causing it to thrash in and out. Moving its placement to the right solves the issue.

- Also fixes a few react warnings i noticed while fixing this issue

