### PR TITLE
Fix infinite scrolling cards C-2979

### DIFF
--- a/packages/web/src/hooks/useTabs/TabStyles.module.css
+++ b/packages/web/src/hooks/useTabs/TabStyles.module.css
@@ -103,11 +103,6 @@
   overflow: hidden;
 }
 
-.clippedOverflow {
-  overflow-x: hidden;
-  overflow-y: hidden;
-}
-
 .elementWrapper {
   display: flex;
 }

--- a/packages/web/src/hooks/useTabs/useTabs.tsx
+++ b/packages/web/src/hooks/useTabs/useTabs.tsx
@@ -839,7 +839,6 @@ const BodyContainer = memo(
         className={cn(
           styles.bodyContainer,
           styles.bodyContainerDesktop,
-          styles.clippedOverflow,
           containerClassName
         )}
         ref={containerCallbackRef}

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.module.css
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.module.css
@@ -79,6 +79,7 @@
 /* Albums */
 .cardsContainer {
   gap: var(--unit-6) var(--unit-4);
+  margin-bottom: var(--unit-4);
 }
 
 .playButtonContainer {


### PR DESCRIPTION
### Description
Before: Infinite scroll was flaky on desktop card screens (e.g. Favorites playlists tab page). Sometimes it would clip off at the bottom if you scrolled too fast, and the scroll threshold was not working at all (everything would just load in one after the other without any scrolling).

After: Works as expected.

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

