### PR TITLE
Call the DN selection callback in AudiusBackend if using a cached DN

### DIFF
--- a/packages/common/src/services/audius-backend/AudiusBackend.ts
+++ b/packages/common/src/services/audius-backend/AudiusBackend.ts
@@ -697,6 +697,14 @@ export const audiusBackend = ({
     if (useSdkDiscoveryNodeSelector) {
       discoveryNodeSelector = await discoveryNodeSelectorService.getInstance()
 
+      const initialSelectedNode: string | undefined =
+        // TODO: Need a synchronous method to check if a discovery node is already selected?
+        // Alternatively, remove all this AudiusBackend/Libs init/APIClient init stuff in favor of SDK
+        // @ts-ignore config is private
+        discoveryNodeSelector.config.initialSelectedNode
+      if (initialSelectedNode) {
+        discoveryProviderSelectionCallback(initialSelectedNode, [])
+      }
       discoveryNodeSelector.addEventListener('change', (endpoint) => {
         console.debug('[AudiusBackend] DiscoveryNodeSelector changed', endpoint)
         discoveryProviderSelectionCallback(endpoint, [])


### PR DESCRIPTION
### Description

Our endless retry logic happened again. I so want to rework this AudiusAPIClient and AudiusBackend nonsense but in the meantime, just added this minor hack to allow cached DNs to work.

It calls the AudiusBackend DN change listener if the config for DN selector has an initialSelectedNode.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Relies on using a private member of DN selector, `config`, and as such requires a `@ts-ignore`.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

