### PR TITLE
[C-2809] Remove user from image hooks

### DIFF
--- a/packages/mobile/src/components/audio/Audio.tsx
+++ b/packages/mobile/src/components/audio/Audio.tsx
@@ -625,7 +625,6 @@ export const Audio = () => {
           ? getImageSourceOptimistic({
               cid,
               endpoints: storageNodeSelector.getNodes(cid),
-              user: trackOwner,
               size: SquareSizes.SIZE_1000_BY_1000,
               localSource: localTrackImageSource
             })?.uri ?? DEFAULT_IMAGE_URL

--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -3,10 +3,9 @@ import type {
   ID,
   Maybe,
   Nullable,
-  SquareSizes,
-  User
+  SquareSizes
 } from '@audius/common'
-import { reachabilitySelectors, cacheUsersSelectors } from '@audius/common'
+import { reachabilitySelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import imageEmpty from 'app/assets/images/imageBlank2x.png'
@@ -20,7 +19,6 @@ import type { FastImageProps } from './FastImage'
 import { FastImage } from './FastImage'
 
 const { getIsReachable } = reachabilitySelectors
-const { getUser } = cacheUsersSelectors
 
 type UseCollectionImageOptions = {
   collection: Nullable<
@@ -30,7 +28,6 @@ type UseCollectionImageOptions = {
     >
   >
   size: SquareSizes
-  user?: Pick<User, 'creator_node_endpoint'>
 }
 
 const useLocalCollectionImageUri = (collectionId: Maybe<ID>) => {
@@ -56,14 +53,10 @@ const useLocalCollectionImageUri = (collectionId: Maybe<ID>) => {
 }
 
 export const useCollectionImage = (options: UseCollectionImageOptions) => {
-  const { collection, size, user } = options
+  const { collection, size } = options
   const cid = collection
     ? collection.cover_art_sizes || collection.cover_art
     : null
-
-  const selectedUser = useSelector((state) =>
-    getUser(state, { id: collection?.playlist_owner_id })
-  )
 
   const localCollectionImageUri = useLocalCollectionImageUri(
     collection?.playlist_id
@@ -72,7 +65,6 @@ export const useCollectionImage = (options: UseCollectionImageOptions) => {
   const contentNodeSource = useContentNodeImage({
     cid,
     size,
-    user: selectedUser ?? user ?? null,
     fallbackImageSource: imageEmpty,
     localSource: localCollectionImageUri
       ? { uri: localCollectionImageUri }
@@ -85,9 +77,9 @@ export const useCollectionImage = (options: UseCollectionImageOptions) => {
 type CollectionImageProps = UseCollectionImageOptions & Partial<FastImageProps>
 
 export const CollectionImage = (props: CollectionImageProps) => {
-  const { collection, size, user, style, ...other } = props
+  const { collection, size, style, ...other } = props
 
-  const collectionImageSource = useCollectionImage({ collection, size, user })
+  const collectionImageSource = useCollectionImage({ collection, size })
   const { neutralLight6 } = useThemeColors()
 
   if (!collectionImageSource) return null

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -1,12 +1,5 @@
-import type {
-  User,
-  Track,
-  Nullable,
-  SquareSizes,
-  ID,
-  Maybe
-} from '@audius/common'
-import { reachabilitySelectors, cacheUsersSelectors } from '@audius/common'
+import type { Track, Nullable, SquareSizes, ID, Maybe } from '@audius/common'
+import { reachabilitySelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import imageEmpty from 'app/assets/images/imageBlank2x.png'
@@ -23,14 +16,10 @@ export const DEFAULT_IMAGE_URL =
   'https://download.audius.co/static-resources/preview-image.jpg'
 
 const { getIsReachable } = reachabilitySelectors
-const { getUser } = cacheUsersSelectors
 
 type UseTrackImageOptions = {
-  track: Nullable<
-    Pick<Track, 'track_id' | 'cover_art_sizes' | 'cover_art' | 'owner_id'>
-  >
+  track: Nullable<Pick<Track, 'track_id' | 'cover_art_sizes' | 'cover_art'>>
   size: SquareSizes
-  user?: Pick<User, 'creator_node_endpoint'>
 }
 
 const useLocalTrackImageUri = (trackId: Maybe<ID>) => {
@@ -50,19 +39,14 @@ const useLocalTrackImageUri = (trackId: Maybe<ID>) => {
   return trackImageUri
 }
 
-export const useTrackImage = ({ track, size, user }: UseTrackImageOptions) => {
+export const useTrackImage = ({ track, size }: UseTrackImageOptions) => {
   const cid = track ? track.cover_art_sizes || track.cover_art : null
-
-  const selectedUser = useSelector((state) =>
-    getUser(state, { id: track?.owner_id })
-  )
 
   const localTrackImageUri = useLocalTrackImageUri(track?.track_id)
 
   const contentNodeSource = useContentNodeImage({
     cid,
     size,
-    user: user ?? selectedUser,
     fallbackImageSource: imageEmpty,
     localSource: localTrackImageUri ? { uri: localTrackImageUri } : null
   })
@@ -73,9 +57,9 @@ export const useTrackImage = ({ track, size, user }: UseTrackImageOptions) => {
 type TrackImageProps = UseTrackImageOptions & Partial<FastImageProps>
 
 export const TrackImage = (props: TrackImageProps) => {
-  const { track, size, user, style, ...other } = props
+  const { track, size, style, ...other } = props
 
-  const trackImageSource = useTrackImage({ track, size, user })
+  const trackImageSource = useTrackImage({ track, size })
   const { neutralLight8 } = useThemeColors()
 
   if (!trackImageSource) return null

--- a/packages/mobile/src/components/image/UserCoverImage.tsx
+++ b/packages/mobile/src/components/image/UserCoverImage.tsx
@@ -25,13 +25,7 @@ const interpolateImageTranslate = (animatedValue: Animated.Value) =>
   })
 
 type CoverImageUser = Nullable<
-  Pick<
-    User,
-    | 'cover_photo_sizes'
-    | 'cover_photo'
-    | 'creator_node_endpoint'
-    | 'updatedCoverPhoto'
-  >
+  Pick<User, 'cover_photo_sizes' | 'cover_photo' | 'updatedCoverPhoto'>
 >
 
 export const useUserCoverImage = (user: CoverImageUser) => {
@@ -39,7 +33,6 @@ export const useUserCoverImage = (user: CoverImageUser) => {
 
   const contentNodeImage = useContentNodeImage({
     cid,
-    user,
     size: WidthSizes.SIZE_640,
     fallbackImageSource: imageCoverPhotoBlank
   })

--- a/packages/mobile/src/components/image/UserImage.tsx
+++ b/packages/mobile/src/components/image/UserImage.tsx
@@ -10,10 +10,7 @@ type UseUserImageOptions = {
   user: Nullable<
     Pick<
       User,
-      | 'profile_picture_sizes'
-      | 'profile_picture'
-      | 'creator_node_endpoint'
-      | 'updatedProfilePicture'
+      'profile_picture_sizes' | 'profile_picture' | 'updatedProfilePicture'
     >
   >
   size: SquareSizes
@@ -25,7 +22,6 @@ export const useUserImage = ({ user, size }: UseUserImageOptions) => {
   const contentNodeImage = useContentNodeImage({
     cid,
     size,
-    user,
     fallbackImageSource: profilePicEmpty
   })
 

--- a/packages/mobile/src/screens/search-screen/SearchResults/SearchItem.tsx
+++ b/packages/mobile/src/screens/search-screen/SearchResults/SearchItem.tsx
@@ -95,7 +95,6 @@ const TrackSearchResult = (props: TrackSearchResultProps) => {
       <TrackImage
         track={track}
         size={SquareSizes.SIZE_150_BY_150}
-        user={track.user}
         style={styles.squareImage}
       />
       <View style={styles.nameContainer}>
@@ -134,7 +133,6 @@ const PlaylistSearchResult = (props: PlaylistSearchResultProps) => {
       <CollectionImage
         collection={playlist}
         size={SquareSizes.SIZE_150_BY_150}
-        user={playlist.user}
         style={styles.squareImage}
       />
       <View style={styles.nameContainer}>
@@ -173,7 +171,6 @@ const AlbumSearchResult = (props: AlbumSearchResultProps) => {
       <CollectionImage
         collection={album}
         size={SquareSizes.SIZE_150_BY_150}
-        user={album.user}
         style={styles.squareImage}
       />
       <View style={styles.nameContainer}>

--- a/packages/mobile/src/store/account/sagas.ts
+++ b/packages/mobile/src/store/account/sagas.ts
@@ -29,7 +29,6 @@ function* cacheUserImages(user: User) {
     const profileImageUri = profile_picture_sizes
       ? getImageSourceOptimistic({
           cid: profile_picture_sizes,
-          user,
           endpoints: storageNodeSelector.getNodes(profile_picture_sizes),
           size: SquareSizes.SIZE_150_BY_150
         })?.uri
@@ -38,7 +37,6 @@ function* cacheUserImages(user: User) {
     const coverPhotoUri = cover_photo_sizes
       ? getImageSourceOptimistic({
           cid: cover_photo_sizes,
-          user,
           endpoints: storageNodeSelector.getNodes(cover_photo_sizes),
           size: WidthSizes.SIZE_640
         }).uri

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadCollectionWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadCollectionWorker.ts
@@ -1,4 +1,4 @@
-import type { UserCollectionMetadata } from '@audius/common'
+import type { CollectionMetadata, UserCollectionMetadata } from '@audius/common'
 import {
   removeNullable,
   SquareSizes,
@@ -148,15 +148,14 @@ function* downloadCollectionAsync(
   return OfflineDownloadStatus.SUCCESS
 }
 
-function* downloadCollectionCoverArt(collection: UserCollectionMetadata) {
-  const { cover_art_sizes, cover_art, user, playlist_id } = collection
+function* downloadCollectionCoverArt(collection: CollectionMetadata) {
+  const { cover_art_sizes, cover_art, playlist_id } = collection
   const cid = cover_art_sizes ?? cover_art
   const storageNodeSelector = yield* call(getStorageNodeSelector)
 
   const imageSources = createAllImageSources({
     cid,
     endpoints: cid ? storageNodeSelector.getNodes(cid) : [],
-    user,
     size: SquareSizes.SIZE_1000_BY_1000
   })
 

--- a/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/offlineQueueSagas/workers/downloadTrackWorker.ts
@@ -1,4 +1,10 @@
-import type { ID, QueryParams, Track, UserTrackMetadata } from '@audius/common'
+import type {
+  ID,
+  QueryParams,
+  Track,
+  TrackMetadata,
+  UserTrackMetadata
+} from '@audius/common'
 import {
   getQueryParams,
   FeatureFlags,
@@ -192,8 +198,8 @@ function* downloadTrackAudio(track: UserTrackMetadata) {
   throw new Error('Unable to download track audio')
 }
 
-function* downloadTrackCoverArt(track: UserTrackMetadata) {
-  const { cover_art_sizes, cover_art, user, track_id } = track
+function* downloadTrackCoverArt(track: TrackMetadata) {
+  const { cover_art_sizes, cover_art, track_id } = track
   const cid = cover_art_sizes ?? cover_art
 
   const storageNodeSelector = yield* call(getStorageNodeSelector)
@@ -201,7 +207,6 @@ function* downloadTrackCoverArt(track: UserTrackMetadata) {
   const imageSources = createAllImageSources({
     cid,
     endpoints: cid ? storageNodeSelector.getNodes(cid) : [],
-    user,
     size: SquareSizes.SIZE_1000_BY_1000
   })
 


### PR DESCRIPTION
### Description

Now that we dont need user.creator_node_endpoint, a lot of the mobile image hooks dont need to pull in the user. this is great cause it simplifies the api and also reduces rerender count since we dont listen to user updates.
