### PR TITLE
Update announcement notification style and hover behavior

### DIFF
--- a/packages/web/src/components/notification/Notification/AnnouncementNotification.module.css
+++ b/packages/web/src/components/notification/Notification/AnnouncementNotification.module.css
@@ -8,7 +8,6 @@
   color: var(--secondary);
   font-size: var(--font-m);
   font-weight: var(--font-medium);
-  margin-left: var(--unit-1);
 }
 
 .readMore:hover {

--- a/packages/web/src/components/notification/Notification/AnnouncementNotification.module.css
+++ b/packages/web/src/components/notification/Notification/AnnouncementNotification.module.css
@@ -6,8 +6,6 @@
 .readMore {
   all: unset;
   color: var(--secondary);
-  font-size: var(--font-m);
-  font-weight: var(--font-medium);
 }
 
 .readMore:hover {

--- a/packages/web/src/components/notification/Notification/AnnouncementNotification.tsx
+++ b/packages/web/src/components/notification/Notification/AnnouncementNotification.tsx
@@ -49,7 +49,7 @@ export const AnnouncementNotification = (
   return (
     <NotificationTile
       notification={notification}
-      onClick={handleClick}
+      onClick={longDescription ? handleClick : undefined}
       disableClosePanel
     >
       <NotificationHeader icon={<IconAnnouncement />}>

--- a/packages/web/src/components/notification/Notification/AnnouncementNotification.tsx
+++ b/packages/web/src/components/notification/Notification/AnnouncementNotification.tsx
@@ -67,7 +67,7 @@ export const AnnouncementNotification = (
         />
         {longDescription ? (
           <button
-            className={styles.readMore}
+            className={cn(notificationBodyStyles.root, styles.readMore)}
             onClick={handleOpenNotificationModal}
           >
             {messages.readMore}

--- a/packages/web/src/components/notification/Notification/AnnouncementNotification.tsx
+++ b/packages/web/src/components/notification/Notification/AnnouncementNotification.tsx
@@ -5,6 +5,7 @@ import {
   AnnouncementNotification as AnnouncementNotificationType
 } from '@audius/common'
 import { MarkdownViewer } from '@audius/stems'
+import cn from 'classnames'
 import { useDispatch } from 'react-redux'
 
 import { make, useRecord } from 'common/store/analytics/actions'
@@ -12,6 +13,7 @@ import { openNotificationModal } from 'store/application/ui/notifications/notifi
 
 import styles from './AnnouncementNotification.module.css'
 import { NotificationBody } from './components/NotificationBody'
+import notificationBodyStyles from './components/NotificationBody.module.css'
 import { NotificationFooter } from './components/NotificationFooter'
 import { NotificationHeader } from './components/NotificationHeader'
 import { NotificationTile } from './components/NotificationTile'
@@ -50,6 +52,7 @@ export const AnnouncementNotification = (
     <NotificationTile
       notification={notification}
       onClick={longDescription ? handleClick : undefined}
+      disabled={!longDescription}
       disableClosePanel
     >
       <NotificationHeader icon={<IconAnnouncement />}>
@@ -58,7 +61,10 @@ export const AnnouncementNotification = (
         </NotificationTitle>
       </NotificationHeader>
       <NotificationBody className={styles.body}>
-        <MarkdownViewer markdown={shortDescription} />
+        <MarkdownViewer
+          markdown={shortDescription}
+          className={cn(styles.description, notificationBodyStyles.root)}
+        />
         {longDescription ? (
           <button
             className={styles.readMore}

--- a/packages/web/src/components/notification/Notification/components/NotificationTile.module.css
+++ b/packages/web/src/components/notification/Notification/components/NotificationTile.module.css
@@ -7,7 +7,7 @@
   transition: all 0.12s ease-in-out;
 }
 
-.root:hover {
+.active:hover {
   box-shadow: 0px 0px 1px -2px rgba(133, 129, 153, 0.1),
     0px 1px 0px -2px #e3e3e3, 1px 2px 5px rgba(133, 129, 153, 0.25);
   transform: scale3d(1.015, 1.015, 1.015);

--- a/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
+++ b/packages/web/src/components/notification/Notification/components/NotificationTile.tsx
@@ -17,7 +17,7 @@ type NotificationTileProps = {
   notification: Notification
   children: ReactNode
   onClick?: ReactEventHandler
-  // When `true` disable :active transforms
+  // When `true` disable :active and :hover transforms
   disabled?: boolean
   // When `true` do not close notification panel onClick
   disableClosePanel?: boolean

--- a/packages/web/src/components/notification/NotificationPage.tsx
+++ b/packages/web/src/components/notification/NotificationPage.tsx
@@ -28,9 +28,7 @@ const {
 const messages = {
   documentTitle: 'Notifications',
   description: 'View your notifications on Audius',
-  title: 'NOTIFICATIONS',
-  empty: 'There’s Nothing Here Yet!',
-  readMore: 'Read More'
+  title: 'NOTIFICATIONS'
 }
 
 // The threshold of distance from the bottom of the scroll container in the

--- a/packages/web/src/components/notification/NotificationPanel.tsx
+++ b/packages/web/src/components/notification/NotificationPanel.tsx
@@ -49,9 +49,7 @@ const getScrollParent = () => {
 }
 
 const messages = {
-  title: 'Notifications',
-  empty: 'There’s Nothing Here Yet!',
-  readMore: 'Read More'
+  title: 'Notifications'
 }
 
 type NotificationPanelProps = {


### PR DESCRIPTION
### Description
Bonus: removed a few unused messages that were annoying during ctrl+f

### Dragons

Now if `NotificationTile` `disabled` prop is true, hover animation is also disabled. Originally it was only `active` styles that were disabled. Only other place that uses this is `TipReceivedNotification`, don't entirely understand the purpose of this but I tested against current stage and behavior seemed the same. cc @dylanjeffers .

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web stage

https://github.com/AudiusProject/audius-client/assets/3893871/94973579-ac76-446f-a50b-d5e46cb77f2e

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

