### PR TITLE
[C-3028] make the usdc inputs white

### DIFF
--- a/packages/web/src/components/data-entry/InputV2.tsx
+++ b/packages/web/src/components/data-entry/InputV2.tsx
@@ -28,6 +28,7 @@ export type InputV2Props = Omit<ComponentPropsWithoutRef<'input'>, 'size'> & {
     | RefCallback<HTMLInputElement>
   warning?: boolean
   error?: boolean
+  inputRootClassName?: string
   inputClassName?: string
   label?: string
   helperText?: string
@@ -40,6 +41,7 @@ export const InputV2 = (props: InputV2Props) => {
     required,
     label: labelProp,
     className,
+    inputRootClassName,
     maxLength,
     showMaxLength,
     size = InputV2Size.MEDIUM,
@@ -119,7 +121,7 @@ export const InputV2 = (props: InputV2Props) => {
 
   return (
     <div className={cn(styles.root, className)}>
-      <div className={cn(styles.inputRoot, style)}>
+      <div className={cn(styles.inputRoot, inputRootClassName, style)}>
         {elevatePlaceholder ? (
           <label className={styles.elevatedLabel}>
             <span

--- a/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.module.css
+++ b/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.module.css
@@ -7,5 +7,5 @@
 }
 
 .inputRoot {
-  background: var(--background-white)
+  background: var(--background-white);
 }

--- a/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.module.css
+++ b/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.module.css
@@ -5,3 +5,7 @@
   border: 1px solid var(--border-strong);
   background: var(--background-surface-1);
 }
+
+.input > div:first-child {
+  background: var(--background-white)
+}

--- a/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.module.css
+++ b/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.module.css
@@ -6,6 +6,6 @@
   background: var(--background-surface-1);
 }
 
-.input > div:first-child {
+.inputRoot {
   background: var(--background-white)
 }

--- a/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.tsx
@@ -155,7 +155,7 @@ const BoxedTextField = (props: BoxedTextFieldProps) => {
         <Text variant='title'>{title}</Text>
         <Text>{description}</Text>
       </div>
-      <TextField className={styles.input} {...inputProps} />
+      <TextField inputRootClassName={styles.inputRoot} {...inputProps} />
     </div>
   )
 }

--- a/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.tsx
+++ b/packages/web/src/pages/upload-page/fields/availability/UsdcPurchaseFields.tsx
@@ -155,7 +155,7 @@ const BoxedTextField = (props: BoxedTextFieldProps) => {
         <Text variant='title'>{title}</Text>
         <Text>{description}</Text>
       </div>
-      <TextField {...inputProps} />
+      <TextField className={styles.input} {...inputProps} />
     </div>
   )
 }


### PR DESCRIPTION
### Description

Make the inputs white so they don't look disabled

### Screenshots

![image](https://github.com/AudiusProject/audius-client/assets/2358254/5d179c85-e83e-432d-b721-9945327bd201)
