### PR TITLE
[PAY-1587] Mobile USDC Purchase Drawer Skeleton

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -103,6 +103,12 @@ export type PremiumConditions =
   | PremiumConditionsTipGated
   | PremiumConditionsUSDCPurchase
 
+export enum PremiumContentType {
+  COLLECTIBLE_GATED = 'collectible gated',
+  SPECIAL_ACCESS = 'special access',
+  USDC_PURCHASE = 'usdc purchase'
+}
+
 export const isPremiumContentCollectibleGated = (
   premiumConditions?: Nullable<PremiumConditions>
 ): premiumConditions is PremiumConditionsCollectibleGated =>

--- a/packages/mobile/src/app/Drawers.tsx
+++ b/packages/mobile/src/app/Drawers.tsx
@@ -25,6 +25,7 @@ import { InboxUnavailableDrawer } from 'app/components/inbox-unavailable-drawer/
 import { LockedContentDrawer } from 'app/components/locked-content-drawer'
 import { OverflowMenuDrawer } from 'app/components/overflow-menu-drawer'
 import { PlaybackRateDrawer } from 'app/components/playback-rate-drawer'
+import { PremiumTrackPurchaseDrawer } from 'app/components/premium-track-purchase-drawer'
 import { ProfileActionsDrawer } from 'app/components/profile-actions-drawer'
 import { PublishPlaylistDrawer } from 'app/components/publish-playlist-drawer'
 import { RateCtaDrawer } from 'app/components/rate-cta-drawer'
@@ -126,7 +127,8 @@ const nativeDrawersMap: { [DrawerName in Drawer]?: ComponentType } = {
   BlockMessages: BlockMessagesDrawer,
   DeleteChat: DeleteChatDrawer,
   SupportersInfo: SupportersInfoDrawer,
-  InboxUnavailable: InboxUnavailableDrawer
+  InboxUnavailable: InboxUnavailableDrawer,
+  PremiumTrackPurchase: PremiumTrackPurchaseDrawer
 }
 
 const commonDrawers = Object.entries(commonDrawersMap) as [

--- a/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
+++ b/packages/mobile/src/components/details-tile/DetailsTileNoAccess.tsx
@@ -29,6 +29,7 @@ import LoadingSpinner from 'app/components/loading-spinner'
 import UserBadges from 'app/components/user-badges'
 import { useDrawer } from 'app/hooks/useDrawer'
 import { useNavigation } from 'app/hooks/useNavigation'
+import { setVisibility } from 'app/store/drawers/slice'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
 
@@ -208,6 +209,16 @@ export const DetailsTileNoAccess = ({
     navigation.navigate('TipArtist')
   }, [tippedUser, navigation, dispatch, source, trackId])
 
+  const handlePurchasePress = useCallback(() => {
+    dispatch(
+      setVisibility({
+        drawer: 'PremiumTrackPurchase',
+        visible: true,
+        data: { trackId }
+      })
+    )
+  }, [dispatch, trackId])
+
   const handlePressArtistName = useCallback(
     (handle: string) => () => {
       navigation.push('Profile', { handle })
@@ -345,9 +356,7 @@ export const DetailsTileNoAccess = ({
               formatUSDCWeiToUSDString(premiumConditions.usdc_purchase.price)
             )}
             size='large'
-            onPress={() => {
-              console.log('Buy button pressed')
-            }}
+            onPress={handlePurchasePress}
             fullWidth
           />
         </>
@@ -375,7 +384,8 @@ export const DetailsTileNoAccess = ({
     renderLockedSpecialAccessDescription,
     handleFollowArtist,
     tippedUser,
-    handleSendTip
+    handleSendTip,
+    handlePurchasePress
   ])
 
   const renderUnlockingSpecialAccessDescription = useCallback(

--- a/packages/mobile/src/components/lineup-tile/LineupTilePremiumContentTypeTag.tsx
+++ b/packages/mobile/src/components/lineup-tile/LineupTilePremiumContentTypeTag.tsx
@@ -3,7 +3,8 @@ import { useMemo } from 'react'
 import {
   isPremiumContentCollectibleGated,
   isPremiumContentUSDCPurchaseGated,
-  type PremiumConditions
+  type PremiumConditions,
+  PremiumContentType
 } from '@audius/common'
 import { View } from 'react-native'
 
@@ -32,12 +33,6 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
     fontFamily: typography.fontByWeight.medium
   }
 }))
