### PR TITLE
[C-2918] Don't show supporting section on web if all supportings are deactivated users (web)

### DIFF
--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingList.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/SupportingList.tsx
@@ -54,7 +54,7 @@ export const SupportingList = () => {
     }
   }, [supporting_count, shouldFetchSupporting, dispatch, user_id])
 
-  const supportingSorted = useRankedSupportingForUser(user_id)
+  const supportingSorted = useRankedSupportingForUser({ userId: user_id })
 
   const supportingListData = useMemo(() => {
     if (supportingSorted.length === 0) {

--- a/packages/mobile/src/screens/profile-screen/ProfileHeader/ViewAllSupportingTile.tsx
+++ b/packages/mobile/src/screens/profile-screen/ProfileHeader/ViewAllSupportingTile.tsx
@@ -54,7 +54,7 @@ export const ViewAllSupportingTile = () => {
     'supporting_count'
   ])
 
-  const rankedSupportingList = useRankedSupportingForUser(user_id)
+  const rankedSupportingList = useRankedSupportingForUser({ userId: user_id })
 
   const rankedSupportingUsers = useProxySelector(
     (state) => {

--- a/packages/web/src/components/tipping/support/SupportingList.tsx
+++ b/packages/web/src/components/tipping/support/SupportingList.tsx
@@ -37,7 +37,10 @@ const formatViewAllMessage = (count: number) => {
 
 const SupportingListForProfile = ({ profile }: { profile: User }) => {
   const dispatch = useDispatch()
-  const rankedSupportingList = useRankedSupportingForUser(profile.user_id)
+  const rankedSupportingList = useRankedSupportingForUser({
+    userId: profile.user_id,
+    excludeDeactivated: true
+  })
 
   const handleClick = useCallback(() => {
     if (profile) {


### PR DESCRIPTION
### Description
Companion PR: https://github.com/AudiusProject/audius-client/pull/3830

Before:
If all supportings are deactivated users, the "Supporting" sectionon user profile shows up but the content is empty

After:
Web: If all supportings are deactivated users, the "Supporting" section does not show up on user profile
Mobile: Still same as before :( Due to the mobile component's logic (which uses `user.supporting_count` to determine whether to render), it'd be more complex/risky to fix it there - figured it wasn't worth it now since this is a pretty edge-casey bug.

Notes:
The optimal fix would be to exclude deactivated users from the /supporters response, but that is much more time consuming/risky due to the way that query is set up than the quick fix here. Should revisit in the future though.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

