### PR TITLE
[PAY-1595] Hide chat textinput until chat exists

### DIFF
--- a/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
+++ b/packages/mobile/src/screens/chat-screen/ChatScreen.tsx
@@ -676,7 +676,7 @@ export const ChatScreen = () => {
               </View>
             )}
 
-            {canSendMessage ? (
+            {canSendMessage && chat ? (
               <View
                 style={styles.composeView}
                 onLayout={measureChatContainerBottom}

--- a/packages/web/src/pages/chat-page/ChatPage.tsx
+++ b/packages/web/src/pages/chat-page/ChatPage.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef } from 'react'
 
-import { chatActions, FeatureFlags, useCanSendMessage } from '@audius/common'
+import {
+  chatActions,
+  FeatureFlags,
+  useCanSendMessage,
+  chatSelectors
+} from '@audius/common'
 import { ResizeObserver } from '@juggle/resize-observer'
 import { push as pushRoute } from 'connected-react-router'
 import { useDispatch } from 'react-redux'
@@ -8,6 +13,7 @@ import useMeasure from 'react-use-measure'
 
 import Page from 'components/page/Page'
 import { useFlag } from 'hooks/useRemoteConfig'
+import { useSelector } from 'utils/reducer'
 import { chatPage } from 'utils/route'
 
 import styles from './ChatPage.module.css'
@@ -18,6 +24,7 @@ import { ChatMessageList } from './components/ChatMessageList'
 import { CreateChatPrompt } from './components/CreateChatPrompt'
 
 const { fetchPermissions } = chatActions
+const { getChat } = chatSelectors
 
 const messages = {
   messages: 'Messages'
@@ -27,6 +34,7 @@ export const ChatPage = ({ currentChatId }: { currentChatId?: string }) => {
   const dispatch = useDispatch()
   const { isEnabled: isChatEnabled } = useFlag(FeatureFlags.CHAT_ENABLED)
   const { firstOtherUser, canSendMessage } = useCanSendMessage(currentChatId)
+  const chat = useSelector((state) => getChat(state, currentChatId ?? ''))
 
   // Get the height of the header so we can slide the messages list underneath it for the blur effect
   const [headerRef, headerBounds] = useMeasure({
@@ -101,7 +109,7 @@ export const ChatPage = ({ currentChatId }: { currentChatId?: string }) => {
                 className={styles.messageList}
                 chatId={currentChatId}
               />
-              {canSendMessage ? (
+              {canSendMessage && chat ? (
                 <ChatComposer
                   chatId={currentChatId}
                   onMessageSent={handleMessageSent}

--- a/packages/web/src/pages/chat-page/components/ChatMessageList.module.css
+++ b/packages/web/src/pages/chat-page/components/ChatMessageList.module.css
@@ -6,8 +6,10 @@
 .listRoot {
   display: flex;
   flex-direction: column-reverse;
+  justify-content: flex-end;
   gap: 8px;
   padding: 32px;
+  height: 100%;
 }
 
 .separator {


### PR DESCRIPTION
### Description
If a user tries to message someone whose inbox is tip-gated, they can optimistically navigate to an empty chat page even though the chat hasn't been created yet (has to wait for tip to be indexed). This can take a while and in this state if the user sends a message, the app crashes (on both mobile and web). Solution is to hide the textinput until the chat is actually created.

Also center the loading spinner.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local web + mobile stage

Including other screenshots to show that behavior of chat messages + say hello prompt has not changed with the css layout changes in this PR.

![Simulator Screenshot - iPhone 14 Pro - 2023-07-14 at 11 38 09](https://github.com/AudiusProject/audius-client/assets/3893871/2bdd80fc-0c50-4fba-9463-1555a1837d8d)
<img width="1728" alt="Screenshot 2023-07-14 at 11 56 01 AM" src="https://github.com/AudiusProject/audius-client/assets/3893871/2a914970-9773-465b-a13d-b50b9733ebf7">
<img width="1728" alt="Screenshot 2023-07-14 at 11 56 18 AM" src="https://github.com/AudiusProject/audius-client/assets/3893871/ea0434a3-1949-41f0-b7e4-5acf71584c59">
<img width="1728" alt="Screenshot 2023-07-14 at 11 56 27 AM" src="https://github.com/AudiusProject/audius-client/assets/3893871/03224f21-34ef-450b-863c-2c3bd0432f13">
<img width="1728" alt="Screenshot 2023-07-14 at 11 56 28 AM" src="https://github.com/AudiusProject/audius-client/assets/3893871/7419afe0-2b81-411c-930d-e81bdd2974c1">


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

