### PR TITLE
Revert premium_conditions empty object change

### DIFF
--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -97,7 +97,6 @@ export type PremiumConditionsUSDCPurchase = {
 }
 
 export type PremiumConditions =
-  | {}
   | PremiumConditionsCollectibleGated
   | PremiumConditionsFollowGated
   | PremiumConditionsTipGated

--- a/packages/web/src/components/data-entry/AccessAndSaleModalLegacy.tsx
+++ b/packages/web/src/components/data-entry/AccessAndSaleModalLegacy.tsx
@@ -142,7 +142,7 @@ export const AccessAndSaleModalLegacy = (
       case TrackAvailabilityType.PUBLIC: {
         newState.is_premium = false
         newState.unlisted = false
-        newState.premium_conditions = {}
+        newState.premium_conditions = null
         break
       }
       case TrackAvailabilityType.USDC_PURCHASE: {
@@ -169,7 +169,7 @@ export const AccessAndSaleModalLegacy = (
       newState = {
         ...newState,
         ...(get(values, FIELD_VISIBILITY) ?? undefined),
-        premium_conditions: {},
+        premium_conditions: null,
         unlisted: true
       }
     } else {

--- a/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
+++ b/packages/web/src/pages/upload-page/fields/AccessAndSaleField.tsx
@@ -519,10 +519,10 @@ export const AccessAndSaleMenuFields = (props: AccesAndSaleMenuFieldsProps) => {
             isPremiumContentCollectibleGated(premiumConditionsValue)
           )
             break
-          setPremiumConditionsValue({})
+          setPremiumConditionsValue(null)
           break
         case TrackAvailabilityType.HIDDEN:
-          setPremiumConditionsValue({})
+          setPremiumConditionsValue(null)
           if (!fieldVisibilityValue) break
           setfieldVisibilityValue({
             ...fieldVisibilityValue,


### PR DESCRIPTION
### Description

Revert change to use `{}` instead of `null` for empty `premium_conditions`

### How Has This Been Tested?
local web

