### PR TITLE
[C-3014] Add prompt on leaving upload form in progress

### DIFF
--- a/packages/web/src/components/navigation-prompt/NavigationPrompt.module.css
+++ b/packages/web/src/components/navigation-prompt/NavigationPrompt.module.css
@@ -1,0 +1,11 @@
+.title {
+  align-self: center;
+}
+
+.body {
+  text-align: center;
+}
+
+.button {
+  flex-grow: 1;
+}

--- a/packages/web/src/components/navigation-prompt/NavigationPrompt.tsx
+++ b/packages/web/src/components/navigation-prompt/NavigationPrompt.tsx
@@ -1,11 +1,21 @@
 import React, { useEffect, useState } from 'react'
 
-import { Modal, ModalContent, ModalHeader, ModalTitle } from '@audius/stems'
+import {
+  HarmonyButton,
+  HarmonyButtonType,
+  Modal,
+  ModalContent,
+  ModalHeader
+} from '@audius/stems'
+import cn from 'classnames'
 import { Location } from 'history'
 import { Prompt } from 'react-router-dom'
 
-import ConfirmationBox from 'components/confirmation-box/ConfirmationBox'
+import layoutStyles from 'components/layout/layout.module.css'
+import { Text } from 'components/typography'
 import { useNavigateToPage } from 'hooks/useNavigateToPage'
