### PR TITLE
[PAY-1615] Fix display of "Artist Pick" text

### DIFF
--- a/packages/web/src/components/track/desktop/TrackTile.module.css
+++ b/packages/web/src/components/track/desktop/TrackTile.module.css
@@ -260,6 +260,22 @@
   justify-content: flex-start;
 }
 
+.artistPickLabelContainer {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--unit-1);
+  color: var(--neutral-light-4);
+}
+
+.artistPickIcon {
+  height: var(--unit-4);
+  width: var(--unit-4);
+}
+.artistPickIcon path {
+  fill: var(--neutral-light-4);
+}
+
 /* Right side of the track tile */
 .topRight {
   position: absolute;

--- a/packages/web/src/components/track/desktop/TrackTile.tsx
+++ b/packages/web/src/components/track/desktop/TrackTile.tsx
@@ -213,6 +213,26 @@ const TrackTile = ({
         premiumConditions
       })
 
+  let specialContentLabel = null
+  if (!isLoading) {
+    if (isPremium) {
+      specialContentLabel = (
+        <PremiumContentLabel
+          premiumConditions={premiumConditions}
+          doesUserHaveAccess={!!doesUserHaveAccess}
+          isOwner={isOwner}
+        />
+      )
+    } else if (isArtistPick) {
+      specialContentLabel = (
+        <div className={styles.artistPickLabelContainer}>
+          <IconStar className={styles.artistPickIcon} />
+          {messages.artistPick}
+        </div>
+      )
+    }
+  }
+
   return (
     <div
       className={cn(styles.container, {
@@ -306,24 +326,12 @@ const TrackTile = ({
               <Skeleton width='30%' className={styles.skeleton} />
             ) : (
               <>
-                {!isLoading && isPremium && (
-                  <PremiumContentLabel
-                    premiumConditions={premiumConditions}
-                    doesUserHaveAccess={!!doesUserHaveAccess}
-                    isOwner={isOwner}
-                  />
-                )}
+                {specialContentLabel}
                 {stats}
               </>
             )}
           </div>
           <div className={cn(typeStyles.bodyXSmall, styles.topRight)}>
-            {isArtistPick ? (
-              <div className={styles.topRightIconLabel}>
-                <IconStar className={styles.topRightIcon} />
-                {messages.artistPick}
-              </div>
-            ) : null}
             {isUnlisted ? (
               <div className={styles.topRightIconLabel}>
                 <IconHidden className={styles.topRightIcon} />

--- a/packages/web/src/components/track/mobile/TrackTile.module.css
+++ b/packages/web/src/components/track/mobile/TrackTile.module.css
@@ -246,6 +246,22 @@
   margin: var(--unit-2) 0;
 }
 
+.artistPickLabelContainer {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: var(--unit-1);
+  color: var(--neutral-light-4);
+}
+
+.artistPickIcon {
+  height: var(--unit-4);
+  width: var(--unit-4);
+}
+.artistPickIcon path {
+  fill: var(--neutral-light-4);
+}
+
 .stats {
   align-items: center;
   display: flex;

--- a/packages/web/src/components/track/mobile/TrackTile.tsx
+++ b/packages/web/src/components/track/mobile/TrackTile.tsx
@@ -239,6 +239,27 @@ const TrackTile = (props: CombinedProps) => {
 
   const isReadonly = variant === 'readonly'
 
+  let specialContentLabel = null
+
+  if (!isLoading) {
+    if (isPremium) {
+      specialContentLabel = (
+        <PremiumContentLabel
+          premiumConditions={premiumConditions}
+          doesUserHaveAccess={!!doesUserHaveAccess}
+          isOwner={isOwner}
+        />
+      )
+    } else if (isArtistPick) {
+      specialContentLabel = (
+        <div className={styles.artistPickLabelContainer}>
+          <IconStar className={styles.artistPickIcon} />
+          {messages.artistPick}
+        </div>
+      )
+    }
+  }
+
   return (
     <div
       className={cn(
@@ -260,12 +281,6 @@ const TrackTile = (props: CombinedProps) => {
             styles.statText
           )}
         >
-          {isArtistPick ? (
-            <div className={styles.topRightIcon}>
-              <IconStar />
-              {messages.artistPick}
-            </div>
-          ) : null}
           {props.isUnlisted ? (
             <div className={styles.topRightIcon}>
               <IconHidden />
@@ -372,13 +387,7 @@ const TrackTile = (props: CombinedProps) => {
               isVisible={isTrending && artworkLoaded && !showSkeleton}
               className={styles.rankIconContainer}
             />
-            {!isLoading && isPremium ? (
-              <PremiumContentLabel
-                premiumConditions={premiumConditions}
-                doesUserHaveAccess={!!doesUserHaveAccess}
-                isOwner={isOwner}
-              />
-            ) : null}
+            {specialContentLabel}
             {!(props.repostCount || props.saveCount) ? null : (
               <>
                 <div


### PR DESCRIPTION
### Description
According to the designs, Artist Pick should show in the same location as the other special content labels. This change moves the text from the upper right to the middle and shows it if the track is not premium.

### Dragons
None

### How Has This Been Tested?
Verified locally on web and mobile web emulator

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

### Screenshots

![Screenshot 2023-07-21 at 11 10 42 AM](https://github.com/AudiusProject/audius-client/assets/1815175/28e1e33f-652d-4785-b604-880ba33da2a7)

---

![Screenshot 2023-07-21 at 11 11 15 AM](https://github.com/AudiusProject/audius-client/assets/1815175/4bbd8e4b-d55b-4bae-80a9-79bbc811124d)

---

![Screenshot 2023-07-21 at 11 12 11 AM](https://github.com/AudiusProject/audius-client/assets/1815175/03cde972-9620-4bd4-afea-18a37a680f45)

---

![Screenshot 2023-07-21 at 11 11 30 AM](https://github.com/AudiusProject/audius-client/assets/1815175/31f7d714-97a6-42c8-b4a1-d5c64235ea0d)


