### PR TITLE
QA-588 Fix collection card profile link 

### DIFF
--- a/packages/web/src/pages/explore-page/components/desktop/CollectionsPage.tsx
+++ b/packages/web/src/pages/explore-page/components/desktop/CollectionsPage.tsx
@@ -65,7 +65,10 @@ const CollectionsPage = ({
       <ArtistPopover handle={playlist.user.handle}>
         <span
           className={styles.userName}
-          onClick={(e: MouseEvent) => goToProfilePage(e, playlist.user.handle)}
+          onClick={(e: MouseEvent) => {
+            e.preventDefault()
+            goToProfilePage(e, playlist.user.handle)
+          }}
         >
           {playlist.user.name}
         </span>


### PR DESCRIPTION
### Description
https://linear.app/audius/issue/QA-588/[qa]-artist-names-on-album-tiles-failing-to-redirect
Before: When a user clicks on an artist's name in an album tile, they are redirected through the profile to the album, rather than just being directed to the artist's profile.

After: Fixed
### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

