### PR TITLE
Fix jupiter Buffer is not defined

### DIFF
--- a/packages/web/src/services/audius-backend/Jupiter.ts
+++ b/packages/web/src/services/audius-backend/Jupiter.ts
@@ -4,8 +4,7 @@ import {
   convertJSBIToAmountObject
 } from '@audius/common'
 import { TransactionHandler } from '@audius/sdk/dist/core'
-import type { Jupiter as JupiterInstance } from '@jup-ag/core'
-import { SwapMode } from '@jup-ag/core'
+import type { Jupiter as JupiterInstance, SwapMode } from '@jup-ag/core'
 import { Cluster, Connection, PublicKey, Transaction } from '@solana/web3.js'
 import JSBI from 'jsbi'
 
@@ -58,7 +57,7 @@ const getQuote = async ({
   inputAmount,
   forceFetch,
   slippage,
-  swapMode = SwapMode.ExactIn,
+  swapMode = 'ExactIn' as SwapMode,
   onlyDirectRoutes = false
 }: {
   inputTokenSymbol: JupiterTokenSymbol

--- a/packages/web/src/services/audius-backend/Jupiter.ts
+++ b/packages/web/src/services/audius-backend/Jupiter.ts
@@ -76,7 +76,7 @@ const getQuote = async ({
     )
   }
   const amount =
-    swapMode === SwapMode.ExactIn
+    swapMode === 'ExactIn'
       ? JSBI.BigInt(Math.ceil(inputAmount * 10 ** inputToken.decimals))
       : JSBI.BigInt(Math.floor(inputAmount * 10 ** outputToken.decimals))
   const jup = await getInstance()

--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -1,4 +1,4 @@
-import { SwapMode } from '@jup-ag/core'
+import type { SwapMode } from '@jup-ag/core'
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
   Token,
@@ -56,7 +56,7 @@ export const getSwapUSDCUserBankInstructions = async (
     outputTokenSymbol: 'SOL',
     inputAmount: feeAmount,
     slippage: USDC_SLIPPAGE,
-    swapMode: SwapMode.ExactOut,
+    swapMode: 'ExactOut' as SwapMode,
     onlyDirectRoutes: true
   })
   const usdcNeededAmount = quoteRoute.inputAmount


### PR DESCRIPTION
### Description
Importing Jupiter in the new workspaces setup throws a `Buffer is not defined` error at runtime. This seems to be bc Jupiter expects global `Buffer` to exist when it is imported, but bc of the workspaces change, Buffer doesn't exist until `index.tsx` is run. 

We really only need the string value of the enum so we can avoid importing Jupiter for now. The real fix will be to make webpack ProvidePlugin properly put Buffer into the global namespace 


### How Has This Been Tested?


### Screenshots

