### PR TITLE
Update to reroute to trending when deleting a playlist if the playlist is viewed

### DIFF
--- a/packages/web/src/components/collection/desktop/EditButton.tsx
+++ b/packages/web/src/components/collection/desktop/EditButton.tsx
@@ -20,7 +20,10 @@ export const EditButton = (props: EditButtonProps) => {
   const dispatch = useDispatch()
 
   const handleEdit = useCallback(
-    () => dispatch(openEditCollectionModal({ collectionId })),
+    () =>
+      dispatch(
+        openEditCollectionModal({ collectionId, isCollectionViewed: true })
+      ),
     [dispatch, collectionId]
   )
 

--- a/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
+++ b/packages/web/src/components/edit-playlist/desktop/EditPlaylistModal.tsx
@@ -13,6 +13,7 @@ import {
   ModalHeader,
   ModalTitle
 } from '@audius/stems'
+import { push as pushRoute } from 'connected-react-router'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 
@@ -22,10 +23,12 @@ import { DeleteCollectionConfirmationModal } from 'components/nav/desktop/Playli
 import {
   getCollectionId,
   getInitialFocusedField,
+  getIsCollectionViewed,
   getIsOpen
 } from 'store/application/ui/editPlaylistModal/selectors'
 import { close } from 'store/application/ui/editPlaylistModal/slice'
 import { AppState } from 'store/types'
+import { TRENDING_PAGE } from 'utils/route'
 import zIndex from 'utils/zIndex'
 
 import styles from './EditPlaylistModal.module.css'
@@ -54,9 +57,11 @@ type EditPlaylistModalProps = OwnProps &
 const EditPlaylistModal = (props: EditPlaylistModalProps) => {
   const {
     isOpen,
+    isCollectionViewed,
     initialFocusedField,
     collectionId,
     collection,
+    goToRoute,
     onClose,
     fetchSavedPlaylists,
     editPlaylist
@@ -95,7 +100,10 @@ const EditPlaylistModal = (props: EditPlaylistModalProps) => {
   const handleDelete = useCallback(() => {
     setShowDeleteConfirmation(false)
     onClose()
-  }, [onClose])
+    if (isCollectionViewed) {
+      goToRoute(TRENDING_PAGE)
+    }
+  }, [onClose, goToRoute, isCollectionViewed])
 
   return (
     <>
@@ -145,6 +153,7 @@ const mapStateToProps = (state: AppState) => {
   return {
     isOpen: getIsOpen(state),
     initialFocusedField: getInitialFocusedField(state),
+    isCollectionViewed: getIsCollectionViewed(state),
     collectionId: getCollectionId(state),
     collection: getCollectionWithUser(state, { id: collectionId || undefined })
   }
@@ -153,6 +162,7 @@ const mapStateToProps = (state: AppState) => {
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   onClose: () => dispatch(close()),
   fetchSavedPlaylists: () => dispatch(fetchSavedPlaylists()),
+  goToRoute: (route: string) => dispatch(pushRoute(route)),
   editPlaylist: (playlistId: ID, formFields: any) =>
     dispatch(editPlaylist(playlistId, formFields))
 })

--- a/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
+++ b/packages/web/src/components/nav/desktop/PlaylistLibrary/CollectionNavItem.tsx
@@ -15,6 +15,7 @@ import {
 import { PopupMenuItem } from '@audius/stems'
 import cn from 'classnames'
 import { useDispatch } from 'react-redux'
+import { useRouteMatch } from 'react-router-dom'
 import { useToggle } from 'react-use'
 
 import { make, useRecord } from 'common/store/analytics/actions'
@@ -71,6 +72,7 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
   const [isHovering, setIsHovering] = useState(false)
   const dispatch = useDispatch()
   const record = useRecord()
+  const isCollectionViewed = useRouteMatch(url)
   const [isDeleteConfirmationOpen, toggleDeleteConfirmationOpen] =
     useToggle(false)
 
@@ -92,10 +94,15 @@ export const CollectionNavItem = (props: CollectionNavItemProps) => {
 
   const handleEdit = useCallback(() => {
     if (typeof id === 'number') {
-      dispatch(openEditPlaylistModal({ collectionId: id }))
+      dispatch(
+        openEditPlaylistModal({
+          collectionId: id,
+          isCollectionViewed: isCollectionViewed?.isExact ?? false
+        })
+      )
       record(make(Name.PLAYLIST_OPEN_EDIT_FROM_LIBRARY, {}))
     }
-  }, [dispatch, id, record])
+  }, [dispatch, id, record, isCollectionViewed])
 
   const handleShare = useCallback(() => {
     if (typeof id === 'number') {

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -1017,7 +1017,9 @@ function mapDispatchToProps(dispatch: Dispatch) {
       ),
     setModalVisibility: () => dispatch(setVisibility(true)),
     onEditCollection: (collectionId: ID) =>
-      dispatch(openEditCollectionModal({ collectionId })),
+      dispatch(
+        openEditCollectionModal({ collectionId, isCollectionViewed: true })
+      ),
     updatePlaylistLastViewedAt: (playlistId: ID) =>
       dispatch(updatedPlaylistViewed({ playlistId })),
     onClickDescriptionInternalLink: (path: string) => dispatch(pushRoute(path))

--- a/packages/web/src/store/application/ui/editPlaylistModal/selectors.ts
+++ b/packages/web/src/store/application/ui/editPlaylistModal/selectors.ts
@@ -12,3 +12,7 @@ export const getCollectionId = (state: AppState) => {
 export const getInitialFocusedField = (state: AppState) => {
   return getBase(state).initialFocusedField
 }
+
+export const getIsCollectionViewed = (state: AppState) => {
+  return getBase(state).isCollectionViewed
+}

--- a/packages/web/src/store/application/ui/editPlaylistModal/slice.ts
+++ b/packages/web/src/store/application/ui/editPlaylistModal/slice.ts
@@ -7,18 +7,23 @@ export type EditPlaylistModalState = {
   isOpen: boolean
   collectionId: ID | null
   initialFocusedField: Nullable<FocusableFields>
+  isCollectionViewed: boolean
 }
 
 const initialState: EditPlaylistModalState = {
   isOpen: false,
   collectionId: null,
-  initialFocusedField: null
+  initialFocusedField: null,
+  isCollectionViewed: false
 }
 
 type OpenPayload = PayloadAction<{
   collectionId: ID
   // Which field in edit-playlist form should be autofocused
   initialFocusedField?: 'name' | 'description' | 'artwork'
+  // Is the collection currently being viewed
+  // Used to check if we should reroute back to trending on delete
+  isCollectionViewed?: boolean
 }>
 
 const slice = createSlice({
@@ -26,9 +31,12 @@ const slice = createSlice({
   initialState,
   reducers: {
     open: (state, action: OpenPayload) => {
-      const { collectionId, initialFocusedField } = action.payload
+      const { collectionId, initialFocusedField, isCollectionViewed } =
+        action.payload
+
       state.isOpen = true
       state.collectionId = collectionId
+      state.isCollectionViewed = isCollectionViewed ?? false
       if (initialFocusedField) {
         state.initialFocusedField = initialFocusedField
       }
@@ -37,6 +45,7 @@ const slice = createSlice({
       state.isOpen = false
       state.collectionId = null
       state.initialFocusedField = null
+      state.isCollectionViewed = false
     }
   }
 })


### PR DESCRIPTION
### Description
Pass a param to the edit playlist modal to reroute to the trending page if the playlist is being viewed

### Dragons

N/A

### How Has This Been Tested?

Manually tested

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

