### PR TITLE
Fix mobile share of playlist permalink

### DIFF
--- a/packages/common/src/models/Collection.ts
+++ b/packages/common/src/models/Collection.ts
@@ -45,7 +45,7 @@ export type CollectionMetadata = {
   playlist_id: ID
   cover_art: CID | null
   cover_art_sizes: Nullable<CID>
-  permalink: string
+  permalink?: string
   playlist_name: string
   playlist_owner_id: ID
   repost_count: number

--- a/packages/common/src/models/Collection.ts
+++ b/packages/common/src/models/Collection.ts
@@ -45,7 +45,7 @@ export type CollectionMetadata = {
   playlist_id: ID
   cover_art: CID | null
   cover_art_sizes: Nullable<CID>
-  permalink?: string
+  permalink: string
   playlist_name: string
   playlist_owner_id: ID
   repost_count: number

--- a/packages/mobile/src/utils/routes.tsx
+++ b/packages/mobile/src/utils/routes.tsx
@@ -25,7 +25,7 @@ export const getCollectionRoute = (
 ) => {
   const { permalink } = collection
 
-  return fullUrl ? `${AUDIUS_URL}${permalink}` : permalink
+  return fullUrl ? `${AUDIUS_URL}${permalink}` : permalink || ''
 }
 
 export const getSearchRoute = (query: string, fullUrl = false) => {

--- a/packages/mobile/src/utils/routes.tsx
+++ b/packages/mobile/src/utils/routes.tsx
@@ -23,14 +23,9 @@ export const getCollectionRoute = (
   collection: UserCollection,
   fullUrl = false
 ) => {
-  const { playlist_name, playlist_id, is_album, user } = collection
-  const { handle } = user
-  const encodedHandle = encodeUrlName(handle)
-  const encodedPlaylistName = encodeUrlName(playlist_name)
-  const collectionType = is_album ? 'album' : 'playlist'
-  const route = `/${encodedHandle}/${collectionType}/${encodedPlaylistName}-${playlist_id}`
+  const { permalink } = collection
 
-  return fullUrl ? `${AUDIUS_URL}${route}` : route
+  return fullUrl ? `${AUDIUS_URL}${permalink}` : permalink
 }
 
 export const getSearchRoute = (query: string, fullUrl = false) => {


### PR DESCRIPTION
### Description
mobile client is returning the old style permalink still which is incorrect with what we have stored in our playlist routes table. this returns new permalinks

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

