### PR TITLE
[PAY-1655] Add ColorValue prop to Text component

### DIFF
--- a/packages/mobile/src/components/core/Text.tsx
+++ b/packages/mobile/src/components/core/Text.tsx
@@ -1,6 +1,10 @@
 import { useMemo } from 'react'
 
-import type { TextProps as RNTextProps, TextStyle } from 'react-native'
+import type {
+  ColorValue,
+  TextProps as RNTextProps,
+  TextStyle
+} from 'react-native'
 import { Platform, Text as RNText } from 'react-native'
 
 import type { FontSize, FontWeight, TextVariant } from 'app/styles'
@@ -13,6 +17,7 @@ export type TextProps = RNTextProps & {
   variant?: TextVariant
   noGutter?: boolean
   color?: 'inherit' | 'error' | 'warning' | keyof ThemeColors
+  colorValue?: ColorValue
   weight?: FontWeight
   fontSize?: FontSize | 'inherit'
   textTransform?: TextStyle['textTransform']
@@ -32,6 +37,7 @@ export const Text = (props: TextProps) => {
     noGutter,
     style,
     color = 'neutral',
+    colorValue,
     weight,
     fontSize: fontSizeProp,
     textTransform,
@@ -52,7 +58,7 @@ export const Text = (props: TextProps) => {
             ? palette.accentRed
             : color === 'warning'
             ? palette.accentOrange
-            : palette[color]
+            : colorValue ?? palette[color]
       },
       weight && {
         fontFamily: typography.fontByWeight[weight],
@@ -67,7 +73,16 @@ export const Text = (props: TextProps) => {
       noGutter && { marginBottom: 0 },
       { textTransform }
     ],
-    [variant, color, weight, fontSize, noGutter, textTransform, palette]
+    [
+      variant,
+      color,
+      palette,
+      colorValue,
+      weight,
+      fontSize,
+      noGutter,
+      textTransform
+    ]
   )
 
   return <RNText style={[styles.root, customStyles, style]} {...other} />

--- a/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
+++ b/packages/mobile/src/components/track-details-tile/TrackDetailsTile.tsx
@@ -12,6 +12,7 @@ import {
   isPremiumContentUSDCPurchaseGated,
   PremiumContentType
 } from '@audius/common'
+import type { ColorValue } from 'react-native'
 import { View } from 'react-native'
 import type { SvgProps } from 'react-native-svg'
 import { useSelector } from 'react-redux'
@@ -25,7 +26,6 @@ import UserBadges from 'app/components/user-badges'
 import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { makeStyles, flexRowCentered, typography } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
-import type { ThemeColors } from 'app/utils/theme'
 import { useThemeColors } from 'app/utils/theme'
 
 const { getUser } = cacheUsersSelectors
@@ -109,28 +109,24 @@ export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
     [k in PremiumContentType]: {
       message: string
       icon: ComponentType<SvgProps>
-      color: string
-      colorString: keyof ThemeColors
+      color: ColorValue
     }
   } = useMemo(() => {
     return {
       [PremiumContentType.COLLECTIBLE_GATED]: {
         message: messages.collectibleGated,
         icon: IconCollectible,
-        color: accentBlue,
-        colorString: 'accentBlue'
+        color: accentBlue
       },
       [PremiumContentType.SPECIAL_ACCESS]: {
         message: messages.specialAccess,
         icon: IconSpecialAccess,
-        color: accentBlue,
-        colorString: 'accentBlue'
+        color: accentBlue
       },
       [PremiumContentType.USDC_PURCHASE]: {
         message: messages.premiumTrack,
         icon: IconCart,
-        color: specialLightGreen1,
-        colorString: 'specialLightGreen1'
+        color: specialLightGreen1
       }
     }
   }, [accentBlue, specialLightGreen1])
@@ -139,12 +135,7 @@ export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
     return null
   }
 
-  const {
-    message: title,
-    icon: IconComponent,
-    color,
-    colorString
-  } = headerAttributes[type]
+  const { message: title, icon: IconComponent, color } = headerAttributes[type]
 
   return (
     <View style={styles.root}>
@@ -164,7 +155,7 @@ export const TrackDetailsTile = ({ trackId }: TrackDetailsTileProps) => {
             />
             <Text
               fontSize='small'
-              color={colorString}
+              colorValue={color}
               weight='demiBold'
               textTransform='uppercase'
               style={styles.premiumContentLabel}


### PR DESCRIPTION
### Description
Adds support for `Text` to accept a `colorValue` prop like `palette.accentBlue` rather than a string like `accentBlue`.
Updates the usage of `Text` in `TrackDetailsTile` to use this prop.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

