### PR TITLE
[PAY-1720] Implements PlainButton

### DIFF
--- a/packages/stems/src/components/HarmonyButton/BaseButton.module.css
+++ b/packages/stems/src/components/HarmonyButton/BaseButton.module.css
@@ -1,0 +1,43 @@
+/* ===Base Styles=== */
+.button {
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-flex;
+  flex-shrink: 0;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  text-align: center;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.button:focus {
+  outline: none !important;
+}
+
+/* Only add hover styles on devices which support it */
+@media (hover: hover) {
+  .button:not(.disabled):hover {
+    transition: all var(--hover);
+    transform: scale(1.04);
+  }
+}
+
+.button:not(.disabled):active {
+  transition: all var(--press);
+  transform: scale(0.98);
+}
+
+.button.disabled {
+  pointer-events: none;
+}
+
+.icon path {
+  fill: currentColor;
+}
+
+.fullWidth {
+  width: 100%;
+}

--- a/packages/stems/src/components/HarmonyButton/BaseButton.tsx
+++ b/packages/stems/src/components/HarmonyButton/BaseButton.tsx
@@ -8,8 +8,8 @@ import baseStyles from './BaseButton.module.css'
 import { BaseButtonProps } from './types'
 
 /**
- * A common Button component. Includes a few variants and options to
- * include and position icons.
+ * Base component for Harmony buttons. Not intended to be used directly. Use
+ * `HarmonyButton` or `HarmonyPlainButton`.
  */
 export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
   function BaseButton(props, ref) {

--- a/packages/stems/src/components/HarmonyButton/BaseButton.tsx
+++ b/packages/stems/src/components/HarmonyButton/BaseButton.tsx
@@ -1,0 +1,76 @@
+import { forwardRef } from 'react'
+
+import cn from 'classnames'
+
+import { useMediaQueryListener } from 'hooks/useMediaQueryListener'
+
+import baseStyles from './BaseButton.module.css'
+import { BaseButtonProps } from './types'
+
+/**
+ * A common Button component. Includes a few variants and options to
+ * include and position icons.
+ */
+export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
+  function BaseButton(props, ref) {
+    const {
+      text,
+      iconLeft: LeftIconComponent,
+      iconRight: RightIconComponent,
+      disabled,
+      widthToHideText,
+      minWidth,
+      className,
+      'aria-label': ariaLabelProp,
+      fullWidth,
+      styles,
+      style,
+      ...other
+    } = props
+    const { isMatch: textIsHidden } = useMediaQueryListener(
+      `(max-width: ${widthToHideText}px)`
+    )
+
+    const isTextVisible = !!text && !textIsHidden
+
+    const getAriaLabel = () => {
+      if (ariaLabelProp) return ariaLabelProp
+      // Use the text prop as the aria-label if the text becomes hidden
+      // and no aria-label was provided to keep the button accessible.
+      else if (textIsHidden && typeof text === 'string') return text
+      return undefined
+    }
+
+    return (
+      <button
+        aria-label={getAriaLabel()}
+        className={cn(
+          baseStyles.button,
+          styles.button,
+          {
+            [baseStyles.disabled]: disabled,
+            [baseStyles.fullWidth]: fullWidth
+          },
+          className
+        )}
+        disabled={disabled}
+        ref={ref}
+        style={{
+          minWidth: minWidth && isTextVisible ? `${minWidth}px` : 'unset',
+          ...style
+        }}
+        {...other}
+      >
+        {LeftIconComponent ? (
+          <LeftIconComponent className={cn(baseStyles.icon, styles.icon)} />
+        ) : null}
+        {isTextVisible ? (
+          <span className={cn(baseStyles.text, styles.text)}>{text}</span>
+        ) : null}
+        {RightIconComponent ? (
+          <RightIconComponent className={cn(baseStyles.icon, styles.icon)} />
+        ) : null}
+      </button>
+    )
+  }
+)

--- a/packages/stems/src/components/HarmonyButton/HarmonyButton.module.css
+++ b/packages/stems/src/components/HarmonyButton/HarmonyButton.module.css
@@ -4,41 +4,9 @@
   --text-color: var(--static-white);
   --overlay-color: transparent;
   --overlay-opacity: 0;
-  align-items: center;
   border: 1px solid var(--button-color);
   border-radius: var(--unit-1);
-  box-sizing: border-box;
   color: var(--text-color);
-  cursor: pointer;
-  display: inline-flex;
-  flex-shrink: 0;
-  justify-content: center;
-  overflow: hidden;
-  position: relative;
-  text-align: center;
-  user-select: none;
-  white-space: nowrap;
-}
-
-.button:focus {
-  outline: none !important;
-}
-
-/* Only add hover styles on devices which support it */
-@media (hover: hover) {
-  .button:not(.disabled):hover {
-    transition: all var(--hover);
-    transform: scale(1.04);
-  }
-}
-
-.button:not(.disabled):active {
-  transition: all var(--press);
-  transform: scale(0.98);
-}
-
-.button.disabled {
-  pointer-events: none;
 }
 
 /* Overlay used for hover/press styling */
