### PR TITLE
Improve sentry-cli usage in CI

### DIFF
--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -58,9 +58,6 @@ mobile-prepare-ios:
     - run:
         name: update bundler
         command: sudo gem install bundler:1.17.3
-    - run:
-        name: copy sentry-cli
-        command: cp packages/mobile/node_modules/@sentry/cli/bin/sentry-cli packages/mobile/ios
     - restore_cache:
         key: 1-gems-{{ checksum "packages/mobile/ios/Gemfile.lock" }}
     - run: cd packages/mobile/ios && (bundle check || bundle install --path vendor/bundle)

--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -58,6 +58,9 @@ mobile-prepare-ios:
     - run:
         name: update bundler
         command: sudo gem install bundler:1.17.3
+    - run:
+        name: copy sentry-cli
+        command: cp node_modules/@sentry/cli/bin/sentry-cli packages/mobile/ios
     - restore_cache:
         key: 1-gems-{{ checksum "packages/mobile/ios/Gemfile.lock" }}
     - run: cd packages/mobile/ios && (bundle check || bundle install --path vendor/bundle)

--- a/.circleci/src/commands/@mobile-commands.yml
+++ b/.circleci/src/commands/@mobile-commands.yml
@@ -60,7 +60,7 @@ mobile-prepare-ios:
         command: sudo gem install bundler:1.17.3
     - run:
         name: copy sentry-cli
-        command: cp node_modules/@sentry/cli/bin/sentry-cli packages/mobile/ios
+        command: cp packages/mobile/node_modules/@sentry/cli/bin/sentry-cli packages/mobile/ios
     - restore_cache:
         key: 1-gems-{{ checksum "packages/mobile/ios/Gemfile.lock" }}
     - run: cd packages/mobile/ios && (bundle check || bundle install --path vendor/bundle)

--- a/packages/mobile/ios/scripts/bundleReactNative.sh
+++ b/packages/mobile/ios/scripts/bundleReactNative.sh
@@ -3,5 +3,4 @@ export SENTRY_PROPERTIES=sentry.properties
 export EXTRA_PACKAGER_ARGS=\"--sourcemap-output $DERIVED_FILE_DIR/main.jsbundle.map\" 
 export PROJECT_ROOT=$PWD/.. 
  
-cp ../node_modules/@sentry/cli/bin/sentry-cli .
 sentry-cli react-native xcode ../../../node_modules/react-native/scripts/react-native-xcode.sh 

--- a/packages/mobile/ios/scripts/uploadSentryDebugSymbols.sh
+++ b/packages/mobile/ios/scripts/uploadSentryDebugSymbols.sh
@@ -1,5 +1,4 @@
 export NODE_BINARY=node
 export SENTRY_PROPERTIES=sentry.properties
 
-cp ../node_modules/@sentry/cli/bin/sentry-cli .
 sentry-cli upload-dsym


### PR DESCRIPTION
### Description

This will fix the stray sentry-cli file that's appearing in our working directory. Copying sentry was necessary when it was at the root but after the sentry update it's no longer hoisted


### How Has This Been Tested?


### Screenshots

