### PR TITLE
[PAY-1639] Fix mobile hidden track dog ear

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -164,6 +164,7 @@ export const DetailsTile = ({
   isPlayable = true,
   isPlaylist = false,
   isPublished = true,
+  isUnlisted = false,
   onPressEdit,
   onPressFavorites,
   onPressOverflow,
@@ -231,7 +232,8 @@ export const DetailsTile = ({
   const renderDogEar = () => {
     const dogEarType = getDogEarType({
       isOwner,
-      premiumConditions
+      premiumConditions,
+      isUnlisted
     })
     return dogEarType ? <DogEar type={dogEarType} /> : null
   }

--- a/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
@@ -69,8 +69,7 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     ...flexRowCentered(),
     justifyContent: 'space-between',
     marginHorizontal: spacing(2),
-    marginVertical: spacing(1),
-    backgroundColor: palette.accentGreen
+    marginVertical: spacing(1)
   },
   title: {
     fontFamily: typography.fontByWeight.heavy,

--- a/packages/mobile/src/components/details-tile/types.ts
+++ b/packages/mobile/src/components/details-tile/types.ts
@@ -73,6 +73,9 @@ export type DetailsTileProps = {
   /** Is the item loaded published */
   isPublished?: boolean
 
+  /** Is the item unlisted (hidden) */
+  isUnlisted?: boolean
+
   /** Function to call when the edit button is pressed */
   onPressEdit?: GestureResponderHandler
 

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -75,7 +75,8 @@ export const LineupTile = ({
     premiumConditions,
     isOwner,
     doesUserHaveAccess,
-    isArtistPick: showArtistPick && isArtistPick
+    isArtistPick: showArtistPick && isArtistPick,
+    isUnlisted
   })
 
   const handlePress = useCallback(() => {

--- a/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/track-screen/TrackScreenDetailsTile.tsx
@@ -538,6 +538,7 @@ export const TrackScreenDetailsTile = ({
       hideListenCount={is_unlisted && !field_visibility?.play_count}
       hideRepostCount={is_unlisted}
       isPlaying={isPlaying && isPlayingId}
+      isUnlisted={is_unlisted}
       onPressFavorites={handlePressFavorites}
       onPressOverflow={handlePressOverflow}
       onPressPlay={handlePressPlay}


### PR DESCRIPTION
### Description
Adds dog ear for hidden tracks.
Also gets rid of green background in track screen details section.

Decided to plumb down `isUnlisted` prop to `DetailsTile` etc bc that's the pre-existing pattern (instead of just using `track?.is_unlisted` directly.

### Dragons

I know the hidden track lineup tile is still weird, will follow up in another PR.

### How Has This Been Tested?

![Simulator Screenshot - iPhone 14 Pro - 2023-07-18 at 15 43 53](https://github.com/AudiusProject/audius-client/assets/3893871/adab4e8e-2cd2-46a8-8239-887a23a90c2a)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-18 at 15 43 57](https://github.com/AudiusProject/audius-client/assets/3893871/7b129d91-6858-4f3c-8021-fd354896140f)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-18 at 15 44 44](https://github.com/AudiusProject/audius-client/assets/3893871/2404853e-c414-44af-87d8-299e36c9e761)


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

