### PR TITLE
[C-3017] Reset the new upload flow state when the upload button in the side nav is clicked

### DIFF
--- a/packages/common/src/store/upload/selectors.ts
+++ b/packages/common/src/store/upload/selectors.ts
@@ -6,6 +6,7 @@ export const getUploadProgress = (state: CommonState) =>
 export const getUploadSuccess = (state: CommonState) => state.upload.success
 export const getTracks = (state: CommonState) => state.upload.tracks
 export const getIsUploading = (state: CommonState) => state.upload.uploading
+export const getShouldReset = (state: CommonState) => state.upload.shouldReset
 
 export const getUploadPercentage = (state: CommonState) => {
   const uploadProgress = getUploadProgress(state)


### PR DESCRIPTION
### Description
Add a new selector for shouldReset and add effect in the new upload flow to listen for it and reset the state

### How Has This Been Tested?
Manually tested

### Screenshots
[reset upload flow image here]
