### PR TITLE
Use does_current_user_subscribe API field

### DIFF
--- a/packages/common/src/models/User.ts
+++ b/packages/common/src/models/User.ts
@@ -18,6 +18,7 @@ export type UserMetadata = {
   creator_node_endpoint: Nullable<string>
   current_user_followee_follow_count: number
   does_current_user_follow: boolean
+  does_current_user_subscribe?: boolean
   followee_count: number
   follower_count: number
   supporter_count: number

--- a/packages/common/src/services/audius-api-client/types.ts
+++ b/packages/common/src/services/audius-api-client/types.ts
@@ -47,6 +47,7 @@ export type APIUser = {
   creator_node_endpoint: Nullable<string>
   current_user_followee_follow_count: number
   does_current_user_follow: boolean
+  does_current_user_subscribe?: boolean
   handle_lc: string
   updated_at: string
   cover_photo_sizes: Nullable<CID>
@@ -73,6 +74,7 @@ export type APISearchUser = Omit<
   | 'track_count'
   | 'current_user_followee_follow_count'
   | 'does_current_user_follow'
+  | 'does_current_user_subscribe'
 >
 
 export type APIRepost = {

--- a/packages/web/src/common/store/profile/sagas.js
+++ b/packages/web/src/common/store/profile/sagas.js
@@ -327,10 +327,13 @@ function* fetchProfileAsync(action) {
     yield fork(fetchSolanaCollectibles, user)
 
     // Get current user notification & subscription status
-    const isSubscribed = yield call(
-      audiusBackendInstance.getUserSubscribed,
-      user.user_id
-    )
+    // TODO(michelle) simply use user.does_current_user_subscribe after all DNs
+    // are running >v0.4.6
+    const isSubscribed =
+      'does_current_user_subscribe' in user
+        ? user.does_current_user_subscribe
+        : yield call(audiusBackendInstance.getUserSubscribed, user.user_id)
+
     yield put(
       profileActions.setNotificationSubscription(
         user.user_id,

--- a/packages/web/src/common/store/social/users/sagas.ts
+++ b/packages/web/src/common/store/social/users/sagas.ts
@@ -273,6 +273,17 @@ export function* subscribeToUserAsync(userId: ID) {
     return
   }
 
+  yield* put(
+    cacheActions.update(Kind.USERS, [
+      {
+        id: userId,
+        metadata: {
+          does_current_user_subscribe: true
+        }
+      }
+    ])
+  )
+
   yield* call(confirmSubscribeToUser, userId, accountId)
 }
 
@@ -306,6 +317,16 @@ export function* confirmSubscribeToUser(userId: ID, accountId: ID) {
             timeout ? 'Timeout' : message
           )
         )
+        yield* put(
+          cacheActions.update(Kind.USERS, [
+            {
+              id: userId,
+              metadata: {
+                does_current_user_subscribe: false
+              }
+            }
+          ])
+        )
       }
     )
   )
@@ -319,6 +340,16 @@ export function* unsubscribeFromUserAsync(userId: ID) {
     return
   }
 
+  yield* put(
+    cacheActions.update(Kind.USERS, [
+      {
+        id: userId,
+        metadata: {
+          does_current_user_subscribe: false
+        }
+      }
+    ])
+  )
   yield* call(confirmUnsubscribeFromUser, userId, accountId)
 }
 
@@ -351,6 +382,16 @@ export function* confirmUnsubscribeFromUser(userId: ID, accountId: ID) {
             userId,
             timeout ? 'Timeout' : message
           )
+        )
+        yield* put(
+          cacheActions.update(Kind.USERS, [
+            {
+              id: userId,
+              metadata: {
+                does_current_user_subscribe: true
+              }
+            }
+          ])
         )
       }
     )


### PR DESCRIPTION
### Description
Discovery v0 API returns a `does_current_user_subscribe` field now, just like it has `does_current_user_follow`. Use this to render the subscribe button on prof pages rather than issuing a separate network req.

### How Has This Been Tested?
pointed client to stage, verified via debugger the API field was being used. subscribed/unsubscribed + navigated away and back to verify caching 

### Screenshots

