### PR TITLE
[PAY-1590] Hook up content previews for USDC content

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -1034,6 +1034,7 @@ export enum PlaybackSource {
 type PlaybackPlay = {
   eventName: Name.PLAYBACK_PLAY
   id?: string
+  isPreview?: boolean
   source: PlaybackSource
 }
 type PlaybackPause = {

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -200,7 +200,8 @@ export type TrackMetadata = {
     category: StemCategory
   }
   remix_of: Nullable<RemixOf>
-  preview_start_seconds?: number
+  preview_cid?: Nullable<CID>
+  preview_start_seconds?: Nullable<number>
 
   // Added fields
   dateListened?: string

--- a/packages/common/src/store/lineup/actions.ts
+++ b/packages/common/src/store/lineup/actions.ts
@@ -164,10 +164,11 @@ export class LineupActions {
     }
   }
 
-  play(uid?: UID) {
+  play(uid?: UID, { isPreview = false }: { isPreview?: boolean } = {}) {
     return {
       type: addPrefix(this.prefix, PLAY),
-      uid
+      uid,
+      isPreview
     }
   }
 

--- a/packages/common/src/store/player/selectors.ts
+++ b/packages/common/src/store/player/selectors.ts
@@ -11,6 +11,7 @@ export const getTrackId = (state: CommonState) => state.player.trackId
 export const getCollectible = (state: CommonState) => state.player.collectible
 
 export const getPlaying = (state: CommonState) => state.player.playing
+export const getPreviewing = (state: CommonState) => state.player.previewing
 export const getPaused = (state: CommonState) => !state.player.playing
 export const getCounter = (state: CommonState) => state.player.counter
 export const getBuffering = (state: CommonState) => state.player.buffering

--- a/packages/common/src/store/player/slice.ts
+++ b/packages/common/src/store/player/slice.ts
@@ -16,6 +16,9 @@ export type PlayerState = {
   // object to allow components to subscribe to changes.
   playing: boolean
 
+  // Indicates that current playback session is a track preview
+  previewing: boolean
+
   // Keep 'buffering' in the store separately from the audio
   // object to allow components to subscribe to changes.
   buffering: boolean
@@ -42,6 +45,7 @@ export const initialState: PlayerState = {
   collectible: null,
 
   playing: false,
+  previewing: false,
   buffering: false,
   counter: 0,
   playbackRate: '1x',
@@ -52,10 +56,12 @@ export const initialState: PlayerState = {
 type PlayPayload = Maybe<{
   uid?: Nullable<UID>
   trackId?: ID
+  isPreview?: boolean
   onEnd?: (...args: any) => any
 }>
 
 type PlaySucceededPayload = {
+  isPreview?: boolean
   uid?: Nullable<UID>
   trackId?: ID
 }
@@ -122,6 +128,7 @@ const slice = createSlice({
       state.trackId = trackId || state.trackId
       state.collectible = null
       state.counter = state.counter + 1
+      state.previewing = !!action.payload.isPreview
     },
     playCollectible: (
       _state,

--- a/packages/common/src/store/queue/slice.ts
+++ b/packages/common/src/store/queue/slice.ts
@@ -48,6 +48,7 @@ export const initialState: State = {
 
 type PlayPayload = {
   uid?: Nullable<UID>
+  isPreview?: boolean
   trackId?: Nullable<ID>
   collectible?: Collectible
   source?: Nullable<string>

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -66,11 +66,12 @@ const { getIsReachable } = reachabilitySelectors
 const PLAYER_SUBSCRIBER_NAME = 'PLAYER'
 const RECORD_LISTEN_SECONDS = 1
 const RECORD_LISTEN_INTERVAL = 1000
+const PREVIEW_LENGTH_SECONDS = 15
 
 export function* watchPlay() {
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')
   yield* takeLatest(play.type, function* (action: ReturnType<typeof play>) {
-    const { uid, trackId, onEnd } = action.payload ?? {}
+    const { uid, trackId, isPreview, onEnd } = action.payload ?? {}
 
     const audioPlayer = yield* getContext('audioPlayer')
     const isNativeMobile = yield getContext('isNativeMobile')
@@ -113,6 +114,19 @@ export function* watchPlay() {
         audiusBackendInstance,
         premiumContentSignature
       })
+
+      let trackDuration = track.duration
+
+      if (isPreview) {
+        // Add preview query string and calculate preview duration for use later
+        const previewStartSeconds = track.preview_start_seconds || 0
+        queryParams.preview = true
+        trackDuration = Math.min(
+          track.duration - previewStartSeconds,
+          PREVIEW_LENGTH_SECONDS
+        )
+      }
+
       const mp3Url = apiClient.makeUrl(
         `/tracks/${encodedTrackId}/stream`,
         queryParams
@@ -124,7 +138,7 @@ export function* watchPlay() {
       const currentUserId = yield* select(getUserId)
       const endChannel = eventChannel((emitter) => {
         audioPlayer.load(
-          track.duration ||
+          trackDuration ||
             track.track_segments.reduce(
               (duration, segment) => duration + parseFloat(segment.duration),
               0
@@ -182,7 +196,7 @@ export function* watchPlay() {
             )
           } else {
             audioPlayer.play()
-            yield* put(playSucceeded({ uid, trackId }))
+            yield* put(playSucceeded({ uid, trackId, isPreview }))
             yield* put(seek({ seconds: trackPlaybackInfo.playbackPosition }))
             return
           }
@@ -196,9 +210,9 @@ export function* watchPlay() {
     // Play if user has access to track.
     const track = yield* select(getTrack, { id: trackId })
     const doesUserHaveAccess = yield* call(doesUserHaveTrackAccess, track)
-    if (doesUserHaveAccess) {
+    if (doesUserHaveAccess || isPreview) {
       audioPlayer.play()
-      yield* put(playSucceeded({ uid, trackId }))
+      yield* put(playSucceeded({ uid, trackId, isPreview }))
     } else {
       yield* put(queueActions.next({}))
     }

--- a/packages/web/src/common/store/player/sagas.ts
+++ b/packages/web/src/common/store/player/sagas.ts
@@ -66,7 +66,7 @@ const { getIsReachable } = reachabilitySelectors
 const PLAYER_SUBSCRIBER_NAME = 'PLAYER'
 const RECORD_LISTEN_SECONDS = 1
 const RECORD_LISTEN_INTERVAL = 1000
-const PREVIEW_LENGTH_SECONDS = 15
+const PREVIEW_LENGTH_SECONDS = 30
 
 export function* watchPlay() {
   const getFeatureEnabled = yield* getContext('getFeatureEnabled')

--- a/packages/web/src/components/track/GiantTrackTile.tsx
+++ b/packages/web/src/components/track/GiantTrackTile.tsx
@@ -105,11 +105,13 @@ export type GiantTrackTileProps = {
   onMakePublic: (trackId: ID) => void
   onFollow: () => void
   onPlay: () => void
+  onPreview: () => void
   onRepost: () => void
   onSave: () => void
   onShare: () => void
   onUnfollow: () => void
   playing: boolean
+  previewing: boolean
   premiumConditions: Nullable<PremiumConditions>
   released: string
   repostCount: number
@@ -150,6 +152,7 @@ export const GiantTrackTile = ({
   onFollow,
   onMakePublic,
   onPlay,
+  onPreview,
   onSave,
   onShare,
   onRepost,
@@ -158,6 +161,7 @@ export const GiantTrackTile = ({
   repostCount,
   saveCount,
   playing,
+  previewing,
   premiumConditions,
   tags,
   trackId,
@@ -182,11 +186,6 @@ export const GiantTrackTile = ({
   const showPreview = isUSDCPurchaseGated && (isOwner || !doesUserHaveAccess)
   // Play button is conditionally hidden for USDC-gated tracks when the user does not have access
   const showPlay = isUSDCPurchaseGated ? doesUserHaveAccess : true
-
-  // TODO: https://linear.app/audius/issue/PAY-1590/[webmobileweb]-add-support-for-playing-previews
-  const onPreview = useCallback(() => {
-    console.info('Preview Clicked')
-  }, [])
 
   const renderCardTitle = (className: string) => {
     return (
@@ -531,14 +530,14 @@ export const GiantTrackTile = ({
             {showPlay ? (
               <PlayPauseButton
                 disabled={!doesUserHaveAccess}
-                playing={playing}
+                playing={playing && !previewing}
                 onPlay={onPlay}
                 trackId={trackId}
               />
             ) : null}
             {showPreview ? (
               <PlayPauseButton
-                playing={playing}
+                playing={playing && previewing}
                 onPlay={onPreview}
                 trackId={trackId}
                 isPreview

--- a/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
+++ b/packages/web/src/components/track/desktop/ConnectedTrackTile.tsx
@@ -148,6 +148,7 @@ const ConnectedTrackTile = ({
   const isTrackPlaying = isActive && isPlaying
   const isOwner = handle === userHandle
   const isArtistPick = showArtistPick && artist_pick_track_id === trackId
+  const hasPreview = !!track?.preview_cid
 
   const { isUserAccessTBD, doesUserHaveAccess } =
     usePremiumContentAccess(trackWithFallback)
@@ -187,7 +188,7 @@ const ConnectedTrackTile = ({
       showSkeleton: loading,
       callback: () => setArtworkLoaded(true),
       label: `${title} by ${name}`,
-      doesUserHaveAccess
+      doesUserHaveAccess: doesUserHaveAccess || hasPreview
     }
     return <TrackArtwork {...artworkProps} />
   }
@@ -317,7 +318,7 @@ const ConnectedTrackTile = ({
 
       // Show the locked content modal if gated track and user does not have access.
       // Also skip toggle play in this case.
-      if (trackId && !doesUserHaveAccess) {
+      if (trackId && !doesUserHaveAccess && !hasPreview) {
         dispatch(setLockedContentId({ id: trackId }))
         setLockedContentVisibility(true)
         return
@@ -327,6 +328,7 @@ const ConnectedTrackTile = ({
     },
     [
       togglePlay,
+      hasPreview,
       uid,
       trackId,
       doesUserHaveAccess,

--- a/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/desktop/TrackPage.tsx
@@ -41,9 +41,16 @@ export type OwnProps = {
   hasValidRemixParent: boolean
   user: User | null
   heroPlaying: boolean
+  previewing: boolean
   userId: ID | null
   badge: string | null
-  onHeroPlay: (isPlaying: boolean) => void
+  onHeroPlay: ({
+    isPlaying,
+    isPreview
+  }: {
+    isPlaying: boolean
+    isPreview?: boolean
+  }) => void
   goToAllRemixesPage: () => void
   goToParentRemixesPage: () => void
   onHeroShare: (trackId: ID) => void
@@ -75,6 +82,7 @@ const TrackPage = ({
   heroTrack,
   user,
   heroPlaying,
+  previewing,
   userId,
   badge,
   onHeroPlay,
@@ -108,7 +116,10 @@ const TrackPage = ({
     usePremiumContentAccess(heroTrack)
   const loading = !heroTrack || isUserAccessTBD
 
-  const onPlay = () => onHeroPlay(heroPlaying)
+  const onPlay = () => onHeroPlay({ isPlaying: heroPlaying })
+  const onPreview = () =>
+    onHeroPlay({ isPlaying: heroPlaying, isPreview: true })
+
   const onSave = isOwner
     ? () => {}
     : () => heroTrack && onSaveTrack(isSaved, heroTrack.track_id)
@@ -122,6 +133,7 @@ const TrackPage = ({
     <GiantTrackTile
       loading={loading}
       playing={heroPlaying}
+      previewing={previewing}
       trackTitle={defaults.title}
       trackId={defaults.trackId}
       aiAttributionUserId={defaults.aiAttributionUserId}
@@ -158,6 +170,7 @@ const TrackPage = ({
       coSign={defaults.coSign}
       // Actions
       onPlay={onPlay}
+      onPreview={onPreview}
       onShare={onShare}
       onRepost={onRepost}
       onSave={onSave}

--- a/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackHeader.tsx
@@ -99,6 +99,7 @@ const PreviewButton = ({ playing, onPlay }: PlayButtonProps) => {
 type TrackHeaderProps = {
   isLoading: boolean
   isPlaying: boolean
+  isPreviewing: boolean
   isOwner: boolean
   isSaved: boolean
   isReposted: boolean
@@ -130,6 +131,7 @@ type TrackHeaderProps = {
     overflowActions: OverflowAction[]
   ) => void
   onPlay: () => void
+  onPreview: () => void
   onShare: () => void
   onSave: () => void
   onRepost: () => void
@@ -150,6 +152,7 @@ const TrackHeader = ({
   duration,
   isLoading,
   isPlaying,
+  isPreviewing,
   isSaved,
   isReposted,
   isUnlisted,
@@ -168,6 +171,7 @@ const TrackHeader = ({
   tags,
   aiAttributedUserId,
   onPlay,
+  onPreview,
   onShare,
   onSave,
   onRepost,
@@ -186,9 +190,6 @@ const TrackHeader = ({
   const showPlay = isUSDCPurchaseGated ? doesUserHaveAccess : true
   const showListenCount =
     isOwner || (!isPremium && (isUnlisted || fieldVisibility.play_count))
-
-  // TODO: https://linear.app/audius/issue/PAY-1590/[webmobileweb]-add-support-for-playing-previews
-  const onPreview = useCallback(() => console.info('Preview Clicked'), [])
 
   const image = useTrackCoverArt(
     trackId,
@@ -389,7 +390,7 @@ const TrackHeader = ({
       {showPlay ? (
         <PlayButton
           disabled={!doesUserHaveAccess}
-          playing={isPlaying}
+          playing={isPlaying && !isPreviewing}
           onPlay={onPlay}
         />
       ) : null}
@@ -407,7 +408,7 @@ const TrackHeader = ({
         />
       ) : null}
       {showPreview ? (
-        <PreviewButton playing={isPlaying} onPlay={onPreview} />
+        <PreviewButton playing={isPlaying && isPreviewing} onPlay={onPreview} />
       ) : null}
       <ActionButtonRow
         showRepost={showSocials}

--- a/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
+++ b/packages/web/src/pages/track-page/components/mobile/TrackPage.tsx
@@ -44,8 +44,15 @@ export type OwnProps = {
   heroTrack: Track | null
   user: User | null
   heroPlaying: boolean
+  previewing: boolean
   userId: ID | null
-  onHeroPlay: (isPlaying: boolean) => void
+  onHeroPlay: ({
+    isPlaying,
+    isPreview
+  }: {
+    isPlaying: boolean
+    isPreview?: boolean
+  }) => void
   onHeroShare: (trackId: ID) => void
   goToAllRemixesPage: () => void
   goToParentRemixesPage: () => void
@@ -78,6 +85,7 @@ const TrackPage = ({
   heroTrack,
   user,
   heroPlaying,
+  previewing,
   userId,
   onHeroPlay,
   onHeroShare,
@@ -120,7 +128,9 @@ const TrackPage = ({
     usePremiumContentAccess(heroTrack)
   const loading = !heroTrack || isUserAccessTBD
 
-  const onPlay = () => onHeroPlay(heroPlaying)
+  const onPlay = () => onHeroPlay({ isPlaying: heroPlaying })
+  const onPreview = () =>
+    onHeroPlay({ isPlaying: heroPlaying, isPreview: true })
   const onSave = isOwner
     ? () => {}
     : () => heroTrack && onSaveTrack(isSaved, heroTrack.track_id)
@@ -156,6 +166,7 @@ const TrackPage = ({
         <TrackPageHeader
           isLoading={loading}
           isPlaying={heroPlaying}
+          isPreviewing={previewing}
           isReposted={isReposted}
           isFollowing={isFollowing}
           title={defaults.title}
@@ -179,6 +190,7 @@ const TrackPage = ({
           // Actions (Wire up once we add backend integrations)
           onClickMobileOverflow={onClickMobileOverflow}
           onPlay={onPlay}
+          onPreview={onPreview}
           onSave={onSave}
           onShare={onShare}
           onRepost={onRepost}


### PR DESCRIPTION
### Description
This PR hooks up track previews for web and mobile web.

I added logic to the player saga to detect attempts to play tracks to which the user does not have access, switching to a preview instead if its available. This can be overridden by passing a boolean flag to the action. The previewing state is stored in the slice for retrieval later, which is helpful for determining the source of playback (full access of preview). I opted _not_ to use a new UID for this as it felt like it would have gotten quite complicated attempting to combine multiple sources (previewing from a lineup vs playing the same track from a lineup?). 

The TrackPageProvider is the only place that uses the boolean override, since we need to allow the track owner to preview the track.

The track page also makes use of the previewing state flag to determine which button shows "pause" when we're playing a preview. And we also make use of the previewing flag in the queue saga to force a reset if you switch from preview to full access.

### How Has This Been Tested?
Tested locally in Chrome (desktop and mobile web emulation)

### Screenshots

Playing Preview for non-owner

https://github.com/AudiusProject/audius-client/assets/1815175/95cd5ebb-ee1a-408c-ac49-ace4555dc211

---

Playing Preview for non-owner from lineups

https://github.com/AudiusProject/audius-client/assets/1815175/7a87bf0f-2c56-4bf7-85f8-0ffbc928b1e1

---

Playing preview for owner

https://github.com/AudiusProject/audius-client/assets/1815175/03f844f8-0252-46ae-8112-1c515376d139

