### PR TITLE
[C-2901] Fix menu types

### DIFF
--- a/packages/web/src/components/card/desktop/CollectionArtCard.tsx
+++ b/packages/web/src/components/card/desktop/CollectionArtCard.tsx
@@ -16,7 +16,7 @@ import { Dispatch } from 'redux'
 import { ReactComponent as IconKebabHorizontal } from 'assets/img/iconKebabHorizontal.svg'
 import { ArtistPopover } from 'components/artist/ArtistPopover'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
-import Menu, { MenuType } from 'components/menu/Menu'
+import Menu from 'components/menu/Menu'
 import PerspectiveCard from 'components/perspective-card/PerspectiveCard'
 import RepostFavoritesStats, {
   Size
@@ -132,7 +132,7 @@ const CollectionArtCard = g(
     }, [image, setDidLoad, index])
 
     const menu = {
-      type: (is_album ? 'album' : 'playlist') as MenuType,
+      type: is_album ? ('album' as const) : ('playlist' as const),
       handle,
       playlistId: playlist_id,
       playlistName: playlist_name,

--- a/packages/web/src/components/menu/CollectionMenu.tsx
+++ b/packages/web/src/components/menu/CollectionMenu.tsx
@@ -22,18 +22,18 @@ type PlaylistId = number
 
 export type OwnProps = {
   children: (items: PopupMenuItem[]) => JSX.Element
-  extraMenuItems: PopupMenuItem[]
+  extraMenuItems?: PopupMenuItem[]
   handle: string
   includeEdit?: boolean
-  includeEmbed: boolean
-  includeFavorite: boolean
-  includeRepost: boolean
-  includeShare: boolean
-  includeVisitPage: boolean
-  isFavorited: boolean
-  isOwner: boolean
-  isPublic: boolean
-  isReposted: boolean
+  includeEmbed?: boolean
+  includeFavorite?: boolean
+  includeRepost?: boolean
+  includeShare?: boolean
+  includeVisitPage?: boolean
+  isFavorited?: boolean
+  isOwner?: boolean
+  isPublic?: boolean
+  isReposted?: boolean
   onClose?: () => void
   onRepost?: () => void
   onShare?: () => void
@@ -146,7 +146,7 @@ const CollectionMenu = (props: CollectionMenuProps) => {
     if (includeVisitPage) {
       menu.items.push(playlistPageMenuItem)
     }
-    if (extraMenuItems.length > 0) {
+    if (extraMenuItems && extraMenuItems.length > 0) {
       menu.items = menu.items.concat(extraMenuItems)
     }
     if (includeEmbed && isPublic) {

--- a/packages/web/src/components/menu/Menu.tsx
+++ b/packages/web/src/components/menu/Menu.tsx
@@ -16,15 +16,15 @@ import TrackMenu, { OwnProps as TrackMenuProps } from './TrackMenu'
 import UserMenu, { OwnProps as UserMenuProps } from './UserMenu'
 
 export type MenuOptionType =
-  | UserMenuProps
-  | CollectionMenuProps
-  | TrackMenuProps
+  | Omit<UserMenuProps, 'children'>
+  | Omit<CollectionMenuProps, 'children'>
+  | Omit<TrackMenuProps, 'children'>
 
 export type MenuType = MenuOptionType['type']
 
 export type MenuProps = {
   children: PopupMenuProps['renderTrigger']
-  menu: Omit<MenuOptionType, 'children'>
+  menu: MenuOptionType
   onClose?: () => void
   zIndex?: number
 }
@@ -47,28 +47,18 @@ const Menu = forwardRef<HTMLDivElement, MenuProps>((props, ref) => {
   )
 
   if (menu.type === 'user') {
-    return <UserMenu {...(menu as UserMenuProps)}>{renderMenu}</UserMenu>
+    return <UserMenu {...menu}>{renderMenu}</UserMenu>
   } else if (menu.type === 'album' || menu.type === 'playlist') {
     return (
-      <CollectionMenu
-        onClose={props.onClose}
-        {...(menu as CollectionMenuProps)}
-      >
+      <CollectionMenu onClose={props.onClose} {...menu}>
         {renderMenu}
       </CollectionMenu>
     )
   } else if (menu.type === 'track') {
-    return <TrackMenu {...(menu as TrackMenuProps)}>{renderMenu}</TrackMenu>
+    return <TrackMenu {...menu}>{renderMenu}</TrackMenu>
   } else if (menu.type === 'notification') {
   }
   return null
 })
-
-Menu.defaultProps = {
-  menu: {
-    type: 'track',
-    handle: ''
-  }
-}
 
 export default Menu

--- a/packages/web/src/components/menu/TrackMenu.tsx
+++ b/packages/web/src/components/menu/TrackMenu.tsx
@@ -65,24 +65,24 @@ export type OwnProps = {
   children: (items: PopupMenuItem[]) => JSX.Element
   extraMenuItems?: PopupMenuItem[]
   handle: string
-  includeAddToPlaylist: boolean
-  includeArtistPick: boolean
-  includeEdit: boolean
+  includeAddToPlaylist?: boolean
+  includeArtistPick?: boolean
+  includeEdit?: boolean
   includeEmbed?: boolean
-  includeFavorite: boolean
-  includeRepost: boolean
-  includeShare: boolean
-  includeTrackPage: boolean
-  isArtistPick: boolean
-  isDeleted: boolean
-  isFavorited: boolean
-  isOwner: boolean
+  includeFavorite?: boolean
+  includeRepost?: boolean
+  includeShare?: boolean
+  includeTrackPage?: boolean
+  isArtistPick?: boolean
+  isDeleted?: boolean
+  isFavorited?: boolean
+  isOwner?: boolean
   isOwnerDeactivated?: boolean
-  isReposted: boolean
+  isReposted?: boolean
   isUnlisted?: boolean
   trackId: ID
   trackTitle: string
-  genre: Genre
+  genre?: Genre
   trackPermalink: string
   type: 'track'
 }

--- a/packages/web/src/components/table/components/OverflowMenuButton.tsx
+++ b/packages/web/src/components/table/components/OverflowMenuButton.tsx
@@ -2,33 +2,20 @@ import cn from 'classnames'
 
 import { ReactComponent as IconOptions } from 'assets/img/iconKebabHorizontal.svg'
 import tabStyles from 'components/actions-tab/ActionsTab.module.css'
-import Menu, { MenuProps } from 'components/menu/Menu'
+import Menu from 'components/menu/Menu'
+import { OwnProps as TrackMenuProps } from 'components/menu/TrackMenu'
 
 import styles from './OverflowMenuButton.module.css'
 
-type OverflowMenuButtonProps = {
-  albumId?: number | null
-  albumName?: string | null
+type BaseOverflowMenuButtonProps = Omit<TrackMenuProps, 'children' | 'type'>
+
+type OverflowMenuButtonProps = BaseOverflowMenuButtonProps & {
   className?: string
   date?: any
-  handle: string
-  hiddenUntilHover?: boolean
-  includeEdit?: boolean
-  includeAddToPlaylist?: boolean
-  includeFavorite?: boolean
   index?: number
-  isArtistPick?: boolean
-  isDeleted?: boolean
-  isFavorited?: boolean
-  isOwner?: boolean
-  isOwnerDeactivated?: boolean
-  isReposted?: boolean
   onClick?: (e: any) => void
   onRemove?: (trackId: number, index: number, uid: string, date: number) => void
   removeText?: string
-  trackId?: number
-  trackPermalink?: string
-  trackTitle?: string
   uid?: string
 }
 
@@ -36,16 +23,14 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
   const {
     className,
     date,
-    includeEdit = true,
     index,
-    isFavorited,
-    isOwnerDeactivated,
     onClick,
     onRemove,
     removeText,
-    trackId,
-    uid
+    uid,
+    ...other
   } = props
+  const { includeEdit = true, isFavorited, isOwnerDeactivated, trackId } = other
 
   const removeMenuItem = {
     text: removeText,
@@ -57,14 +42,12 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
   }
 
   const overflowMenu = {
-    menu: {
-      type: 'track' as MenuProps['menu']['type'],
-      mount: 'page',
-      includeEdit,
-      includeShare: true,
-      ...props,
-      extraMenuItems: onRemove ? [removeMenuItem] : []
-    }
+    ...other,
+    type: 'track' as const,
+    mount: 'page',
+    includeEdit,
+    includeShare: true,
+    extraMenuItems: onRemove ? [removeMenuItem] : []
   }
 
   if (isOwnerDeactivated && !onRemove && !isFavorited) {
@@ -73,7 +56,7 @@ export const OverflowMenuButton = (props: OverflowMenuButtonProps) => {
 
   return (
     <div onClick={onClick} className={cn(styles.tableOptionsButton, className)}>
-      <Menu {...overflowMenu}>
+      <Menu menu={overflowMenu}>
         {(ref, triggerPopup) => (
           <div
             className={tabStyles.iconKebabHorizontalWrapper}

--- a/packages/web/src/components/tracks-table/TracksTable.tsx
+++ b/packages/web/src/components/tracks-table/TracksTable.tsx
@@ -407,8 +407,6 @@ export const TracksTable = ({
             isArtistPick={track.user?.artist_pick_track_id === track.track_id}
             index={cellInfo.row.index}
             trackTitle={track.name}
-            albumId={null}
-            albumName={null}
             trackPermalink={track.permalink}
           />
         </div>


### PR DESCRIPTION
### Description

Fixes menu types that broke due to `Omit<>` breaking up the discriminated union, causing casting issues, and preventing menu usages from typing track vs album vs playlist vs user correctly
