### PR TITLE
[PAY-1588] Use existing balance in purchase flow on mobile

### DIFF
--- a/packages/common/src/store/purchase-content/utils.ts
+++ b/packages/common/src/store/purchase-content/utils.ts
@@ -15,15 +15,17 @@ export const isContentPurchaseInProgress = (stage: PurchaseContentStage) => {
   ].includes(stage)
 }
 
-export const getPurchaseSummaryValues = (
-  price: number,
-  currentBalance: BNUSDC = zeroBalance()
-): {
+type PurchaseSummaryValues = {
   amountDue: number
   existingBalance: number | undefined
   basePrice: number
   artistCut: number
-} => {
+}
+
+export const getPurchaseSummaryValues = (
+  price: number,
+  currentBalance: BNUSDC = zeroBalance()
+): PurchaseSummaryValues => {
   let amountDue = price
   let existingBalance
   const priceBN = new BN(price).mul(BN_USDC_CENT_WEI)

--- a/packages/common/src/store/purchase-content/utils.ts
+++ b/packages/common/src/store/purchase-content/utils.ts
@@ -1,4 +1,11 @@
+import BN from 'bn.js'
+
+import { BNUSDC } from 'models/Wallet'
+import { BN_USDC_CENT_WEI, ceilingBNUSDCToNearestCent } from 'utils/wallet'
+
 import { PurchaseContentStage } from './types'
+
+export const zeroBalance = () => new BN(0) as BNUSDC
 
 export const isContentPurchaseInProgress = (stage: PurchaseContentStage) => {
   return [
@@ -6,4 +13,36 @@ export const isContentPurchaseInProgress = (stage: PurchaseContentStage) => {
     PurchaseContentStage.PURCHASING,
     PurchaseContentStage.CONFIRMING_PURCHASE
   ].includes(stage)
+}
+
+export const getPurchaseSummaryValues = (
+  price: number,
+  currentBalance: BNUSDC = zeroBalance()
+): {
+  amountDue: number
+  existingBalance: number | undefined
+  basePrice: number
+  artistCut: number
+} => {
+  let amountDue = price
+  let existingBalance
+  const priceBN = new BN(price).mul(BN_USDC_CENT_WEI)
+
+  if (currentBalance.gte(priceBN)) {
+    amountDue = 0
+    existingBalance = price
+  }
+  // Only count the balance if it's greater than 1 cent
+  else if (currentBalance.gt(BN_USDC_CENT_WEI)) {
+    // Note: Rounding amount due *up* to nearest cent for cases where the balance
+    // is between cents so that we aren't advertising *lower* than what the user
+    // will have to pay.
+    const diff = priceBN.sub(currentBalance)
+    amountDue = ceilingBNUSDCToNearestCent(diff as BNUSDC)
+      .div(BN_USDC_CENT_WEI)
+      .toNumber()
+    existingBalance = price - amountDue
+  }
+
+  return { amountDue, existingBalance, basePrice: price, artistCut: price }
 }

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSummaryTable.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSummaryTable.tsx
@@ -1,3 +1,4 @@
+import { formatPrice } from '@audius/common'
 import { View } from 'react-native'
 
 import { Text } from 'app/components/core'
@@ -48,17 +49,22 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
 }))
 
 type PurchaseSummaryTableProps = {
-  price: string
+  amountDue: number
+  artistCut: number
+  basePrice: number
+  existingBalance?: number
   isPurchaseSuccessful: boolean
-  existingBalance?: string
 }
 
 export const PurchaseSummaryTable = ({
-  price,
-  isPurchaseSuccessful,
-  existingBalance
+  amountDue,
+  artistCut,
+  basePrice,
+  existingBalance,
+  isPurchaseSuccessful
 }: PurchaseSummaryTableProps) => {
   const styles = useStyles()
+  const amountDueFormatted = formatPrice(amountDue)
 
   return (
     <>
@@ -74,7 +80,7 @@ export const PurchaseSummaryTable = ({
         </View>
         <View style={styles.summaryRow}>
           <Text>{messages.artistCut}</Text>
-          <Text>{messages.price(price)}</Text>
+          <Text>{messages.price(formatPrice(artistCut))}</Text>
         </View>
         <View style={styles.summaryRow}>
           <Text>{messages.audiusCut}</Text>
@@ -83,7 +89,7 @@ export const PurchaseSummaryTable = ({
         {existingBalance ? (
           <View style={styles.summaryRow}>
             <Text>{messages.existingBalance}</Text>
-            <Text>{messages.subtractPrice(existingBalance)}</Text>
+            <Text>{messages.subtractPrice(formatPrice(existingBalance))}</Text>
           </View>
         ) : null}
         <View style={[styles.summaryRow, styles.lastRow, styles.greyRow]}>
@@ -98,15 +104,15 @@ export const PurchaseSummaryTable = ({
                   color='secondary'
                   style={styles.strikeThrough}
                 >
-                  {messages.price(price)}
+                  {messages.price(formatPrice(basePrice))}
                 </Text>
                 <Text weight='bold' color='secondary'>
-                  {messages.price('0.50')}
+                  {messages.price(amountDueFormatted)}
                 </Text>
               </>
             ) : (
               <Text weight='bold' color='secondary'>
-                {messages.price(price)}
+                {messages.price(amountDueFormatted)}
               </Text>
             )}
           </View>

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseSummaryTable.tsx
@@ -16,7 +16,7 @@ const messages = {
   price: (val: string) => `$${val}`
 }
 
-export type PurchaseSummaryTableProps = {
+type PurchaseSummaryTableProps = {
   amountDue: number
   artistCut: number
   basePrice: number


### PR DESCRIPTION
### Description
Moved some of the util fns in `web` over to `common` and used them to calculate `existingBalance`/`amountDue` for the `PurchaseSummaryTable`.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

Confirmed web behavior is correct.

![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 16 05 58](https://github.com/AudiusProject/audius-client/assets/3893871/927392ca-370c-4bba-aedb-00623a442866)
![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 16 05 32](https://github.com/AudiusProject/audius-client/assets/3893871/2c3dceb1-e72e-48fe-8165-27294e0c6117)
![Simulator Screenshot - iPhone 14 Pro - 2023-08-14 at 16 37 04](https://github.com/AudiusProject/audius-client/assets/3893871/e22df341-48ae-4035-acc7-4a03b3906375)


### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

