### PR TITLE
Change mobile drawer background to white

### DIFF
--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -35,7 +35,7 @@ const OVERFLOW_FRICTION = 4
 
 export const useStyles = makeStyles(({ palette }) => ({
   drawer: {
-    backgroundColor: palette.neutralLight10,
+    backgroundColor: palette.white,
     position: 'absolute',
     top: 0,
     left: 0,


### PR DESCRIPTION
### Description
Drawer background should be `palette.white` instead of `palette.neutralLight10`.

### Dragons

Have not tested every single drawer, but it's a very slight color change so should be fine. The only problem I can think of is, if there was some content that was `palette.white` in order to stand out against the background, this would make that less visible. Again, very slight color change.

### How Has This Been Tested?

Local ios stage
![Simulator Screenshot - iPhone 14 Pro - 2023-07-21 at 16 26 21](https://github.com/AudiusProject/audius-client/assets/3893871/12c1f2db-bae4-459b-81ad-3f6de37c1fd2)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-21 at 16 26 48](https://github.com/AudiusProject/audius-client/assets/3893871/5e686ff1-6acd-4a68-bcc7-8c402ff1223c)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-21 at 16 27 12](https://github.com/AudiusProject/audius-client/assets/3893871/cf10c190-259c-4459-8965-3d22eeba9c72)




### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

