### PR TITLE
Preserve CIDs for track and collection cover arts

### DIFF
--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -24,7 +24,11 @@ type UseCollectionImageOptions = {
   collection: Nullable<
     Pick<
       Collection,
-      'playlist_id' | 'cover_art_sizes' | 'cover_art' | 'playlist_owner_id'
+      | 'playlist_id'
+      | 'cover_art_sizes'
+      | 'cover_art'
+      | 'playlist_owner_id'
+      | '_cover_art_sizes'
     >
   >
   size: SquareSizes
@@ -54,6 +58,7 @@ const useLocalCollectionImageUri = (collectionId: Maybe<ID>) => {
 
 export const useCollectionImage = (options: UseCollectionImageOptions) => {
   const { collection, size } = options
+  const optimisticCoverArt = collection?._cover_art_sizes.OVERRIDE
   const cid = collection
     ? collection.cover_art_sizes || collection.cover_art
     : null
@@ -62,13 +67,13 @@ export const useCollectionImage = (options: UseCollectionImageOptions) => {
     collection?.playlist_id
   )
 
+  const localSourceUri = optimisticCoverArt || localCollectionImageUri
+
   const contentNodeSource = useContentNodeImage({
     cid,
     size,
     fallbackImageSource: imageEmpty,
-    localSource: localCollectionImageUri
-      ? { uri: localCollectionImageUri }
-      : null
+    localSource: localSourceUri ? { uri: localSourceUri } : null
   })
 
   return contentNodeSource

--- a/packages/mobile/src/components/image/CollectionImage.tsx
+++ b/packages/mobile/src/components/image/CollectionImage.tsx
@@ -3,6 +3,7 @@ import type {
   ID,
   Maybe,
   Nullable,
+  SearchPlaylist,
   SquareSizes
 } from '@audius/common'
 import { reachabilitySelectors } from '@audius/common'
@@ -23,7 +24,7 @@ const { getIsReachable } = reachabilitySelectors
 type UseCollectionImageOptions = {
   collection: Nullable<
     Pick<
-      Collection,
+      Collection | SearchPlaylist,
       | 'playlist_id'
       | 'cover_art_sizes'
       | 'cover_art'
@@ -58,7 +59,7 @@ const useLocalCollectionImageUri = (collectionId: Maybe<ID>) => {
 
 export const useCollectionImage = (options: UseCollectionImageOptions) => {
   const { collection, size } = options
-  const optimisticCoverArt = collection?._cover_art_sizes.OVERRIDE
+  const optimisticCoverArt = collection?._cover_art_sizes?.OVERRIDE
   const cid = collection
     ? collection.cover_art_sizes || collection.cover_art
     : null

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -1,4 +1,11 @@
-import type { Track, Nullable, SquareSizes, ID, Maybe } from '@audius/common'
+import type {
+  Track,
+  Nullable,
+  SquareSizes,
+  ID,
+  Maybe,
+  SearchTrack
+} from '@audius/common'
 import { reachabilitySelectors } from '@audius/common'
 import { useSelector } from 'react-redux'
 
@@ -20,7 +27,7 @@ const { getIsReachable } = reachabilitySelectors
 type UseTrackImageOptions = {
   track: Nullable<
     Pick<
-      Track,
+      Track | SearchTrack,
       'track_id' | 'cover_art_sizes' | 'cover_art' | '_cover_art_sizes'
     >
   >
@@ -46,7 +53,7 @@ const useLocalTrackImageUri = (trackId: Maybe<ID>) => {
 
 export const useTrackImage = ({ track, size }: UseTrackImageOptions) => {
   const cid = track ? track.cover_art_sizes || track.cover_art : null
-  const optimisticCoverArt = track?._cover_art_sizes.OVERRIDE
+  const optimisticCoverArt = track?._cover_art_sizes?.OVERRIDE
 
   const localTrackImageUri = useLocalTrackImageUri(track?.track_id)
   const localSourceUri = optimisticCoverArt || localTrackImageUri

--- a/packages/mobile/src/components/image/TrackImage.tsx
+++ b/packages/mobile/src/components/image/TrackImage.tsx
@@ -18,7 +18,12 @@ export const DEFAULT_IMAGE_URL =
 const { getIsReachable } = reachabilitySelectors
 
 type UseTrackImageOptions = {
-  track: Nullable<Pick<Track, 'track_id' | 'cover_art_sizes' | 'cover_art'>>
+  track: Nullable<
+    Pick<
+      Track,
+      'track_id' | 'cover_art_sizes' | 'cover_art' | '_cover_art_sizes'
+    >
+  >
   size: SquareSizes
 }
 
@@ -41,14 +46,16 @@ const useLocalTrackImageUri = (trackId: Maybe<ID>) => {
 
 export const useTrackImage = ({ track, size }: UseTrackImageOptions) => {
   const cid = track ? track.cover_art_sizes || track.cover_art : null
+  const optimisticCoverArt = track?._cover_art_sizes.OVERRIDE
 
   const localTrackImageUri = useLocalTrackImageUri(track?.track_id)
+  const localSourceUri = optimisticCoverArt || localTrackImageUri
 
   const contentNodeSource = useContentNodeImage({
     cid,
     size,
     fallbackImageSource: imageEmpty,
-    localSource: localTrackImageUri ? { uri: localTrackImageUri } : null
+    localSource: localSourceUri ? { uri: localSourceUri } : null
   })
 
   return contentNodeSource

--- a/packages/mobile/src/components/share-drawer/ShareToStorySticker.tsx
+++ b/packages/mobile/src/components/share-drawer/ShareToStorySticker.tsx
@@ -20,7 +20,12 @@ const messages = {
 type ShareToStoryStickerProps = {
   track: Pick<
     Track,
-    'cover_art_sizes' | 'cover_art' | 'owner_id' | 'title' | 'track_id'
+    | 'cover_art_sizes'
+    | 'cover_art'
+    | 'owner_id'
+    | 'title'
+    | 'track_id'
+    | '_cover_art_sizes'
   >
   user?: Pick<User, 'creator_node_endpoint'>
   artist: Pick<User, 'user_id' | 'name' | 'is_verified'>

--- a/packages/mobile/src/hooks/useContentNodeImage.ts
+++ b/packages/mobile/src/hooks/useContentNodeImage.ts
@@ -57,14 +57,6 @@ export const createAllImageSources = ({
     return []
   }
 
-  if (
-    cid.startsWith('data:image') ||
-    cid.startsWith('file://') ||
-    cid.startsWith('/')
-  ) {
-    return [...(localSource ? [localSource] : []), { uri: cid }]
-  }
-
   const newImageSources = createImageSourcesForEndpoints({
     endpoints,
     createUri: (endpoint) => `${endpoint}/content/${cid}/${size}.jpg`

--- a/packages/web/src/common/store/cache/collections/utils/optimisticUpdateCollection.ts
+++ b/packages/web/src/common/store/cache/collections/utils/optimisticUpdateCollection.ts
@@ -7,7 +7,6 @@ export function* optimisticUpdateCollection(collection: Collection) {
     const { artwork } = optimisticCollection
     const { url } = artwork
     optimisticCollection.artwork = artwork
-    optimisticCollection.cover_art_sizes = url!
     const coverArtSizes = optimisticCollection._cover_art_sizes ?? {}
     coverArtSizes.OVERRIDE = url
     optimisticCollection._cover_art_sizes = coverArtSizes

--- a/packages/web/src/common/store/cache/tracks/sagas.js
+++ b/packages/web/src/common/store/cache/tracks/sagas.js
@@ -125,8 +125,8 @@ function* editTrackAsync(action) {
   const track = { ...action.formFields }
   track.track_id = action.trackId
   if (track.artwork?.file) {
-    track.cover_art_sizes = track.artwork.url
     track._cover_art_sizes = {
+      ...track._cover_art_sizes,
       [DefaultSizes.OVERRIDE]: track.artwork.url
     }
   }


### PR DESCRIPTION
### Description

Before this PR, edits to tracks and playlists would result in the `cover_image_sizes` prop on the entity being set to the local URL of the file (eg. blob:// or file://). This was so that we could load the image optimistically on mobile. However, the downside was that the local URL would also get written on a subsequent update to the track and break the cover art.

This changes makes it so that we never touch the `cover_art_sizes` field, even on mobile, and updates mobile to check for overrides in `_cover_art_sizes` instead for optimistic updates.