@@ -53,14 +21,6 @@
   background: var(--overlay-color, transparent);
   opacity: var(--overlay-opacity, 0);
   pointer-events: none;
-}
-
-.icon path {
-  fill: currentColor;
-}
-
-.fullWidth {
-  width: 100%;
 }
 
 /* === Sizes === */

--- a/packages/stems/src/components/HarmonyButton/HarmonyButton.stories.tsx
+++ b/packages/stems/src/components/HarmonyButton/HarmonyButton.stories.tsx
@@ -27,6 +27,7 @@ const Template: Story<HarmonyButtonProps> = (args) => (
       display: 'flex',
       flexDirection: 'column',
       gap: '16px',
+      justifyContent: 'center',
       alignItems: 'flex-start'
     }}
   >

--- a/packages/stems/src/components/HarmonyButton/HarmonyButton.tsx
+++ b/packages/stems/src/components/HarmonyButton/HarmonyButton.tsx
@@ -1,16 +1,16 @@
-import { CSSProperties, forwardRef } from 'react'
+import { forwardRef } from 'react'
 
 import cn from 'classnames'
 
-import { useMediaQueryListener } from 'hooks/useMediaQueryListener'
 import { CSSCustomProperties } from 'styles/types'
 import { toCSSVariableName } from 'utils/styles'
 
