### PR TITLE
[C-2827] Fix hidden dog ear on search results

### DIFF
--- a/packages/web/src/components/card/desktop/Card.tsx
+++ b/packages/web/src/components/card/desktop/Card.tsx
@@ -154,7 +154,7 @@ const Card = ({
   isReposted,
   isSaved,
   playlistId,
-  isPublic,
+  isPublic = true,
   playlistName,
   primaryText,
   secondaryText,


### PR DESCRIPTION
### Description

Fixes issue where hidden dog ear shows up on some cards because `isPublic` is missing. Defaulting it to true is a good default.
