### PR TITLE
[PAY-1573] Convert premium_content to discriminated union

### DIFF
--- a/packages/common/src/hooks/usePremiumContent.ts
+++ b/packages/common/src/hooks/usePremiumContent.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 
 import { useSelector } from 'react-redux'
 
-import { Chain, ID, PremiumConditions, Track } from 'models'
+import { Chain, ID, PremiumConditions, PremiumContentType, Track } from 'models'
 import { getAccountUser } from 'store/account/selectors'
 import { cacheTracksSelectors, cacheUsersSelectors } from 'store/cache'
 import { premiumContentSelectors } from 'store/premium-content'
@@ -29,7 +29,8 @@ export const usePremiumContentAccess = (track: Nullable<Partial<Track>>) => {
     const hasPremiumContentSignature =
       !!track.premium_content_signature ||
       !!(trackId && premiumTrackSignatureMap[trackId])
-    const isCollectibleGated = !!track.premium_conditions?.nft_collection
+    const isCollectibleGated =
+      track.premium_conditions?.type === PremiumContentType.COLLECTIBLE_GATED
     const isSignatureToBeFetched =
       isCollectibleGated &&
       !!trackId &&
@@ -67,7 +68,8 @@ export const usePremiumContentAccessMap = (tracks: Partial<Track>[]) => {
       const hasPremiumContentSignature = !!(
         track.premium_content_signature || premiumTrackSignatureMap[trackId]
       )
-      const isCollectibleGated = !!track.premium_conditions?.nft_collection
+      const isCollectibleGated =
+        track.premium_conditions?.type === PremiumContentType.COLLECTIBLE_GATED
       const isSignatureToBeFetched =
         isCollectibleGated &&
         premiumTrackSignatureMap[trackId] === undefined &&
@@ -88,11 +90,18 @@ export const usePremiumContentAccessMap = (tracks: Partial<Track>[]) => {
 export const usePremiumConditionsEntity = (
   premiumConditions: Nullable<PremiumConditions>
 ) => {
-  const {
-    follow_user_id: followUserId,
-    tip_user_id: tipUserId,
-    nft_collection: nftCollection
-  } = premiumConditions ?? {}
+  const followUserId =
+    premiumConditions?.type === PremiumContentType.FOLLOW_GATED
+      ? premiumConditions?.follow_user_id
+      : null
+  const tipUserId =
+    premiumConditions?.type === PremiumContentType.TIP_GATED
+      ? premiumConditions?.tip_user_id
+      : null
+  const nftCollection =
+    premiumConditions?.type === PremiumContentType.COLLECTIBLE_GATED
+      ? premiumConditions?.nft_collection
+      : null
 
   const users = useSelector((state: CommonState) =>
     getUsers(state, {

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -10,6 +10,7 @@ import { Repost } from './Repost'
 import { StemCategory } from './Stems'
 import { Timestamped } from './Timestamped'
 import { User, UserMetadata } from './User'
+import { StringUSDC } from './Wallet'
 
 type EpochTimeStamp = number
 
@@ -109,7 +110,10 @@ type PremiumConditionsTipGated = {
 
 type PremiumConditionsUSDCPurchase = {
   type: PremiumContentType.USDC_PURCHASE
-  usdc_purchase: PremiumConditionsUSDCPurchase
+  usdc_purchase: {
+    price: StringUSDC
+    slot: number
+  }
 }
 
 export type PremiumConditionsWithType =

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -91,11 +91,15 @@ type PremiumConditionsBase = {
   usdc_purchase?: PremiumConditionsUSDCPurchase
 }
 
+// Must include undefined because during upload flow, the user could have selected
+// Collectible-gated option without specifying a collection yet. But afterweards
+// when we read PremiumConditions, nft_collection should always exist.
 type PremiumConditionsCollectibleGated = {
   type: PremiumContentType.COLLECTIBLE_GATED
   nft_collection:
     | PremiumConditionsEthNFTCollection
     | PremiumConditionsSolNFTCollection
+    | undefined
 }
 
 type PremiumConditionsFollowGated = {

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -94,7 +94,7 @@ type PremiumConditionsBase = {
 // Must include undefined because during upload flow, the user could have selected
 // Collectible-gated option without specifying a collection yet. But afterweards
 // when we read PremiumConditions, nft_collection should always exist.
-type PremiumConditionsCollectibleGated = {
+type PremiumConditionsCollectibleGated = PremiumConditionsBase & {
   type: PremiumContentType.COLLECTIBLE_GATED
   nft_collection:
     | PremiumConditionsEthNFTCollection
@@ -102,17 +102,17 @@ type PremiumConditionsCollectibleGated = {
     | undefined
 }
 
-type PremiumConditionsFollowGated = {
+type PremiumConditionsFollowGated = PremiumConditionsBase & {
   type: PremiumContentType.FOLLOW_GATED
   follow_user_id: number
 }
 
-type PremiumConditionsTipGated = {
+type PremiumConditionsTipGated = PremiumConditionsBase & {
   type: PremiumContentType.TIP_GATED
   tip_user_id: number
 }
 
-type PremiumConditionsUSDCPurchase = {
+type PremiumConditionsUSDCPurchase = PremiumConditionsBase & {
   type: PremiumContentType.USDC_PURCHASE
   usdc_purchase: {
     price: StringUSDC
@@ -120,14 +120,11 @@ type PremiumConditionsUSDCPurchase = {
   }
 }
 
-export type PremiumConditionsWithType =
+export type PremiumConditions =
   | PremiumConditionsCollectibleGated
   | PremiumConditionsFollowGated
   | PremiumConditionsTipGated
   | PremiumConditionsUSDCPurchase
-
-export type PremiumConditions = PremiumConditionsBase &
-  PremiumConditionsWithType
 
 export type PremiumContentSignature = {
   data: string

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -80,14 +80,33 @@ export type PremiumConditionsUSDCPurchase = {
   slot: number
 }
 
-export type PremiumConditions = {
-  nft_collection?:
-    | PremiumConditionsEthNFTCollection
-    | PremiumConditionsSolNFTCollection
-  follow_user_id?: number
-  tip_user_id?: number
-  usdc_purchase?: PremiumConditionsUSDCPurchase
+export enum PremiumContentType {
+  COLLECTIBLE_GATED = 'collectible gated',
+  FOLLOW_GATED = 'follower gated',
+  TIP_GATED = 'tip gated',
+  USDC_PURCHASE = 'usdc purchase'
 }
+
+export type PremiumConditions =
+  | {
+      type: PremiumContentType.COLLECTIBLE_GATED
+      nft_collection:
+        | PremiumConditionsEthNFTCollection
+        | PremiumConditionsSolNFTCollection
+    }
+  | {
+      type: PremiumContentType.FOLLOW_GATED
+      follow_user_id: number
+    }
+  | {
+      type: PremiumContentType.TIP_GATED
+      tip_user_id: number
+    }
+  | {
+      type: PremiumContentType.USDC_PURCHASE
+      usdc_purchase: PremiumConditionsUSDCPurchase
+    }
+  | null
 
 export type PremiumContentSignature = {
   data: string

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -10,7 +10,6 @@ import { Repost } from './Repost'
 import { StemCategory } from './Stems'
 import { Timestamped } from './Timestamped'
 import { User, UserMetadata } from './User'
-import { StringUSDC } from './Wallet'
 
 type EpochTimeStamp = number
 
@@ -75,11 +74,6 @@ export type PremiumConditionsSolNFTCollection = {
   externalLink: Nullable<string>
 }
 
-export type PremiumConditionsUSDCPurchase = {
-  price: StringUSDC
-  slot: number
-}
-
 export enum PremiumContentType {
   COLLECTIBLE_GATED = 'collectible gated',
   FOLLOW_GATED = 'follower gated',
@@ -87,26 +81,45 @@ export enum PremiumContentType {
   USDC_PURCHASE = 'usdc purchase'
 }
 
-export type PremiumConditions =
-  | {
-      type: PremiumContentType.COLLECTIBLE_GATED
-      nft_collection:
-        | PremiumConditionsEthNFTCollection
-        | PremiumConditionsSolNFTCollection
-    }
-  | {
-      type: PremiumContentType.FOLLOW_GATED
-      follow_user_id: number
-    }
-  | {
-      type: PremiumContentType.TIP_GATED
-      tip_user_id: number
-    }
-  | {
-      type: PremiumContentType.USDC_PURCHASE
-      usdc_purchase: PremiumConditionsUSDCPurchase
-    }
-  | null
+type PremiumConditionsBase = {
+  nft_collection?:
+    | PremiumConditionsEthNFTCollection
+    | PremiumConditionsSolNFTCollection
+  follow_user_id?: number
+  tip_user_id?: number
+  usdc_purchase?: PremiumConditionsUSDCPurchase
+}
+
+type PremiumConditionsCollectibleGated = {
+  type: PremiumContentType.COLLECTIBLE_GATED
+  nft_collection:
+    | PremiumConditionsEthNFTCollection
+    | PremiumConditionsSolNFTCollection
+}
+
+type PremiumConditionsFollowGated = {
+  type: PremiumContentType.FOLLOW_GATED
+  follow_user_id: number
+}
+
+type PremiumConditionsTipGated = {
+  type: PremiumContentType.TIP_GATED
+  tip_user_id: number
+}
+
+type PremiumConditionsUSDCPurchase = {
+  type: PremiumContentType.USDC_PURCHASE
+  usdc_purchase: PremiumConditionsUSDCPurchase
+}
+
+export type PremiumConditionsWithType =
+  | PremiumConditionsCollectibleGated
+  | PremiumConditionsFollowGated
+  | PremiumConditionsTipGated
+  | PremiumConditionsUSDCPurchase
+
+export type PremiumConditions = PremiumConditionsBase &
+  PremiumConditionsWithType
 
 export type PremiumContentSignature = {
   data: string

--- a/packages/common/src/store/premium-content/sagas.ts
+++ b/packages/common/src/store/premium-content/sagas.ts
@@ -159,6 +159,7 @@ function* getTokenIdMap({
           )
         )
       }
+      if (nftCollection === undefined) return
 
       if (nftCollection.chain === Chain.Eth) {
         // skip this track entry if user does not own an nft from its nft collection gate
@@ -239,8 +240,8 @@ function* handleSpecialAccessTrackSubscriptions(tracks: Track[]) {
 
     const hasNoSignature = !premiumContentSignature
     const isFollowGated =
-      premiumConditions.type === PremiumContentType.FOLLOW_GATED
-    const isTipGated = premiumConditions.type === PremiumContentType.TIP_GATED
+      premiumConditions?.type === PremiumContentType.FOLLOW_GATED
+    const isTipGated = premiumConditions?.type === PremiumContentType.TIP_GATED
     const shouldHaveSignature =
       (isFollowGated && followeeIds.includes(ownerId)) ||
       (isTipGated && tippedUserIds.includes(ownerId))

--- a/packages/common/src/utils/dogEarUtils.ts
+++ b/packages/common/src/utils/dogEarUtils.ts
@@ -1,5 +1,5 @@
 import { DogEarType } from 'models/DogEar'
-import { PremiumConditions } from 'models/Track'
+import { PremiumConditions, PremiumContentType } from 'models/Track'
 
 import { Nullable } from './typeUtils'
 
@@ -25,14 +25,13 @@ export const getDogEarType = ({
 
   // Show premium variants for track owners or if user does not yet have access
   if ((isOwner || !doesUserHaveAccess) && premiumConditions != null) {
-    if (premiumConditions.usdc_purchase) {
-      return DogEarType.USDC_PURCHASE
-    }
-    if (premiumConditions.nft_collection) {
-      return DogEarType.COLLECTIBLE_GATED
-    }
-    if (premiumConditions.follow_user_id || premiumConditions.tip_user_id) {
-      return DogEarType.SPECIAL_ACCESS
+    switch (premiumConditions.type) {
+      case PremiumContentType.COLLECTIBLE_GATED:
+        return DogEarType.COLLECTIBLE_GATED
+      case PremiumContentType.FOLLOW_GATED || PremiumContentType.TIP_GATED:
+        return DogEarType.SPECIAL_ACCESS
+      case PremiumContentType.USDC_PURCHASE:
+        return DogEarType.USDC_PURCHASE
     }
   }
 

--- a/packages/mobile/src/screens/edit-track-screen/components/CollectibleGatedAvailability.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/CollectibleGatedAvailability.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import type { Nullable, PremiumConditions } from '@audius/common'
-import { collectiblesSelectors } from '@audius/common'
+import { PremiumContentType, collectiblesSelectors } from '@audius/common'
 import { useField } from 'formik'
 import { View, Image, Dimensions } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
@@ -181,7 +181,12 @@ export const CollectibleGatedAvailability = ({
       setTrackAvailabilityFields(
         {
           is_premium: true,
-          premium_conditions: { nft_collection: selectedNFTCollection },
+          premium_conditions: selectedNFTCollection
+            ? {
+                type: PremiumContentType.COLLECTIBLE_GATED,
+                nft_collection: selectedNFTCollection
+              }
+            : null,
           'field_visibility.remixes': false
         },
         true

--- a/packages/mobile/src/screens/edit-track-screen/components/CollectibleGatedAvailability.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/CollectibleGatedAvailability.tsx
@@ -181,12 +181,10 @@ export const CollectibleGatedAvailability = ({
       setTrackAvailabilityFields(
         {
           is_premium: true,
-          premium_conditions: selectedNFTCollection
-            ? {
-                type: PremiumContentType.COLLECTIBLE_GATED,
-                nft_collection: selectedNFTCollection
-              }
-            : null,
+          premium_conditions: {
+            type: PremiumContentType.COLLECTIBLE_GATED,
+            nft_collection: selectedNFTCollection
+          },
           'field_visibility.remixes': false
         },
         true

--- a/packages/mobile/src/screens/edit-track-screen/components/SpecialAccessAvailability.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/components/SpecialAccessAvailability.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import type { PremiumConditions, Nullable } from '@audius/common'
-import { accountSelectors } from '@audius/common'
+import { accountSelectors, PremiumContentType } from '@audius/common'
 import { useField } from 'formik'
 import { Dimensions, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
@@ -114,8 +114,8 @@ export const SpecialAccessAvailability = ({
   const [{ value: premiumConditions }] =
     useField<Nullable<PremiumConditions>>('premium_conditions')
   const currentUserId = useSelector(getUserId)
-  const defaultSpecialAccess = currentUserId
-    ? { follow_user_id: currentUserId }
+  const defaultSpecialAccess: Nullable<PremiumConditions> = currentUserId
+    ? { type: PremiumContentType.FOLLOW_GATED, follow_user_id: currentUserId }
     : null
   const [selectedSpecialAccessGate, setSelectedSpecialAccessGate] = useState(
     !('nft_collection' in (previousPremiumConditions ?? {}))
@@ -141,13 +141,19 @@ export const SpecialAccessAvailability = ({
 
   const handlePressFollowers = useCallback(() => {
     if (currentUserId) {
-      setSelectedSpecialAccessGate({ follow_user_id: currentUserId })
+      setSelectedSpecialAccessGate({
+        type: PremiumContentType.FOLLOW_GATED,
+        follow_user_id: currentUserId
+      })
     }
   }, [currentUserId])
 
   const handlePressSupporters = useCallback(() => {
     if (currentUserId) {
-      setSelectedSpecialAccessGate({ tip_user_id: currentUserId })
+      setSelectedSpecialAccessGate({
+        type: PremiumContentType.TIP_GATED,
+        tip_user_id: currentUserId
+      })
     }
   }, [currentUserId])
 

--- a/packages/mobile/src/screens/edit-track-screen/screens/NFTCollectionsScreen.tsx
+++ b/packages/mobile/src/screens/edit-track-screen/screens/NFTCollectionsScreen.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useMemo } from 'react'
 
 import type { Nullable, PremiumConditions } from '@audius/common'
-import { Chain, collectiblesSelectors } from '@audius/common'
+import {
+  Chain,
+  PremiumContentType,
+  collectiblesSelectors
+} from '@audius/common'
 import { useField } from 'formik'
 import { View, Image } from 'react-native'
 import { useSelector } from 'react-redux'
@@ -118,6 +122,7 @@ export const NFTCollectionsScreen = () => {
     (value: string) => {
       if (ethCollectionMap[value]) {
         setPremiumConditions({
+          type: PremiumContentType.COLLECTIBLE_GATED,
           nft_collection: {
             chain: Chain.Eth,
             standard: ethCollectionMap[value].standard,
@@ -130,6 +135,7 @@ export const NFTCollectionsScreen = () => {
         })
       } else if (solCollectionMap[value]) {
         setPremiumConditions({
+          type: PremiumContentType.COLLECTIBLE_GATED,
           nft_collection: {
             chain: Chain.Sol,
             address: value,

--- a/packages/web/src/common/store/cache/tracks/utils/reformat.ts
+++ b/packages/web/src/common/store/cache/tracks/utils/reformat.ts
@@ -67,7 +67,7 @@ const setDefaultFolloweeSaves = <T extends TrackMetadata>(track: T) => {
 }
 
 const setTypedPremiumConditions = <T extends TrackMetadata>(track: T) => {
-  const premium_conditions = track.premium_conditions as any
+  const premium_conditions = track.premium_conditions as unknown as any
   let type
   if (premium_conditions?.nft_collection != null) {
     type = PremiumContentType.COLLECTIBLE_GATED

--- a/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
+++ b/packages/web/src/components/track-availability-modal/CollectibleGatedAvailability.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react'
 import {
   Chain,
   collectiblesSelectors,
+  PremiumContentType,
   TrackAvailabilityType
 } from '@audius/common'
 import { useSelector } from 'react-redux'
@@ -124,6 +125,7 @@ export const CollectibleGatedAvailability = ({
           if (ethCollectionMap[value]) {
             onStateUpdate(
               {
+                type: PremiumContentType.COLLECTIBLE_GATED,
                 nft_collection: {
                   chain: Chain.Eth,
                   standard: ethCollectionMap[value].standard,
@@ -139,6 +141,7 @@ export const CollectibleGatedAvailability = ({
           } else if (solCollectionMap[value]) {
             onStateUpdate(
               {
+                type: PremiumContentType.COLLECTIBLE_GATED,
                 nft_collection: {
                   chain: Chain.Sol,
                   address: value,

--- a/packages/web/src/components/track-availability-modal/SpecialAccessAvailability.tsx
+++ b/packages/web/src/components/track-availability-modal/SpecialAccessAvailability.tsx
@@ -1,6 +1,10 @@
 import { ChangeEvent, useCallback } from 'react'
 
-import { accountSelectors, TrackAvailabilityType } from '@audius/common'
+import {
+  accountSelectors,
+  PremiumContentType,
+  TrackAvailabilityType
+} from '@audius/common'
 import { IconInfo, RadioButton, RadioButtonGroup } from '@audius/stems'
 import cn from 'classnames'
 import { useSelector } from 'react-redux'
@@ -39,12 +43,15 @@ export const SpecialAccessAvailability = ({
       if (accountUserId) {
         if (type === SpecialAccessType.FOLLOW) {
           onStateUpdate(
-            { follow_user_id: accountUserId },
+            {
+              type: PremiumContentType.FOLLOW_GATED,
+              follow_user_id: accountUserId
+            },
             TrackAvailabilityType.SPECIAL_ACCESS
           )
         } else if (type === SpecialAccessType.TIP) {
           onStateUpdate(
-            { tip_user_id: accountUserId },
+            { type: PremiumContentType.TIP_GATED, tip_user_id: accountUserId },
             TrackAvailabilityType.SPECIAL_ACCESS
           )
         }

--- a/packages/web/src/components/track-availability-modal/TrackAvailabilityModal.tsx
+++ b/packages/web/src/components/track-availability-modal/TrackAvailabilityModal.tsx
@@ -6,7 +6,8 @@ import {
   TrackAvailabilityType,
   collectiblesSelectors,
   Nullable,
-  Track
+  Track,
+  PremiumContentType
 } from '@audius/common'
 import {
   Modal,
@@ -171,8 +172,14 @@ const TrackAvailabilityModal = ({
   const noHidden = !isUpload && !initialForm.is_unlisted
 
   const accountUserId = useSelector(getUserId)
-  const defaultSpecialAccess = useMemo(
-    () => (accountUserId ? { follow_user_id: accountUserId } : null),
+  const defaultSpecialAccess: Nullable<PremiumConditions> = useMemo(
+    () =>
+      accountUserId
+        ? {
+            type: PremiumContentType.FOLLOW_GATED,
+            follow_user_id: accountUserId
+          }
+        : null,
     [accountUserId]
   )
 
@@ -216,7 +223,7 @@ const TrackAvailabilityModal = ({
 
         // Keep track of previously selected collectible and special access gates
         // in case the user switches back and forth between radio items
-        if (premiumConditions.nft_collection) {
+        if (premiumConditions.type === PremiumContentType.COLLECTIBLE_GATED) {
           setSelectedNFTCollection(premiumConditions.nft_collection)
         } else {
           setSelectedSpecialAccessGate(premiumConditions)
@@ -232,9 +239,12 @@ const TrackAvailabilityModal = ({
         didUpdateState({
           ...defaultAvailabilityFields,
           is_premium: true,
-          premium_conditions: {
-            nft_collection: selectedNFTCollection
-          }
+          premium_conditions: selectedNFTCollection
+            ? {
+                type: PremiumContentType.COLLECTIBLE_GATED,
+                nft_collection: selectedNFTCollection
+              }
+            : null
         })
       }
     },

--- a/packages/web/src/components/track-availability-modal/TrackAvailabilityModal.tsx
+++ b/packages/web/src/components/track-availability-modal/TrackAvailabilityModal.tsx
@@ -239,12 +239,10 @@ const TrackAvailabilityModal = ({
         didUpdateState({
           ...defaultAvailabilityFields,
           is_premium: true,
-          premium_conditions: selectedNFTCollection
-            ? {
-                type: PremiumContentType.COLLECTIBLE_GATED,
-                nft_collection: selectedNFTCollection
-              }
-            : null
+          premium_conditions: {
+            type: PremiumContentType.COLLECTIBLE_GATED,
+            nft_collection: selectedNFTCollection
+          }
         })
       }
     },


### PR DESCRIPTION
### Description
Converts `premium_content` to a discriminated union. Updates usages in `usPremiumContent` and the premium content saga. Also updates setters in web and mobile to include a `type` field.

### Dragons
Note the `as unknown as any` in `reformat`. `premium_content` comes from the backend as the old `PremiumConditions` type (no `type` field), but we treat it as if it were the new type and therefore get type errors if we try to read `nft_collection`, `follower_user_id` directly. Open to ideas here.

### How Has This Been Tested?

Local ios stage + web stage. Tested both uploading + editing collectible-gated tracks on web + mobile.

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

