### PR TITLE
[PAY-1652] Update LockedContentDrawer on mobile

### DIFF
--- a/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
@@ -63,13 +63,12 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
     backgroundColor: palette.neutralLight10,
     borderWidth: 1,
     borderColor: palette.neutralLight7,
-    borderRadius: spacing(2)
+    borderRadius: spacing(2),
+    gap: spacing(2)
   },
   titleContainer: {
     ...flexRowCentered(),
-    justifyContent: 'space-between',
-    marginHorizontal: spacing(2),
-    marginVertical: spacing(1)
+    justifyContent: 'space-between'
   },
   title: {
     fontFamily: typography.fontByWeight.heavy,
@@ -78,8 +77,7 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   },
   descriptionContainer: {
     ...flexRowCentered(),
-    flexWrap: 'wrap',
-    margin: spacing(2)
+    flexWrap: 'wrap'
   },
   description: {
     flexShrink: 0,

--- a/packages/mobile/src/components/locked-content-drawer/LockedContentDrawer.tsx
+++ b/packages/mobile/src/components/locked-content-drawer/LockedContentDrawer.tsx
@@ -1,146 +1,53 @@
 import { useCallback } from 'react'
 
-import type { Track, User } from '@audius/common'
 import {
   useLockedContent,
   premiumContentActions,
-  SquareSizes,
-  usePremiumContentAccess,
-  isPremiumContentCollectibleGated
+  usePremiumContentAccess
 } from '@audius/common'
-import { Dimensions, View } from 'react-native'
+import { View } from 'react-native'
 import { useDispatch } from 'react-redux'
 
-import IconCollectible from 'app/assets/images/iconCollectible.svg'
 import IconLock from 'app/assets/images/iconLock.svg'
-import IconSpecialAccess from 'app/assets/images/iconSpecialAccess.svg'
 import { Text } from 'app/components/core'
 import { DetailsTilePremiumAccess } from 'app/components/details-tile/DetailsTilePremiumAccess'
 import { NativeDrawer } from 'app/components/drawer'
-import { TrackImage } from 'app/components/image/TrackImage'
-import UserBadges from 'app/components/user-badges'
-import { makeStyles, flexRowCentered, typography } from 'app/styles'
+import { TrackDetailsTile } from 'app/components/track-details-tile/TrackDetailsTile'
+import { makeStyles, flexRowCentered } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
 import { useColor } from 'app/utils/theme'
 
 const LOCKED_CONTENT_MODAL_NAME = 'LockedContent'
 
-const screenWidth = Dimensions.get('screen').width
-
 const { resetLockedContentId } = premiumContentActions
 
 const messages = {
-  howToUnlock: 'HOW TO UNLOCK',
-  collectibleGated: 'COLLECTIBLE GATED',
-  specialAccess: 'SPECIAL ACCESS'
+  howToUnlock: 'HOW TO UNLOCK'
 }
 
 const useStyles = makeStyles(({ spacing, palette }) => ({
   drawer: {
-    marginVertical: spacing(8),
-    alignItems: 'center'
+    paddingVertical: spacing(6),
+    alignItems: 'center',
+    backgroundColor: palette.white,
+    paddingHorizontal: spacing(4),
+    gap: spacing(6)
   },
   titleContainer: {
     ...flexRowCentered(),
-    marginBottom: spacing(6)
-  },
-  titleText: {
-    marginLeft: spacing(3),
-    fontFamily: typography.fontByWeight.heavy,
-    fontSize: typography.fontSize.medium,
-    color: palette.neutralLight2
-  },
-  trackDetails: {
-    ...flexRowCentered(),
-    width: screenWidth - spacing(8),
-    marginBottom: spacing(8),
-    padding: spacing(2),
-    backgroundColor: palette.neutralLight10,
-    borderWidth: 1,
-    borderColor: palette.neutralLight7,
-    borderRadius: spacing(2)
-  },
-  trackImage: {
-    marginRight: spacing(2),
-    width: spacing(22),
-    height: spacing(22),
-    borderRadius: spacing(1)
-  },
-  premiumContentLabelContainer: {
-    ...flexRowCentered(),
-    marginBottom: spacing(4)
-  },
-  premiumContentLabel: {
-    marginLeft: spacing(2),
-    fontFamily: typography.fontByWeight.demiBold,
-    fontSize: typography.fontSize.small,
-    color: palette.accentBlue,
-    letterSpacing: spacing(0.5)
-  },
-  trackName: {
-    width: screenWidth - spacing(36),
-    marginBottom: spacing(2),
-    fontFamily: typography.fontByWeight.bold,
-    fontSize: typography.fontSize.medium,
-    textTransform: 'capitalize'
-  },
-  trackOwnerContainer: {
-    ...flexRowCentered()
-  },
-  trackOwner: {
-    fontFamily: typography.fontByWeight.medium,
-    fontSize: typography.fontSize.medium
+    justifyContent: 'center',
+    paddingBottom: spacing(4),
+    gap: spacing(2),
+    borderBottomColor: palette.neutralLight8,
+    borderBottomWidth: 1,
+    width: '100%'
   },
   premiumTrackSection: {
-    marginHorizontal: spacing(2),
-    marginBottom: 0,
+    padding: 0,
     borderWidth: 0,
     backgroundColor: 'transparent'
   }
 }))
-
-type TrackDetailsProps = {
-  track: Track
-  owner: User
-}
-
-const TrackDetails = ({ track, owner }: TrackDetailsProps) => {
-  const styles = useStyles()
-  const accentBlue = useColor('accentBlue')
-  const isCollectibleGated = isPremiumContentCollectibleGated(
-    track.premium_conditions
-  )
-
-  return (
-    <View style={styles.trackDetails}>
-      <TrackImage
-        style={styles.trackImage}
-        track={track}
-        size={SquareSizes.SIZE_150_BY_150}
-      />
-      <View>
-        <View style={styles.premiumContentLabelContainer}>
-          {isCollectibleGated ? (
-            <IconCollectible fill={accentBlue} width={24} height={24} />
-          ) : (
-            <IconSpecialAccess fill={accentBlue} width={24} height={24} />
-          )}
-          <Text style={styles.premiumContentLabel}>
-            {isCollectibleGated
-              ? messages.collectibleGated
-              : messages.specialAccess}
-          </Text>
-        </View>
-        <Text style={styles.trackName} numberOfLines={1}>
-          {track.title}
-        </Text>
-        <View style={styles.trackOwnerContainer}>
-          <Text style={styles.trackOwner}>{owner.name}</Text>
-          <UserBadges badgeSize={16} user={owner} hideName />
-        </View>
-      </View>
-    </View>
-  )
-}
 
 export const LockedContentDrawer = () => {
   const styles = useStyles()
@@ -161,12 +68,16 @@ export const LockedContentDrawer = () => {
     <NativeDrawer drawerName={LOCKED_CONTENT_MODAL_NAME} onClose={handleClose}>
       <View style={styles.drawer}>
         <View style={styles.titleContainer}>
-          <IconLock fill={neutralLight2} width={24} height={24} />
-          <Text style={styles.titleText} weight='heavy' color='neutral'>
+          <IconLock
+            fill={neutralLight2}
+            width={spacing(6)}
+            height={spacing(6)}
+          />
+          <Text weight='heavy' color='neutralLight2' fontSize='xl'>
             {messages.howToUnlock}
           </Text>
         </View>
-        <TrackDetails track={track} owner={owner} />
+        <TrackDetailsTile trackId={track.track_id} />
         <DetailsTilePremiumAccess
           style={styles.premiumTrackSection}
           trackId={track.track_id}

--- a/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
+++ b/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
@@ -1,0 +1,146 @@
+import type { ID } from '@audius/common'
+import {
+  SquareSizes,
+  getDogEarType,
+  isPremiumContentCollectibleGated,
+  usePremiumContentAccess,
+  cacheUsersSelectors,
+  cacheTracksSelectors
+} from '@audius/common'
+import { View } from 'react-native'
+import { useSelector } from 'react-redux'
+
+import IconCollectible from 'app/assets/images/iconCollectible.svg'
+import IconSpecialAccess from 'app/assets/images/iconSpecialAccess.svg'
+import { DogEar, Text } from 'app/components/core'
+import { TrackImage } from 'app/components/image/TrackImage'
+import UserBadges from 'app/components/user-badges'
+import { makeStyles, flexRowCentered, typography } from 'app/styles'
+import { spacing } from 'app/styles/spacing'
+import { useColor } from 'app/utils/theme'
+
+const { getUser } = cacheUsersSelectors
+const { getTrack } = cacheTracksSelectors
+
+const messages = {
+  collectibleGated: 'COLLECTIBLE GATED',
+  specialAccess: 'SPECIAL ACCESS'
+}
+
+const useStyles = makeStyles(({ spacing, palette }) => ({
+  root: {
+    backgroundColor: palette.neutralLight10,
+    borderWidth: 1,
+    borderColor: palette.neutralLight8,
+    borderRadius: spacing(2),
+    width: '100%'
+  },
+  trackDetails: {
+    ...flexRowCentered(),
+    padding: spacing(4),
+    gap: spacing(4)
+  },
+  trackImage: {
+    width: spacing(22),
+    height: spacing(22),
+    borderRadius: spacing(1),
+    borderColor: palette.neutralLight8
+  },
+  metadataContainer: {
+    gap: spacing(1),
+    flexShrink: 1
+  },
+  premiumContentLabelContainer: {
+    ...flexRowCentered(),
+    gap: spacing(2)
+  },
+  premiumContentLabel: {
+    letterSpacing: spacing(0.5)
+  },
+  trackOwnerContainer: {
+    ...flexRowCentered(),
+    marginTop: spacing(1)
+  },
+  trackOwner: {
+    fontFamily: typography.fontByWeight.medium,
+    fontSize: typography.fontSize.medium
+  }
+}))
+
+type TrackDetailsTileProps = {
+  trackId: ID
+}
+
+export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
+  const styles = useStyles()
+  const accentBlue = useColor('accentBlue')
+  const track = useSelector((state) => getTrack(state, { id: trackId }))
+  const owner = useSelector((state) => getUser(state, { id: track?.owner_id }))
+  const isCollectibleGated = isPremiumContentCollectibleGated(
+    track?.premium_conditions
+  )
+  const { doesUserHaveAccess } = usePremiumContentAccess(track)
+
+  const dogEarType = getDogEarType({
+    doesUserHaveAccess,
+    premiumConditions: track?.premium_conditions
+  })
+
+  if (!track || !owner) {
+    return null
+  }
+
+  return (
+    <View style={styles.root}>
+      {dogEarType ? <DogEar type={dogEarType} /> : null}
+      <View style={styles.trackDetails}>
+        <TrackImage
+          style={styles.trackImage}
+          track={track}
+          size={SquareSizes.SIZE_150_BY_150}
+        />
+        <View style={styles.metadataContainer}>
+          <View style={styles.premiumContentLabelContainer}>
+            {isCollectibleGated ? (
+              <IconCollectible
+                fill={accentBlue}
+                width={spacing(5)}
+                height={spacing(5)}
+              />
+            ) : (
+              <IconSpecialAccess
+                fill={accentBlue}
+                width={spacing(5)}
+                height={spacing(5)}
+              />
+            )}
+            <Text
+              fontSize='small'
+              color='accentBlue'
+              weight='demiBold'
+              style={styles.premiumContentLabel}
+            >
+              {isCollectibleGated
+                ? messages.collectibleGated
+                : messages.specialAccess}
+            </Text>
+          </View>
+          <Text
+            fontSize='xl'
+            weight='bold'
+            textTransform='capitalize'
+            numberOfLines={1}
+          >
+            {track.title}
+          </Text>
+          <View style={styles.trackOwnerContainer}>
+            <Text color='secondary' weight='demiBold' fontSize='small'>
+              {owner.name}
+            </Text>
+            <UserBadges badgeSize={spacing(4)} user={owner} hideName />
+          </View>
+        </View>
+      </View>
+    </View>
+  )
+}

--- a/packages/mobile/src/components/track-details-tile/index.ts
+++ b/packages/mobile/src/components/track-details-tile/index.ts
@@ -1,0 +1,1 @@
+export * from './TrackDetailsTile'


### PR DESCRIPTION
### Description
To keep the layout/design consistent with the incoming USDC Purchase drawer.

### Dragons

`TrackDetailsTile` is kind of generic-sounding, open to suggestions.

### How Has This Been Tested?

Confirmed it doesn't break existing track screen layout.
![Simulator Screenshot - iPhone 14 Pro - 2023-07-21 at 17 01 40](https://github.com/AudiusProject/audius-client/assets/3893871/06307028-8609-4127-93be-e6a68d53716c)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-21 at 17 01 48](https://github.com/AudiusProject/audius-client/assets/3893871/94ce1a51-54bc-4c32-90dc-5e824f3ac5fe)
![Simulator Screenshot - iPhone 14 Pro - 2023-07-21 at 17 01 33](https://github.com/AudiusProject/audius-client/assets/3893871/d5735832-1b22-49b3-86c7-f499f2d5b815)


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

