### PR TITLE
[PAY-1575] Always show premium DogEars on track details page

### DIFF
--- a/packages/common/src/utils/dogEarUtils.ts
+++ b/packages/common/src/utils/dogEarUtils.ts
@@ -11,6 +11,15 @@ type GetDogEarTypeArgs = {
   premiumConditions?: Nullable<PremiumConditions>
 }
 
+/** Determines appropriate DogEar type based on conditions provided. Note: all conditions
+ * are optional. Omitting a condition is effectively ignoring it. This can be used, for example
+ * to always show premium variants if present by omitting `doesUserHaveAccess`.
+ * Behavior:
+ * * isArtistPick: if true and doesUserHaveAccess is true, prefers artist pick variant
+ * * doesUserHaveAccess: if true, will never return premium variants
+ * * isOwner: if true, will always return premium variants if present
+ * * isUnlisted: if true, will always return hidden variant
+ */
 export const getDogEarType = ({
   doesUserHaveAccess,
   isArtistPick,

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -457,13 +457,12 @@ export const GiantTrackTile = ({
   }
 
   const isLoading = loading || artworkLoading
+  // Omitting isOwner and doesUserHaveAccess so that we always show premium DogEars
   const dogEarType = isLoading
     ? undefined
     : getDogEarType({
         premiumConditions,
-        isUnlisted,
-        isOwner,
-        doesUserHaveAccess
+        isUnlisted
       })
 
   const overflowMenuExtraItems = []

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -339,9 +339,8 @@ const TrackHeader = ({
   )
 
   const renderDogEar = () => {
+    // Omitting isOwner and doesUserHaveAccess to ensure we always show premium DogEars
     const DogEarType = getDogEarType({
-      doesUserHaveAccess,
-      isOwner,
       isUnlisted,
       premiumConditions
     })


### PR DESCRIPTION
### Description
I noticed we were (cleverly) omitting arguments on mobile to force showing dog ears on track details pages. This approach felt cleaner than my attempts to break the combination of access/owner logic out to individual components. So I documented the behavior of `getDogEarType` and updated the web variants to use this strategy.

### Dragons
None
,
### How Has This Been Tested?
Locally verified on web and mobile web

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

