### PR TITLE
[C-3006][C-3005] Fix tag field wrapping

### DIFF
--- a/packages/web/src/components/data-entry/DropdownInput.js
+++ b/packages/web/src/components/data-entry/DropdownInput.js
@@ -148,7 +148,8 @@ class DropdownInput extends Component {
             placeholder={
               <div className={styles.placeholder}>{placeholder}</div>
             }
-            showArrow={false}
+            showArrow={true}
+            suffixIcon={<IconCaretDown className={styles.arrow} />}
             defaultActiveFirstOption={false}
             optionFilterProp='children'
             onSelect={this.onSelect}
@@ -162,7 +163,6 @@ class DropdownInput extends Component {
           >
             {options}
           </Select>
-          <IconCaretDown className={styles.arrow} />
         </div>
         {helperText ? (
           <HelperText error={error}>{helperText}</HelperText>

--- a/packages/web/src/components/data-entry/DropdownInput.module.css
+++ b/packages/web/src/components/data-entry/DropdownInput.module.css
@@ -145,10 +145,7 @@
 }
 
 .arrow {
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  transform: translateY(-50%);
+  margin-right: 4px;
   height: 6px;
   width: 10px;
   cursor: pointer;

--- a/packages/web/src/components/form-fields/ArtworkField.module.css
+++ b/packages/web/src/components/form-fields/ArtworkField.module.css
@@ -1,0 +1,4 @@
+.uploadArtwork {
+  width: 218px;
+  height: 218px;
+}

--- a/packages/web/src/components/form-fields/ArtworkField.tsx
+++ b/packages/web/src/components/form-fields/ArtworkField.tsx
@@ -9,6 +9,8 @@ import UploadArtwork, {
 } from 'components/upload/UploadArtwork'
 import { resizeImage } from 'utils/imageProcessingUtil'
 
+import styles from './ArtworkField.module.css'
+
 type ArtworkFieldProps = Partial<UploadArtworkProps> & {
   name: string
 }
@@ -39,6 +41,7 @@ export const ArtworkField = (props: ArtworkFieldProps) => {
   return (
     <div>
       <UploadArtwork
+        className={styles.uploadArtwork}
         {...otherField}
         artworkUrl={value?.url}
         onDropArtwork={handleDropArtwork}

--- a/packages/web/src/components/layout/layout.module.css
+++ b/packages/web/src/components/layout/layout.module.css
@@ -27,3 +27,7 @@
 .gap6 {
   gap: var(--unit-6);
 }
+
+.gapAuto {
+  justify-content: space-between;
+}

--- a/packages/web/src/pages/upload-page/UploadPageNew.tsx
+++ b/packages/web/src/pages/upload-page/UploadPageNew.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import {
   UploadType,

--- a/packages/web/src/pages/upload-page/fields/TrackMetadataFields.module.css
+++ b/packages/web/src/pages/upload-page/fields/TrackMetadataFields.module.css
@@ -1,39 +1,8 @@
-.basic {
-  display: flex;
-  flex-wrap: wrap;
+.metadataFields {
+  flex-grow: 1;
+  height: 100%;
 }
 
-.artwork {
-  margin-right: var(--unit-6);
-  padding-bottom: var(--unit-4);
-}
-
-.fields {
-  flex: 1 auto;
-  min-width: 335px;
-}
-
-.fields > div {
-  margin-bottom: var(--unit-4);
-}
-
-.fields > div.description > .textArea > textarea {
-  min-height: 90px;
-}
-
-.fields > div.description {
-  margin-bottom: var(--unit-4);
-}
-
-.categorization {
-  display: flex;
-  align-items: flex-start;
-}
-
-.categorization > div {
-  flex: 1 auto;
-}
-
-.categorization > div:first-child {
-  margin-right: var(--unit-2);
+.topRow {
+  height: 218px;
 }

--- a/packages/web/src/pages/upload-page/fields/TrackMetadataFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/TrackMetadataFields.tsx
@@ -1,6 +1,8 @@
+import cn from 'classnames'
 import { useField } from 'formik'
 
 import { ArtworkField, TagField, TextAreaField } from 'components/form-fields'
+import layoutStyles from 'components/layout/layout.module.css'
 
 import { getTrackFieldName } from '../hooks'
 
@@ -17,30 +19,34 @@ export const TrackMetadataFields = () => {
   const [{ value: index }] = useField('trackMetadatasIndex')
 
   return (
-    <div className={styles.basic}>
-      <div className={styles.artwork}>
+    <div className={cn(layoutStyles.col, layoutStyles.gap4)}>
+      <div className={cn(styles.topRow, layoutStyles.row, layoutStyles.gap4)}>
         <ArtworkField name={getTrackFieldName(index, 'artwork')} />
-      </div>
-      <div className={styles.fields}>
-        <div className={styles.trackName}>
+        <div
+          className={cn(
+            styles.metadataFields,
+            layoutStyles.col,
+            layoutStyles.gapAuto
+          )}
+        >
           <TrackNameField name={getTrackFieldName(index, 'title')} />
+          <div className={cn(layoutStyles.row, layoutStyles.gap2)}>
+            <SelectGenreField name={getTrackFieldName(index, 'genre')} />
+            <SelectMoodField name={getTrackFieldName(index, 'mood')} />
+          </div>
+          <div className={styles.tags}>
+            <TagField name={getTrackFieldName(index, 'tags')} />
+          </div>
         </div>
-        <div className={styles.categorization}>
-          <SelectGenreField name={getTrackFieldName(index, 'genre')} />
-          <SelectMoodField name={getTrackFieldName(index, 'mood')} />
-        </div>
-        <div className={styles.tags}>
-          <TagField name={getTrackFieldName(index, 'tags')} />
-        </div>
-        <div className={styles.description}>
-          <TextAreaField
-            name={getTrackFieldName(index, 'description')}
-            className={styles.textArea}
-            placeholder={messages.description}
-            maxLength={1000}
-            showMaxLength
-          />
-        </div>
+      </div>
+      <div className={styles.description}>
+        <TextAreaField
+          name={getTrackFieldName(index, 'description')}
+          className={styles.textArea}
+          placeholder={messages.description}
+          maxLength={1000}
+          showMaxLength
+        />
       </div>
     </div>
   )

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.module.css
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.module.css
@@ -2,8 +2,6 @@
   width: 100%;
   background-color: var(--white);
 
-  display: flex;
-  flex-direction: column;
   border-radius: 8px;
   box-shadow: var(--shadow-far);
 }

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -113,9 +113,15 @@ const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
   return (
     <Form>
       <div className={cn(layoutStyles.row, layoutStyles.gap2)}>
-        <div className={styles.formContainer}>
+        <div className={cn(styles.formContainer, layoutStyles.col)}>
           {isMultiTrack ? <MultiTrackHeader /> : null}
-          <div className={styles.trackEditForm}>
+          <div
+            className={cn(
+              styles.trackEditForm,
+              layoutStyles.col,
+              layoutStyles.gap4
+            )}
+          >
             <TrackMetadataFields />
             <div className={cn(layoutStyles.col, layoutStyles.gap4)}>
               <ReleaseDateField />


### PR DESCRIPTION
### Description

- Fix tag field wrapping
- Move description below art
- Make dropdown arrows clickable

_Note:_
The metadata inputs are currently 50px height but should be 60px to match designs. Currently, this results in too much gap between the fields.

### How Has This Been Tested?
Local web

### Screenshots

![image](https://github.com/AudiusProject/audius-client/assets/2358254/518d1b1e-534c-4a7a-9a2b-1673b818d429)

