### PR TITLE
[PAY-1742] Remove useMetaMask on invalid account

### DIFF
--- a/packages/web/src/common/store/account/sagas.js
+++ b/packages/web/src/common/store/account/sagas.js
@@ -186,6 +186,10 @@ export function* fetchAccountAsync({ isSignUp = false }) {
         reason: 'ACCOUNT_NOT_FOUND'
       })
     )
+    if (!isNativeMobile) {
+      const localStorage = yield getContext('localStorage')
+      yield call([localStorage, 'removeItem'], 'useMetaMask')
+    }
     return
   }
   if (account.is_deactivated) {

--- a/packages/web/src/components/banner/Web3ErrorBanner.tsx
+++ b/packages/web/src/components/banner/Web3ErrorBanner.tsx
@@ -15,7 +15,7 @@ const messages = {
 }
 
 const META_MASK_SETUP_URL =
-  'https://medium.com/@audius/configuring-metamask-for-use-with-audius-91e24bf6840'
+  'https://help.audius.co/help/configuring-metamask-for-use-with-audius-2d446'
 
 /**
  * Displays an error banner if the user is trying to use Metamask but it's configured incorrectly

--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -755,7 +755,6 @@ const BodyContainer = memo(
     dimensionsAreDirty,
     didSetDimensions
   }: BodyContainerProps) => {
-    console.log('hmm', elements, activeIndex)
     // Get a ref to the element to use for calculating height
     const {
       containerWidth,

--- a/packages/web/src/pages/sign-on/SignOnProvider.tsx
+++ b/packages/web/src/pages/sign-on/SignOnProvider.tsx
@@ -61,7 +61,7 @@ const messages = {
 }
 
 const META_MASK_SETUP_URL =
-  'https://support.audius.co/help/Configuring-MetaMask-For-Use-With-Audius'
+  'https://help.audius.co/help/configuring-metamask-for-use-with-audius-2d446'
 
 type OwnProps = {
   children: ComponentType<MobileSignOnProps> | ComponentType<DesktopSignOnProps>

--- a/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
+++ b/packages/web/src/pages/sign-on/components/desktop/SignOnPage.tsx
@@ -143,10 +143,6 @@ const animatedStyle = {
   }
 }
 
-/**
- * TODO: When the user selects the metamask option, set the localStorage key 'useMetaMask' to true
- * Reference the setup function in Audius backend. A new instance of Audiusbackend will have to be created
- */
 const SignOnPage = ({
   title,
   description,


### PR DESCRIPTION
### Description

Drop `useMetaMask` local storage item when account fetch fails on web.
Address issue where a user may accidentally get halfway through the MetaMask flow, bail out, and then brick themselves from future sign up attempts.

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

1. Start MetaMask sign up flow
2. Verify useMetaMask set in local storage
3. Exit sign up, refresh, watch it get removed
