### PR TITLE
[PAY-1650] Update play/preview buttons on track details to use HarmonyButton

### DIFF
--- a/packages/web/src/components/track/PlayPauseButton.tsx
+++ b/packages/web/src/components/track/PlayPauseButton.tsx
@@ -7,9 +7,9 @@ import {
   CommonState
 } from '@audius/common'
 import {
-  Button,
-  ButtonSize,
-  ButtonType,
+  HarmonyButton,
+  HarmonyButtonSize,
+  HarmonyButtonType,
   IconPause,
   IconPlay
 } from '@audius/stems'
@@ -78,12 +78,14 @@ export const PlayPauseButton = ({
   }
 
   return (
-    <Button
+    <HarmonyButton
       name={isPreview ? 'preview' : 'play'}
-      size={ButtonSize.LARGE}
-      type={isPreview ? ButtonType.SECONDARY : ButtonType.PRIMARY_ALT}
+      size={HarmonyButtonSize.LARGE}
+      variant={
+        isPreview ? HarmonyButtonType.SECONDARY : HarmonyButtonType.PRIMARY
+      }
       text={playing ? messages.pause : playText}
-      leftIcon={playing ? <IconPause /> : <PlayIconComponent />}
+      leftIcon={playing ? IconPause : PlayIconComponent}
       onClick={onPlay}
       minWidth={180}
       disabled={disabled}

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -20,9 +20,9 @@ import {
   isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import {
-  HarmonyButton,
-  HarmonyButtonSize,
-  HarmonyButtonType,
+  Button,
+  ButtonSize,
+  ButtonType,
   IconCart,
   IconCollectible,
   IconPause,
@@ -76,13 +76,13 @@ type PlayButtonProps = {
 
 const PlayButton = ({ disabled, playing, onPlay }: PlayButtonProps) => {
   return (
-    <HarmonyButton
+    <Button
       disabled={disabled}
-      variant={HarmonyButtonType.PRIMARY}
+      type={ButtonType.PRIMARY_ALT}
       text={playing ? messages.pause : messages.play}
-      leftIcon={playing ? IconPause : IconPlay}
+      leftIcon={playing ? <IconPause /> : <IconPlay />}
       onClick={onPlay}
-      size={HarmonyButtonSize.LARGE}
+      size={ButtonSize.LARGE}
       fullWidth
     />
   )
@@ -90,10 +90,10 @@ const PlayButton = ({ disabled, playing, onPlay }: PlayButtonProps) => {
 
 const PreviewButton = ({ playing, onPlay }: PlayButtonProps) => {
   return (
-    <HarmonyButton
-      variant={HarmonyButtonType.SECONDARY}
+    <Button
+      type={ButtonType.SECONDARY}
       text={playing ? messages.pause : messages.preview}
-      leftIcon={playing ? IconPause : IconPlay}
+      leftIcon={playing ? <IconPause /> : <IconPlay />}
       onClick={onPlay}
       fullWidth
     />
@@ -191,7 +191,7 @@ const TrackHeader = ({
     isPremiumContentUSDCPurchaseGated(premiumConditions)
   // Preview button is shown for USDC-gated tracks if user does not have access
   // or is the owner
-  const showPreview = !isUSDCPurchaseGated && (isOwner || !doesUserHaveAccess)
+  const showPreview = isUSDCPurchaseGated && (isOwner || !doesUserHaveAccess)
   // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
   const showPlay = isUSDCPurchaseGated ? doesUserHaveAccess : true
   const showListenCount =

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -20,9 +20,9 @@ import {
   isPremiumContentUSDCPurchaseGated
 } from '@audius/common'
 import {
-  Button,
-  ButtonSize,
-  ButtonType,
+  HarmonyButton,
+  HarmonyButtonSize,
+  HarmonyButtonType,
   IconCart,
   IconCollectible,
   IconPause,
@@ -76,13 +76,13 @@ type PlayButtonProps = {
 
 const PlayButton = ({ disabled, playing, onPlay }: PlayButtonProps) => {
   return (
-    <Button
+    <HarmonyButton
       disabled={disabled}
-      type={ButtonType.PRIMARY_ALT}
+      variant={HarmonyButtonType.PRIMARY}
       text={playing ? messages.pause : messages.play}
-      leftIcon={playing ? <IconPause /> : <IconPlay />}
+      leftIcon={playing ? IconPause : IconPlay}
       onClick={onPlay}
-      size={ButtonSize.LARGE}
+      size={HarmonyButtonSize.LARGE}
       fullWidth
     />
   )
@@ -90,10 +90,10 @@ const PlayButton = ({ disabled, playing, onPlay }: PlayButtonProps) => {
 
 const PreviewButton = ({ playing, onPlay }: PlayButtonProps) => {
   return (
-    <Button
-      type={ButtonType.SECONDARY}
+    <HarmonyButton
+      variant={HarmonyButtonType.SECONDARY}
       text={playing ? messages.pause : messages.preview}
-      leftIcon={playing ? <IconPause /> : <IconPlay />}
+      leftIcon={playing ? IconPause : IconPlay}
       onClick={onPlay}
       fullWidth
     />
@@ -191,7 +191,7 @@ const TrackHeader = ({
     isPremiumContentUSDCPurchaseGated(premiumConditions)
   // Preview button is shown for USDC-gated tracks if user does not have access
   // or is the owner
-  const showPreview = isUSDCPurchaseGated && (isOwner || !doesUserHaveAccess)
+  const showPreview = !isUSDCPurchaseGated && (isOwner || !doesUserHaveAccess)
   // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
   const showPlay = isUSDCPurchaseGated ? doesUserHaveAccess : true
   const showListenCount =


### PR DESCRIPTION
### Description
This reintroduces the correct styling for the Play/Pause button on the web and mobile web track details page. I had originally reverted the styling changes on `Button` because it caused some issues elsewhere. Now we have the  new `HarmonyButton` component and can use that instead.

### Dragons
None

### How Has This Been Tested?
Verified locally on Chrome

### How will this change be monitored?
N/A

### Feature Flags ###
Display of the preview variant which uses the new styling is behind the USDC feature flag