-
-enum PremiumContentType {
-  COLLECTIBLE_GATED = 'collectible gated',
-  SPECIAL_ACCESS = 'special access',
-  USDC_PURCHASE = 'usdc purchase'
-}
 
 type LineupTilePremiumContentTypeTagProps = {
   premiumConditions: PremiumConditions

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -1,0 +1,167 @@
+import { useCallback } from 'react'
+
+import {
+  cacheTracksSelectors,
+  formatUSDCWeiToUSDString,
+  isPremiumContentUSDCPurchaseGated
+} from '@audius/common'
+import { View } from 'react-native'
+import { useSelector } from 'react-redux'
+
+import IconCart from 'app/assets/images/iconCart.svg'
+import { LockedStatusBadge, Text, Button } from 'app/components/core'
+import { NativeDrawer } from 'app/components/drawer'
+import { useDrawer } from 'app/hooks/useDrawer'
+import { makeStyles, flexRowCentered } from 'app/styles'
+import { useThemeColors } from 'app/utils/theme'
+
+import { TrackDetailsTile } from '../track-details-tile'
+
+const { getTrack } = cacheTracksSelectors
+
+const PREMIUM_TRACK_PURCHASE_MODAL_NAME = 'PremiumTrackPurchase'
+
+const messages = {
+  title: 'Complete Purchase',
+  summary: 'Summary',
+  artistCut: 'Artist Cut',
+  audiusCut: 'Audius Cut',
+  alwaysZero: 'Always $0',
+  youPay: 'You Pay',
+  price: (price: string) => `$${price}`,
+  payToUnlock: 'Pay-To-Unlock',
+  disclaimer:
+    'By clicking on "Buy", you agree to our Terms of Use. Your purchase will be made in USDC via 3rd party payment provider. Additional payment provider fees may apply. Any remaining USDC balance in your Audius wallet will be applied to this transaction. Once your payment is confirmed, your premium content will be unlocked and available to stream.',
+  buy: (price: string) => `Buy $${price}`
+}
+
+const useStyles = makeStyles(({ spacing, typography, palette }) => ({
+  drawer: {
+    paddingVertical: spacing(6),
+    paddingHorizontal: spacing(4),
+    gap: spacing(6),
+    backgroundColor: palette.white
+  },
+  titleContainer: {
+    ...flexRowCentered(),
+    gap: spacing(2),
+    marginBottom: spacing(2),
+    alignSelf: 'center'
+  },
+  title: {
+    fontSize: typography.fontSize.xl,
+    fontFamily: typography.fontByWeight.heavy,
+    color: palette.neutralLight2,
+    textTransform: 'uppercase',
+    lineHeight: typography.fontSize.xl * 1.25
+  },
+  trackTileContainer: {
+    ...flexRowCentered(),
+    borderColor: palette.neutralLight8,
+    borderWidth: 1,
+    borderRadius: spacing(2),
+    backgroundColor: palette.neutralLight10
+  },
+  summaryContainer: {
+    borderColor: palette.neutralLight8,
+    borderWidth: 1,
+    borderRadius: spacing(1)
+  },
+  summaryRow: {
+    ...flexRowCentered(),
+    justifyContent: 'space-between',
+    paddingVertical: spacing(3),
+    paddingHorizontal: spacing(6),
+    borderBottomColor: palette.neutralLight8,
+    borderBottomWidth: 1
+  },
+  lastRow: {
+    borderBottomWidth: 0
+  },
+  greyRow: {
+    backgroundColor: palette.neutralLight10
+  },
+  summaryTitle: {
+    letterSpacing: 1
+  },
+  payToUnlockTitleContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing(2),
+    marginBottom: spacing(2)
+  }
+}))
+
+export const PremiumTrackPurchaseDrawer = () => {
+  const styles = useStyles()
+  const { neutralLight2, specialLightGreen1 } = useThemeColors()
+  const { data } = useDrawer('PremiumTrackPurchase')
+  const { trackId } = data
+  const track = useSelector((state) => getTrack(state, { id: trackId }))
+
+  const handleConfirmPress = useCallback(() => {
+    console.log('buy button pressed')
+  }, [])
+
+  const { premium_conditions: premiumConditions } = track ?? {}
+
+  if (!track || !isPremiumContentUSDCPurchaseGated(premiumConditions))
+    return null
+
+  const price = formatUSDCWeiToUSDString(premiumConditions.usdc_purchase.price)
+
+  return (
+    <NativeDrawer drawerName={PREMIUM_TRACK_PURCHASE_MODAL_NAME}>
+      <View style={styles.drawer}>
+        <View style={styles.titleContainer}>
+          <IconCart fill={neutralLight2} />
+          <Text style={styles.title}>{messages.title}</Text>
+        </View>
+        <TrackDetailsTile trackId={track.track_id} />
+        <View style={styles.summaryContainer}>
+          <View style={[styles.summaryRow, styles.greyRow]}>
+            <Text
+              weight='bold'
+              textTransform='uppercase'
+              style={styles.summaryTitle}
+            >
+              {messages.summary}
+            </Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text>{messages.artistCut}</Text>
+            <Text>{messages.price(price)}</Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text>{messages.audiusCut}</Text>
+            <Text>{messages.alwaysZero}</Text>
+          </View>
+          <View style={[styles.summaryRow, styles.lastRow, styles.greyRow]}>
+            <Text weight='bold'>{messages.youPay}</Text>
+            <Text weight='bold' color='secondary'>
+              {messages.price(price)}
+            </Text>
+          </View>
+        </View>
+        <View>
+          <View style={styles.payToUnlockTitleContainer}>
+            <Text weight='heavy' textTransform='uppercase' fontSize='small'>
+              {messages.payToUnlock}
+            </Text>
+            <LockedStatusBadge locked />
+          </View>
+          <Text>{messages.disclaimer}</Text>
+        </View>
+        <Button
+          title={messages.buy(price)}
+          onPress={handleConfirmPress}
+          variant={'primary'}
+          size='large'
+          color={specialLightGreen1}
+          fullWidth
+        />
+      </View>
+    </NativeDrawer>
+  )
+}

