### PR TITLE
[PAY-1621] Reverse order of mobile lineup tile stat icon and number

### DIFF
--- a/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTileStats.tsx
@@ -165,15 +165,15 @@ export const LineupTileStats = ({
               disabled={!repostCount || isReadonly}
               onPress={handlePressReposts}
             >
-              <Text style={trackTileStyles.statText}>
-                {formatCount(repostCount)}
-              </Text>
               <IconRepost
                 height={spacing(4)}
                 width={spacing(4)}
                 fill={neutralLight4}
                 style={styles.repostStat}
               />
+              <Text style={trackTileStyles.statText}>
+                {formatCount(repostCount)}
+              </Text>
             </TouchableOpacity>
             <TouchableOpacity
               style={[
@@ -184,15 +184,15 @@ export const LineupTileStats = ({
               disabled={!saveCount || isReadonly}
               onPress={handlePressFavorites}
             >
-              <Text style={trackTileStyles.statText}>
-                {formatCount(saveCount)}
-              </Text>
               <IconHeart
                 style={styles.favoriteStat}
                 height={spacing(3.5)}
                 width={spacing(3.5)}
                 fill={neutralLight4}
               />
+              <Text style={trackTileStyles.statText}>
+                {formatCount(saveCount)}
+              </Text>
             </TouchableOpacity>
             <View style={[trackTileStyles.statItem]}>
               {downloadStatusIndicator}

--- a/packages/web/src/components/track/mobile/TrackTile.module.css
+++ b/packages/web/src/components/track/mobile/TrackTile.module.css
@@ -87,6 +87,7 @@
   align-items: center;
   transform: scale(1);
   transition: transform 0.07s ease-in-out;
+  gap: var(--unit-1);
 }
 
 .statItem:active {
@@ -276,7 +277,6 @@
 .favoriteButton {
   height: calc(var(--unit) * 3.5);
   width: calc(var(--unit) * 3.5);
-  margin-left: var(--unit-1);
 }
 
 .readonly .repostButtonWrapper:hover {
@@ -286,7 +286,6 @@
 .repostButton {
   height: var(--unit-4);
   width: var(--unit-4);
-  margin-left: var(--unit-1);
 }
 
 .hide {

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -388,7 +388,6 @@ const TrackTile = (props: CombinedProps) => {
                       : undefined
                   }
                 >
-                  {formatCount(props.repostCount)}
                   <RepostButton
                     iconMode
                     isMatrixMode={isMatrix}
@@ -396,6 +395,7 @@ const TrackTile = (props: CombinedProps) => {
                     className={styles.repostButton}
                     wrapperClassName={styles.repostButtonWrapper}
                   />
+                  {formatCount(props.repostCount)}
                 </div>
                 <div
                   className={cn(styles.statItem, fadeIn, {
@@ -408,7 +408,6 @@ const TrackTile = (props: CombinedProps) => {
                       : undefined
                   }
                 >
-                  {formatCount(props.saveCount)}
                   <FavoriteButton
                     iconMode
                     isDarkMode={darkMode}
@@ -416,6 +415,7 @@ const TrackTile = (props: CombinedProps) => {
                     className={styles.favoriteButton}
                     wrapperClassName={styles.favoriteButtonWrapper}
                   />
+                  {formatCount(props.saveCount)}
                 </div>
               </>
             )}


### PR DESCRIPTION
### Description
Icon should be first, followed by stat number.
Fixed on both mobile and mobile web.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?
<img width="1728" alt="Screenshot 2023-07-17 at 4 20 54 PM" src="https://github.com/AudiusProject/audius-client/assets/3893871/02d751b9-0f8b-460f-b28d-3ba613e78284">

![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 16 13 38](https://github.com/AudiusProject/audius-client/assets/3893871/056e06b6-6eb0-4219-8be8-7572efb84da5)



### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

