### PR TITLE
[plat-1055] revert legacy playlist route formatting in embed player to use permalink

### DIFF
--- a/packages/embed/src/components/app.jsx
+++ b/packages/embed/src/components/app.jsx
@@ -435,15 +435,9 @@ const App = (props) => {
 
     const artworkURL = getArtworkUrl(tracksResponse || collectionsResponse)
     const artworkClickURL =
-      tracksResponse?.permalink ||
-      `${collectionsResponse?.permalink}-${decodeHashId(
-        collectionsResponse?.id
-      )}`
+      tracksResponse?.permalink || collectionsResponse?.permalink
         ? stripLeadingSlash(
-            tracksResponse?.permalink ||
-              `${collectionsResponse?.permalink}-${decodeHashId(
-                collectionsResponse?.id
-              )}`
+            tracksResponse?.permalink || collectionsResponse?.permalink
           )
         : null
     const listenOnAudiusURL = artworkClickURL

--- a/packages/embed/src/components/collection/CollectionHelmet.jsx
+++ b/packages/embed/src/components/collection/CollectionHelmet.jsx
@@ -2,7 +2,6 @@ import { h } from 'preact'
 import { Helmet } from 'react-helmet'
 
 import { getAudiusHostname } from '../../util/getEnv'
-import { decodeHashId } from '../../util/hashIds'
 
 const CollectionHelmet = ({ collection }) => {
   if (!collection) {
@@ -12,9 +11,7 @@ const CollectionHelmet = ({ collection }) => {
   const title = `${collection.playlistName} by ${collection.user.name} • Audius`
   const description = `Listen on Audius: ${collection.playlistName}`
   const hostname = getAudiusHostname()
-  const url = `https://${hostname}${collection.permalink}-${decodeHashId(
-    collection.id
-  )}`
+  const url = `https://${hostname}${collection.permalink}`
   const isAlbum = collection.isAlbum
   const type = isAlbum ? 'MusicAlbum' : 'MusicPlaylist'
   const structuredData = {

--- a/packages/embed/src/components/collection/CollectionPlayerCard.jsx
+++ b/packages/embed/src/components/collection/CollectionPlayerCard.jsx
@@ -6,7 +6,6 @@ import 'simplebar/dist/simplebar.min.css'
 import IconVerified from '../../assets/img/iconVerified.svg'
 import { isBItem } from '../../util/bitems'
 import { getArtworkUrl } from '../../util/getArtworkUrl'
-import { decodeHashId } from '../../util/hashIds'
 import { stripLeadingSlash } from '../../util/stringUtil'
 import Artwork from '../artwork/Artwork'
 import AudiusLogoButton from '../button/AudiusLogoButton'
@@ -93,9 +92,7 @@ const CollectionPlayerCard = ({
   isTwitter
 }) => {
   const makeOnTogglePlay = (index) => () => onTogglePlay(index)
-  const permalink = `${stripLeadingSlash(collection.permalink)}-${decodeHashId(
-    collection?.id
-  )}`
+  const permalink = `${stripLeadingSlash(collection.permalink)}`
   return (
     <Card
       isTwitter={isTwitter}


### PR DESCRIPTION

### Description
manually reverts the changes here: https://github.com/AudiusProject/audius-client/commit/121b054f58ee9f3c94dcc320da8239b88aa44253
since we're soon preparing for the launch of removing playlist ids from urls

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

