### PR TITLE
Change nullish check to falsey check for collection track times

### DIFF
--- a/packages/web/src/common/store/pages/collection/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/collection/lineups/sagas.js
@@ -38,7 +38,7 @@ function* getCollectionTracks() {
 
   const trackIds = tracks.map((t) => t.track)
   // TODO: Conform all timestamps to be of the same format so we don't have to do any special work here.
-  const times = tracks.map((t) => t.metadata_time ?? t.time)
+  const times = tracks.map((t) => t.metadata_time || t.time)
 
   // Reconcile fetching this playlist with the queue.
   // Search the queue for its currently playing uids. If any are sourced


### PR DESCRIPTION
### Description
Small change to fix how we process falling back to the time from metadata_time of a track.
Was causing an issue when a track had a metadata_time of 0

### Dragons

N/A

### How Has This Been Tested?

N/A

### How will this change be monitored?

N/A

### Feature Flags ###

N/A

