### PR TITLE
Move setCollectionPermalink within fetchCollectionSucceeded action

### DIFF
--- a/packages/common/src/store/pages/collection/actions.ts
+++ b/packages/common/src/store/pages/collection/actions.ts
@@ -8,12 +8,6 @@ export const RESET_COLLECTION = 'RESET_COLLECTION'
 export const RESET_AND_FETCH_COLLECTION_TRACKS =
   'RESET_AND_FETCH_COLLECTION_TRACKS'
 export const SET_SMART_COLLECTION = 'SET_SMART_COLLECTION'
-export const SET_COLLECTION_PERMALINK = 'SET_COLLECTION_PERMALINK'
-
-export const setCollectionPermalink = (permalink: string) => ({
-  type: SET_COLLECTION_PERMALINK,
-  permalink
-})
 
 export const fetchCollection = (
   id: Nullable<number>,
@@ -29,11 +23,13 @@ export const fetchCollection = (
 export const fetchCollectionSucceeded = (
   collectionId: ID,
   collectionUid: string,
+  collectionPermalink: string,
   userUid: string
 ) => ({
   type: FETCH_COLLECTION_SUCCEEDED,
   collectionId,
   collectionUid,
+  collectionPermalink,
   userUid
 })
 

--- a/packages/common/src/store/pages/collection/reducer.ts
+++ b/packages/common/src/store/pages/collection/reducer.ts
@@ -11,8 +11,7 @@ import {
   FETCH_COLLECTION_SUCCEEDED,
   FETCH_COLLECTION_FAILED,
   RESET_COLLECTION,
-  SET_SMART_COLLECTION,
-  SET_COLLECTION_PERMALINK
+  SET_SMART_COLLECTION
 } from './actions'
 import { PREFIX as tracksPrefix } from './lineup/actions'
 
@@ -22,7 +21,8 @@ export const initialState = {
   userUid: null,
   status: null,
   smartCollectionVariant: null,
-  tracks: initialLineupState
+  tracks: initialLineupState,
+  collectionPermalink: null
 }
 
 const actionsMap = {
@@ -33,19 +33,14 @@ const actionsMap = {
       smartCollectionVariant: null
     }
   },
-  [SET_COLLECTION_PERMALINK](state, action) {
-    return {
-      ...state,
-      permalink: action.permalink
-    }
-  },
   [FETCH_COLLECTION_SUCCEEDED](state, action) {
     return {
       ...state,
       collectionId: action.collectionId,
       collectionUid: action.collectionUid,
       userUid: action.userUid,
-      status: Status.SUCCESS
+      status: Status.SUCCESS,
+      collectionPermalink: action.collectionPermalink
     }
   },
   [FETCH_COLLECTION_FAILED](state, action) {

--- a/packages/common/src/store/pages/collection/selectors.ts
+++ b/packages/common/src/store/pages/collection/selectors.ts
@@ -17,7 +17,7 @@ export const getCollectionStatus = (state: CommonState) =>
 export const getSmartCollectionVariant = (state: CommonState) =>
   state.pages.collection.smartCollectionVariant
 export const getCollectionPermalink = (state: CommonState) =>
-  state.pages.collection.permalink
+  state.pages.collection.collectionPermalink
 export const getCollection = (state: CommonState, params?: { id: ID }) => {
   const smartCollectionVariant = getSmartCollectionVariant(state)
   if (smartCollectionVariant) {

--- a/packages/common/src/store/pages/collection/types.ts
+++ b/packages/common/src/store/pages/collection/types.ts
@@ -15,7 +15,7 @@ export type CollectionTrack = LineupTrack & { dateAdded: Moment } & {
 }
 
 export type CollectionsPageState = {
-  permalink: string
+  collectionPermalink: string
   collectionId: ID | null
   collectionUid: UID | null
   status: Status | null

--- a/packages/web/src/common/store/pages/collection/sagas.js
+++ b/packages/web/src/common/store/pages/collection/sagas.js
@@ -65,6 +65,7 @@ function* watchFetchCollection() {
         fetchCollectionSucceeded(
           collection.playlist_id,
           collectionUid,
+          collection.permalink,
           userUid,
           collection.playlist_contents.track_ids.length
         )

--- a/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPageProvider.tsx
@@ -246,8 +246,12 @@ class CollectionPage extends Component<
     if (metadata && metadata._moved && !updatingRoute) {
       this.setState({ updatingRoute: true })
       const collectionId = Uid.fromString(metadata._moved).id
-      // TODO: Put fetch collection succeeded and then replace route
-      fetchCollectionSucceeded(collectionId, metadata._moved, userUid)
+      fetchCollectionSucceeded(
+        collectionId,
+        metadata._moved,
+        metadata.permalink || '',
+        userUid
+      )
       const newPath = pathname.replace(
         `${metadata.playlist_id}`,
         collectionId.toString()
@@ -364,7 +368,6 @@ class CollectionPage extends Component<
     if (params?.permalink) {
       const { permalink, collectionId } = params
       if (forceFetch || params.permalink) {
-        this.props.setCollectionPermalink(permalink)
         this.props.fetchCollection(collectionId, permalink)
         this.props.fetchTracks()
       }
@@ -389,7 +392,6 @@ class CollectionPage extends Component<
 
   resetCollection = () => {
     const { collectionUid, userUid } = this.props
-    this.props.setCollectionPermalink('')
     this.props.resetCollection(collectionUid, userUid)
   }
 
@@ -875,8 +877,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
       dispatch(collectionActions.fetchCollection(id, permalink)),
     fetchTracks: () =>
       dispatch(tracksActions.fetchLineupMetadatas(0, 200, false, undefined)),
-    setCollectionPermalink: (permalink: string) =>
-      dispatch(collectionActions.setCollectionPermalink(permalink)),
     resetCollection: (collectionUid: string, userUid: string) =>
       dispatch(collectionActions.resetCollection(collectionUid, userUid)),
     goToRoute: (route: string) => dispatch(pushRoute(route)),
@@ -977,12 +977,14 @@ function mapDispatchToProps(dispatch: Dispatch) {
     fetchCollectionSucceeded: (
       collectionId: ID,
       collectionUid: string,
+      collectionPermalink: string,
       userId: string
     ) =>
       dispatch(
         collectionActions.fetchCollectionSucceeded(
           collectionId,
           collectionUid,
+          collectionPermalink,
           userId
         )
       ),


### PR DESCRIPTION
### Description
slight refactor that we discussed where we can set the collection permalink in the state as part of fetch collection succeeded, instead of a separate action that has to be called in conjunction with fetch collection

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

