### PR TITLE
Fix Share to IG/T/S sticker consistency [C-3009]

### DIFF
--- a/packages/mobile/src/components/action-drawer/ActionDrawer.tsx
+++ b/packages/mobile/src/components/action-drawer/ActionDrawer.tsx
@@ -25,6 +25,7 @@ type ActionSheetModalProps = {
   title?: string
   renderTitle?: () => React.ReactNode
   styles?: { row?: ViewStyle }
+  disableAutoClose?: boolean
 }
 
 const useStyles = makeStyles(({ palette, typography, spacing }) => ({
@@ -57,19 +58,28 @@ const useStyles = makeStyles(({ palette, typography, spacing }) => ({
 
 // `ActionDrawer` is a drawer that presents a list of clickable rows with text
 const ActionDrawer = (props: ActionSheetModalProps) => {
-  const { modalName, rows, title, renderTitle, styles: stylesProp } = props
+  const {
+    modalName,
+    rows,
+    title,
+    renderTitle,
+    styles: stylesProp,
+    disableAutoClose
+  } = props
   const styles = useStyles()
   const { onClose } = useDrawerState(modalName)
 
   const didSelectRow = useCallback(
     (index: number) => {
       const { callback } = rows[index]
-      onClose()
+      if (!disableAutoClose) {
+        onClose()
+      }
       if (callback) {
         callback()
       }
     },
-    [rows, onClose]
+    [rows, onClose, disableAutoClose]
   )
 
   const { neutralLight9 } = useThemeColors()

--- a/packages/mobile/src/components/drawer/Drawer.tsx
+++ b/packages/mobile/src/components/drawer/Drawer.tsx
@@ -618,7 +618,7 @@ export const Drawer: DrawerComponent = ({
     return (
       <View
         pointerEvents={isOpen ? undefined : 'none'}
-        style={styles.backgroundRoot}
+        style={[styles.backgroundRoot, { zIndex }]}
       >
         <TouchableWithoutFeedback
           onPress={isGestureSupported ? onClose : undefined}

--- a/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
+++ b/packages/mobile/src/components/share-drawer/ShareDrawer.tsx
@@ -32,6 +32,7 @@ import { useThemeColors } from 'app/utils/theme'
 
 import ActionDrawer from '../action-drawer'
 import { Text } from '../core'
+import { useDrawerState } from '../drawer/AppDrawer'
 
 import { ShareToStorySticker } from './ShareToStorySticker'
 import { messages } from './messages'
@@ -91,6 +92,7 @@ export const ShareDrawer = () => {
   const { isEnabled: isShareSoundToTikTokEnabled } = useFeatureFlag(
     FeatureFlags.SHARE_SOUND_TO_TIKTOK
   )
+  const { onClose } = useDrawerState('Share')
 
   const { secondary, neutralLight2 } = useThemeColors()
   const dispatch = useDispatch()
@@ -180,23 +182,33 @@ export const ShareDrawer = () => {
     isShareSoundToTikTokEnabled && isOwner && isShareableTrack
   )
 
+  const performActionAndClose = useCallback(
+    (action: () => void) => {
+      return () => {
+        action()
+        onClose()
+      }
+    },
+    [onClose]
+  )
+
   const getRows = useCallback(() => {
     const shareToChatAction = {
       icon: <IconMessage fill={secondary} height={26} width={26} />,
       text: messages.directMessage,
-      callback: handleShareToDirectMessage
+      callback: performActionAndClose(handleShareToDirectMessage)
     }
 
     const shareToTwitterAction = {
       icon: <IconTwitterBird fill={secondary} height={20} width={26} />,
       text: messages.twitter,
-      callback: handleShareToTwitter
+      callback: performActionAndClose(handleShareToTwitter)
     }
 
     const shareSoundToTiktokAction = {
       text: messages.tikTokSound,
       icon: <TikTokIcon height={26} width={26} />,
-      callback: handleShareSoundToTikTok
+      callback: performActionAndClose(handleShareSoundToTikTok)
     }
 
     const shareVideoToTiktokAction = {
@@ -208,13 +220,13 @@ export const ShareDrawer = () => {
     const copyLinkAction = {
       text: messages.copyLink,
       icon: <IconLink height={26} width={26} fill={secondary} />,
-      callback: handleCopyLink
+      callback: performActionAndClose(handleCopyLink)
     }
 
     const shareSheetAction = {
       text: messages.shareSheet,
       icon: <IconShare height={26} width={26} fill={secondary} />,
-      callback: handleOpenShareSheet
+      callback: performActionAndClose(handleOpenShareSheet)
     }
 
     const shareToSnapchatAction = {
@@ -250,17 +262,18 @@ export const ShareDrawer = () => {
 
     return result
   }, [
+    secondary,
+    performActionAndClose,
+    handleShareToDirectMessage,
     handleShareToTwitter,
     handleShareSoundToTikTok,
-    secondary,
+    handleShareVideoToTiktok,
     handleCopyLink,
     handleOpenShareSheet,
     handleShareToSnapchat,
     handleShareToInstagramStory,
     shouldIncludeTikTokSoundAction,
-    isShareableTrack,
-    handleShareVideoToTiktok,
-    handleShareToDirectMessage
+    isShareableTrack
   ])
 
   return (
@@ -281,6 +294,7 @@ export const ShareDrawer = () => {
         </ViewShot>
       ) : null}
       <ActionDrawer
+        disableAutoClose={true}
         modalName='Share'
         rows={getRows()}
         renderTitle={() => (

--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -293,19 +293,14 @@ export const useShareToStory = ({
         toggleProgressDrawer(true, platform)
         dispatch(setProgress(10))
 
-        // Step 1/2: Render and take a screenshot of the sticker, calculate the dominant colors of the cover art:
+        // Step 1: Render and take a screenshot of the sticker
         let stickerUri: string | undefined
+
+        // Step 2: Calculate the dominant colors of the cover art:
         let rawDominantColorsResult: Color[] | string | undefined // `getDominantRgb` returns a string containing a single default color if it couldn't find dominant colors
-        let dominantColorHex1: string
-        let dominantColorHex2: string
-        if (trackImageUri) {
-          try {
-            rawDominantColorsResult = await getDominantRgb(trackImageUri)
-          } catch (e) {}
-        } else {
-          ;[dominantColorHex1, dominantColorHex2] = DEFAULT_DOMINANT_COLORS
-        }
+
         try {
+          // Execute Steps 1 and 2 concurrently:
           ;[rawDominantColorsResult, stickerUri] = await Promise.all([
             trackImageUri
               ? getDominantRgb(trackImageUri)
@@ -338,8 +333,8 @@ export const useShareToStory = ({
                 (c: Color) => convertRGBToHex(c)
               )
             : DEFAULT_DOMINANT_COLORS
-        dominantColorHex1 = finalDominantColorsResult[0]
-        dominantColorHex2 = finalDominantColorsResult[1]
+        const dominantColorHex1 = finalDominantColorsResult[0]
+        const dominantColorHex2 = finalDominantColorsResult[1]
 
         if (cancelRef.current) {
           cleanup()
@@ -603,7 +598,11 @@ export const ShareToStoryProgressDrawer = () => {
   }
 
   return (
-    <NativeDrawer drawerName='ShareToStoryProgress' onClose={handleCancel}>
+    <NativeDrawer
+      zIndex={10}
+      drawerName='ShareToStoryProgress'
+      onClose={handleCancel}
+    >
       <View style={styles.container}>
         <View style={styles.title}>
           <IconWavform

--- a/packages/mobile/src/components/share-drawer/useShareToStory.tsx
+++ b/packages/mobile/src/components/share-drawer/useShareToStory.tsx
@@ -21,7 +21,7 @@ import { FFmpegKit, FFmpegKitConfig, ReturnCode } from 'ffmpeg-kit-react-native'
 import { Platform, View } from 'react-native'
 import Config from 'react-native-config'
 import RNFS from 'react-native-fs'
-import { check, request, PERMISSIONS, RESULTS } from 'react-native-permissions'
+import { check, PERMISSIONS, request, RESULTS } from 'react-native-permissions'
 import Share from 'react-native-share'
 import {
   init as initTikTokShare,
@@ -291,30 +291,36 @@ export const useShareToStory = ({
         activateKeepAwake()
         dispatch(setCancel(() => cancelStory(platform)))
         toggleProgressDrawer(true, platform)
+        dispatch(setProgress(10))
 
-        // Step 1: Render and take a screenshot of the sticker:
-        // Note: We have to capture the sticker image first because it doesn't work if you get the dominant colors first (mysterious).
-        const encodedTrackId = encodeHashId(content.track.track_id)
-        const streamMp3Url = apiClient.makeUrl(
-          `/tracks/${encodedTrackId}/stream`
-        )
-        const storyVideoPath = path.join(
-          RNFS.TemporaryDirectoryPath,
-          `storyVideo-${uuid()}.mp4`
-        )
-        const audioStartOffsetConfig =
-          content.track.duration && content.track.duration >= 20
-            ? '-ss 10 '
-            : ''
-
+        // Step 1/2: Render and take a screenshot of the sticker, calculate the dominant colors of the cover art:
         let stickerUri: string | undefined
-
+        let rawDominantColorsResult: Color[] | string | undefined // `getDominantRgb` returns a string containing a single default color if it couldn't find dominant colors
+        let dominantColorHex1: string
+        let dominantColorHex2: string
+        if (trackImageUri) {
+          try {
+            rawDominantColorsResult = await getDominantRgb(trackImageUri)
+          } catch (e) {}
+        } else {
+          ;[dominantColorHex1, dominantColorHex2] = DEFAULT_DOMINANT_COLORS
+        }
         try {
-          stickerUri = await captureStickerImage()
+          ;[rawDominantColorsResult, stickerUri] = await Promise.all([
+            trackImageUri
+              ? getDominantRgb(trackImageUri)
+              : Promise.resolve(undefined),
+            captureStickerImage()
+          ])
         } catch (e) {
-          handleError(platform, e, 'Error at generate sticker step')
+          handleError(
+            platform,
+            e,
+            'Error at generate sticker + dominant colors step'
+          )
           return
         }
+
         if (!stickerUri) {
           handleError(
             platform,
@@ -323,30 +329,18 @@ export const useShareToStory = ({
           )
           return
         }
-        dispatch(setProgress(10))
-        // Step 2: Calculate the dominant colors of the cover art
-        let rawDominantColorsResult: Color[] | string // `getDominantRgb` returns a string containing a single default color if it couldn't find dominant colors
-        let dominantColorHex1: string
-        let dominantColorHex2: string
-        if (trackImageUri) {
-          try {
-            rawDominantColorsResult = await getDominantRgb(trackImageUri)
-          } catch (e) {
-            handleError(platform, e, 'Error at calculate dominant colors step')
-            return
-          }
-          const finalDominantColorsResult =
-            Array.isArray(rawDominantColorsResult) &&
-            rawDominantColorsResult.length > 0
-              ? pickTwoMostDominantAndVibrant(rawDominantColorsResult).map(
-                  (c: Color) => convertRGBToHex(c)
-                )
-              : DEFAULT_DOMINANT_COLORS
-          dominantColorHex1 = finalDominantColorsResult[0]
-          dominantColorHex2 = finalDominantColorsResult[1]
-        } else {
-          ;[dominantColorHex1, dominantColorHex2] = DEFAULT_DOMINANT_COLORS
-        }
+
+        const finalDominantColorsResult =
+          rawDominantColorsResult &&
+          Array.isArray(rawDominantColorsResult) &&
+          rawDominantColorsResult.length > 0
+            ? pickTwoMostDominantAndVibrant(rawDominantColorsResult).map(
+                (c: Color) => convertRGBToHex(c)
+              )
+            : DEFAULT_DOMINANT_COLORS
+        dominantColorHex1 = finalDominantColorsResult[0]
+        dominantColorHex2 = finalDominantColorsResult[1]
+
         if (cancelRef.current) {
           cleanup()
           return
@@ -361,6 +355,19 @@ export const useShareToStory = ({
         }
         // For simplicity, assume that calculating dominant colors and generating the sticker takes 20% of the total loading time:
         dispatch(setProgress(20))
+
+        const encodedTrackId = encodeHashId(content.track.track_id)
+        const streamMp3Url = apiClient.makeUrl(
+          `/tracks/${encodedTrackId}/stream`
+        )
+        const storyVideoPath = path.join(
+          RNFS.TemporaryDirectoryPath,
+          `storyVideo-${uuid()}.mp4`
+        )
+        const audioStartOffsetConfig =
+          content.track.duration && content.track.duration >= 20
+            ? '-ss 10 '
+            : ''
 
         // Step 3: Generate the background video using FFmpeg
         FFmpegKitConfig.enableStatisticsCallback((statistics) => {


### PR DESCRIPTION
### Description
Bug: share to X sticker (square with track/artist info) would not show up sometimes

This was a doozy

- Keep Share Drawer open while story being generated
  - Since the share drawer would close right after the button was clicked, the sticker component would occasionally unmount  before the capture was taken 
  -  Note: I tried to move the sticker component out to both the App level and the on progress drawer, but this did not work after hours of trying for various reasons 💀. Can try again another time - I think the drawer thing is an OK solution for now. 

- Fixing this issue now allows us to compute dominant colors and take the screenshot concurrently for perf win

### How Has This Been Tested?
On Android device

### Screenshots

https://github.com/AudiusProject/audius-client/assets/36916764/bef2bfe1-7fe0-4724-8cfd-0bfe2ce9b01d


