### PR TITLE
[PAY-1612] Change mobile hidden track header color

### DIFF
--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -125,11 +125,11 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   hiddenTrackLabel: {
     marginTop: spacing(1),
     marginLeft: spacing(2),
-    color: palette.accentOrange,
     fontFamily: typography.fontByWeight.demiBold,
     fontSize: 14,
     letterSpacing: 2,
-    textTransform: 'uppercase'
+    textTransform: 'uppercase',
+    color: palette.neutralLight4
   },
 
   bottomContent: {
@@ -212,8 +212,7 @@ export const TrackScreenDetailsTile = ({
   )
   const styles = useStyles()
   const navigation = useNavigation()
-  const { accentOrange, white, aiPrimary, aiSecondary, neutralLight4 } =
-    useThemeColors()
+  const { white, aiPrimary, aiSecondary, neutralLight4 } = useThemeColors()
 
   const isOfflineEnabled = useIsOfflineModeEnabled()
   const isReachable = useSelector(getIsReachable)
@@ -465,7 +464,7 @@ export const TrackScreenDetailsTile = ({
   const renderHeader = () => {
     return is_unlisted ? (
       <View style={styles.hiddenDetailsTileWrapper}>
-        <IconHidden fill={accentOrange} />
+        <IconHidden fill={neutralLight4} />
         <Text style={styles.hiddenTrackLabel}>{messages.hiddenTrack}</Text>
       </View>
     ) : (


### PR DESCRIPTION
### Description
Dup of https://github.com/AudiusProject/audius-client/pull/3755 - re-doing PR bc we just merged a giant feature branch into main that caused lots of conflicts, the rebase was going to be insane for this tiny change.

Change hidden track track screen header to `neutralLight4` to match other track header types.


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

![254022643-c136062a-b7f4-42cd-8933-94ce91e4e578](https://github.com/AudiusProject/audius-client/assets/3893871/16e77fb5-ebfa-4080-b35d-d32ff3f50aa4)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

