### PR TITLE
[PAY-1635] Always show share button for track owners on hidden tracks

### DIFF
--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -215,7 +215,8 @@ export const GiantTrackTile = ({
   }
 
   const renderShareButton = () => {
-    const shouldShow = (!isUnlisted && !isPublishing) || fieldVisibility.share
+    const shouldShow =
+      (!isUnlisted && !isPublishing) || fieldVisibility.share || isOwner
     return (
       shouldShow && (
         <EntityActionButton

--- a/packages/web/src/components/track/desktop/BottomRow.tsx
+++ b/packages/web/src/components/track/desktop/BottomRow.tsx
@@ -77,7 +77,9 @@ export const BottomRow = ({
 
   const repostLabel = isReposted ? messages.unrepostLabel : messages.repostLabel
 
-  const hideShare: boolean = fieldVisibility
+  const hideShare: boolean = isOwner
+    ? false
+    : fieldVisibility
     ? fieldVisibility.share === false
     : false
 

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -436,7 +436,7 @@ const TrackHeader = ({
       <ActionButtonRow
         showRepost={showSocials}
         showFavorite={showSocials}
-        showShare={!isUnlisted || fieldVisibility.share}
+        showShare={!isUnlisted || fieldVisibility.share || isOwner}
         showOverflow
         shareToastDisabled
         isOwner={isOwner}


### PR DESCRIPTION
### Description
Track owners should be able to share a hidden track they own regardless of visibility settings for the button. This updates the various components on web/mobile web to make sure the button is visible in that case.

### Dragons
None

### How Has This Been Tested?
Verified locally on web / mobile web emulator

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

