### PR TITLE
[C-2941] Modify cloudflare worker to pull in SEO data from discovery nodes

### DIFF
--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -14,6 +14,7 @@
 /coverage
 
 # build
+/sourcemaps
 /build
 /build-development
 /build-demo

--- a/packages/web/public/index.html
+++ b/packages/web/public/index.html
@@ -21,22 +21,13 @@
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
 
-    <!-- SEO -->
-    <meta name="description" content="Audius is a music streaming and sharing platform that puts power back into the hands of content creators." data-react-helmet="true">
-
-    <!-- Social -->
-    <meta property="og:title" content="Audius - Empowering Creators">
+    <meta name="application-name" content="Audius">
     <meta property="og:site_name" content="Audius">
-    <meta property="og:description" content="Audius is a music streaming and sharing platform that puts power back into the hands of content creators.">
-    <meta property="og:image" content="%PUBLIC_URL%/ogImage.jpg">
     <meta property="fb:app_id" content="123553997750078" />
-
-    <meta name="twitter:title" content="Audius - Empowering Creators">
-    <meta name="twitter:description" content="Audius is a music streaming and sharing platform that puts power back into the hands of content creators.">
-    <meta name="twitter:image" content="%PUBLIC_URL%/ogImage.jpg">
-    <meta name="twitter:image:alt" content="The Audius Platform">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@AudiusProject">
+    <meta property="twitter:app:name:iphone" content="Audius Music">
+    <meta property="twitter:app:name:googleplay" content="Audius Music">
 
     <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
 
@@ -45,8 +36,6 @@
       onLoad="window.web3Loaded = true; window.dispatchEvent(new CustomEvent('WEB3_LOADED'))"
       src="%PUBLIC_URL%/scripts/web3.min.js"
     ></script>
-
-    <title>Audius</title>
 
     <script async type="text/javascript">
       // Account recovery
@@ -82,6 +71,7 @@
         console.error(e)
       }
     </script>
+
     <!-- start Google Analytics -->
     <script async src="%PUBLIC_URL%/analytics/gtag.js?id=%REACT_APP_GA_MEASUREMENT_ID%"></script>
     <script async>
@@ -102,7 +92,7 @@
     <!-- end Google Analytics -->
 
     <!-- start Adroll -->
-    <script type="text/javascript">
+    <script async type="text/javascript">
       const adroll_adv_id = '%REACT_APP_ADROLL_AVD_ID%';
       const adroll_pix_id = '%REACT_APP_ADROLL_PIX_ID%';
       const adroll_version = "2.0";

