### PR TITLE
[C-2879] Add validation to single track upload flow

### DIFF
--- a/packages/web/src/components/ai-attribution-modal/AiAttributionDropdown.tsx
+++ b/packages/web/src/components/ai-attribution-modal/AiAttributionDropdown.tsx
@@ -47,7 +47,10 @@ const selectSearchResults = createSelector(getSearchResults, (results) => {
   return { items }
 })
 
-type AiAttributionDropdownProps = SelectProps
+type AiAttributionDropdownProps = SelectProps & {
+  error?: string | false
+  helperText?: string | false
+}
 
 export const AiAttributionDropdown = (props: AiAttributionDropdownProps) => {
   const dispatch = useDispatch()
@@ -69,6 +72,7 @@ export const AiAttributionDropdown = (props: AiAttributionDropdownProps) => {
       size='large'
       input={searchInput}
       onSearch={handleSearch}
+      layout='vertical'
       {...props}
     />
   )

--- a/packages/web/src/components/ai-attribution-modal/DropdownInput.js
+++ b/packages/web/src/components/ai-attribution-modal/DropdownInput.js
@@ -5,6 +5,7 @@ import cn from 'classnames'
 import PropTypes from 'prop-types'
 
 import { ReactComponent as IconCaretDown } from 'assets/img/iconCaretDown.svg'
+import { HelperText } from 'components/data-entry/HelperText'
 
 import styles from './DropdownInput.module.css'
 
@@ -37,6 +38,7 @@ class DropdownInput extends Component {
       labelStyle,
       dropdownStyle,
       dropdownInputStyle,
+      helperText,
       layout,
       size,
       variant,
@@ -155,6 +157,9 @@ class DropdownInput extends Component {
           </Select>
           <IconCaretDown className={styles.arrow} />
         </div>
+        {helperText ? (
+          <HelperText error={error}>{helperText}</HelperText>
+        ) : null}
       </div>
     )
   }

--- a/packages/web/src/components/data-entry/ContextualMenu.tsx
+++ b/packages/web/src/components/data-entry/ContextualMenu.tsx
@@ -164,9 +164,9 @@ export const ContextualMenu = <
   const handleSubmit = useCallback(
     (values: FormValues, helpers: FormikHelpers<FormValues>) => {
       onSubmit(values, helpers)
-      toggleMenu()
+      if (!error) toggleMenu()
     },
-    [onSubmit, toggleMenu]
+    [error, onSubmit, toggleMenu]
   )
 
   return (

--- a/packages/web/src/components/data-entry/HelperText.tsx
+++ b/packages/web/src/components/data-entry/HelperText.tsx
@@ -14,7 +14,6 @@ export const HelperText = (props: HelperTextProps) => {
   return (
     <div className={styles.root}>
       <Text
-        variant='body'
         size='xSmall'
         strength='default'
         // @ts-expect-error

--- a/packages/web/src/pages/upload-page/fields/ModalField.tsx
+++ b/packages/web/src/pages/upload-page/fields/ModalField.tsx
@@ -1,8 +1,8 @@
-import React, { PropsWithChildren, ReactElement, useState } from 'react'
+import { PropsWithChildren, ReactElement, useState } from 'react'
 
 import {
-  Button,
-  ButtonType,
+  HarmonyButton,
+  HarmonyButtonType,
   IconCaretRight,
   Modal,
   ModalContent,
@@ -11,6 +11,7 @@ import {
   ModalTitle
 } from '@audius/stems'
 import { useFormikContext } from 'formik'
+import { isEmpty } from 'lodash'
 
 import styles from './ModalField.module.css'
 
@@ -27,7 +28,7 @@ type ModalFieldProps = PropsWithChildren & {
 export const ModalField = (props: ModalFieldProps) => {
   const { children, title, icon, preview } = props
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const { submitForm, resetForm } = useFormikContext()
+  const { submitForm, resetForm, errors } = useFormikContext()
 
   const open = () => setIsModalOpen(true)
   const close = () => setIsModalOpen(false)
@@ -45,14 +46,14 @@ export const ModalField = (props: ModalFieldProps) => {
       </ModalHeader>
       <ModalContent>{children}</ModalContent>
       <ModalFooter>
-        <Button
-          type={ButtonType.PRIMARY}
+        <HarmonyButton
+          variant={HarmonyButtonType.PRIMARY}
           text={messages.save}
           onClick={() => {
             submitForm()
-            close()
+            isEmpty(errors) && close()
           }}
-          buttonType='submit'
+          type='submit'
         />
       </ModalFooter>
     </Modal>

--- a/packages/web/src/pages/upload-page/fields/ReleaseDateField.tsx
+++ b/packages/web/src/pages/upload-page/fields/ReleaseDateField.tsx
@@ -37,7 +37,9 @@ export const ReleaseDateField = () => {
 
   const onSubmit = useCallback(
     (values: ReleaseDateFormValues) => {
-      setValue(values[RELEASE_DATE])
+      const date = new Date(values[RELEASE_DATE].toString())
+      // @ts-ignore - There are slight differences in the sdk and common track metadata types
+      setValue(date)
     },
     [setValue]
   )

--- a/packages/web/src/pages/upload-page/fields/TrackMetadataFields.module.css
+++ b/packages/web/src/pages/upload-page/fields/TrackMetadataFields.module.css
@@ -12,23 +12,28 @@
   flex: 1 auto;
   min-width: 335px;
 }
+
 .fields > div {
   margin-bottom: var(--unit-4);
 }
+
 .fields > div.description > .textArea > textarea {
   min-height: 90px;
 }
+
 .fields > div.description {
   margin-bottom: var(--unit-4);
 }
 
 .categorization {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
 }
+
 .categorization > div {
   flex: 1 auto;
 }
+
 .categorization > div:first-child {
   margin-right: var(--unit-2);
 }

--- a/packages/web/src/pages/upload-page/forms/AttributionModalForm.module.css
+++ b/packages/web/src/pages/upload-page/forms/AttributionModalForm.module.css
@@ -31,3 +31,8 @@
 .licenseIcons {
   gap: 6px;
 }
+
+.textFieldContainer {
+  flex: 1 1 0;
+  align-self: flex-start;
+}

--- a/packages/web/src/pages/upload-page/forms/AttributionModalForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/AttributionModalForm.tsx
@@ -1,15 +1,23 @@
 import { useCallback, useMemo } from 'react'
 
-import { Nullable, creativeCommons } from '@audius/common'
+import {
+  Nullable,
+  creativeCommons,
+  encodeHashId,
+  decodeHashId
+} from '@audius/common'
 import { SegmentedControl } from '@audius/stems'
 import cn from 'classnames'
 import { Formik, useField } from 'formik'
 import { get, set } from 'lodash'
+import { z } from 'zod'
+import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { ReactComponent as IconCreativeCommons } from 'assets/img/iconCreativeCommons.svg'
 import { AiAttributionDropdown } from 'components/ai-attribution-modal/AiAttributionDropdown'
-import { InputV2, InputV2Variant } from 'components/data-entry/InputV2'
+import { InputV2Variant } from 'components/data-entry/InputV2'
 import { Divider } from 'components/divider'
+import { TextField } from 'components/form-fields'
 import layoutStyles from 'components/layout/layout.module.css'
 import { Text } from 'components/typography'
 
@@ -30,15 +38,18 @@ const messages = {
     header: 'Mark this track as AI generated',
     description:
       'If your AI generated track was trained on an existing Audius artist, you can give them credit here. Only users who have opted-in will appear in this list.',
-    placeholder: 'Search for Users'
+    placeholder: 'Search for Users',
+    requiredError: 'Valid user must be selected'
   },
   isrc: {
     header: 'ISRC',
-    placeholder: 'CC-XXX-YY-NNNNN'
+    placeholder: 'CC-XXX-YY-NNNNN',
+    validError: 'Must be valid ISRC format'
   },
   iswc: {
     header: 'ISWC',
-    placeholder: 'T-345246800-1'
+    placeholder: 'T-345246800-1',
+    validError: 'Must be valid ISWC format'
   },
   licenseType: 'License Type',
   allowAttribution: {
@@ -67,6 +78,7 @@ const messages = {
 
 const IS_AI_ATTRIBUTED = 'isAiAttribution'
 const AI_USER_ID = 'ai_attribution_user_id'
+const AI_USER_NUM_ID = 'ai_attribution_user_num_id'
 const ISRC = 'isrc'
 const ISWC = 'iswc'
 const LICENSE_TYPE = 'licenseType'
@@ -93,19 +105,39 @@ const derivativeWorksValues = [
   { key: null, text: messages.derivativeWorks.options.null }
 ]
 
-type AttributionFormValues = {
-  [IS_AI_ATTRIBUTED]: boolean
-  [AI_USER_ID]?: number
-  [ISRC]: string
-  [ISWC]: string
-  [ALLOW_ATTRIBUTION]: boolean
-  [COMMERCIAL_USE]: boolean
-  [DERIVATIVE_WORKS]: Nullable<boolean>
-}
+const isrcRegex = /^[A-Z]{2}-[A-Z\d]{3}-\d{2}-\d{5}$/i
+const iswcRegex = /^T-\d{9}-\d$/i
+
+const AttributionFormSchema = z
+  .object({
+    [IS_AI_ATTRIBUTED]: z.optional(z.boolean()),
+    [AI_USER_ID]: z.optional(z.string().nullable()),
+    [AI_USER_NUM_ID]: z.optional(z.number().nullable()),
+    [ISRC]: z.optional(z.string().nullable()),
+    [ISWC]: z.optional(z.string().nullable()),
+    [ALLOW_ATTRIBUTION]: z.optional(z.boolean()),
+    [COMMERCIAL_USE]: z.optional(z.boolean()),
+    [DERIVATIVE_WORKS]: z.optional(z.boolean().nullable())
+  })
+  .refine((form) => !form[IS_AI_ATTRIBUTED] || form[AI_USER_ID], {
+    message: messages.aiGenerated.requiredError,
+    path: [AI_USER_ID]
+  })
+  .refine((form) => !form[ISRC] || isrcRegex.test(form[ISRC]), {
+    message: messages.isrc.validError,
+    path: [ISRC]
+  })
+  .refine((form) => !form[ISWC] || iswcRegex.test(form[ISWC]), {
+    message: messages.iswc.validError,
+    path: [ISWC]
+  })
+
+export type AttributionFormValues = z.input<typeof AttributionFormSchema>
 
 export const AttributionModalForm = () => {
-  const [{ value: aiUserId }, , { setValue: setAiUserId }] =
-    useTrackField<SingleTrackEditValues[typeof AI_USER_ID]>(AI_USER_ID)
+  const [{ value: aiUserId }, , { setValue: setAiUserId }] = useTrackField<
+    string | undefined
+  >(AI_USER_ID)
   const [{ value: isrcValue }, , { setValue: setIsrc }] =
     useTrackField<SingleTrackEditValues[typeof ISRC]>(ISRC)
   const [{ value: iswcValue }, , { setValue: setIswc }] =
@@ -126,6 +158,11 @@ export const AttributionModalForm = () => {
   const initialValues = useMemo(() => {
     const initialValues = {}
     set(initialValues, AI_USER_ID, aiUserId)
+    set(
+      initialValues,
+      AI_USER_NUM_ID,
+      aiUserId ? decodeHashId(aiUserId) : undefined
+    )
     if (aiUserId) {
       set(initialValues, IS_AI_ATTRIBUTED, true)
     }
@@ -147,22 +184,28 @@ export const AttributionModalForm = () => {
   const onSubmit = useCallback(
     (values: AttributionFormValues) => {
       if (get(values, IS_AI_ATTRIBUTED)) {
-        setAiUserId(get(values, AI_USER_ID))
+        setAiUserId(get(values, AI_USER_ID) ?? aiUserId)
       } else {
         setAiUserId(undefined)
       }
-      setIsrc(get(values, ISRC))
-      setIswc(get(values, ISWC))
-      setAllowAttribution(get(values, ALLOW_ATTRIBUTION))
+      setIsrc(get(values, ISRC) ?? isrcValue)
+      setIswc(get(values, ISWC) ?? iswcValue)
+      setAllowAttribution(get(values, ALLOW_ATTRIBUTION) ?? allowAttribution)
       if (get(values, ALLOW_ATTRIBUTION)) {
-        setCommercialUse(get(values, COMMERCIAL_USE))
-        setDerivateWorks(get(values, DERIVATIVE_WORKS))
+        setCommercialUse(get(values, COMMERCIAL_USE) ?? commercialUse)
+        setDerivateWorks(get(values, DERIVATIVE_WORKS) ?? derivativeWorks)
       } else {
         setCommercialUse(false)
         setDerivateWorks(false)
       }
     },
     [
+      aiUserId,
+      allowAttribution,
+      commercialUse,
+      derivativeWorks,
+      isrcValue,
+      iswcValue,
       setAiUserId,
       setAllowAttribution,
       setCommercialUse,
@@ -185,11 +228,12 @@ export const AttributionModalForm = () => {
     <Formik<AttributionFormValues>
       initialValues={initialValues}
       onSubmit={onSubmit}
+      validationSchema={toFormikValidationSchema(AttributionFormSchema)}
       enableReinitialize
     >
       <ModalField
         title={messages.title}
-        icon={<IconCreativeCommons className={styles.titleIcon} />}
+        icon={<IconCreativeCommons />}
         preview={preview}
       >
         <AttributionModalFields />
@@ -199,9 +243,13 @@ export const AttributionModalForm = () => {
 }
 
 const AttributionModalFields = () => {
-  const [aiUserIdField, , { setValue: setAiUserId }] = useField({
-    name: AI_USER_ID,
-    type: 'select'
+  const [aiUserIdField, aiUserHelperFields, { setValue: setAiUserId }] =
+    useField({
+      name: AI_USER_ID,
+      type: 'select'
+    })
+  const [aiUserNumIdField, , { setValue: setAiUserNumId }] = useField({
+    name: AI_USER_NUM_ID
   })
   const [isrcField] = useField(ISRC)
   const [iswcField] = useField(ISWC)
@@ -225,6 +273,9 @@ const AttributionModalFields = () => {
     derivativeWorks
   )
 
+  const dropdownHasError =
+    aiUserHelperFields.touched && aiUserHelperFields.error
+
   return (
     <div className={cn(layoutStyles.col, layoutStyles.gap4)}>
       <SwitchRowField
@@ -234,9 +285,14 @@ const AttributionModalFields = () => {
       >
         <AiAttributionDropdown
           {...aiUserIdField}
-          onSelect={(value: AttributionFormValues[typeof AI_USER_ID]) =>
-            setAiUserId(value)
-          }
+          {...aiUserHelperFields}
+          error={dropdownHasError}
+          helperText={dropdownHasError && aiUserHelperFields.error}
+          value={aiUserNumIdField.value}
+          onSelect={(value: SingleTrackEditValues[typeof AI_USER_ID]) => {
+            setAiUserId(value ? encodeHashId(value) : null)
+            setAiUserNumId(value ?? null)
+          }}
         />
       </SwitchRowField>
       <Divider />
@@ -245,18 +301,22 @@ const AttributionModalFields = () => {
           {`${messages.isrc.header} / ${messages.iswc.header}`}
         </Text>
         <span className={cn(layoutStyles.row, layoutStyles.gap6)}>
-          <InputV2
-            {...isrcField}
-            variant={InputV2Variant.ELEVATED_PLACEHOLDER}
-            label={messages.isrc.header}
-            placeholder={messages.isrc.placeholder}
-          />
-          <InputV2
-            {...iswcField}
-            variant={InputV2Variant.ELEVATED_PLACEHOLDER}
-            label={messages.iswc.header}
-            placeholder={messages.iswc.placeholder}
-          />
+          <div className={styles.textFieldContainer}>
+            <TextField
+              {...isrcField}
+              variant={InputV2Variant.ELEVATED_PLACEHOLDER}
+              label={messages.isrc.header}
+              placeholder={messages.isrc.placeholder}
+            />
+          </div>
+          <div className={styles.textFieldContainer}>
+            <TextField
+              {...iswcField}
+              variant={InputV2Variant.ELEVATED_PLACEHOLDER}
+              label={messages.iswc.header}
+              placeholder={messages.iswc.placeholder}
+            />
+          </div>
         </span>
       </div>
       <Divider />

--- a/packages/web/src/pages/upload-page/forms/SourceFilesModalForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/SourceFilesModalForm.tsx
@@ -24,10 +24,13 @@ import { processFiles } from '../store/utils/processFiles'
 import styles from './SourceFilesModalForm.module.css'
 import { useTrackField } from './utils'
 
+// NOTE: SDK uses camel casing for the fields within download
 const ALLOW_DOWNLOAD_BASE = 'is_downloadable'
-const ALLOW_DOWNLOAD = 'download.is_downloadable'
+// const ALLOW_DOWNLOAD = 'download.is_downloadable'
+const ALLOW_DOWNLOAD = 'download.isDownloadable'
 const FOLLOWER_GATED_BASE = 'requires_follow'
-const FOLLOWER_GATED = 'download.requires_follow'
+// const FOLLOWER_GATED = 'download.requires_follow'
+const FOLLOWER_GATED = 'download.requiresFollow'
 const STEMS = 'stems'
 
 const messages = {
@@ -78,11 +81,21 @@ export const SourceFilesModalForm = () => {
 
   const onSubmit = useCallback(
     (values: SourceFilesFormValues) => {
-      setAllowDownloadValue(get(values, ALLOW_DOWNLOAD))
-      setFollowerGatedValue(get(values, FOLLOWER_GATED))
+      setAllowDownloadValue(
+        get(values, ALLOW_DOWNLOAD) ?? allowDownloadValue ?? false
+      )
+      setFollowerGatedValue(
+        get(values, FOLLOWER_GATED) ?? followerGatedValue ?? false
+      )
       setStemsValue(get(values, STEMS))
     },
-    [setAllowDownloadValue, setFollowerGatedValue, setStemsValue]
+    [
+      allowDownloadValue,
+      followerGatedValue,
+      setAllowDownloadValue,
+      setFollowerGatedValue,
+      setStemsValue
+    ]
   )
 
   const preview = (
@@ -107,13 +120,13 @@ export const SourceFilesModalForm = () => {
         icon={<IconSourceFiles className={styles.titleIcon} />}
         preview={preview}
       >
-        <SourceFilesModalFiels />
+        <SourceFilesModalFields />
       </ModalField>
     </Formik>
   )
 }
 
-const SourceFilesModalFiels = () => {
+const SourceFilesModalFields = () => {
   const [
     { onChange: allowDownloadOnChange },
     ,


### PR DESCRIPTION
### Description

* Adding validation to the single track upload flow using the track metadata schema from sdk.
* Some work needs to be done to update the schema in sdk and then import it here, but it should be an easy hot swap.
* There was a lot of work here to try to bridge the track metadata types between the sdk and common, but open to suggestions on how to clean up some of the checks and data marshalling.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Lots of manual testing

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

