### PR TITLE
[PAY-1618] Update DogEar rendering and fix spacing

### DIFF
--- a/packages/mobile/src/assets/images/dogEarRectangle.svg
+++ b/packages/mobile/src/assets/images/dogEarRectangle.svg
@@ -5,15 +5,6 @@
     <path fill-rule="evenodd" clip-rule="evenodd" d="M0 8C0 3.58172 3.58172 0 8 0H40L0 40V8Z" fill="url(#paint1_radial_2088_1481)" fill-opacity="0.2"/>
   </g>
   <defs>
-    <filter id="filter0_d_2088_1481" x="-8" y="-8" width="56" height="56" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-      <feOffset/>
-      <feGaussianBlur stdDeviation="4"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2088_1481"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2088_1481" result="shape"/>
-    </filter>
     <radialGradient id="paint0_radial_2088_1481" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="scale(33 11.7534)">
       <stop stop-color="white"/>
       <stop offset="1" stop-color="white" stop-opacity="0"/>

--- a/packages/mobile/src/components/card/Card.tsx
+++ b/packages/mobile/src/components/card/Card.tsx
@@ -105,7 +105,7 @@ export const Card = (props: CardProps) => {
       {...TileProps}
     >
       {props.type === 'collection' ? (
-        <CollectionDogEar collectionId={props.id} />
+        <CollectionDogEar collectionId={props.id} borderOffset={1} />
       ) : null}
       {renderImage({
         style: [styles.cardImage, props.type === 'user' && styles.userImage]

--- a/packages/mobile/src/components/card/CollectionDogEar.tsx
+++ b/packages/mobile/src/components/card/CollectionDogEar.tsx
@@ -7,11 +7,12 @@ import { DogEar } from '../core'
 const { getCollection } = cacheCollectionsSelectors
 
 type CollectionDogEarProps = {
+  borderOffset?: number
   collectionId: ID
 }
 
 export const CollectionDogEar = (props: CollectionDogEarProps) => {
-  const { collectionId } = props
+  const { borderOffset, collectionId } = props
 
   const isPrivate = useSelector(
     (state) => getCollection(state, { id: collectionId })?.is_private
@@ -20,7 +21,7 @@ export const CollectionDogEar = (props: CollectionDogEarProps) => {
   const dogEarType = isPrivate ? DogEarType.HIDDEN : null
 
   if (dogEarType) {
-    return <DogEar type={dogEarType} />
+    return <DogEar type={dogEarType} borderOffset={borderOffset} />
   }
 
   return null

--- a/packages/mobile/src/components/core/DogEar.tsx
+++ b/packages/mobile/src/components/core/DogEar.tsx
@@ -1,8 +1,8 @@
 import { DogEarType } from '@audius/common'
 import type { ViewStyle } from 'react-native'
 import { View } from 'react-native'
-import LinearGradient from 'react-native-linear-gradient'
 
+import DogEarRectangle from 'app/assets/images/dogEarRectangle.svg'
 import IconCart from 'app/assets/images/iconCart.svg'
 import IconCollectible from 'app/assets/images/iconCollectible.svg'
 import IconHidden from 'app/assets/images/iconHidden.svg'
@@ -12,38 +12,50 @@ import { makeStyles } from 'app/styles'
 import { useThemeColors } from 'app/utils/theme'
 
 const useStyles = makeStyles(({ spacing }) => ({
-  bannerIcon: {
-    position: 'absolute',
-    zIndex: 10,
-    width: 80,
-    height: 80,
-    overflow: 'hidden',
-    borderRadius: spacing(2),
-
-    shadowOpacity: 0.3,
-    shadowOffset: { width: 0, height: 1 },
-    shadowRadius: 3
-  },
-
   container: {
     position: 'absolute',
-    transform: [{ rotate: '45deg' }, { translateX: -68 }],
-    width: spacing(20),
-    height: spacing(20)
+    top: 0,
+    left: 0,
+    zIndex: 10,
+    width: spacing(12),
+    height: spacing(12),
+    overflow: 'hidden',
+    borderRadius: spacing(2)
   },
+
+  rectangle: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: spacing(12),
+    height: spacing(12),
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 0
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: spacing(2),
+    elevation: 5
+  },
+
   icon: {
-    marginTop: spacing(1),
-    marginLeft: spacing(1)
+    position: 'absolute',
+    width: spacing(4),
+    height: spacing(4),
+    top: spacing(1),
+    left: spacing(1)
   }
 }))
 
-type DogEarProps = {
+export type DogEarProps = {
+  borderOffset?: number
   type: DogEarType
   style?: ViewStyle
 }
 
 export const DogEar = (props: DogEarProps) => {
-  const { type, style } = props
+  const { borderOffset, type, style } = props
   const styles = useStyles()
   const {
     neutral,
@@ -78,15 +90,14 @@ export const DogEar = (props: DogEarProps) => {
     }
   }[type]
 
+  const borderOffsetStyle = borderOffset
+    ? { left: -borderOffset, top: -borderOffset }
+    : undefined
+
   return (
-    <View style={[styles.bannerIcon, style]}>
-      <LinearGradient
-        colors={colors}
-        style={[styles.container]}
-        start={{ x: 1, y: 1 }}
-        end={{ x: 0, y: 0 }}
-      />
-      <Icon fill={staticWhite} height={16} width={16} style={styles.icon} />
+    <View style={[styles.container, borderOffsetStyle, style]}>
+      <DogEarRectangle fill={colors[0]} style={styles.rectangle} />
+      <Icon width={16} height={16} fill={staticWhite} style={styles.icon} />
     </View>
   )
 }

--- a/packages/mobile/src/components/core/DogEar.tsx
+++ b/packages/mobile/src/components/core/DogEar.tsx
@@ -35,8 +35,7 @@ const useStyles = makeStyles(({ spacing }) => ({
       height: 0
     },
     shadowOpacity: 0.25,
-    shadowRadius: spacing(2),
-    elevation: 5
+    shadowRadius: spacing(2)
   },
 
   icon: {

--- a/packages/mobile/src/components/core/DogEar.tsx
+++ b/packages/mobile/src/components/core/DogEar.tsx
@@ -9,6 +9,7 @@ import IconHidden from 'app/assets/images/iconHidden.svg'
 import IconSpecialAccess from 'app/assets/images/iconSpecialAccess.svg'
 import IconStar from 'app/assets/images/iconStar.svg'
 import { makeStyles } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
 import { useThemeColors } from 'app/utils/theme'
 
 const useStyles = makeStyles(({ spacing }) => ({
@@ -96,7 +97,12 @@ export const DogEar = (props: DogEarProps) => {
   return (
     <View style={[styles.container, borderOffsetStyle, style]}>
       <DogEarRectangle fill={colors[0]} style={styles.rectangle} />
-      <Icon width={16} height={16} fill={staticWhite} style={styles.icon} />
+      <Icon
+        width={spacing(4)}
+        height={spacing(4)}
+        fill={staticWhite}
+        style={styles.icon}
+      />
     </View>
   )
 }

--- a/packages/mobile/src/components/details-tile/DetailsTile.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTile.tsx
@@ -233,7 +233,7 @@ export const DetailsTile = ({
       isOwner,
       premiumConditions
     })
-    return dogEarType ? <DogEar type={dogEarType} /> : null
+    return dogEarType ? <DogEar type={dogEarType} borderOffset={1} /> : null
   }
 
   const renderDetailLabels = () => {

--- a/packages/mobile/src/components/lineup-tile/LineupTile.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTile.tsx
@@ -101,9 +101,7 @@ export const LineupTile = ({
       scaleTo={scale}
       {...TileProps}
     >
-      {dogEarType ? (
-        <DogEar type={dogEarType} style={{ shadowRadius: 1 }} />
-      ) : null}
+      {dogEarType ? <DogEar type={dogEarType} borderOffset={1} /> : null}
       <View>
         <LineupTileTopRight
           duration={duration}

--- a/packages/web/src/assets/img/dogEarRectangle.svg
+++ b/packages/web/src/assets/img/dogEarRectangle.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none">
   <g filter="url(#filter0_d_2088_1481)">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M0 8C0 3.58172 3.58172 0 8 0H40L0 40V8Z" fill="#000"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M0 8C0 3.58172 3.58172 0 8 0H40L0 40V8Z" fill="currentColor"/>
     <path fill-rule="evenodd" clip-rule="evenodd" d="M0 8C0 3.58172 3.58172 0 8 0H40L0 40V8Z" fill="url(#paint0_radial_2088_1481)" fill-opacity="0.2"/>
     <path fill-rule="evenodd" clip-rule="evenodd" d="M0 8C0 3.58172 3.58172 0 8 0H40L0 40V8Z" fill="url(#paint1_radial_2088_1481)" fill-opacity="0.2"/>
   </g>

--- a/packages/web/src/assets/img/dogEarRectangle.svg
+++ b/packages/web/src/assets/img/dogEarRectangle.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none">
+  <g filter="url(#filter0_di_2014_3539)">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M0 8C0 3.58172 3.58172 0 8 0H40L0 40V8Z"/>
+  </g>
+  <defs>
+    <filter id="filter0_di_2014_3539" x="-8" y="-8" width="56" height="56" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset/>
+      <feGaussianBlur stdDeviation="4"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2014_3539"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2014_3539" result="shape"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dx="4" dy="4"/>
+      <feGaussianBlur stdDeviation="4"/>
+      <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.2 0"/>
+      <feBlend mode="normal" in2="shape" result="effect2_innerShadow_2014_3539"/>
+    </filter>
+  </defs>
+</svg>

--- a/packages/web/src/components/dog-ear/DogEar.module.css
+++ b/packages/web/src/components/dog-ear/DogEar.module.css
@@ -1,61 +1,50 @@
-.artistPick {
+.container {
   position: absolute;
   top: 0;
   left: 0;
   z-index: 10;
-  width: 80px;
+  border-radius: var(--unit-2) 0px 0px 0px;
+  width: var(--unit-12);
+  height: var(--unit-12);
   pointer-events: none;
-}
-
-.container {
-  position: absolute;
-  transform: rotate(45deg) translateX(-64px);
-  box-shadow: 1px 1px 7px -2px rgba(0, 0, 0, 0.5);
-  width: 80px;
-  height: 80px;
   overflow: hidden;
 }
 
-.gated {
-  background: var(--accent-blue);
-}
-
-.purchase {
-  background: var(--special-light-green);
-}
-
-.star {
-  background: linear-gradient(314.61deg, #7e1bcc 0%, #a22feb 100%);
-}
-
-.hidden {
-  background: linear-gradient(314.61deg, #858199 0%, #c2c0cc 100%);
-}
-
-.matrix .container {
-  background: var(--page-header-gradient);
-}
-
-.isMobile .container {
-  transform: rotate(45deg) translateX(-68px);
-}
-
-.artistPick svg {
+.rectangle {
   position: absolute;
-  left: 0;
   top: 0;
-  margin-left: 5px;
-  margin-top: 2px;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  box-shadow: var(--unit-1) var(--unit-1) var(--unit-2) 0px
+    rgba(255, 255, 255, 0.2) inset;
+  filter: drop-shadow(0px 0px var(--unit-2) rgba(0, 0, 0, 0.25));
+}
+
+.gated path {
+  fill: var(--accent-blue);
+}
+
+.purchase path {
+  fill: var(--special-light-green);
+}
+
+.artistPick path {
+  fill: var(--secondary);
+}
+
+.hidden path {
+  fill: var(--neutral);
+}
+
+.icon {
+  position: absolute;
+  top: var(--unit-1);
+  left: var(--unit-1);
   width: var(--unit-4);
-  height: var(--unit-6);
+  height: var(--unit-4);
 }
 
-.isMobile svg {
-  margin: 4px 0px 0px 4px;
-  width: 16px;
-  height: 16px;
-}
-
-.artistPick svg path {
+.icon path {
   fill: var(--static-white);
 }

--- a/packages/web/src/components/dog-ear/DogEar.module.css
+++ b/packages/web/src/components/dog-ear/DogEar.module.css
@@ -16,9 +16,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  box-shadow: var(--unit-1) var(--unit-1) var(--unit-2) 0px
-    rgba(255, 255, 255, 0.2) inset;
-  filter: drop-shadow(0px 0px var(--unit-2) rgba(0, 0, 0, 0.25));
 }
 
 .gated path {

--- a/packages/web/src/components/dog-ear/DogEar.module.css
+++ b/packages/web/src/components/dog-ear/DogEar.module.css
@@ -18,20 +18,22 @@
   height: 100%;
 }
 
-.gated path {
-  fill: var(--accent-blue);
+/* Note: dogEarRectangle has multiple `path` elements, but we only want to fill one of them.
+That path uses `fill='currentColor'`, allowing us to set `color` here instead of `fill` */
+.gated {
+  color: var(--accent-blue);
 }
 
-.purchase path {
-  fill: var(--special-light-green);
+.purchase {
+  color: var(--special-light-green);
 }
 
-.artistPick path {
-  fill: var(--secondary);
+.artistPick {
+  color: var(--secondary);
 }
 
-.hidden path {
-  fill: var(--neutral);
+.hidden {
+  color: var(--neutral);
 }
 
 .icon {

--- a/packages/web/src/components/dog-ear/DogEar.tsx
+++ b/packages/web/src/components/dog-ear/DogEar.tsx
@@ -7,6 +7,7 @@ import {
 } from '@audius/stems'
 import cn from 'classnames'
 
+import { ReactComponent as Rectangle } from 'assets/img/dogEarRectangle.svg'
 import { ReactComponent as IconHidden } from 'assets/img/iconHidden.svg'
 import { ReactComponent as IconStar } from 'assets/img/iconStar.svg'
 import { isMobile } from 'utils/clientUtil'
@@ -17,50 +18,52 @@ import styles from './DogEar.module.css'
 export type DogEarProps = {
   type: DogEarType
   className?: string
-  containerClassName?: string
+}
+
+const getIcon = (type: DogEarType) => {
+  switch (type) {
+    case DogEarType.STAR:
+      return IconStar
+    case DogEarType.HIDDEN:
+      return IconHidden
+    case DogEarType.LOCKED:
+      return IconLock
+    case DogEarType.COLLECTIBLE_GATED:
+      return IconCollectible
+    case DogEarType.USDC_PURCHASE:
+      return IconCart
+    case DogEarType.SPECIAL_ACCESS:
+    default:
+      return IconSpecialAccess
+  }
 }
 
 export const DogEar = (props: DogEarProps) => {
-  const { type, className, containerClassName } = props
+  const { type, className } = props
   const isMatrixMode = isMatrix()
   const isMobileMode = isMobile()
-  const renderIcon = () => {
-    switch (type) {
-      case DogEarType.STAR:
-        return <IconStar />
-      case DogEarType.HIDDEN:
-        return <IconHidden />
-      case DogEarType.LOCKED:
-        return <IconLock />
-      case DogEarType.COLLECTIBLE_GATED:
-        return <IconCollectible />
-      case DogEarType.USDC_PURCHASE:
-        return <IconCart />
-      case DogEarType.SPECIAL_ACCESS:
-        return <IconSpecialAccess />
-    }
-  }
+  const Icon = getIcon(type)
 
   return (
     <div
-      className={cn(styles.artistPick, className, {
+      className={cn(styles.container, className, {
         [styles.isMobile]: isMobileMode,
         [styles.matrix]: isMatrixMode
       })}
     >
-      <div
-        className={cn(styles.container, containerClassName, {
+      <Rectangle
+        className={cn(styles.rectangle, {
           [styles.gated]: [
             DogEarType.COLLECTIBLE_GATED,
             DogEarType.SPECIAL_ACCESS,
             DogEarType.LOCKED
           ].includes(type),
           [styles.purchase]: type === DogEarType.USDC_PURCHASE,
-          [styles.star]: type === DogEarType.STAR,
+          [styles.artistPick]: type === DogEarType.STAR,
           [styles.hidden]: type === DogEarType.HIDDEN
         })}
       />
-      {renderIcon()}
+      <Icon className={styles.icon} />
     </div>
   )
 }

--- a/packages/web/src/components/tile/Tile.module.css
+++ b/packages/web/src/components/tile/Tile.module.css
@@ -1,12 +1,18 @@
 .root {
+  --border-width: 1px;
   display: flex;
   flex-direction: column;
   position: relative;
-  border: 1px solid var(--neutral-light-8);
+  border: var(--border-width) solid var(--neutral-light-8);
   border-radius: var(--unit-2);
   background-color: var(--white);
   transition: all var(--expressive);
-  overflow: hidden;
+}
+
+.borderOffset {
+  position: absolute;
+  top: calc(-1 * var(--border-width));
+  left: calc(-1 * var(--border-width));
 }
 
 .near {

--- a/packages/web/src/components/tile/Tile.tsx
+++ b/packages/web/src/components/tile/Tile.tsx
@@ -44,7 +44,11 @@ export const Tile = <
       )}
       {...other}
     >
-      {dogEar ? <DogEar type={dogEar} /> : null}
+      {dogEar ? (
+        <div className={styles.borderOffset}>
+          <DogEar type={dogEar} />
+        </div>
+      ) : null}
       {children}
     </RootComponent>
   )

--- a/packages/web/src/components/track/GiantTrackTile.module.css
+++ b/packages/web/src/components/track/GiantTrackTile.module.css
@@ -11,6 +11,7 @@
   flex-direction: row;
   flex-wrap: wrap;
   position: relative;
+  border-radius: var(--unit-3) var(--unit-3) 0px 0px;
   background-color: var(--neutral-light-10);
 
   padding: var(--unit-6);

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.module.css
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.module.css
@@ -1,7 +1,8 @@
 .container {
+  --border-width: 1px;
   position: relative;
   background: var(--white);
-  border: 1px solid var(--neutral-light-8);
+  border: var(--border-width) solid var(--neutral-light-8);
   border-radius: 8px 8px 0px 0px;
   display: inline-flex;
   width: 100%;

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.module.css
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.module.css
@@ -4,7 +4,6 @@
   border: 1px solid var(--neutral-light-8);
   border-radius: 8px 8px 0px 0px;
   display: inline-flex;
-  overflow: hidden;
   width: 100%;
   cursor: pointer;
 }

--- a/packages/web/src/components/track/desktop/TrackTile.module.css
+++ b/packages/web/src/components/track/desktop/TrackTile.module.css
@@ -1,10 +1,10 @@
 .container {
+  --border-width: 1px;
   position: relative;
   background: var(--white);
-  border: 1px solid var(--neutral-light-8);
+  border: var(--border-width) solid var(--neutral-light-8);
   border-radius: var(--unit-2) var(--unit-2) 0px 0px;
   display: inline-flex;
-  overflow: hidden;
   width: 100%;
   cursor: pointer;
   transition: all 0.18s ease-in-out;
@@ -41,6 +41,12 @@
 
 .container.small {
   height: 124px;
+}
+
+.borderOffset {
+  position: absolute;
+  top: calc(-1 * var(--border-width));
+  left: calc(-1 * var(--border-width));
 }
 
 .order {

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -244,7 +244,11 @@ const TrackTile = ({
       >
         {artwork}
       </div>
-      {dogEarType ? <DogEar type={dogEarType} /> : null}
+      {dogEarType ? (
+        <div className={styles.borderOffset}>
+          <DogEar type={dogEarType} />
+        </div>
+      ) : null}
       <div
         className={cn(styles.body, {
           // if track and not playlist/album

--- a/packages/web/src/components/track/mobile/TrackTile.module.css
+++ b/packages/web/src/components/track/mobile/TrackTile.module.css
@@ -8,7 +8,6 @@
     0 2px 5px -2px var(--tile-shadow-3);
   display: flex;
   padding: var(--unit-2);
-  overflow: hidden;
   border-radius: var(--unit-2);
   max-width: 400px;
   cursor: pointer;

--- a/packages/web/src/components/track/mobile/TrackTile.module.css
+++ b/packages/web/src/components/track/mobile/TrackTile.module.css
@@ -1,8 +1,9 @@
 .container {
+  --border-width: 1px;
   position: relative;
   min-height: 152px;
   flex: 1 1 352px;
-  border: 1px solid var(--neutral-light-8);
+  border: var(--border-width) solid var(--neutral-light-8);
   background-color: var(--white);
   box-shadow: 0 0 1px 0 var(--tile-shadow-1), 0 1px 0 0 var(--tile-shadow-2),
     0 2px 5px -2px var(--tile-shadow-3);
@@ -16,7 +17,14 @@
   margin: 0px auto var(--unit-3);
 }
 
+.borderOffset {
+  position: absolute;
+  top: calc(-1 * var(--border-width));
+  left: calc(-1 * var(--border-width));
+}
+
 .container.readonly {
+  --border-width: 0px;
   min-width: 448px;
   min-height: unset;
   margin-bottom: 0;

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -247,7 +247,11 @@ const TrackTile = (props: CombinedProps) => {
         containerClassName
       )}
     >
-      {DogEarIconType ? <DogEar type={DogEarIconType} /> : null}
+      {DogEarIconType ? (
+        <div className={styles.borderOffset}>
+          <DogEar type={DogEarIconType} />
+        </div>
+      ) : null}
       <div className={styles.mainContent} onClick={handleClick}>
         <div
           className={cn(

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
@@ -9,8 +9,7 @@
   align-items: center;
   background: var(--white);
   border: var(--border-width) solid var(--neutral-light-8);
-  border-radius: 6px;
-  overflow: hidden;
+  border-radius: var(--unit-2);
   box-shadow: 0 0 1px 0 var(--tile-shadow-1), 0 1px 0 0 var(--tile-shadow-2),
     0 2px 5px -2px var(--tile-shadow-3);
 }

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.module.css
@@ -1,16 +1,24 @@
 .trackHeader {
+  --border-width: 1px;
   padding: var(--unit-4);
+  position: relative;
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: var(--unit-4);
   align-items: center;
   background: var(--white);
-  border: 1px solid var(--neutral-light-8);
+  border: var(--border-width) solid var(--neutral-light-8);
   border-radius: 6px;
   overflow: hidden;
   box-shadow: 0 0 1px 0 var(--tile-shadow-1), 0 1px 0 0 var(--tile-shadow-2),
     0 2px 5px -2px var(--tile-shadow-3);
+}
+
+.borderOffset {
+  position: absolute;
+  top: calc(-1 * var(--border-width));
+  left: calc(-1 * var(--border-width));
 }
 
 .typeLabel {
@@ -221,12 +229,6 @@
   height: 24px;
   width: 100% !important;
   margin-bottom: 24px;
-}
-
-.DogEar {
-  position: relative;
-  top: -10px;
-  left: calc(-50vw + 58px);
 }
 
 .premiumContentLabel {

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -346,7 +346,11 @@ const TrackHeader = ({
       premiumConditions
     })
     if (!isLoading && DogEarType) {
-      return <DogEar type={DogEarType} className={styles.DogEar} />
+      return (
+        <div className={styles.borderOffset}>
+          <DogEar type={DogEarType} className={styles.DogEar} />
+        </div>
+      )
     }
     return null
   }


### PR DESCRIPTION
### Description
DogEars were rendering with a visible gap around the outside (the border of the container beneath them). The fix for this turned out to be a little trickier than expected, partially due to the way the component was implemented.

The original implementation was done with an 80x80px square linear gradient, rotated 45 degrees and then clipped by the parent container's border box to achieve the desired shape. While this works, it had two disadvantages:
* It requires `overflow:hidden` to be set on the parent. When using this overflow setting, no child is allowed to exceed the border box. And that means the DogEar cannot overlap the border, and the border will be visible around the outside.
* It was not in sync with the vectors being used in the Figma designs

I brought in the new SVG, which uses a path to draw the rounded edge and has the correct gradients built in. Overflow behavior was removed from the parent container, and logic was added to allow parents to position the `DogEar` with an offset to account for their own borders.

### Dragons
This did involve some changes to the `Tile` component on desktop, which is used as a base for components other than the TrackTile. But the changes are minimal and I did a verification pass to make sure none of them looked strange without the overflow behavior.

### How Has This Been Tested?
Tested locally in Chrome (web and mobile web emulator), on iOS Simulator and physical Android device.

### How will this change be monitored?
Will verify as part of RC process and revert if necessary.

### Feature Flags ###
N/A

### Screenshots

**Web Track Tile**
Before
![Screenshot 2023-07-20 at 10 57 34 AM](https://github.com/AudiusProject/audius-client/assets/1815175/5d58bdfd-9b82-4cac-a8b9-58502000eb29)

After
![Screenshot 2023-07-20 at 10 50 16 AM](https://github.com/AudiusProject/audius-client/assets/1815175/fc999658-5e29-4328-a426-69918e34617b)

---

**Mobile Web Track Tile**
Before
![Screenshot 2023-07-20 at 10 56 39 AM](https://github.com/AudiusProject/audius-client/assets/1815175/e41c744d-d49c-4cbe-b2ab-1ad932375e27)

After
![Screenshot 2023-07-20 at 10 50 54 AM](https://github.com/AudiusProject/audius-client/assets/1815175/8f0f28af-e6c7-4676-9eb3-2f6c5706fc37)

--- 

**Mobile Track Tile**
Before
![Screenshot 2023-07-20 at 10 59 00 AM](https://github.com/AudiusProject/audius-client/assets/1815175/29f55c24-0079-4b6b-b03c-b39e454a15e7)

After
![Screenshot 2023-07-20 at 10 06 02 AM](https://github.com/AudiusProject/audius-client/assets/1815175/ee0ec1db-d302-4475-9e73-629f1ced599d)

---

**Web Track Details**
Before
![Screenshot 2023-07-20 at 10 57 44 AM](https://github.com/AudiusProject/audius-client/assets/1815175/299cc8ed-9293-429b-8f5b-866675a9f12e)

After
![Screenshot 2023-07-20 at 11 04 06 AM](https://github.com/AudiusProject/audius-client/assets/1815175/742bd456-10f8-44eb-a86e-a779b1024894)


---

**Mobile Web Track Details**
Before
![Screenshot 2023-07-20 at 10 57 02 AM](https://github.com/AudiusProject/audius-client/assets/1815175/35a27404-2134-4194-afbb-bf6d754dfb9b)

After
![Screenshot 2023-07-20 at 11 01 04 AM](https://github.com/AudiusProject/audius-client/assets/1815175/5ae9d284-6148-465e-864f-7c31594e9f67)

---

**Mobile Track Details**
Before
![Screenshot 2023-07-20 at 10 58 46 AM](https://github.com/AudiusProject/audius-client/assets/1815175/8d094d35-5d41-4ab5-8840-0d033bfe0216)

After
![Screenshot 2023-07-20 at 10 52 32 AM](https://github.com/AudiusProject/audius-client/assets/1815175/62d818dd-299e-41ea-b9ae-78d0c89c2b42)