+
+import styles from './NavigationPrompt.module.css'
 
 interface Props {
   when?: boolean | undefined
@@ -21,7 +31,7 @@ interface Props {
 /**
  * Adapted from https://gist.github.com/michchan/0b142324b2a924a108a689066ad17038#file-routeleavingguard-function-ts-ca839f5faf39-tsx
  */
-const RouteLeavingGuard = (props: Props) => {
+export const NavigationPrompt = (props: Props) => {
   const { when, shouldBlockNavigation, messages } = props
   const [modalVisible, setModalVisible] = useState(false)
   const [lastLocation, setLastLocation] = useState<Location | null>(null)
@@ -32,10 +42,11 @@ const RouteLeavingGuard = (props: Props) => {
     setModalVisible(false)
   }
 
+  // Returning false blocks navigation; true allows it
   const handleBlockedNavigation = (nextLocation: Location): boolean => {
     if (
       !confirmedNavigation &&
-      (!shouldBlockNavigation || shouldBlockNavigation?.(nextLocation))
+      (!shouldBlockNavigation || shouldBlockNavigation(nextLocation))
     ) {
       setModalVisible(true)
       setLastLocation(nextLocation)
@@ -61,19 +72,38 @@ const RouteLeavingGuard = (props: Props) => {
       <Prompt when={when} message={handleBlockedNavigation} />
       <Modal isOpen={modalVisible} onClose={closeModal} size='small'>
         <ModalHeader>
-          <ModalTitle title={messages.title} />
+          <Text
+            className={styles.title}
+            size='xLarge'
+            variant='label'
+            strength='strong'
+            color='neutralLight2'
+          >
+            {messages.title}
+          </Text>
         </ModalHeader>
         <ModalContent>
-          <ConfirmationBox
-            text={messages.body}
-            leftText={messages.cancel}
-            rightText={messages.proceed}
-            leftClick={closeModal}
-            rightClick={handleConfirmNavigationClick}
-          />
+          <div className={cn(layoutStyles.col, layoutStyles.gap6)}>
+            <Text className={styles.body} size='large'>
+              {messages.body}
+            </Text>
+            <div className={cn(layoutStyles.row, layoutStyles.gap2)}>
+              <HarmonyButton
+                className={styles.button}
+                text={messages.cancel}
+                variant={HarmonyButtonType.SECONDARY}
+                onClick={closeModal}
+              />
+              <HarmonyButton
+                className={styles.button}
+                text={messages.proceed}
+                variant={HarmonyButtonType.DESTRUCTIVE}
+                onClick={handleConfirmNavigationClick}
+              />
+            </div>
+          </div>
         </ModalContent>
       </Modal>
     </>
   )
 }
-export default RouteLeavingGuard

--- a/packages/web/src/components/navigation-prompt/NavigationPrompt.tsx
+++ b/packages/web/src/components/navigation-prompt/NavigationPrompt.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react'
+
+import { Modal, ModalContent, ModalHeader, ModalTitle } from '@audius/stems'
+import { Location } from 'history'
+import { Prompt } from 'react-router-dom'
+
+import ConfirmationBox from 'components/confirmation-box/ConfirmationBox'
+import { useNavigateToPage } from 'hooks/useNavigateToPage'
+
+interface Props {
+  when?: boolean | undefined
+  shouldBlockNavigation?: (location: Location) => boolean
+  messages: {
+    title: string
+    body: string
+    cancel: string
+    proceed: string
+  }
+}
+
+/**
+ * Adapted from https://gist.github.com/michchan/0b142324b2a924a108a689066ad17038#file-routeleavingguard-function-ts-ca839f5faf39-tsx
+ */
+const RouteLeavingGuard = (props: Props) => {
+  const { when, shouldBlockNavigation, messages } = props
+  const [modalVisible, setModalVisible] = useState(false)
+  const [lastLocation, setLastLocation] = useState<Location | null>(null)
+  const [confirmedNavigation, setConfirmedNavigation] = useState(false)
+  const navigate = useNavigateToPage()
+
+  const closeModal = () => {
+    setModalVisible(false)
+  }
+
+  const handleBlockedNavigation = (nextLocation: Location): boolean => {
+    if (
+      !confirmedNavigation &&
+      (!shouldBlockNavigation || shouldBlockNavigation?.(nextLocation))
+    ) {
+      setModalVisible(true)
+      setLastLocation(nextLocation)
+      return false
+    }
+    return true
+  }
+
+  const handleConfirmNavigationClick = () => {
+    setModalVisible(false)
+    setConfirmedNavigation(true)
+  }
+
+  useEffect(() => {
+    if (confirmedNavigation && lastLocation) {
+      // Navigate to the previous blocked location with your navigate function
+      navigate(lastLocation.pathname)
+    }
+  }, [confirmedNavigation, lastLocation, navigate])
+
+  return (
+    <>
+      <Prompt when={when} message={handleBlockedNavigation} />
+      <Modal isOpen={modalVisible} onClose={closeModal} size='small'>
+        <ModalHeader>
+          <ModalTitle title={messages.title} />
+        </ModalHeader>
+        <ModalContent>
+          <ConfirmationBox
+            text={messages.body}
+            leftText={messages.cancel}
+            rightText={messages.proceed}
+            leftClick={closeModal}
+            rightClick={handleConfirmNavigationClick}
+          />
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}
+export default RouteLeavingGuard

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -15,7 +15,7 @@ import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { ReactComponent as IconCaretLeft } from 'assets/img/iconCaretLeft.svg'
 import layoutStyles from 'components/layout/layout.module.css'
-import NavigationPrompt from 'components/navigation-prompt/NavigationPrompt'
+import { NavigationPrompt } from 'components/navigation-prompt/NavigationPrompt'
 import { Text } from 'components/typography'
 import PreviewButton from 'components/upload/PreviewButton'
 

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -10,12 +10,12 @@ import {
 import cn from 'classnames'
 import { Form, Formik, FormikProps, useField } from 'formik'
 import moment from 'moment'
-import { Prompt } from 'react-router-dom'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
 import { ReactComponent as IconCaretLeft } from 'assets/img/iconCaretLeft.svg'
 import layoutStyles from 'components/layout/layout.module.css'
+import NavigationPrompt from 'components/navigation-prompt/NavigationPrompt'
 import { Text } from 'components/typography'
 import PreviewButton from 'components/upload/PreviewButton'
 
@@ -36,12 +36,16 @@ const messages = {
   titleError: 'Your track must have a name.',
   artworkError: 'Artwork is required.',
   genreError: 'Genre is required.',
-  navigationWarning:
-    'You have unsaved changes. Do you want to leave this page?',
   multiTrackCount: (index: number, total: number) =>
     `TRACK ${index} of ${total}`,
   prev: 'Prev',
-  next: 'Next Track'
+  next: 'Next Track',
+  navigationPrompt: {
+    title: 'Discard upload?',
+    body: "Are you sure you want to leave this page?\nAny changes you've made will be lost.",
+    cancel: 'Cancel',
+    proceed: 'Discard'
+  }
 }
 
 type EditTrackFormProps = {
@@ -115,7 +119,7 @@ const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
 
   return (
     <Form>
-      <Prompt message={messages.navigationWarning} when={dirty} />
+      <NavigationPrompt when={dirty} messages={messages.navigationPrompt} />
       <div className={cn(layoutStyles.row, layoutStyles.gap2)}>
         <div className={cn(styles.formContainer, layoutStyles.col)}>
           {isMultiTrack ? <MultiTrackHeader /> : null}

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -10,6 +10,7 @@ import {
 import cn from 'classnames'
 import { Form, Formik, FormikProps, useField } from 'formik'
 import moment from 'moment'
+import { Prompt } from 'react-router-dom'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
@@ -35,6 +36,8 @@ const messages = {
   titleError: 'Your track must have a name.',
   artworkError: 'Artwork is required.',
   genreError: 'Genre is required.',
+  navigationWarning:
+    'You have unsaved changes. Do you want to leave this page?',
   multiTrackCount: (index: number, total: number) =>
     `TRACK ${index} of ${total}`,
   prev: 'Prev',
@@ -107,11 +110,12 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
 }
 
 const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
-  const { values } = props
+  const { values, dirty } = props
   const isMultiTrack = values.trackMetadatas.length > 1
 
   return (
     <Form>
+      <Prompt message={messages.navigationWarning} when={dirty} />
       <div className={cn(layoutStyles.row, layoutStyles.gap2)}>
         <div className={cn(styles.formContainer, layoutStyles.col)}>
           {isMultiTrack ? <MultiTrackHeader /> : null}


### PR DESCRIPTION
### Description
Adds a warning before navigating away if the form has any changed values.
Does not trigger on form submission or on the screen's back button.

*Note: Currently, this only blocks navigation within the app. Refreshing the page or navigating away via the address bar does not trip the condition.*

### Screenshots
![Screenshot 2023-09-01 at 3 24 50 PM](https://github.com/AudiusProject/audius-client/assets/2358254/3328c316-ae3d-4c56-bce5-6471c9e7b694)
