### PR TITLE
[C-2917] Don't show supporters section if all are deactivated users (web)

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
@@ -85,7 +85,6 @@ const useSelectTopSupporters = (userId: number) =>
       const topSupporters = topSupporterIds
         .map((id) => supporterUsers[id])
         .filter(removeNullable)
-        .filter((user) => !user.is_deactivated)
       return topSupporters
     },
     [userId]

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/TopSupporters.tsx
@@ -85,6 +85,7 @@ const useSelectTopSupporters = (userId: number) =>
       const topSupporters = topSupporterIds
         .map((id) => supporterUsers[id])
         .filter(removeNullable)
+        .filter((user) => !user.is_deactivated)
       return topSupporters
     },
     [userId]

--- a/packages/web/src/components/tipping/support/TopSupporters.tsx
+++ b/packages/web/src/components/tipping/support/TopSupporters.tsx
@@ -52,6 +52,7 @@ export const TopSupporters = () => {
       })
       .map((k) => usersMap[k as unknown as ID])
       .filter(Boolean)
+      .filter((u: User) => !u.is_deactivated)
   })
 
   const handleClick = useCallback(() => {


### PR DESCRIPTION
### Description
Before:
If all supporters are deactivated users, the "top supporters" box on user profile shows up but is empty

After:
Web: If all supporters are deactivated users, the "top supporters" box does not show up on user profile
Mobile: Still same as before :( Due to the mobile component's logic (which uses `user.supporters_count` to determine whether to render), it'd be more complex/risky to fix it there - figured it wasn't worth it now since this is a pretty edge-casey bug.

Notes:
The optimal fix would be to exclude deactivated users from the /supporters response, but that is much more time consuming/risky due to the way that query is set up than the quick fix here. Should revisit in the future though. Ticket here: https://linear.app/audius/issue/PAY-1683/[mobile]-empty-top-supporterssupportings-list-on-user-profile-if-all

After:
<img width="373" alt="Screenshot 2023-07-31 at 9 19 14 PM" src="https://github.com/AudiusProject/audius-client/assets/36916764/49a838b0-ebaa-499a-acbf-825ff9cafd91">

Before:
<img width="285" alt="Screenshot 2023-08-01 at 9 18 37 AM" src="https://github.com/AudiusProject/audius-client/assets/36916764/9d4419d1-dccf-4c2b-9a41-7d2144de7563">


### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

