### PR TITLE
[PAY-1561][PAY-1558] Implement USDC variants on track details page

### DIFF
--- a/packages/stems/src/assets/styles/colors.css
+++ b/packages/stems/src/assets/styles/colors.css
@@ -64,6 +64,11 @@ root {
 
   --special-light-green: #13c65a;
 
+  /* Semantic text */
+  --text-default: var(--neutral);
+  --text-subdued: var(--neutral-light-4);
+  --text-disabled: var(--neutral-light-7);
+
   --primary-gradient: linear-gradient(135deg, #ee00ed 0%, #c514e0 100%);
   --secondary-gradient: linear-gradient(315deg, #6b0fb3 0%, #7e1bcc 100%);
   --page-header-gradient-color-1: #5b23e1;

--- a/packages/stems/src/components/Button/Button.module.css
+++ b/packages/stems/src/components/Button/Button.module.css
@@ -32,6 +32,25 @@
   height: var(--unit-8);
 }
 
+.button.large {
+  padding: var(--unit-5) var(--unit-6);
+  height: var(--unit-15);
+  gap: var(--unit-2);
+}
+
+.button.large .textLabel {
+  font-size: var(--font-xl);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.25px;
+  line-height: var(--unit-5);
+  text-transform: uppercase;
+}
+
+.button.large .icon,
+.button.large .icon.left {
+  margin-right: 0;
+}
+
 .button.tiny {
   height: var(--unit-7);
   padding-left: var(--unit-4);
@@ -43,6 +62,10 @@
 }
 
 .button.small .icon svg {
+  width: var(--unit-4);
+}
+
+.button.tiny .icon svg {
   width: var(--unit-4);
 }
 
@@ -164,13 +187,13 @@
 /* Secondary Button */
 
 .secondary {
-  border: 1px solid var(--primary-dark-1);
+  border: 1px solid var(--neutral-light-5);
   border-radius: 4px;
   background: var(--white);
 }
 
 .secondary .textLabel {
-  color: var(--primary);
+  color: var(--text-default);
   font-size: var(--font-l);
   font-weight: var(--font-bold);
 }
@@ -187,28 +210,35 @@
 
 .secondary .icon path,
 .secondary .icon use {
-  fill: var(--primary);
+  fill: var(--text-default);
 }
 
 .secondary.includeHoverAnimations:hover:enabled {
   transform: var(--grow);
-  border: 1px solid var(--primary-dark-2);
-  background: var(--primary);
+  border-color: var(--primary);
 }
 
 .secondary.includeHoverAnimations:hover:enabled .textLabel {
-  color: var(--primary-secondary-text);
+  color: var(--primary);
 }
 
 .secondary.includeHoverAnimations:hover:enabled .icon path,
 .secondary.includeHoverAnimations:hover:enabled .icon use {
-  fill: var(--primary-secondary-text);
+  fill: var(--primary);
 }
 
 .secondary.includeHoverAnimations:active:enabled {
   transform: perspective(1px) scale3d(0.99, 0.99, 0.99);
-  border: 1px solid var(--primary-dark-2);
-  background: var(--primary-dark-2);
+  border-color: var(--primary-dark-2);
+}
+
+.secondary.includeHoverAnimations:active:enabled .textLabel {
+  color: var(--primary-dark-2)
+}
+
+.secondary.includeHoverAnimations:active:enabled .icon path,
+.secondary.includeHoverAnimations:active:enabled .icon use {
+  fill: var(--primary-dark-2);
 }
 
 /* Tertiary Button */

--- a/packages/stems/src/components/Button/Button.stories.tsx
+++ b/packages/stems/src/components/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import { Story } from '@storybook/react'
 
 import * as Icons from 'components/Icons'
+import { ButtonSize } from 'index'
 
 import { Button } from './Button'
 import { ButtonProps, Type } from './types'
@@ -17,7 +18,12 @@ const baseProps: ButtonProps = {
 }
 
 const Template: Story<ButtonProps> = (args) => (
-  <Button {...baseProps} {...args} />
+  <div style={{ alignItems: 'center', display: 'flex', gap: '16px' }}>
+    <Button {...baseProps} size={ButtonSize.TINY} {...args} />
+    <Button {...baseProps} size={ButtonSize.SMALL} {...args} />
+    <Button {...baseProps} size={ButtonSize.MEDIUM} {...args} />
+    <Button {...baseProps} size={ButtonSize.LARGE} {...args} />
+  </div>
 )
 
 const BackgroundTemplate: Story<ButtonProps> = (args) => (

--- a/packages/stems/src/components/Button/Button.tsx
+++ b/packages/stems/src/components/Button/Button.tsx
@@ -12,7 +12,8 @@ import { ButtonProps, Type, Size } from './types'
 const SIZE_STYLE_MAP = {
   [Size.TINY]: styles.tiny,
   [Size.SMALL]: styles.small,
-  [Size.MEDIUM]: styles.medium
+  [Size.MEDIUM]: styles.medium,
+  [Size.LARGE]: styles.large
 }
 
 const TYPE_STYLE_MAP = {

--- a/packages/stems/src/components/Button/types.ts
+++ b/packages/stems/src/components/Button/types.ts
@@ -19,7 +19,8 @@ export enum Type {
 export enum Size {
   TINY = 'tiny',
   SMALL = 'small',
-  MEDIUM = 'medium'
+  MEDIUM = 'medium',
+  LARGE = 'large'
 }
 
 type BaseButtonProps = Omit<

--- a/packages/web/src/components/locked-content-modal/LockedContentModal.tsx
+++ b/packages/web/src/components/locked-content-modal/LockedContentModal.tsx
@@ -64,7 +64,8 @@ const TrackDetails = ({ track, owner }: { track: Track; owner: User }) => {
   })
   const label = `${title} by ${owner.name}`
   const isCollectibleGated = isPremiumContentCollectibleGated(premiumConditions)
-  const isPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
+  const isUSDCPurchaseGated =
+    isPremiumContentUSDCPurchaseGated(premiumConditions)
 
   let IconComponent = IconSpecialAccess
   let message = messages.specialAccess
@@ -72,7 +73,7 @@ const TrackDetails = ({ track, owner }: { track: Track; owner: User }) => {
   if (isCollectibleGated) {
     IconComponent = IconCollectible
     message = messages.collectibleGated
-  } else if (isPurchaseGated) {
+  } else if (isUSDCPurchaseGated) {
     IconComponent = IconCart
     message = messages.premiumContent
   }

--- a/packages/web/src/components/locked-content-modal/LockedContentModal.tsx
+++ b/packages/web/src/components/locked-content-modal/LockedContentModal.tsx
@@ -8,7 +8,8 @@ import {
   Track,
   useLockedContent,
   usePremiumContentAccess,
-  User
+  User,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import {
   IconLock,
@@ -16,7 +17,8 @@ import {
   ModalHeader,
   ModalTitle,
   IconCollectible,
-  IconSpecialAccess
+  IconSpecialAccess,
+  IconCart
 } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch } from 'react-redux'
@@ -38,7 +40,8 @@ const { resetLockedContentId } = premiumContentActions
 const messages = {
   howToUnlock: 'HOW TO UNLOCK',
   collectibleGated: 'COLLECTIBLE GATED',
-  specialAccess: 'SPECIAL ACCESS'
+  specialAccess: 'SPECIAL ACCESS',
+  premiumContent: 'PREMIUM CONTENT'
 }
 
 const TrackDetails = ({ track, owner }: { track: Track; owner: User }) => {
@@ -61,6 +64,18 @@ const TrackDetails = ({ track, owner }: { track: Track; owner: User }) => {
   })
   const label = `${title} by ${owner.name}`
   const isCollectibleGated = isPremiumContentCollectibleGated(premiumConditions)
+  const isPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
+
+  let IconComponent = IconSpecialAccess
+  let message = messages.specialAccess
+
+  if (isCollectibleGated) {
+    IconComponent = IconCollectible
+    message = messages.collectibleGated
+  } else if (isPurchaseGated) {
+    IconComponent = IconCart
+    message = messages.premiumContent
+  }
 
   return (
     <div className={styles.trackDetails}>
@@ -73,12 +88,8 @@ const TrackDetails = ({ track, owner }: { track: Track; owner: User }) => {
       {dogEarType ? <DogEar type={dogEarType} /> : null}
       <div>
         <div className={styles.premiumContentLabel}>
-          {isCollectibleGated ? <IconCollectible /> : <IconSpecialAccess />}
-          <span>
-            {isCollectibleGated
-              ? messages.collectibleGated
-              : messages.specialAccess}
-          </span>
+          <IconComponent />
+          <span>{message}</span>
         </div>
         <p className={styles.trackTitle}>{title}</p>
         <div className={styles.trackOwner}>
@@ -145,6 +156,7 @@ export const LockedContentModal = () => {
               wrapperClassName={styles.premiumTrackSectionWrapper}
               className={styles.premiumTrackSection}
               buttonClassName={styles.premiumTrackSectionButton}
+              ownerId={owner.user_id}
             />
           </div>
         )}

--- a/packages/web/src/components/track/CardTitle.tsx
+++ b/packages/web/src/components/track/CardTitle.tsx
@@ -2,9 +2,10 @@ import {
   FeatureFlags,
   Nullable,
   PremiumConditions,
-  isPremiumContentCollectibleGated
+  isPremiumContentCollectibleGated,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
-import { IconCollectible, IconSpecialAccess } from '@audius/stems'
+import { IconCart, IconCollectible, IconSpecialAccess } from '@audius/stems'
 import cn from 'classnames'
 
 import Tooltip from 'components/tooltip/Tooltip'
@@ -20,7 +21,8 @@ const messages = {
   remixTitle: 'REMIX',
   hiddenTrackTooltip: 'Anyone with a link to this page will be able to see it',
   collectibleGated: 'COLLECTIBLE GATED',
-  specialAccess: 'SPECIAL ACCESS'
+  specialAccess: 'SPECIAL ACCESS',
+  premiumContent: 'PREMIUM TRACK'
 }
 
 type CardTitleProps = {
@@ -54,6 +56,9 @@ export const CardTitle = ({
     if (isPremiumContentCollectibleGated(premiumConditions)) {
       icon = <IconCollectible />
       message = messages.collectibleGated
+    } else if (isPremiumContentUSDCPurchaseGated(premiumConditions)) {
+      icon = <IconCart />
+      message = messages.premiumContent
     } else {
       icon = <IconSpecialAccess />
       message = messages.specialAccess

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -113,27 +113,12 @@
   margin-top: 7px;
   display: flex;
   align-items: center;
+  gap: var(--unit-6);
   flex-wrap: wrap;
 }
 
 .playSection > * {
   margin-top: var(--unit-4);
-}
-
-.playButton {
-  width: 180px !important;
-  height: var(--unit-15) !important;
-  padding: 0;
-  display: flex;
-  justify-content: center;
-  margin-right: var(--unit-6);
-}
-
-.playButton .playButtonText {
-  font-size: var(--font-xl);
-  font-weight: var(--font-bold);
-  letter-spacing: 0.71px;
-  text-transform: uppercase;
 }
 
 .infoSection .numberOfListens {

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -234,6 +234,10 @@
   margin-bottom: var(--unit-2);
 }
 
+.premiumContentSectionDescription {
+  text-align: left;
+}
+
 .premiumContentSectionDescription > p {
   display: flex;
   align-items: center;
@@ -446,10 +450,6 @@
 
 .spinner path {
   stroke: var(--neutral-light-4);
-}
-
-.premiumContentSectionDescription > div {
-  text-align: left;
 }
 
 .premiumContentSectionDescription > div > span {

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -309,15 +309,13 @@
   color: var(--secondary-dark-2);
 }
 
-.collectibleIcon,
-.specialAccessIcon {
+.gatedContentIcon {
   margin-right: var(--unit-2);
   width: var(--unit-4);
   height: var(--unit-4);
 }
 
-.collectibleIcon path,
-.specialAccessIcon path {
+.gatedContentIcon path {
   fill: var(--neutral);
 }
 

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -188,8 +188,13 @@ export const GiantTrackTile = ({
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED,
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
-  const isPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
-  const showPreview = isOwner || (isPurchaseGated && !doesUserHaveAccess)
+  const isUSDCPurchaseGated =
+    isPremiumContentUSDCPurchaseGated(premiumConditions)
+  // Preview button is shown for USDC-gated tracks if user does not have access
+  // or is the owner
+  const showPreview = isUSDCPurchaseGated && (isOwner || !doesUserHaveAccess)
+  // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
+  const showPlay = isUSDCPurchaseGated ? doesUserHaveAccess : true
 
   // TODO: https://linear.app/audius/issue/PAY-1590/[webmobileweb]-add-support-for-playing-previews
   const onPreview = useCallback(() => {
@@ -537,9 +542,9 @@ export const GiantTrackTile = ({
           </div>
 
           <div className={cn(styles.playSection, fadeIn)}>
-            {doesUserHaveAccess ? (
+            {showPlay ? (
               <PlayPauseButton
-                doesUserHaveAccess={doesUserHaveAccess}
+                disabled={!doesUserHaveAccess}
                 playing={playing}
                 onPlay={onPlay}
                 trackId={trackId}
@@ -551,7 +556,6 @@ export const GiantTrackTile = ({
                 onPlay={onPreview}
                 trackId={trackId}
                 isPreview
-                doesUserHaveAccess
               />
             ) : null}
             {isLongFormContent && isNewPodcastControlsEnabled ? (

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -190,6 +190,8 @@ export const GiantTrackTile = ({
   )
   const isPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
   const showPreview = isOwner || (isPurchaseGated && !doesUserHaveAccess)
+
+  // TODO: https://linear.app/audius/issue/PAY-1590/[webmobileweb]-add-support-for-playing-previews
   const onPreview = useCallback(() => {
     console.log('Preview Clicked')
   }, [])

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -189,7 +189,7 @@ export const GiantTrackTile = ({
     FeatureFlags.PODCAST_CONTROL_UPDATES_ENABLED_FALLBACK
   )
   const isPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
-  const isPreview = !isOwner && isPurchaseGated && !doesUserHaveAccess
+  const showPreview = isOwner || (isPurchaseGated && !doesUserHaveAccess)
   const onPreview = useCallback(() => {
     console.log('Preview Clicked')
   }, [])
@@ -535,15 +535,15 @@ export const GiantTrackTile = ({
           </div>
 
           <div className={cn(styles.playSection, fadeIn)}>
-            <PlayPauseButton
-              doesUserHaveAccess={doesUserHaveAccess}
-              isPreview={isPreview}
-              playing={playing}
-              onPlay={isPreview ? onPreview : onPlay}
-              trackId={trackId}
-            />
-            {/* Always render preview button for owner */}
-            {isOwner ? (
+            {doesUserHaveAccess ? (
+              <PlayPauseButton
+                doesUserHaveAccess={doesUserHaveAccess}
+                playing={playing}
+                onPlay={onPlay}
+                trackId={trackId}
+              />
+            ) : null}
+            {showPreview ? (
               <PlayPauseButton
                 playing={playing}
                 onPlay={onPreview}

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -596,6 +596,7 @@ export const GiantTrackTile = ({
           premiumConditions={premiumConditions}
           doesUserHaveAccess={doesUserHaveAccess}
           isOwner={isOwner}
+          ownerId={userId}
         />
       ) : null}
 

--- a/packages/web/src/components/track/PlayPauseButton.tsx
+++ b/packages/web/src/components/track/PlayPauseButton.tsx
@@ -23,7 +23,7 @@ const { getTrackId } = playerSelectors
 const { getTrackPosition } = playbackPositionSelectors
 
 type PlayPauseButtonProps = {
-  doesUserHaveAccess: boolean
+  disabled?: boolean
   isPreview?: boolean
   playing: boolean
   trackId?: ID
@@ -39,7 +39,7 @@ const messages = {
 }
 
 export const PlayPauseButton = ({
-  doesUserHaveAccess,
+  disabled,
   isPreview = false,
   playing,
   trackId,
@@ -86,7 +86,7 @@ export const PlayPauseButton = ({
       leftIcon={playing ? <IconPause /> : <PlayIconComponent />}
       onClick={onPlay}
       minWidth={180}
-      disabled={!doesUserHaveAccess && !isPreview}
+      disabled={disabled}
     />
   )
 }

--- a/packages/web/src/components/track/PlayPauseButton.tsx
+++ b/packages/web/src/components/track/PlayPauseButton.tsx
@@ -6,13 +6,17 @@ import {
   playbackPositionSelectors,
   CommonState
 } from '@audius/common'
-import { Button, ButtonType, IconPause, IconPlay } from '@audius/stems'
+import {
+  Button,
+  ButtonSize,
+  ButtonType,
+  IconPause,
+  IconPlay
+} from '@audius/stems'
 import { useSelector } from 'react-redux'
 
 import { ReactComponent as IconRepeat } from 'assets/img/iconRepeatOff.svg'
 import { useFlag } from 'hooks/useRemoteConfig'
-
-import styles from './GiantTrackTile.module.css'
 
 const { getUserId } = accountSelectors
 const { getTrackId } = playerSelectors
@@ -20,6 +24,7 @@ const { getTrackPosition } = playbackPositionSelectors
 
 type PlayPauseButtonProps = {
   doesUserHaveAccess: boolean
+  isPreview?: boolean
   playing: boolean
   trackId?: ID
   onPlay: () => void
@@ -27,6 +32,7 @@ type PlayPauseButtonProps = {
 
 const messages = {
   play: 'play',
+  preview: 'preview',
   pause: 'pause',
   resume: 'resume',
   replay: 'replay'
@@ -34,6 +40,7 @@ const messages = {
 
 export const PlayPauseButton = ({
   doesUserHaveAccess,
+  isPreview = false,
   playing,
   trackId,
   onPlay
@@ -50,32 +57,36 @@ export const PlayPauseButton = ({
     (state: CommonState) => trackId === getTrackId(state)
   )
 
-  const playText =
-    isNewPodcastControlsEnabled && trackPlaybackInfo
-      ? trackPlaybackInfo.status === 'IN_PROGRESS' || isCurrentTrack
-        ? messages.resume
-        : messages.replay
-      : messages.play
-
-  const playIcon =
-    isNewPodcastControlsEnabled &&
-    trackPlaybackInfo?.status === 'COMPLETED' &&
-    !isCurrentTrack ? (
-      <IconRepeat />
-    ) : (
-      <IconPlay />
-    )
+  let playText
+  let PlayIconComponent
+  if (isPreview) {
+    playText = messages.preview
+    PlayIconComponent = IconPlay
+  } else {
+    playText =
+      isNewPodcastControlsEnabled && trackPlaybackInfo
+        ? trackPlaybackInfo.status === 'IN_PROGRESS' || isCurrentTrack
+          ? messages.resume
+          : messages.replay
+        : messages.play
+    PlayIconComponent =
+      isNewPodcastControlsEnabled &&
+      trackPlaybackInfo?.status === 'COMPLETED' &&
+      !isCurrentTrack
+        ? IconRepeat
+        : IconPlay
+  }
 
   return (
     <Button
-      name='play'
-      className={styles.playButton}
-      textClassName={styles.playButtonText}
-      type={ButtonType.PRIMARY_ALT}
+      name={isPreview ? 'preview' : 'play'}
+      size={ButtonSize.LARGE}
+      type={isPreview ? ButtonType.SECONDARY : ButtonType.PRIMARY_ALT}
       text={playing ? messages.pause : playText}
-      leftIcon={playing ? <IconPause /> : playIcon}
+      leftIcon={playing ? <IconPause /> : <PlayIconComponent />}
       onClick={onPlay}
-      disabled={!doesUserHaveAccess}
+      minWidth={180}
+      disabled={!doesUserHaveAccess && !isPreview}
     />
   )
 }

--- a/packages/web/src/components/track/PremiumTrackSection.tsx
+++ b/packages/web/src/components/track/PremiumTrackSection.tsx
@@ -122,7 +122,8 @@ const LockedPremiumTrackSection = ({
     ? FollowSource.HOW_TO_UNLOCK_MODAL
     : FollowSource.HOW_TO_UNLOCK_TRACK_PAGE
   const account = useSelector(getAccountUser)
-  const isUSDCGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
+  const isUSDCPurchaseGated =
+    isPremiumContentUSDCPurchaseGated(premiumConditions)
 
   // TODO: https://linear.app/audius/issue/PAY-1531/[webmobileweb]-wire-up-purchase-usdc-flow
   const handlePurchase = useCallback(() => {
@@ -356,9 +357,9 @@ const LockedPremiumTrackSection = ({
         >
           <LockedStatusBadge
             locked
-            variant={isUSDCGated ? 'premium' : 'gated'}
+            variant={isUSDCPurchaseGated ? 'premium' : 'gated'}
           />
-          {isUSDCGated ? messages.payToUnlock : messages.howToUnlock}
+          {isUSDCPurchaseGated ? messages.payToUnlock : messages.howToUnlock}
         </div>
         {renderLockedDescription()}
       </div>

--- a/packages/web/src/components/track/PremiumTrackSection.tsx
+++ b/packages/web/src/components/track/PremiumTrackSection.tsx
@@ -124,6 +124,7 @@ const LockedPremiumTrackSection = ({
   const account = useSelector(getAccountUser)
   const isUSDCGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
 
+  // TODO: https://linear.app/audius/issue/PAY-1531/[webmobileweb]-wire-up-purchase-usdc-flow
   const handlePurchase = useCallback(() => {
     console.log('Purchase clicked')
   }, [])

--- a/packages/web/src/components/track/PremiumTrackSection.tsx
+++ b/packages/web/src/components/track/PremiumTrackSection.tsx
@@ -641,25 +641,26 @@ export const PremiumTrackSection = ({
   const premiumTrackStatus = premiumTrackStatusMap[trackId] ?? null
   const isFollowGated = isPremiumContentFollowGated(premiumConditions)
   const isTipGated = isPremiumContentTipGated(premiumConditions)
-  const isPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
+  const isUSDCPurchaseGated =
+    isPremiumContentUSDCPurchaseGated(premiumConditions)
   const shouldDisplay =
     isFollowGated ||
     isTipGated ||
     isPremiumContentCollectibleGated(premiumConditions) ||
-    isPurchaseGated
+    isUSDCPurchaseGated
   const users = useSelector<AppState, { [id: ID]: User }>((state) =>
     getUsers(state, {
       ids: [
         isFollowGated ? premiumConditions.follow_user_id : null,
         isTipGated ? premiumConditions.tip_user_id : null,
-        isPurchaseGated ? ownerId : null
+        isUSDCPurchaseGated ? ownerId : null
       ].filter(removeNullable)
     })
   )
   const followee = isFollowGated
     ? users[premiumConditions.follow_user_id]
     : null
-  const trackOwner = isPurchaseGated ? users[ownerId] : null
+  const trackOwner = isUSDCPurchaseGated ? users[ownerId] : null
   const tippedUser = isTipGated ? users[premiumConditions.tip_user_id] : null
 
   const fadeIn = {

--- a/packages/web/src/pages/track-page/components/HiddenTrackHeader.module.css
+++ b/packages/web/src/pages/track-page/components/HiddenTrackHeader.module.css
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   column-gap: var(--unit-2);
-  margin-bottom: var(--unit-4);
 }
 
 .label {

--- a/packages/web/src/pages/track-page/components/mobile/ActionButtonRow.module.css
+++ b/packages/web/src/pages/track-page/components/mobile/ActionButtonRow.module.css
@@ -45,9 +45,7 @@
   display: flex;
   justify-content: center;
   align-items: stretch;
-  border-bottom: 1px solid var(--neutral-light-7);
-  height: 60px;
-  padding: 12px 0px 8px;
+  height: var(--unit-8);
 }
 
 .animatedIconWrapper {

--- a/packages/web/src/pages/track-page/components/mobile/StatsButtonRow.module.css
+++ b/packages/web/src/pages/track-page/components/mobile/StatsButtonRow.module.css
@@ -54,5 +54,4 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 12px;
 }

--- a/packages/web/src/pages/track-page/components/mobile/StatsButtonRow.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/StatsButtonRow.tsx
@@ -11,6 +11,7 @@ const messages = {
 }
 
 type StatsButtonRowProps = {
+  className?: string
   showListenCount: boolean
   showFavoriteCount: boolean
   showRepostCount: boolean
@@ -23,6 +24,7 @@ type StatsButtonRowProps = {
 
 // A row of stats, visible on playlist and tracks pages.
 const StatsButtonRow = ({
+  className,
   showListenCount,
   showFavoriteCount,
   showRepostCount,
@@ -62,7 +64,7 @@ const StatsButtonRow = ({
   return (
     <>
       {(showListenCount || showFavoriteCount || showRepostCount) && (
-        <div className={styles.statsContainer}>
+        <div className={cn(styles.statsContainer, className)}>
           {showListenCount && renderListenCount()}
           {showFavoriteCount && renderFavoriteCount()}
           {showRepostCount && renderRepostCount()}

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
@@ -1,11 +1,11 @@
 .trackHeader {
-  padding: 16px 24px 0px;
+  padding: var(--unit-4);
   width: 100%;
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
+  gap: var(--unit-4);
   align-items: center;
   background: var(--white);
-
   border: 1px solid var(--neutral-light-8);
   border-radius: 6px;
   overflow: hidden;
@@ -14,7 +14,6 @@
 }
 
 .typeLabel {
-  margin-bottom: 15px;
   height: 18px;
   color: var(--neutral-light-4);
   font-family: var(--font-family);
@@ -28,7 +27,6 @@
 .coverArt {
   height: 195px;
   width: 195px;
-  margin-bottom: 23px;
 }
 
 .imageWrapper {
@@ -45,7 +43,6 @@
   font-weight: var(--font-bold);
   line-height: 25px;
   text-align: center;
-  margin-bottom: 8px;
 }
 
 .artist {
@@ -54,8 +51,8 @@
   font-size: var(--font-l);
   font-weight: var(--font-medium);
   line-height: 24px;
+  justify-content: center;
   text-align: center;
-  margin-bottom: 16px;
   display: flex;
   align-items: center;
 }
@@ -73,35 +70,10 @@
   margin-left: 8px;
 }
 
-/* Button Section */
-.buttonSection {
-  width: 100%;
-  display: inline-flex;
-  flex-direction: column;
-  margin-bottom: 12px;
-}
-
-.playAllButton {
-  width: 100%;
+.titleArtistSection {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 40px !important;
-}
-
-.playAllButton .playAllButtonText {
-  color: var(--darkmode-static-white);
-  font-family: var(--font-family);
-  font-size: var(--font-xl);
-  font-weight: var(--font-bold);
-  letter-spacing: 0.71px;
-  line-height: normal;
-  text-align: center;
-}
-
-.playAllButton svg {
-  width: 24px !important;
-  height: 24px !important;
+  flex-direction: column;
+  gap: var(--unit-3);
 }
 
 .buttonContainer {
@@ -119,18 +91,6 @@
   display: inline-flex;
   flex-wrap: wrap;
   width: 100%;
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--neutral-light-7);
-  margin-bottom: 12px;
-}
-
-/* Info Label Section */
-.infoLabelsSection {
-  display: inline-flex;
-  justify-content: space-evenly;
-  margin-bottom: 16px;
-  margin-top: 24px;
-  width: 100%;
 }
 
 .trackHeader > span {
@@ -139,16 +99,11 @@
 
 .description {
   color: var(--neutral);
-  font-family: var(--font-family);
-  font-size: var(--font-m);
-  font-weight: var(--font-medium);
-  line-height: 26px;
   text-align: left;
   white-space: pre-line;
   text-overflow: ellipsis;
   overflow: hidden;
   width: 100%;
-  margin-bottom: 24px;
 }
 
 .description > a {
@@ -166,22 +121,16 @@
 
 /* Info Section */
 .infoSection {
-  border-top: 1px solid var(--neutral-light-7);
-  display: inline-flex;
+  display: flex;
+  gap: var(--unit-4);
   flex-wrap: wrap;
   width: 100%;
-  padding: 24px 0px 8px;
 }
-
-.infoSection.noStats {
-  border: none;
-}
-
 .infoFact {
   flex: 1;
   display: flex;
+  gap: var(--unit-2);
   text-align: left;
-  margin-bottom: 16px;
   width: 50%;
 }
 
@@ -192,7 +141,6 @@
   font-weight: var(--font-bold);
   letter-spacing: 0.35px;
   text-transform: uppercase;
-  margin-right: 8px;
   display: flex;
   align-items: center;
 }
@@ -218,22 +166,18 @@
 
 /* Download Buttons Container */
 .downloadButtonsContainer {
-  border-top: 1px solid var(--neutral-light-7);
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 16px 0px;
 }
 
 /* Tags */
 .tags {
-  border-top: 1px solid var(--neutral-light-7);
   width: 100%;
   display: inline-flex;
   justify-content: center;
   flex-wrap: wrap;
-  padding: 16px 0px;
 }
 
 .tag {
@@ -279,10 +223,6 @@
   margin-bottom: 24px;
 }
 
-.hiddenTrackHeaderWrapper {
-  margin-bottom: 12px;
-}
-
 .DogEar {
   position: relative;
   top: -10px;
@@ -307,11 +247,6 @@
 .premiumTrackSectionWrapper {
   margin: 0;
   background: var(--neutral-light-10);
-}
-
-.premiumTrackSectionWrapper.unlockedSection {
-  width: 100%;
-  margin: 0 0 var(--unit-4) 0;
 }
 
 .premiumTrackSection {
@@ -343,8 +278,13 @@
       var(--ai-secondary) 100%
     ),
     var(--ai-primary);
-  margin-bottom: 16px;
   width: 100%;
   display: flex;
   justify-content: center;
+}
+
+.withSectionDivider {
+  width: 100%;
+  padding-top: var(--unit-4);
+  border-top: 1px solid var(--neutral-light-9);
 }

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -69,13 +69,15 @@ const messages = {
 }
 
 type PlayButtonProps = {
+  disabled?: boolean
   playing: boolean
   onPlay: () => void
 }
 
-const PlayButton = ({ playing, onPlay }: PlayButtonProps) => {
+const PlayButton = ({ disabled, playing, onPlay }: PlayButtonProps) => {
   return (
     <Button
+      disabled={disabled}
       type={ButtonType.PRIMARY_ALT}
       text={playing ? messages.pause : messages.play}
       leftIcon={playing ? <IconPause /> : <IconPlay />}
@@ -185,8 +187,13 @@ const TrackHeader = ({
   goToRepostsPage
 }: TrackHeaderProps) => {
   const showSocials = !isUnlisted && doesUserHaveAccess
-  const isPurchaseGated = isPremiumContentUSDCPurchaseGated(premiumConditions)
-  const showPreview = isOwner || (isPurchaseGated && !doesUserHaveAccess)
+  const isUSDCPurchaseGated =
+    isPremiumContentUSDCPurchaseGated(premiumConditions)
+  // Preview button is shown for USDC-gated tracks if user does not have access
+  // or is the owner
+  const showPreview = isUSDCPurchaseGated && (isOwner || !doesUserHaveAccess)
+  // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
+  const showPlay = isUSDCPurchaseGated ? doesUserHaveAccess : true
   const showListenCount =
     isOwner || (!isPremium && (isUnlisted || fieldVisibility.play_count))
 
@@ -399,8 +406,12 @@ const TrackHeader = ({
           />
         </div>
       </div>
-      {doesUserHaveAccess ? (
-        <PlayButton playing={isPlaying} onPlay={onPlay} />
+      {showPlay ? (
+        <PlayButton
+          disabled={doesUserHaveAccess}
+          playing={isPlaying}
+          onPlay={onPlay}
+        />
       ) : null}
       {premiumConditions && trackId ? (
         <PremiumTrackSection

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -16,11 +16,13 @@ import {
   PremiumConditions,
   Nullable,
   getDogEarType,
-  isPremiumContentCollectibleGated
+  isPremiumContentCollectibleGated,
+  isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import {
   Button,
   ButtonType,
+  IconCart,
   IconCollectible,
   IconPause,
   IconPlay,
@@ -58,6 +60,7 @@ const messages = {
   play: 'PLAY',
   pause: 'PAUSE',
   collectibleGated: 'COLLECTIBLE GATED',
+  premiumTrack: 'PREMIUM TRACK',
   specialAccess: 'SPECIAL ACCESS',
   generatedWithAi: 'Generated With AI'
 }
@@ -322,18 +325,19 @@ const TrackHeader = ({
 
   const renderHeaderText = () => {
     if (isPremium) {
+      let IconComponent = IconSpecialAccess
+      let titleMessage = messages.specialAccess
+      if (isPremiumContentCollectibleGated(premiumConditions)) {
+        IconComponent = IconCollectible
+        titleMessage = messages.collectibleGated
+      } else if (isPremiumContentUSDCPurchaseGated(premiumConditions)) {
+        IconComponent = IconCart
+        titleMessage = messages.premiumTrack
+      }
       return (
         <div className={cn(styles.typeLabel, styles.premiumContentLabel)}>
-          {isPremiumContentCollectibleGated(premiumConditions) ? (
-            <IconCollectible />
-          ) : (
-            <IconSpecialAccess />
-          )}
-          {isPremiumContentCollectibleGated(premiumConditions) ? (
-            <span>{messages.collectibleGated}</span>
-          ) : (
-            <span>{messages.specialAccess}</span>
-          )}
+          <IconComponent />
+          <span>{titleMessage}</span>
         </div>
       )
     }
@@ -383,6 +387,7 @@ const TrackHeader = ({
             wrapperClassName={styles.premiumTrackSectionWrapper}
             className={styles.premiumTrackSection}
             buttonClassName={styles.premiumTrackSectionButton}
+            ownerId={userId}
           />
         ) : null}
         {doesUserHaveAccess ? (
@@ -417,6 +422,7 @@ const TrackHeader = ({
           )}
           className={styles.premiumTrackSection}
           buttonClassName={styles.premiumTrackSectionButton}
+          ownerId={userId}
         />
       )}
       {coSign && (

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -190,6 +190,7 @@ const TrackHeader = ({
   const showListenCount =
     isOwner || (!isPremium && (isUnlisted || fieldVisibility.play_count))
 
+  // TODO: https://linear.app/audius/issue/PAY-1590/[webmobileweb]-add-support-for-playing-previews
   const onPreview = useCallback(() => console.log('Preview Clicked'), [])
 
   const image = useTrackCoverArt(


### PR DESCRIPTION
### Description
Updates all of the code paths for web and mobile web track details and locked content modal to render the USDC variants for locked, unlocking, unlocked, and owner states.

* Added `Large` variant to Button
* Updated Secondary Button style to match new Harmony versions
  * It's only used in two places at the moment, so should be safe
* Updated Button stories to render all sizes to make things easier to compare
* Cleaned up GiantTrackTile and TrackHeader
  * Both now correctly show the Gated/Premium track section based on type/unlocked/owner status
  * TrackHeader got an overall to make the layout simpler and correctly order the sections (we had two copies of <PremiumTrackSection /> for no apparent reason)
* Added Preview button to both versions of the page. Will show if the user is owner or doesn't have access yet. Currently wired up to a console log

### Dragons
None

### How Has This Been Tested?
Tested in Chrome for desktop and emulated mobile browser

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

### Screenshots

#### Locked

<img width="1089" alt="Screenshot 2023-07-12 at 7 50 20 PM" src="https://github.com/AudiusProject/audius-client/assets/1815175/57dfd7ef-49b7-4b70-8310-ffba53066fa5">
<img width="395" alt="Screenshot 2023-07-12 at 7 52 42 PM" src="https://github.com/AudiusProject/audius-client/assets/1815175/c9901eef-61b6-4a06-8140-f2c6a9f9abd1">

---

#### Unlocked

<img width="1097" alt="Screenshot 2023-07-12 at 7 52 11 PM" src="https://github.com/AudiusProject/audius-client/assets/1815175/2ebc5318-2d25-43b1-ae3b-68a02839b1e7">
<img width="380" alt="Screenshot 2023-07-12 at 7 52 59 PM" src="https://github.com/AudiusProject/audius-client/assets/1815175/32d21c88-5ab7-48c2-bb0e-d3b35b063d33">


---

#### Owner
<img width="1083" alt="Screenshot 2023-07-12 at 7 54 51 PM" src="https://github.com/AudiusProject/audius-client/assets/1815175/419333ca-f3f3-4fb5-82e2-3674f96e332e">
<img width="395" alt="Screenshot 2023-07-12 at 7 55 01 PM" src="https://github.com/AudiusProject/audius-client/assets/1815175/c876a8e6-aa92-467a-8201-ee276e834ed6">

---

#### Button storybook changes

<img width="1067" alt="image" src="https://github.com/AudiusProject/audius-client/assets/1815175/9512103f-b4ef-4e84-b7d1-2d3f9b374510">
