### PR TITLE
[C-1608 C-2750] Fix edit profile/cover photo

### DIFF
--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -167,6 +167,8 @@ const updateImageCache = (existing: Metadata, next: Metadata, merged: any) => {
   ) {
     merged._cover_photo_sizes = {}
   }
+
+  return merged
 }
 
 const addEntries = (state: CacheState, entries: any[], replace?: boolean) => {
@@ -198,13 +200,13 @@ const addEntries = (state: CacheState, entries: any[], replace?: boolean) => {
     ) {
       // do nothing
     } else if (existing) {
-      const newMetadata = mergeWith(
+      let newMetadata = mergeWith(
         {},
         existing,
         entity.metadata,
         mergeCustomizer
       )
-      updateImageCache(existing, entity.metadata, newMetadata)
+      newMetadata = updateImageCache(existing, entity.metadata, newMetadata)
       if (cacheType === 'safe-fast' && isEqual(existing, newMetadata)) {
         // do nothing
       } else {
@@ -267,8 +269,8 @@ const actionsMap = {
 
     action.entries.forEach((e: { id: string | number; metadata: any }) => {
       const existing = { ...unwrapEntry(state.entries[e.id]) }
-      const newEntry = mergeWith({}, existing, e.metadata, mergeCustomizer)
-      updateImageCache(existing, e.metadata, newEntry)
+      let newEntry = mergeWith({}, existing, e.metadata, mergeCustomizer)
+      newEntry = updateImageCache(existing, e.metadata, newEntry)
       newEntries[e.id] = wrapEntry(newEntry)
     })
 

--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -152,6 +152,23 @@ export const mergeCustomizer = (objValue: any, srcValue: any, key: string) => {
   }
 }
 
+const updateImageCache = (existing: Metadata, next: Metadata, merged: any) => {
+  if (
+    'profile_picture_sizes' in existing &&
+    'profile_picture_sizes' in next &&
+    existing.profile_picture_sizes !== next.profile_picture_sizes
+  ) {
+    merged._profile_picture_sizes = {}
+  }
+  if (
+    'cover_photo_sizes' in existing &&
+    'cover_photo_sizes' in next &&
+    existing.cover_photo_sizes !== next.cover_photo_sizes
+  ) {
+    merged._cover_photo_sizes = {}
+  }
+}
+
 const addEntries = (state: CacheState, entries: any[], replace?: boolean) => {
   const { cacheType } = state
   const newEntries = { ...state.entries }
@@ -187,6 +204,7 @@ const addEntries = (state: CacheState, entries: any[], replace?: boolean) => {
         entity.metadata,
         mergeCustomizer
       )
+      updateImageCache(existing, entity.metadata, newMetadata)
       if (cacheType === 'safe-fast' && isEqual(existing, newMetadata)) {
         // do nothing
       } else {
@@ -248,14 +266,10 @@ const actionsMap = {
     const newSubscriptions = { ...state.subscriptions }
 
     action.entries.forEach((e: { id: string | number; metadata: any }) => {
-      newEntries[e.id] = wrapEntry(
-        mergeWith(
-          {},
-          { ...unwrapEntry(state.entries[e.id]) },
-          e.metadata,
-          mergeCustomizer
-        )
-      )
+      const existing = { ...unwrapEntry(state.entries[e.id]) }
+      const newEntry = mergeWith({}, existing, e.metadata, mergeCustomizer)
+      updateImageCache(existing, e.metadata, newEntry)
+      newEntries[e.id] = wrapEntry(newEntry)
     })
 
     action.subscriptions.forEach((s: { id: any; kind: any; uids: any }) => {

--- a/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
+++ b/packages/mobile/src/screens/edit-profile-screen/EditProfileScreen.tsx
@@ -33,7 +33,8 @@ const useStyles = makeStyles(({ palette, spacing }) => ({
   coverPhoto: {
     height: 96,
     width: '100%',
-    borderRadius: 0
+    borderRadius: 0,
+    aspectRatio: undefined
   },
   profilePicture: {
     position: 'absolute',


### PR DESCRIPTION
### Description

Adds a fix to reset the _image cache when a change in the users profile_picture_sizes/cover_photo_sizes cid changes. This fixes an issue where updating your profile image appeared to be broken since refreshing caused the image to seem to revert.