### PR TITLE
Use audius-query in USDC Purchase Drawer

### DIFF
--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -1,10 +1,9 @@
 import {
-  cacheTracksSelectors,
   formatUSDCWeiToUSDString,
-  isPremiumContentUSDCPurchaseGated
+  isPremiumContentUSDCPurchaseGated,
+  useGetTrackById
 } from '@audius/common'
 import { View } from 'react-native'
-import { useSelector } from 'react-redux'
 
 import IconCart from 'app/assets/images/iconCart.svg'
 import { LockedStatusBadge, Text } from 'app/components/core'
@@ -16,8 +15,6 @@ import { useColor } from 'app/utils/theme'
 import { TrackDetailsTile } from '../track-details-tile'
 
 import { StripePurchaseConfirmationButton } from './StripePurchaseConfirmationButton'
-
-const { getTrack } = cacheTracksSelectors
 
 const PREMIUM_TRACK_PURCHASE_MODAL_NAME = 'PremiumTrackPurchase'
 
@@ -97,13 +94,10 @@ export const PremiumTrackPurchaseDrawer = () => {
   const neutralLight2 = useColor('neutralLight2')
   const { data } = useDrawer('PremiumTrackPurchase')
   const { trackId } = data
-  const track = useSelector((state) => getTrack(state, { id: trackId }))
-
+  const { data: track } = useGetTrackById({ id: trackId })
   const { premium_conditions: premiumConditions } = track ?? {}
-
   if (!track || !isPremiumContentUSDCPurchaseGated(premiumConditions))
     return null
-
   const price = formatUSDCWeiToUSDString(premiumConditions.usdc_purchase.price)
 
   return (

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -94,7 +94,10 @@ export const PremiumTrackPurchaseDrawer = () => {
   const neutralLight2 = useColor('neutralLight2')
   const { data } = useDrawer('PremiumTrackPurchase')
   const { trackId } = data
-  const { data: track } = useGetTrackById({ id: trackId })
+  const { data: track } = useGetTrackById(
+    { id: trackId },
+    { disabled: !trackId }
+  )
   const { premium_conditions: premiumConditions } = track ?? {}
   if (!track || !isPremiumContentUSDCPurchaseGated(premiumConditions))
     return null


### PR DESCRIPTION
### Description
Use audius-query to fetch track data. Turns out I didn't need `status` anyway as the track should always exist (since we only open this drawer from a track tile) but might as well merge this!

### Dragons

### How Has This Been Tested?

Local ios stage

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

