### PR TITLE
[C-2853] Fix deletedCount calculation

### DIFF
--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -288,7 +288,10 @@ function* fetchLineupMetadatasAsync(
           return true
         })
 
-      const deletedCount = action.limit - lineupEntries.length - nullCount
+      const deletedCount =
+        lineupMetadatasResponse.length -
+        responseFilteredDeletes.length -
+        nullCount
       yield put(
         lineupActions.fetchLineupMetadatasSucceeded(
           lineupEntries,


### PR DESCRIPTION
### Description

We're relying on `deletedCount` to calculate `hasMore`.
For any request where limit was greater than the remaining entries on discovery, we'd set deleted count to the remainder.

### Dragons

Trying to find out if we rely on this for something. It was originally set in https://github.com/AudiusProject/audius-client/pull/1246

### How Has This Been Tested?

fixes profile loading on local web