### PR TITLE
[PAY-1607] Fix mobile prem content track tile layout

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
@@ -69,7 +69,8 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     ...flexRowCentered(),
     justifyContent: 'space-between',
     marginHorizontal: spacing(2),
-    marginVertical: spacing(1)
+    marginVertical: spacing(1),
+    backgroundColor: palette.accentGreen
   },
   title: {
     fontFamily: typography.fontByWeight.heavy,
@@ -120,14 +121,6 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   collectionChainImage: {
     top: -spacing(0.25),
     left: -spacing(1.25)
-  },
-  iconLockContainer: {
-    backgroundColor: palette.neutralLight4,
-    paddingHorizontal: spacing(2),
-    borderRadius: spacing(10)
-  },
-  icon: {
-    color: palette.white
   },
   mainButton: {
     marginTop: spacing(3),

--- a/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
@@ -24,6 +24,7 @@ import { TrackDownloadStatusIndicator } from 'app/components/offline-downloads/T
 import Text from 'app/components/text'
 import { useNavigation } from 'app/hooks/useNavigation'
 import { makeStyles, flexRowCentered } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
 
 import { LineupTilePremiumContentTypeTag } from './LineupTilePremiumContentTypeTag'
@@ -42,33 +43,38 @@ const formatPlayCount = (playCount?: number) => {
 }
 
 const useStyles = makeStyles(({ spacing, palette }) => ({
-  stats: {
+  root: {
     flexDirection: 'row',
     alignItems: 'stretch',
     paddingVertical: spacing(2),
-    marginHorizontal: spacing(2.5)
+    marginHorizontal: spacing(2.5),
+    justifyContent: 'space-between'
+  },
+  stats: {
+    flexDirection: 'row',
+    gap: spacing(4)
   },
   listenCount: {
     ...flexRowCentered(),
-    justifyContent: 'center',
-    marginLeft: 'auto'
+    justifyContent: 'center'
   },
   leftStats: {
-    ...flexRowCentered()
+    ...flexRowCentered(),
+    gap: spacing(4)
+  },
+  statItem: {
+    gap: spacing(1)
   },
   disabledStatItem: {
     opacity: 0.5
   },
-  statIcon: {
-    marginLeft: 4
-  },
   favoriteStat: {
-    height: 14,
-    width: 14
+    height: spacing(3.5),
+    width: spacing(3.5)
   },
   repostStat: {
-    height: 16,
-    width: 16
+    height: spacing(4),
+    width: spacing(4)
   }
 }))
 
@@ -128,68 +134,72 @@ export const LineupTileStats = ({
   }, [dispatch, id, navigation, repostType])
 
   const downloadStatusIndicator = isCollection ? (
-    <CollectionDownloadStatusIndicator size={18} collectionId={id} />
+    <CollectionDownloadStatusIndicator size={spacing(4)} collectionId={id} />
   ) : (
-    <TrackDownloadStatusIndicator size={18} trackId={id} />
+    <TrackDownloadStatusIndicator size={spacing(4)} trackId={id} />
   )
 
   const isReadonly = variant === 'readonly'
 
   return (
-    <View style={styles.stats}>
-      {isTrending ? (
-        <LineupTileRankIcon showCrown={showRankIcon} index={index} />
-      ) : null}
-      {premiumConditions ? (
-        <LineupTilePremiumContentTypeTag
-          premiumConditions={premiumConditions}
-          doesUserHaveAccess={doesUserHaveAccess}
-          isOwner={isOwner}
-        />
-      ) : null}
-      {hasEngagement && !isUnlisted && (
-        <View style={styles.leftStats}>
-          <TouchableOpacity
-            style={[
-              trackTileStyles.statItem,
-              !repostCount ? styles.disabledStatItem : null
-            ]}
-            disabled={!repostCount || isReadonly}
-            onPress={handlePressReposts}
-          >
-            <Text style={trackTileStyles.statText}>
-              {formatCount(repostCount)}
-            </Text>
-            <IconRepost
-              height={16}
-              width={16}
-              fill={neutralLight4}
-              style={[styles.statIcon, styles.repostStat]}
-            />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[
-              trackTileStyles.statItem,
-              !saveCount ? styles.disabledStatItem : null
-            ]}
-            disabled={!saveCount || isReadonly}
-            onPress={handlePressFavorites}
-          >
-            <Text style={trackTileStyles.statText}>
-              {formatCount(saveCount)}
-            </Text>
-            <IconHeart
-              style={[styles.statIcon, styles.favoriteStat]}
-              height={14}
-              width={14}
-              fill={neutralLight4}
-            />
-          </TouchableOpacity>
-          <View style={[trackTileStyles.statItem]}>
-            {downloadStatusIndicator}
+    <View style={styles.root}>
+      <View style={styles.stats}>
+        {isTrending ? (
+          <LineupTileRankIcon showCrown={showRankIcon} index={index} />
+        ) : null}
+        {premiumConditions ? (
+          <LineupTilePremiumContentTypeTag
+            premiumConditions={premiumConditions}
+            doesUserHaveAccess={doesUserHaveAccess}
+            isOwner={isOwner}
+          />
+        ) : null}
+        {hasEngagement && !isUnlisted && (
+          <View style={styles.leftStats}>
+            <TouchableOpacity
+              style={[
+                trackTileStyles.statItem,
+                styles.statItem,
+                !repostCount ? styles.disabledStatItem : null
+              ]}
+              disabled={!repostCount || isReadonly}
+              onPress={handlePressReposts}
+            >
+              <Text style={trackTileStyles.statText}>
+                {formatCount(repostCount)}
+              </Text>
+              <IconRepost
+                height={spacing(4)}
+                width={spacing(4)}
+                fill={neutralLight4}
+                style={styles.repostStat}
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[
+                trackTileStyles.statItem,
+                styles.statItem,
+                !saveCount ? styles.disabledStatItem : null
+              ]}
+              disabled={!saveCount || isReadonly}
+              onPress={handlePressFavorites}
+            >
+              <Text style={trackTileStyles.statText}>
+                {formatCount(saveCount)}
+              </Text>
+              <IconHeart
+                style={styles.favoriteStat}
+                height={spacing(3.5)}
+                width={spacing(3.5)}
+                fill={neutralLight4}
+              />
+            </TouchableOpacity>
+            <View style={[trackTileStyles.statItem]}>
+              {downloadStatusIndicator}
+            </View>
           </View>
-        </View>
-      )}
+        )}
+      </View>
       {premiumConditions && !isOwner ? (
         <LockedStatusBadge
           locked={!doesUserHaveAccess}

--- a/packages/mobile/src/components/lineup-tile/styles.ts
+++ b/packages/mobile/src/components/lineup-tile/styles.ts
@@ -3,8 +3,7 @@ import { spacing } from 'app/styles/spacing'
 
 export const useStyles = makeStyles(({ palette }) => ({
   statItem: {
-    ...flexRowCentered(),
-    marginHorizontal: spacing(2.5)
+    ...flexRowCentered()
   },
   statTextContainer: {
     flexDirection: 'row',


### PR DESCRIPTION
### Description
- Lock icon in correct position on right
- Changed offline status indicator size to match design
- Update spacing of stats items to match design

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage
![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 15 32 03](https://github.com/AudiusProject/audius-client/assets/3893871/14c9b96e-c76b-4fb0-9dcf-3dbf8cf33149)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 15 32 19](https://github.com/AudiusProject/audius-client/assets/3893871/1abf1555-0ba2-4215-88ef-35e4a0df4d0b)



### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

