### PR TITLE
[C-2858] Fix phantom signing

### DIFF
--- a/packages/web/src/store/token-dashboard/signMessage.ts
+++ b/packages/web/src/store/token-dashboard/signMessage.ts
@@ -2,7 +2,8 @@ import {
   accountSelectors,
   Chain,
   tokenDashboardPageActions,
-  tokenDashboardPageSelectors
+  tokenDashboardPageSelectors,
+  PhantomProvider
 } from '@audius/common'
 import { call, put, select } from 'typed-redux-saga'
 
@@ -10,6 +11,10 @@ import { WalletConnection } from './types'
 const { getUserId } = accountSelectors
 const { getConfirmingWallet } = tokenDashboardPageSelectors
 const { updateWalletError } = tokenDashboardPageActions
+
+const solSign = async (provider: PhantomProvider, msg: Uint8Array) => {
+  return provider.signMessage(msg, 'utf8')
+}
 
 export function* signMessage(connection: WalletConnection) {
   const accountUserId = yield* select(getUserId)
@@ -24,9 +29,9 @@ export function* signMessage(connection: WalletConnection) {
     case Chain.Sol: {
       const encodedMessage = new TextEncoder().encode(message)
       const signedResponse = yield* call(
-        connection.provider.signMessage,
-        encodedMessage,
-        'utf8'
+        solSign,
+        connection.provider,
+        encodedMessage
       )
       const publicKey = signedResponse.publicKey.toString()
       const signature = signedResponse.signature.toString('hex')


### PR DESCRIPTION
### Description

When trying to connect a phantom wallet, we see this error message
```
"Caught error during handleConnectNewWallet:  TypeError: Cannot read private member from an object whose class did not declare it, resetting to initial state"
```
Presumably this is because of some change in a typescript dependency, not directly because of a phantom change.

I am unsure exactly how this change fixes it, but it seems to, probably because `this` context is necessary?

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

N/a

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

1. Ran client against stage
2. Connected phantom wallet

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

https://app.amplitude.com/analytics/audius/chart/1x2oshx

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

N/a
