### PR TITLE
[PAY-1660] Fix layout issues with TrackTile socials row with a lot of stats

### DIFF
--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.module.css
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.module.css
@@ -81,7 +81,8 @@
 
 .socialInfo {
   display: inline-flex;
-  width: 100%;
+  flex: 1 1 100%;
+  min-width: 0;
   justify-content: flex-start;
 }
 

--- a/packages/web/src/components/track/desktop/TrackTile.module.css
+++ b/packages/web/src/components/track/desktop/TrackTile.module.css
@@ -254,9 +254,15 @@
   margin-right: var(--unit-20);
 }
 
+.small .bottomRight {
+  /* Match socialsRow to keep these in line */
+  height: 18px;
+}
+
 .socialInfo {
   display: inline-flex;
-  width: 100%;
+  flex: 1 1 100%;
+  min-width: 0;
   justify-content: flex-start;
 }
 


### PR DESCRIPTION
### Description
The stats row gets large if you happen to be following multiple people which reposted and favorited a track. The styling for the socials row includes a margin to make space for the plays. But it wasn't set up to restrict its content to the available space.

Also for small track tiles, we change the height of the row to 18px, which causes the plays count to be off-center since it is rendered absolutely. There is longer term cleanup needed on the socials row so that the content isn't sized larger than its container and centered. But it wasn't a safe change to make due to the multiple places we use the `Stats` component. This fixes the display issues for now, and we will address it more fully later.

### Dragons
N/A

### How Has This Been Tested?
Verified locally on Chrome

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

### Screenshots

**Before**
![Screenshot 2023-07-28 at 2 35 56 PM](https://github.com/AudiusProject/audius-client/assets/1815175/c2c418c0-a0b4-4517-810a-55c2ee52e09a)

---

**After**
![Screenshot 2023-07-28 at 2 36 37 PM](https://github.com/AudiusProject/audius-client/assets/1815175/6f75e4be-1bcb-44ab-a94f-f6865f620a98)