--- a/packages/mobile/src/components/premium-track-purchase-drawer/index.ts
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/index.ts
@@ -1,0 +1,1 @@
+export { PremiumTrackPurchaseDrawer } from './PremiumTrackPurchaseDrawer'

--- a/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
+++ b/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
@@ -1,3 +1,6 @@
+import type { ComponentType } from 'react'
+import { useMemo } from 'react'
+
 import type { ID } from '@audius/common'
 import {
   SquareSizes,
@@ -5,26 +8,33 @@ import {
   isPremiumContentCollectibleGated,
   usePremiumContentAccess,
   cacheUsersSelectors,
-  cacheTracksSelectors
+  cacheTracksSelectors,
+  isPremiumContentUSDCPurchaseGated,
+  PremiumContentType
 } from '@audius/common'
 import { View } from 'react-native'
+import type { SvgProps } from 'react-native-svg'
 import { useSelector } from 'react-redux'
 
+import IconCart from 'app/assets/images/iconCart.svg'
 import IconCollectible from 'app/assets/images/iconCollectible.svg'
 import IconSpecialAccess from 'app/assets/images/iconSpecialAccess.svg'
 import { DogEar, Text } from 'app/components/core'
 import { TrackImage } from 'app/components/image/TrackImage'
 import UserBadges from 'app/components/user-badges'
+import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { makeStyles, flexRowCentered, typography } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
-import { useColor } from 'app/utils/theme'
+import type { ThemeColors } from 'app/utils/theme'
+import { useThemeColors } from 'app/utils/theme'
 
 const { getUser } = cacheUsersSelectors
 const { getTrack } = cacheTracksSelectors
 
 const messages = {
   collectibleGated: 'COLLECTIBLE GATED',
-  specialAccess: 'SPECIAL ACCESS'
+  specialAccess: 'SPECIAL ACCESS',
+  premiumTrack: 'PREMIUM TRACK'
 }
 
 const useStyles = makeStyles(({ spacing, palette }) => ({
@@ -73,12 +83,15 @@ type TrackDetailsTileProps = {
 
 export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
   const styles = useStyles()
-  const accentBlue = useColor('accentBlue')
+  const { accentBlue, specialLightGreen1 } = useThemeColors()
   const track = useSelector((state) => getTrack(state, { id: trackId }))
   const owner = useSelector((state) => getUser(state, { id: track?.owner_id }))
   const isCollectibleGated = isPremiumContentCollectibleGated(
     track?.premium_conditions
   )
+  const isUSDCPurchaseGated =
+    useIsUSDCEnabled() &&
+    isPremiumContentUSDCPurchaseGated(track?.premium_conditions)
   const { doesUserHaveAccess } = usePremiumContentAccess(track)
 
   const dogEarType = getDogEarType({
@@ -86,9 +99,53 @@ export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
     premiumConditions: track?.premium_conditions
   })
 
+  const type = isUSDCPurchaseGated
+    ? PremiumContentType.USDC_PURCHASE
+    : isCollectibleGated
+    ? PremiumContentType.COLLECTIBLE_GATED
+    : PremiumContentType.SPECIAL_ACCESS
+
+  const headerAttributes: Record<
+    PremiumContentType,
+    {
+      message: string
+      icon: ComponentType<SvgProps>
+      color: string
+      colorString: keyof ThemeColors
+    }
+  > = useMemo(() => {
+    return {
+      [PremiumContentType.COLLECTIBLE_GATED]: {
+        message: messages.collectibleGated,
+        icon: IconCollectible,
+        color: accentBlue,
+        colorString: 'accentBlue'
+      },
+      [PremiumContentType.SPECIAL_ACCESS]: {
+        message: messages.specialAccess,
+        icon: IconSpecialAccess,
+        color: accentBlue,
+        colorString: 'accentBlue'
+      },
+      [PremiumContentType.USDC_PURCHASE]: {
+        message: messages.premiumTrack,
+        icon: IconCart,
+        color: specialLightGreen1,
+        colorString: 'specialLightGreen1'
+      }
+    }
+  }, [accentBlue, specialLightGreen1])
+
   if (!track || !owner) {
     return null
   }
+
+  const {
+    message: title,
+    icon: IconComponent,
+    color,
+    colorString
+  } = headerAttributes[type]
 
   return (
     <View style={styles.root}>
@@ -101,28 +158,19 @@ export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
         />
         <View style={styles.metadataContainer}>
           <View style={styles.premiumContentLabelContainer}>
-            {isCollectibleGated ? (
-              <IconCollectible
-                fill={accentBlue}
-                width={spacing(5)}
-                height={spacing(5)}
-              />
-            ) : (
-              <IconSpecialAccess
-                fill={accentBlue}
-                width={spacing(5)}
-                height={spacing(5)}
-              />
-            )}
+            <IconComponent
+              fill={color}
+              width={spacing(5)}
+              height={spacing(5)}
+            />
             <Text
               fontSize='small'
-              color='accentBlue'
+              color={colorString}
               weight='demiBold'
+              textTransform='uppercase'
               style={styles.premiumContentLabel}
             >
-              {isCollectibleGated
-                ? messages.collectibleGated
-                : messages.specialAccess}
+              {title}
             </Text>
           </View>
           <Text

--- a/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
+++ b/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
@@ -105,15 +105,14 @@ export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
     ? PremiumContentType.COLLECTIBLE_GATED
     : PremiumContentType.SPECIAL_ACCESS
 
-  const headerAttributes: Record<
-    PremiumContentType,
-    {
+  const headerAttributes: {
+    [k in PremiumContentType]: {
       message: string
       icon: ComponentType<SvgProps>
       color: string
       colorString: keyof ThemeColors
     }
-  > = useMemo(() => {
+  } = useMemo(() => {
     return {
       [PremiumContentType.COLLECTIBLE_GATED]: {
         message: messages.collectibleGated,

--- a/packages/mobile/src/store/drawers/slice.ts
+++ b/packages/mobile/src/store/drawers/slice.ts
@@ -29,6 +29,7 @@ export type Drawer =
   | 'DeleteChat'
   | 'SupportersInfo'
   | 'InboxUnavailable'
+  | 'PremiumTrackPurchase'
 
 export type DrawerData = {
   EnablePushNotifications: undefined
@@ -64,6 +65,7 @@ export type DrawerData = {
   DeleteChat: { chatId: string }
   SupportersInfo: undefined
   InboxUnavailable: { userId: number; shouldOpenChat: boolean }
+  PremiumTrackPurchase: { trackId: ID }
 }
 
 export type DrawersState = { [drawer in Drawer]: boolean | 'closing' } & {
@@ -95,6 +97,7 @@ const initialState: DrawersState = {
   DeleteChat: false,
   SupportersInfo: false,
   InboxUnavailable: false,
+  PremiumTrackPurchase: false,
   data: {}
 }
 


### PR DESCRIPTION
### Description
Re-trying this PR, had to close previous one due to git snafu: https://github.com/AudiusProject/audius-client/pull/3791

UI for purchasing USDC-gated tracks.

### Dragons

How do we feel about exporting the PremiumContentType enum in models?
Also cc @dylanjeffers wondering if there's a smarter way to do the colors in TrackDetailsTile. Icon takes a string, while Text takes a keyof ThemeColors.

### How Has This Been Tested?

Local ios stage
![255672581-dde97e31-2354-45fe-9cd4-e8ed7ed16f51](https://github.com/AudiusProject/audius-client/assets/3893871/3c780d64-ad29-451d-8f72-bfc3040426ed)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

