### PR TITLE
Fix mobile LockedStatusBadge padding

### DIFF
--- a/packages/mobile/src/components/core/LockedStatusBadge.tsx
+++ b/packages/mobile/src/components/core/LockedStatusBadge.tsx
@@ -10,6 +10,7 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
   root: {
     backgroundColor: palette.accentBlue,
     paddingHorizontal: spacing(2),
+    paddingVertical: 1,
     borderRadius: spacing(10),
     justifyContent: 'center'
   },
@@ -23,13 +24,13 @@ const useStyles = makeStyles(({ palette, spacing, typography }) => ({
 
 export type LockedStatusBadgeProps = {
   locked: boolean
-  variant: 'purchase' | 'gated'
+  variant?: 'purchase' | 'gated'
 }
 
 /** Renders a small badge with locked or unlocked icon */
 export const LockedStatusBadge = ({
   locked,
-  variant
+  variant = 'gated'
 }: LockedStatusBadgeProps) => {
   const styles = useStyles()
   const staticWhite = useColor('staticWhite')


### PR DESCRIPTION
### Description
Realized vertical padding was 1px off.
Also setting a default for `variant` bc in USDC Purchase Drawer there is a case where the badge will only ever be locked and therefore background color will only ever be gray, so we don't care about which variant is used.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

<img width="378" alt="Screenshot 2023-07-24 at 1 35 09 PM" src="https://github.com/AudiusProject/audius-client/assets/3893871/5eca4ab5-b8ef-4bfd-ab8d-1c78a613675d">

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

