### PR TITLE
[PAY-1723] Purchase content twitter share copy

### DIFF
--- a/packages/common/src/models/Analytics.ts
+++ b/packages/common/src/models/Analytics.ts
@@ -329,6 +329,7 @@ export enum Name {
   PURCHASE_CONTENT_STARTED = 'Purchase Content: Started',
   PURCHASE_CONTENT_SUCCESS = 'Purchase Content: Success',
   PURCHASE_CONTENT_FAILURE = 'Purchase Content: Failure',
+  PURCHASE_CONTENT_TWITTER_SHARE = 'Purchase Content: Twitter Share',
 
   // Rate & Review CTA
   RATE_CTA_DISPLAYED = 'Rate CTA: Displayed',
@@ -1589,6 +1590,10 @@ type PurchaseContentFailure = {
   contentType: string
   error: string
 }
+type PurchaseContentTwitterShare = {
+  eventName: Name.PURCHASE_CONTENT_TWITTER_SHARE
+  text: string
+}
 
 type RateCtaDisplayed = {
   eventName: Name.RATE_CTA_DISPLAYED
@@ -1913,6 +1918,7 @@ export type AllTrackingEvents =
   | PurchaseContentStarted
   | PurchaseContentSuccess
   | PurchaseContentFailure
+  | PurchaseContentTwitterShare
   | RateCtaDisplayed
   | RateCtaResponseNo
   | RateCtaResponseYes

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PremiumTrackPurchaseDrawer.tsx
@@ -166,7 +166,7 @@ export const PremiumTrackPurchaseDrawer = () => {
             isPurchaseSuccessful={isPurchaseSuccessful}
           />
           {isPurchaseSuccessful ? (
-            <PurchaseSuccess />
+            <PurchaseSuccess track={track} />
           ) : (
             <>
               <View>

--- a/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
+++ b/packages/mobile/src/components/premium-track-purchase-drawer/PurchaseSuccess.tsx
@@ -1,15 +1,21 @@
+import { useCallback } from 'react'
+
+import type { UserTrackMetadata } from '@audius/common'
 import { View } from 'react-native'
 
 import IconVerified from 'app/assets/images/iconVerified.svg'
 import { Text } from 'app/components/core'
 import { flexRowCentered, makeStyles } from 'app/styles'
 import { spacing } from 'app/styles/spacing'
+import { EventNames } from 'app/types/analytics'
 import { useThemeColors } from 'app/utils/theme'
 
 import { TwitterButton } from '../twitter-button'
 
 const messages = {
-  success: 'Your purchase was successful!'
+  success: 'Your purchase was successful!',
+  shareTwitterText: (trackTitle: string, handle: string, trackUrl: string) =>
+    `I bought the track ${trackTitle} by ${handle} on Audius! #AudiusPremium ${trackUrl}`
 }
 
 const useStyles = makeStyles(({ spacing, typography, palette }) => ({
@@ -25,9 +31,25 @@ const useStyles = makeStyles(({ spacing, typography, palette }) => ({
   }
 }))
 
-export const PurchaseSuccess = () => {
+export const PurchaseSuccess = ({ track }: { track: UserTrackMetadata }) => {
   const styles = useStyles()
   const { specialGreen, staticWhite } = useThemeColors()
+  const { handle } = track.user
+  const { permalink, title } = track
+
+  const handleTwitterShare = useCallback(
+    (handle: string) => {
+      const shareText = messages.shareTwitterText(title, handle, permalink)
+      return {
+        shareText,
+        analytics: {
+          eventName: EventNames.PURCHASE_CONTENT_TWITTER_SHARE,
+          text: shareText
+        } as const
+      }
+    },
+    [permalink, title]
+  )
 
   return (
     <View style={styles.root}>
@@ -42,9 +64,10 @@ export const PurchaseSuccess = () => {
       </View>
       <TwitterButton
         fullWidth
+        type='dynamic'
+        shareData={handleTwitterShare}
+        handle={handle}
         size='large'
-        type='static'
-        shareText={messages.success}
       />
     </View>
   )


### PR DESCRIPTION
### Description
Updates copy for twitter share buttons on purchase content modal/drawer (both web and mobile)

### How Has This Been Tested?
Tested local web stage (did not test ios yet - will do!)

### Screenshots
<img width="1920" alt="Screenshot 2023-09-01 at 4 40 21 PM" src="https://github.com/AudiusProject/audius-client/assets/3893871/46a132e3-a891-453b-85f9-7faf661bb730">

