### PR TITLE
Fix useAllPaginated query C-2980

### DIFF
--- a/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
+++ b/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { isEqual } from 'lodash'
 import { useCustomCompareEffect } from 'react-use'
 
-import { Status } from 'models/Status'
+import { Status, statusIsNotFinalized } from 'models/Status'
 
 import { QueryHookOptions, QueryHookResults } from '../types'
 
@@ -55,6 +55,7 @@ export const useAllPaginatedQuery = <
   baseArgs: Omit<ArgsType, 'limit' | 'offset'>,
   options: { pageSize: number } & QueryHookOptions
 ) => {
+  const [loadingMore, setLoadingMore] = useState(false)
   const { pageSize, ...queryHookOptions } = options
   const [page, setPage] = useState(0)
   const [allData, setAllData] = useState<Data[]>([])
@@ -64,28 +65,52 @@ export const useAllPaginatedQuery = <
     offset: page * pageSize
   } as ArgsType
   const result = useQueryHook(args, queryHookOptions)
-  useEffect(() => {
-    if (result.status !== Status.SUCCESS) return
-    setAllData((allData) => [...allData, ...result.data])
-  }, [result.status, result.data])
 
   useCustomCompareEffect(
     () => {
       setAllData([])
+      setLoadingMore(false)
     },
     [baseArgs],
-    isEqual
+    (prevDeps, nextDeps) => {
+      return isEqual(prevDeps, nextDeps)
+    }
   )
+
+  useCustomCompareEffect(
+    () => {
+      if (!statusIsNotFinalized(result.status)) {
+        setLoadingMore(false)
+      }
+      if (result.status !== Status.SUCCESS) return
+      setAllData((allData) => [...allData, ...result.data])
+    },
+    [result.status, args],
+    (prevDeps, nextDeps) => {
+      return isEqual(prevDeps, nextDeps)
+    }
+  )
+
+  const hasMore =
+    result.status !== Status.ERROR &&
+    ((result.status === Status.IDLE && allData.length === 0) ||
+      (!result.data && result.status !== Status.SUCCESS) ||
+      result.data?.length === pageSize)
+
+  const loadMore = useCallback(() => {
+    if (loadingMore) {
+      return
+    }
+    setLoadingMore(true)
+    setPage(page + 1)
+  }, [loadingMore, page])
 
   return {
     ...result,
     // TODO: add another status for reloading
     status: allData?.length > 0 ? Status.SUCCESS : result.status,
     data: allData,
-    loadMore: () => setPage(page + 1),
-    hasMore:
-      result.status === Status.IDLE ||
-      (!result.data && result.status === Status.LOADING) ||
-      result.data?.length === pageSize
+    loadMore,
+    hasMore
   }
 }

--- a/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
+++ b/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
@@ -72,9 +72,7 @@ export const useAllPaginatedQuery = <
       setLoadingMore(false)
     },
     [baseArgs],
-    (prevDeps, nextDeps) => {
-      return isEqual(prevDeps, nextDeps)
-    }
+    isEqual
   )
 
   useCustomCompareEffect(
@@ -86,9 +84,7 @@ export const useAllPaginatedQuery = <
       setAllData((allData) => [...allData, ...result.data])
     },
     [result.status, args],
-    (prevDeps, nextDeps) => {
-      return isEqual(prevDeps, nextDeps)
-    }
+    isEqual
   )
 
   const hasMore =

--- a/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
+++ b/packages/common/src/audius-query/hooks/usePaginatedQuery.ts
@@ -87,11 +87,13 @@ export const useAllPaginatedQuery = <
     isEqual
   )
 
+  const notError = result.status !== Status.ERROR
+  const notStarted = result.status === Status.IDLE && allData.length === 0
+  const hasNotFetched = !result.data && result.status !== Status.SUCCESS
+  const fetchedFullPreviousPage = result.data?.length === pageSize
+
   const hasMore =
-    result.status !== Status.ERROR &&
-    ((result.status === Status.IDLE && allData.length === 0) ||
-      (!result.data && result.status !== Status.SUCCESS) ||
-      result.data?.length === pageSize)
+    notError && (notStarted || hasNotFetched || fetchedFullPreviousPage)
 
   const loadMore = useCallback(() => {
     if (loadingMore) {


### PR DESCRIPTION
### Description
Fixes a few issues with useAllPaginated

-Data would load in repeatedly + infinitely due to repeated `loadMore` calls
-Data would not load in at all after it was reset (e.g. due to a baseArgs change)

### Dragons

*Is there anything the reviewer should be on the lookout for? Are there any dangerous changes?*

### How Has This Been Tested?

*Please describe the tests that you ran to verify your changes. Provide repro instructions & any configuration.*

### How will this change be monitored?

*For features that are critical or could fail silently please describe the monitoring/alerting being added.*

### Feature Flags ###

*Are all new features properly feature flagged? Describe added feature flags.*

