### PR TITLE
[C-3022] Fix broken multi-track index after deleting

### DIFF
--- a/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
+++ b/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { MouseEvent, useCallback } from 'react'
 
 import { imageBlank as placeholderArt } from '@audius/common'
 import {
@@ -102,19 +102,20 @@ const TrackRow = (props: TrackRowProps) => {
   const isSelected = index === selectedIndex
 
   const handleRemoveTrack = useCallback(
-    (index: number) => {
+    (e: MouseEvent<HTMLDivElement>, index: number) => {
+      e.stopPropagation()
       const newTrackMetadatas = [...values.trackMetadatas]
-      newTrackMetadatas.splice(index, 1)
       const newTracks = [...values.tracks]
+      newTrackMetadatas.splice(index, 1)
       newTracks.splice(index, 1)
       const newIndex =
         selectedIndex === index ? Math.max(index - 1, 0) : selectedIndex
       setValues({
         ...values,
-        trackMetadatas: newTrackMetadatas
-        // trackMetadatasIndex: newIndex
+        tracks: newTracks,
+        trackMetadatas: newTrackMetadatas,
+        trackMetadatasIndex: newIndex
       })
-      setIndex(newIndex)
     },
     [selectedIndex, setValues, values]
   )
@@ -170,11 +171,11 @@ const TrackRow = (props: TrackRowProps) => {
             </Text>
           </div>
           {values.trackMetadatas.length > 1 ? (
-            <div className={styles.iconRemove}>
-              <IconTrash
-                fill='--default'
-                onClick={() => handleRemoveTrack(index)}
-              />
+            <div
+              className={styles.iconRemove}
+              onClick={(e) => handleRemoveTrack(e, index)}
+            >
+              <IconTrash fill='--default' />
             </div>
           ) : null}
         </div>

--- a/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
+++ b/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
@@ -105,12 +105,16 @@ const TrackRow = (props: TrackRowProps) => {
     (index: number) => {
       const newTrackMetadatas = [...values.trackMetadatas]
       newTrackMetadatas.splice(index, 1)
-      const newIndex = selectedIndex === index ? Math.max(index - 1, 0) : index
+      const newTracks = [...values.tracks]
+      newTracks.splice(index, 1)
+      const newIndex =
+        selectedIndex === index ? Math.max(index - 1, 0) : selectedIndex
       setValues({
         ...values,
-        trackMetadatas: newTrackMetadatas,
-        trackMetadatasIndex: newIndex
+        trackMetadatas: newTrackMetadatas
+        // trackMetadatasIndex: newIndex
       })
+      setIndex(newIndex)
     },
     [selectedIndex, setValues, values]
   )


### PR DESCRIPTION
### Description

#### The problem:
When deleting a track other than the selected track, the form got into a bad state where the selected index could be the deleted track. This was happening because the onClick for the row to select the track as active was also being activated when clicking the delete icon.

#### The fix:
Stop propagation on the onClick for remove track so we don't also set the selected index to the track to be deleted.

#### Also:
- removes the deleted track from the tracks list
- fix bug in selected index calculation after deletion

### How Has This Been Tested?
local web