+import { BaseButton } from './BaseButton'
 import styles from './HarmonyButton.module.css'
 import {
   HarmonyButtonProps,
-  HarmonyButtonType,
-  HarmonyButtonSize
+  HarmonyButtonSize,
+  HarmonyButtonType
 } from './types'
 
 const SIZE_STYLE_MAP: { [k in HarmonyButtonSize]: [string, string, string] } = {
@@ -48,35 +48,13 @@ export const HarmonyButton = forwardRef<HTMLButtonElement, HarmonyButtonProps>(
   function HarmonyButton(props, ref) {
     const {
       color,
-      text,
       variant = HarmonyButtonType.PRIMARY,
       size = HarmonyButtonSize.DEFAULT,
-      iconLeft: LeftIconComponent,
-      iconRight: RightIconComponent,
       disabled,
-      widthToHideText,
-      minWidth,
-      className,
-      'aria-label': ariaLabelProp,
-      fullWidth,
-      ...other
+      ...baseProps
     } = props
-    const { isMatch: textIsHidden } = useMediaQueryListener(
-      `(max-width: ${widthToHideText}px)`
-    )
-
-    const isTextVisible = !!text && !textIsHidden
-
-    const getAriaLabel = () => {
-      if (ariaLabelProp) return ariaLabelProp
-      // Use the text prop as the aria-label if the text becomes hidden
-      // and no aria-label was provided to keep the button accessible.
-      else if (textIsHidden && typeof text === 'string') return text
-      return undefined
-    }
 
     const style: CSSCustomProperties = {
-      minWidth: minWidth && isTextVisible ? `${minWidth}px` : 'unset',
       '--button-color':
         !disabled && color ? `var(${toCSSVariableName(color)})` : undefined
     }
@@ -84,33 +62,22 @@ export const HarmonyButton = forwardRef<HTMLButtonElement, HarmonyButtonProps>(
     const [buttonSizeClass, iconSizeClass, textSizeClass] = SIZE_STYLE_MAP[size]
 
     return (
-      <button
-        aria-label={getAriaLabel()}
-        className={cn(
-          styles.button,
-          buttonSizeClass,
-          TYPE_STYLE_MAP[variant],
-          {
-            [styles.disabled]: disabled,
-            [styles.fullWidth]: fullWidth
-          },
-          className
-        )}
-        disabled={disabled}
+      <BaseButton
         ref={ref}
-        style={style as CSSProperties}
-        {...other}
-      >
-        {LeftIconComponent ? (
-          <LeftIconComponent className={cn(styles.icon, iconSizeClass)} />
-        ) : null}
-        {isTextVisible ? (
-          <span className={cn(styles.text, textSizeClass)}>{text}</span>
-        ) : null}
-        {RightIconComponent ? (
-          <RightIconComponent className={cn(styles.icon, iconSizeClass)} />
-        ) : null}
-      </button>
+        disabled={disabled}
+        styles={{
+          button: cn(
+            styles.button,
+            TYPE_STYLE_MAP[variant],
+            { [styles.disabled]: disabled },
+            buttonSizeClass
+          ),
+          icon: cn(styles.icon, iconSizeClass),
+          text: cn(styles.text, textSizeClass)
+        }}
+        style={style}
+        {...baseProps}
+      />
     )
   }
 )

--- a/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.module.css
+++ b/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.module.css
@@ -57,7 +57,7 @@
   --text-color: var(--secondary-dark-2)
 }
 
-/* Secondary */
+/* Subdued */
 .subdued {
   --text-color: var(--text-subdued);
 }

--- a/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.module.css
+++ b/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.module.css
@@ -1,0 +1,90 @@
+/* ===Base Styles=== */
+.button {
+  --text-color: var(--text-default);
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+}
+
+/* === Sizes === */
+
+/* Default */
+.buttonDefault {
+  gap: var(--unit-1);
+  height: var(--unit-4);
+}
+
+.iconDefault {
+  width: var(--unit-4);
+  height: var(--unit-4);
+}
+
+.textDefault {
+  font-size: var(--font-s);
+  font-weight: var(--font-bold);
+  line-height: var(--unit-4);
+}
+
+/* Large */
+.buttonLarge {
+  gap: var(--unit-2);
+  height: var(--unit-5);
+}
+
+.iconLarge {
+  width: var(--unit-5);
+  height: var(--unit-5);
+}
+
+.textLarge {
+  font-size: var(--font-l);
+  font-weight: var(--font-bold);
+  line-height: calc(4.5 * var(--unit-5));
+}
+
+/* === Color Variants === */
+
+/* Default */
+.default {
+  --text-color: var(--text-default);
+}
+
+.default:hover {
+  --text-color: var(--secondary);
+}
+
+.default:active {
+  --text-color: var(--secondary-dark-2)
+}
+
+/* Secondary */
+.subdued {
+  --text-color: var(--text-subdued);
+}
+
+.subdued:hover {
+  --text-color: var(--secondary);
+}
+.subdued:active {
+  --text-color: var(--secondary-dark-2);
+}
+
+/* Inverted */
+.inverted {
+  --text-color: var(--static-white);
+}
+.inverted:hover {
+  opacity: 0.8;
+}
+.inverted:active {
+  opacity: 0.5;
+}
+
+/* Disabled states */
+.disabled {
+  opacity: 0.2;
+}
+
+.subdued.disabled {
+  --text-color: var(--text-default);
+}

--- a/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.stories.tsx
+++ b/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.stories.tsx
@@ -1,0 +1,82 @@
+import { Story } from '@storybook/react'
+
+import * as Icons from 'components/Icons'
+
+import { HarmonyPlainButton } from './HarmonyPlainButton'
+import {
+  HarmonyPlainButtonProps,
+  HarmonyPlainButtonSize,
+  HarmonyPlainButtonType
+} from './types'
+
+export default {
+  component: HarmonyPlainButton,
+  title: 'Components/HarmonyPlainButton',
+  argTypes: { onClick: { action: 'clicked' } }
+}
+
+const baseProps: HarmonyPlainButtonProps = {
+  iconLeft: Icons.IconCampfire,
+  iconRight: Icons.IconCampfire,
+  text: 'Click Me'
+}
+
+type StoryArgs = {
+  props: Partial<HarmonyPlainButtonProps>
+  dark?: boolean
+}
+
+const Template: Story<StoryArgs> = ({ dark = false, props }) => (
+  <div
+    style={{
+      background: dark ? '#878787' : undefined,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '16px',
+      padding: '16px',
+      justifyContent: 'center',
+      alignItems: 'flex-start'
+    }}
+  >
+    <div style={{ alignItems: 'center', display: 'flex', gap: '16px' }}>
+      <HarmonyPlainButton
+        {...baseProps}
+        size={HarmonyPlainButtonSize.DEFAULT}
+        {...props}
+      />
+      <HarmonyPlainButton
+        {...baseProps}
+        size={HarmonyPlainButtonSize.LARGE}
+        {...props}
+      />
+    </div>
+    <div style={{ alignItems: 'center', display: 'flex', gap: '16px' }}>
+      <HarmonyPlainButton
+        {...baseProps}
+        size={HarmonyPlainButtonSize.DEFAULT}
+        {...props}
+        disabled
+      />
+      <HarmonyPlainButton
+        {...baseProps}
+        size={HarmonyPlainButtonSize.LARGE}
+        {...props}
+        disabled
+      />
+    </div>
+  </div>
+)
+
+// Default
+export const Default = Template.bind({})
+
+// Subdued
+export const Subdued = Template.bind({})
+Subdued.args = { props: { variant: HarmonyPlainButtonType.SUBDUED } }
+
+// Inverted
+export const Inverted = Template.bind({})
+Inverted.args = {
+  dark: true,
+  props: { variant: HarmonyPlainButtonType.INVERTED }
+}

--- a/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.tsx
+++ b/packages/stems/src/components/HarmonyButton/HarmonyPlainButton.tsx
@@ -1,0 +1,68 @@
+import { forwardRef } from 'react'
+
+import cn from 'classnames'
+
+import { BaseButton } from './BaseButton'
+import styles from './HarmonyPlainButton.module.css'
+import {
+  HarmonyPlainButtonProps,
+  HarmonyPlainButtonSize,
+  HarmonyPlainButtonType
+} from './types'
+
+const SIZE_STYLE_MAP: {
+  [k in HarmonyPlainButtonSize]: [string, string, string]
+} = {
+  [HarmonyPlainButtonSize.DEFAULT]: [
+    styles.buttonDefault,
+    styles.iconDefault,
+    styles.textDefault
+  ],
+  [HarmonyPlainButtonSize.LARGE]: [
+    styles.buttonLarge,
+    styles.iconLarge,
+    styles.textLarge
+  ]
+}
+
+const TYPE_STYLE_MAP: { [k in HarmonyPlainButtonType]: string } = {
+  [HarmonyPlainButtonType.DEFAULT]: styles.default,
+  [HarmonyPlainButtonType.SUBDUED]: styles.subdued,
+  [HarmonyPlainButtonType.INVERTED]: styles.inverted
+}
+
+/**
+ * A plain Button component (no border/background). Includes a few variants and options to
+ * include and position icons.
+ */
+export const HarmonyPlainButton = forwardRef<
+  HTMLButtonElement,
+  HarmonyPlainButtonProps
+>(function HarmonyPlainButton(props, ref) {
+  const {
+    variant = HarmonyPlainButtonType.DEFAULT,
+    size = HarmonyPlainButtonSize.DEFAULT,
+    disabled,
+    ...baseProps
+  } = props
+
+  const [buttonSizeClass, iconSizeClass, textSizeClass] = SIZE_STYLE_MAP[size]
+
+  return (
+    <BaseButton
+      ref={ref}
+      disabled={disabled}
+      styles={{
+        button: cn(
+          styles.button,
+          TYPE_STYLE_MAP[variant],
+          { [styles.disabled]: disabled },
+          buttonSizeClass
+        ),
+        icon: cn(styles.icon, iconSizeClass),
+        text: cn(styles.text, textSizeClass)
+      }}
+      {...baseProps}
+    />
+  )
+})

--- a/packages/stems/src/components/HarmonyButton/index.ts
+++ b/packages/stems/src/components/HarmonyButton/index.ts
@@ -1,6 +1,10 @@
 export { HarmonyButton } from './HarmonyButton'
+export { HarmonyPlainButton } from './HarmonyPlainButton'
 export {
   HarmonyButtonProps,
   HarmonyButtonType,
-  HarmonyButtonSize
+  HarmonyButtonSize,
+  HarmonyPlainButtonProps,
+  HarmonyPlainButtonSize,
+  HarmonyPlainButtonType
 } from './types'

--- a/packages/stems/src/components/HarmonyButton/types.ts
+++ b/packages/stems/src/components/HarmonyButton/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 
 import { IconComponent } from 'components/Icons/types'
 import { ColorValue } from 'styles/colors'
-import { BaseButtonProps } from 'utils/types'
+import { BaseButtonProps as ButtonProps } from 'utils/types'
 
 export enum HarmonyButtonType {
   PRIMARY = 'primary',
@@ -19,25 +19,17 @@ export enum HarmonyButtonSize {
   LARGE = 'large'
 }
 
-export type HarmonyButtonProps = {
-  /**
-   * Override the color of the button, only valid for the `PRIMARY` variant
-   */
-  color?: ColorValue
+type BaseButtonStyles = {
+  button: string
+  text: string
+  icon: string
+}
+
+export type BaseButtonProps = {
   /**
    * The text of the button
    */
   text: ReactNode
-
-  /**
-   * The type of the button
-   */
-  variant?: HarmonyButtonType
-
-  /**
-   * The button size
-   */
-  size?: HarmonyButtonSize
 
   /**
    * Optional icon element to include on the left side of the button
@@ -65,4 +57,49 @@ export type HarmonyButtonProps = {
    * If provided, allow button to take up full width of container
    */
   fullWidth?: boolean
-} & BaseButtonProps
+
+  /**
+   * Internal styling used by derived button components
+   */
+  styles: BaseButtonStyles
+} & ButtonProps
+
+export type HarmonyButtonProps = {
+  /**
+   * Override the color of the button, only valid for the `PRIMARY` variant
+   */
+  color?: ColorValue
+
+  /**
+   * The type of the button
+   */
+  variant?: HarmonyButtonType
+
+  /**
+   * The button size
+   */
+  size?: HarmonyButtonSize
+} & Omit<BaseButtonProps, 'styles'>
+
+export enum HarmonyPlainButtonType {
+  DEFAULT = 'default',
+  SUBDUED = 'subdued',
+  INVERTED = 'inverted'
+}
+
+export enum HarmonyPlainButtonSize {
+  DEFAULT = 'default',
+  LARGE = 'large'
+}
+
+export type HarmonyPlainButtonProps = {
+  /**
+   * The type of the button
+   */
+  variant?: HarmonyPlainButtonType
+
+  /**
+   * The button size
+   */
+  size?: HarmonyPlainButtonSize
+} & Omit<BaseButtonProps, 'styles'>


### PR DESCRIPTION
### Description
This adds a full implementation of the harmony PlainButton component, which was originally partially implemented as a variant of HarmonyButton.

* Moved non-styling functionality into a private `BaseButton` component.
* Updated HarmonyButton to layer its styling on top of the new base component
* Added `HarmonyPlainButton` component as a derived component implementing the new button type

### Dragons
Should be none

### How Has This Been Tested?
Locally verified in Storybook

### How will this change be monitored?
N/A

### Feature Flags ###
N/A

### Screenshots

Default Variant
![Kapture 2023-08-17 at 13 24 24](https://github.com/AudiusProject/audius-client/assets/1815175/5cd99b36-1647-4532-84d0-eb88187c734b)

---

Subdued Variant
![Kapture 2023-08-17 at 13 25 34](https://github.com/AudiusProject/audius-client/assets/1815175/70d7d7c6-d00f-4dc6-88b9-4272ae3fb4cc)


---

Inverted Variant
![Kapture 2023-08-17 at 13 26 15](https://github.com/AudiusProject/audius-client/assets/1815175/027c2fa3-b495-4bf5-b20f-8a5d7b6b7795)


