### PR TITLE
[PAY-1776] Fix playing check for track page

### DIFF
--- a/packages/web/src/pages/track-page/TrackPageProvider.tsx
+++ b/packages/web/src/pages/track-page/TrackPageProvider.tsx
@@ -244,7 +244,7 @@ class TrackPageProvider extends Component<
 
   onHeroPlay = ({
     isPlaying,
-    isPreview
+    isPreview = false
   }: {
     isPlaying: boolean
     isPreview?: boolean


### PR DESCRIPTION
### Description
We're using the preview boolean to determine which button was clicked on the track details page, but it wasn't being default initialized, so we were comparing `undefined === false`. 

### How Has This Been Tested?
Chrome on desktop

### Screenshots
N/A
