### PR TITLE
[PAY-1578] Hide USDC-gated tracks if the feature flag is disabled

### DIFF
--- a/packages/web/src/pages/upload-page/fields/availability/collectible-gated/CollectibleGatedFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/collectible-gated/CollectibleGatedFields.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react'
 import {
   Chain,
   collectiblesSelectors,
+  isPremiumContentCollectibleGated,
   TrackAvailabilityType
 } from '@audius/common'
 import { useField } from 'formik'
@@ -106,8 +107,11 @@ export const CollectibleGatedFields = ({
   // which makes the dropdown show the placeholder.
   // Otherwise, the default value is the nft collection which was previously selected,
   // which also includes the collection image.
-  const defaultCollectionName =
-    premiumConditionsValue?.nft_collection?.name ?? ''
+  const defaultCollectionName = isPremiumContentCollectibleGated(
+    premiumConditionsValue
+  )
+    ? premiumConditionsValue.nft_collection?.name ?? ''
+    : ''
   const defaultCollection = menuItems.find(
     (item) => item.text === defaultCollectionName
   )


### PR DESCRIPTION
### Description
Using a similar strategy to #2956 , inserts a step into the lineup processing that treats USDC-gated tracks as "deleted" in all cases. This should take care of all environments since it's done at the generic lineup saga level.

### Dragons
You could still navigate directly to a USDC-gated track. But I think our goal for now is to not surface these tracks into feeds/trending/artist pages.

### How Has This Been Tested?
Tested locally on web/mobile web/ simulator

### How will this change be monitored?
N/A

### Feature Flags ###
Uses the USDC_PURCHASES feature flag. On by default in development.

