### PR TITLE
Fix TextField input spacing

### DIFF
--- a/packages/mobile/src/components/core/TextInput.tsx
+++ b/packages/mobile/src/components/core/TextInput.tsx
@@ -81,9 +81,7 @@ const useStyles = makeStyles(({ typography, palette, spacing }) => ({
     color: palette.neutralLight7
   },
   startAdornment: {},
-  endAdornment: {
-    alignSelf: 'flex-end'
-  },
+  endAdornment: {},
   inputAccessory: {
     flexDirection: 'row',
     justifyContent: 'flex-end'

--- a/packages/mobile/src/components/fields/TextField.tsx
+++ b/packages/mobile/src/components/fields/TextField.tsx
@@ -1,6 +1,6 @@
 import { useField } from 'formik'
 import { capitalize } from 'lodash'
-import { View } from 'react-native'
+import { Platform, View } from 'react-native'
 
 import type { TextInputProps } from 'app/components/core'
 import { TextInput, InputErrorMessage } from 'app/components/core'
@@ -18,7 +18,9 @@ const useStyles = makeStyles(({ spacing, typography }) => ({
   label: { marginBottom: spacing(2) },
   input: {
     fontSize: typography.fontSize.large,
-    fontFamily: typography.fontByWeight.demiBold
+    fontFamily: typography.fontByWeight.demiBold,
+    lineHeight:
+      Platform.OS === 'ios' ? typography.fontSize.xl : typography.fontSize.large
   },
   labelText: {
     fontSize: typography.fontSize.large,
@@ -33,6 +35,7 @@ export const TextField = (props: TextFieldProps) => {
     label: labelProp,
     required,
     errorMessage: errorMessageProp,
+    style,
     styles: stylesProp,
     ...other
   } = props
@@ -44,7 +47,7 @@ export const TextField = (props: TextFieldProps) => {
     errorMessageProp || (error ? `${capitalize(name)} ${error}` : undefined)
 
   return (
-    <View style={styles.root}>
+    <View style={[styles.root, style]}>
       <TextInput
         label={label}
         styles={{


### PR DESCRIPTION
### Description

Fixes issue where "demiBold" fontFamily leads to input text settling too high in it's container. this issue only exists on ios

### Screenshots

Before: 

<img width="403" alt="image" src="https://github.com/AudiusProject/audius-client/assets/8230000/0c1073de-26c0-48a2-941a-93b11f7efc4b">


After:
<img width="403" alt="image" src="https://github.com/AudiusProject/audius-client/assets/8230000/251e587d-7fd4-4db2-a446-1372ae427709">

