### PR TITLE
[C-2997] Disable delete on the last collection upload track

### DIFF
--- a/packages/web/src/pages/upload-page/fields/CollectionTrackField.tsx
+++ b/packages/web/src/pages/upload-page/fields/CollectionTrackField.tsx
@@ -32,10 +32,11 @@ const messages = {
 type CollectionTrackFieldProps = {
   index: number
   remove: (index: number) => void
+  disableDelete: boolean
 }
 
 export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
-  const { index, remove } = props
+  const { disableDelete = false, index, remove } = props
   const [{ value: track }] = useField<CollectionTrackForUpload>(
     `tracks.${index}`
   )
@@ -94,6 +95,7 @@ export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
             iconLeft={IconPlay}
           />
           <HarmonyButton
+            disabled={disableDelete}
             variant={HarmonyButtonType.GHOST}
             size={HarmonyButtonSize.SMALL}
             text={messages.delete}

--- a/packages/web/src/pages/upload-page/fields/CollectionTrackFieldArray.tsx
+++ b/packages/web/src/pages/upload-page/fields/CollectionTrackFieldArray.tsx
@@ -34,7 +34,11 @@ export const CollectionTrackFieldArray = () => {
                         {...provided.draggableProps}
                         {...provided.dragHandleProps}
                       >
-                        <CollectionTrackField index={index} remove={remove} />
+                        <CollectionTrackField
+                          index={index}
+                          remove={remove}
+                          disableDelete={tracks.length === 1}
+                        />
                       </div>
                     )}
                   </Draggable>


### PR DESCRIPTION
### Description
Disable the delete button on the last remaining track in new collection upload flow

### How Has This Been Tested?
Manually Tested

### Screenshots

<img width="1210" alt="Screenshot 2023-08-28 at 4 15 33 PM" src="https://github.com/AudiusProject/audius-client/assets/23732287/4a0ed1bf-b58f-448b-af9f-e5310d4c5d87">