--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -137,7 +137,7 @@ class HeadElementHandler {
     const { metadata, name } = await getMetadata(self.pathname)
 
     if (!metadata || !name) {
-      // We did parse this to anything we have custom tags for, so just return the default tags
+      // We didn't parse this to anything we have custom tags for, so just return the default tags
       const tags = `<meta property="og:title" content="Audius - Empowering Creators">
       <meta name="description" content="Audius is a music streaming and sharing platform that puts power back into the hands of content creators." data-react-helmet="true">
       <meta property="og:description" content="Audius is a music streaming and sharing platform that puts power back into the hands of content creators.">

--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -1,6 +1,27 @@
 import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
 
+/* globals GA, GA_ACCESS_TOKEN, SITEMAP */
+
 const DEBUG = false
+
+const routes = [
+  { pattern: /^\/([^/]+)$/, name: 'user', keys: ['handle'] },
+  {
+    pattern: /^\/([^/]+)\/([^/]+)$/,
+    name: 'track',
+    keys: ['handle', 'title']
+  },
+  {
+    pattern: /^\/([^/]+)\/playlist\/([^/]+)$/,
+    name: 'playlist',
+    keys: ['handle', 'title']
+  },
+  {
+    pattern: /^\/([^/]+)\/album\/([^/]+)$/,
+    name: 'album',
+    keys: ['handle', 'title']
+  }
+]
 
 addEventListener('fetch', (event) => {
   try {
@@ -17,15 +38,93 @@ addEventListener('fetch', (event) => {
   }
 })
 
+function matchRoute(input) {
+  for (const route of routes) {
+    const match = route.pattern.exec(input)
+    if (match) {
+      const result = { name: route.name, params: {} }
+      route.keys.forEach((key, index) => {
+        result.params[key] = match[index + 1]
+      })
+      return result
+    }
+  }
+  return null
+}
+
 function checkIsBot(val) {
   if (!val) {
     return false
   }
-  const botTest = new RegExp(
-    'altavista|baiduspider|bingbot|discordbot|duckduckbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|msnbot|nextgensearchbot|reaper|slackbot|snap url preview service|telegrambot|twitterbot|whatsapp|whatsup|yahoo|yandex|yeti|yodaobot|zend|zoominfobot|embedly',
-    'i'
-  )
+  const botTest =
+    /altavista|baiduspider|bingbot|discordbot|duckduckbot|facebookexternalhit|gigabot|ia_archiver|linkbot|linkedinbot|msnbot|nextgensearchbot|reaper|slackbot|snap url preview service|telegrambot|twitterbot|whatsapp|whatsup|yahoo|yandex|yeti|yodaobot|zend|zoominfobot|embedly/i
   return botTest.test(val)
+}
+
+async function getMetadata(pathname) {
+  const discoveryNode = 'https://discoveryprovider.audius.co'
+  let discoveryRequestPath
+  const route = matchRoute(pathname)
+  switch (route.name) {
+    case 'user': {
+      const { handle } = route.params
+      discoveryRequestPath = `v1/users/handle/${handle}`
+      break
+    }
+    case 'track': {
+      const { handle, title } = route.params
+      discoveryRequestPath = `v1/tracks?handle=${handle}&slug=${title}`
+      break
+    }
+    case 'playlist': {
+      const { handle, title } = route.params
+      discoveryRequestPath = `v1/full/playlists/by_permalink/${handle}/${title}`
+      break
+    }
+    case 'album': {
+      const { handle, title } = route.params
+      discoveryRequestPath = `v1/full/playlists/by_permalink/${handle}/${title}`
+      break
+    }
+    default:
+      return null
+  }
+  try {
+    const res = await fetch(`${discoveryNode}/${discoveryRequestPath}`)
+    if (res.status !== 200) {
+      throw new Error(res.status)
+    }
+    const json = res.json()
+    return { metadata: json, name: route.name }
+  } catch (e) {
+    return null
+  }
+}
+
+async function injectHead(asset, { title, description, image, permalink }) {
+  const canonicalUrl = `https://audius.co/${permalink}`
+  const tags = `
+    <title>${title}</title>
+    <meta name="description" content="${description}">
+
+    <link rel="canonical" href="${canonicalUrl}">
+
+    <meta property="og:title" content="${title}">
+    <meta property="og:description" content="${description}">
+    <meta property="og:image" content="${image}">
+    <meta property="og:url" content="${canonicalUrl}">
+
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="${title}">
+    <meta name="twitter:description" content="${description}">
+    <meta name="twitter:image" content="${canonicalUrl}">
+`
+
+  if (typeof asset === 'string' && asset.includes('</head>')) {
+    asset = asset.replace('</head>', tags + '</head>')
+  }
+
+  return asset
 }
 
 async function handleEvent(event) {
@@ -82,7 +181,50 @@ async function handleEvent(event) {
       }
     }
 
-    return await getAssetFromKV(event, options)
+    const asset = await getAssetFromKV(event, options)
+    let modifiedAsset
+    const { metadata, name } = await getMetadata(pathname)
+    switch (name) {
+      case 'user': {
+        modifiedAsset = injectHead(asset, {
+          title: `${metadata.data.name} (@${metadata.data.name})`,
+          description: metadata.data.bio || '',
+          image: metadata.data.profile_picture['1000x1000'] || '',
+          permalink: metadata.data.handle
+        })
+        break
+      }
+      case 'track': {
+        modifiedAsset = injectHead(asset, {
+          title: `${metadata.data.title} by ${metadata.user.name}`,
+          description: metadata.data.description || '',
+          image: metadata.data.artwork['1000x1000'] || '',
+          permalink: metadata.data.permalink
+        })
+        break
+      }
+      case 'playlist': {
+        modifiedAsset = injectHead(asset, {
+          title: `${metadata.data.playlist_name} by ${metadata.user.name}`,
+          description: metadata.data.description || '',
+          image: metadata.data.artwork['1000x1000'] || '',
+          permalink: metadata.data.permalink
+        })
+        break
+      }
+      case 'album': {
+        modifiedAsset = injectHead(asset, {
+          title: `${metadata.data.playlist_name} by ${metadata.user.name}`,
+          description: metadata.data.description || '',
+          image: metadata.data.artwork['1000x1000'] || '',
+          permalink: metadata.data.permalink
+        })
+        break
+      }
+      default:
+        return null
+    }
+    return modifiedAsset
   } catch (e) {
     return new Response(e.message || e.toString(), { status: 500 })
   }

--- a/packages/web/wrangler.toml
+++ b/packages/web/wrangler.toml
@@ -21,3 +21,9 @@ vars = { ENVIRONMENT = "production", GA = "https://general-admission.audius.co",
 [env.production]
 name = "audius"
 vars = { ENVIRONMENT = "production", GA = "https://general-admission.audius.co", SITEMAP = "http://audius.co.s3-website-us-west-1.amazonaws.com" }
+
+# Test environment, replace `test` with subdomain
+# Invoke with npx wrangler preview --watch --env test
+[env.test]
+name = "test"
+vars = { ENVIRONMENT = "production", GA = "https://general-admission.audius.co", SITEMAP = "http://audius.co.s3-website-us-west-1.amazonaws.com" }


### PR DESCRIPTION
### Description

Most (95+%) of pages aren't recognized by google at all right now.
This does a nifty on the fly html rewrite on the cloudflare side (which is then cached) and injects the proper tags from a request sent to discovery nodes.
This is a fairly well supported pattern:
https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/#async-handlers

This will cause a minor slowdown when things aren't cached, but I think well worth it for discovery purposes.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

Touches main serving.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

```
npx wrangler preview --watch --env ray
```

Verified page source to see the right tags populated for
* track page
* playlist page / album page
* user page
* home page
* /audio page (just to test some other pages)

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

