### PR TITLE
[C-2964] Cannonical URL should be uri encoded

### DIFF
--- a/packages/web/scripts/workers-site/index.js
+++ b/packages/web/scripts/workers-site/index.js
@@ -212,12 +212,12 @@ class SEOHandlerHead {
     const tags = `<title>${clean(title)}</title>
     <meta name="description" content="${clean(description)}">
 
-    <link rel="canonical" href="https://audius.co${permalink}">
+    <link rel="canonical" href="https://audius.co${encodeURI(permalink)}">
 
     <meta property="og:title" content="${clean(title)}">
     <meta property="og:description" content="${clean(ogDescription)}">
     <meta property="og:image" content="${image}">
-    <meta property="og:url" content="https://audius.co${permalink}">
+    <meta property="og:url" content="https://audius.co${encodeURI(permalink)}">
 
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="${clean(title)}">


### PR DESCRIPTION
### Description

See this link:
https://audius.co/withoutmoralbeat/my-march-love-|-analog-trap-beat-160-bpm-377952

view-source:https://audius.co/withoutmoralbeat/my-march-love-%7C-analog-trap-beat-160-bpm-377952

Sitemap does uri encoding for us, so this will ensure things match.

https://discoveryprovider.audius.co/sitemaps/track/9.xml

While another option may be to make permalinks come back from the API as uri encoded, I believe that it is nicer to leave this up to developer or else our multilanguage permalinks will look extraordinarily bad in API responses.

### How Has This Been Tested?

Will ensure on stage via this track

https://staging.audius.co/ray65/%7C-%C3%B8%C7%83%C7%82%C7%86%C7%86%C7%86%CA%83%CA%84%CA%85%CA%86%CA%87%CA%88%CA%89%CA%8A%CA%8B%CA%8C%CA%8D%CA%8E%CA%8F%CA%90%CA%91%CA%92%CA%93%CA%94%CA%95%CA%96%CA%97%CA%98%CA%99%CA%9A%CA%9B%CA%9C%CA%9D%CA%9E%CA%9F%CA%A0%CA%A1%CA%A2%CA%A3%CA%A4%CA%A5%CA%A6%CA%A7%CA%A8%CA%A9%CA%AA%CA%AB%CA%AC%CA%AD%CA%AE%CA%AF-%60%60