### PR TITLE
[C-2547] Lineup pagination fixes

### DIFF
--- a/packages/common/src/models/Lineup.ts
+++ b/packages/common/src/models/Lineup.ts
@@ -38,7 +38,6 @@ export type LineupState<T> = {
   page: number
   isMetadataLoading: boolean
   dedupe?: boolean
-  containsDeleted: boolean
   maxEntries: Nullable<number>
   entryIds?: Nullable<Set<UID>>
 }

--- a/packages/common/src/store/lineup/reducer.ts
+++ b/packages/common/src/store/lineup/reducer.ts
@@ -39,8 +39,6 @@ export const initialLineupState = {
   // Boolean if the lineup fetch call pagination includes deleted tracks/collections
   // e.g. This should be true if we request 10 tracks but only get 9 back because
   // one is deleted
-  // - Used to know if the lineup should stop fetching more content
-  containsDeleted: true,
   // Whether the lineup is limited to a certain length
   maxEntries: null
 }
@@ -132,16 +130,6 @@ export const actionsMap = {
     newState.isMetadataLoading = false
     newState.status = Status.SUCCESS
     newState.hasMore = action.entries.length + action.deleted >= action.limit
-
-    // If the lineup does not fetch deleted tracks and there are missing tracks
-    // in the response (indicated by 'deleted' count), then there is no more content
-    if (
-      !newState.containsDeleted &&
-      !isNaN(action.deleted) &&
-      action.deleted > 0
-    ) {
-      newState.hasMore = false
-    }
 
     // Hack alert:
     // For lineups with max entries (such as trending playlists) and deleted content,

--- a/packages/common/src/store/lineup/reducer.ts
+++ b/packages/common/src/store/lineup/reducer.ts
@@ -131,8 +131,7 @@ export const actionsMap = {
     const newState = { ...state }
     newState.isMetadataLoading = false
     newState.status = Status.SUCCESS
-    newState.hasMore =
-      action.entries.length + action.deleted >= action.limit - action.offset
+    newState.hasMore = action.entries.length + action.deleted >= action.limit
 
     // If the lineup does not fetch deleted tracks and there are missing tracks
     // in the response (indicated by 'deleted' count), then there is no more content

--- a/packages/common/src/store/pages/ai/lineup/reducer.ts
+++ b/packages/common/src/store/pages/ai/lineup/reducer.ts
@@ -5,7 +5,6 @@ import { PREFIX } from './actions'
 
 export const initialState = {
   ...initialLineupState,
-  containsDeleted: false,
   prefix: PREFIX
 }
 

--- a/packages/common/src/store/pages/feed/lineup/reducer.ts
+++ b/packages/common/src/store/pages/feed/lineup/reducer.ts
@@ -8,7 +8,6 @@ export const initialState = {
   ...initialLineupState,
   prefix: PREFIX,
   dedupe: true,
-  containsDeleted: false,
   entryIds: new Set([])
 }
 

--- a/packages/common/src/store/pages/profile/lineups/feed/reducer.ts
+++ b/packages/common/src/store/pages/profile/lineups/feed/reducer.ts
@@ -6,8 +6,7 @@ import { LineupState } from '../../../../../models'
 
 export const initialState: LineupState<{ id: number }> = {
   ...initialLineupState,
-  prefix: PREFIX,
-  containsDeleted: false
+  prefix: PREFIX
 }
 
 type ResetSucceededAction = {

--- a/packages/common/src/store/pages/profile/lineups/tracks/reducer.ts
+++ b/packages/common/src/store/pages/profile/lineups/tracks/reducer.ts
@@ -6,8 +6,7 @@ import { PREFIX } from 'store/pages/profile/lineups/tracks/actions'
 
 export const initialState = {
   ...initialLineupState,
-  prefix: PREFIX,
-  containsDeleted: false
+  prefix: PREFIX
 }
 
 const actionsMap = {

--- a/packages/common/src/store/pages/remixes/lineup/reducer.ts
+++ b/packages/common/src/store/pages/remixes/lineup/reducer.ts
@@ -4,7 +4,6 @@ import { PREFIX } from 'store/pages/remixes/lineup/actions'
 
 export const initialState = {
   ...initialLineupState,
-  containsDeleted: false,
   prefix: PREFIX
 }
 

--- a/packages/common/src/store/pages/search-results/lineup/tracks/reducer.ts
+++ b/packages/common/src/store/pages/search-results/lineup/tracks/reducer.ts
@@ -6,8 +6,7 @@ import { LineupState, Track } from '../../../../../models'
 
 export const initialState: LineupState<Track> = {
   ...initialLineupState,
-  prefix: PREFIX,
-  containsDeleted: false
+  prefix: PREFIX
 }
 
 type ResetSucceededAction = {


### PR DESCRIPTION
### Description

- Removes `containsDeleted` which was causing the bug in remix lineup [C-2547](https://linear.app/audius/issue/C-2547/[qa]-remix-lists-failing-to-load-completely)
- Fixes `hasMore` offset logic

### Dragons

Changing feed is scary

- `containsDeleted` was from https://github.com/AudiusProject/audius-client-old/pull/1043 which we believe is no longer relevant
- hasMore logic was definitely wrong, but maybe was for a case where an absolute limit was passed instead of a pageSize limit. Need to keep an eye on this in stage.