### PR TITLE
Handle local library changes (e.g. favoriting, reposting) PAY-1714

### DIFF
--- a/packages/common/src/api/library.ts
+++ b/packages/common/src/api/library.ts
@@ -37,7 +37,7 @@ const fetchLibraryCollections = async ({
     offset,
     limit,
     category,
-    query = '',
+    query,
     sortMethod = 'added_date',
     sortDirection = 'desc'
   } = args

--- a/packages/common/src/store/cache/collections/selectors.ts
+++ b/packages/common/src/store/cache/collections/selectors.ts
@@ -177,7 +177,7 @@ export const getTracksFromCollection = (
     .filter(Boolean) as EnhancedCollectionTrack[]
 }
 
-type EnhancedCollection = Collection & { user: User }
+export type EnhancedCollection = Collection & { user: User }
 export const getCollectionWithUser = (
   state: CommonState,
   props: { id?: ID }

--- a/packages/common/src/store/pages/index.ts
+++ b/packages/common/src/store/pages/index.ts
@@ -61,6 +61,7 @@ export { tracksActions as savedPageTracksLineupActions } from './saved-page/line
 export * as savedPageActions from './saved-page/actions'
 export * as savedPageSelectors from './saved-page/selectors'
 export * from './saved-page/types'
+export * from './saved-page/utils'
 export { default as savedPageReducer } from './saved-page/reducer'
 
 export {

--- a/packages/common/src/store/pages/saved-page/actions.ts
+++ b/packages/common/src/store/pages/saved-page/actions.ts
@@ -1,5 +1,5 @@
-// @ts-nocheck
-// TODO(nkang) - convert to TS
+import { Favorite } from 'models/Favorite'
+import { UID } from 'models/Identifiers'
 
 import { LibraryCategory, LibraryCategoryType } from './types'
 
@@ -16,8 +16,24 @@ export const FETCH_MORE_SAVES_FAILED = 'SAVED/FETCH_MORE_SAVES_FAILED'
 // Usually when filtering
 export const END_FETCHING = 'SAVED/END_FETCHING'
 
-export const ADD_LOCAL_SAVE = 'SAVED/ADD_LOCAL_SAVE'
-export const REMOVE_LOCAL_SAVE = 'SAVED/REMOVE_LOCAL_SAVE'
+export const ADD_LOCAL_TRACK_FAVORITE = 'SAVED/ADD_LOCAL_TRACK_FAVORITE'
+export const REMOVE_LOCAL_TRACK_FAVORITE = 'SAVED/REMOVE_LOCAL_TRACK_FAVORITE'
+export const ADD_LOCAL_TRACK_REPOST = 'SAVED/ADD_LOCAL_TRACK_REPOST'
+export const REMOVE_LOCAL_TRACK_REPOST = 'SAVED/REMOVE_LOCAL_TRACK_REPOST'
+export const ADD_LOCAL_TRACK_PURCHASE = 'SAVED/ADD_LOCAL_TRACK_PURCHASE'
+
+export const ADD_LOCAL_COLLECTION_FAVORITE =
+  'SAVED/ADD_LOCAL_COLLECTION_FAVORITE'
+export const REMOVE_LOCAL_COLLECTION_FAVORITE =
+  'SAVED/REMOVE_LOCAL_COLLECTION_FAVORITE'
+export const ADD_LOCAL_COLLECTION_REPOST = 'SAVED/ADD_LOCAL_COLLECTION_REPOST'
+export const REMOVE_LOCAL_COLLECTION_REPOST =
+  'SAVED/REMOVE_LOCAL_COLLECTION_REPOST'
+export const ADD_LOCAL_COLLECTION_PURCHASE =
+  'SAVED/ADD_LOCAL_COLLECTION_PURCHASE'
+export const REMOVE_LOCAL_COLLECTION_PURCHASE =
+  'SAVED/REMOVE_LOCAL_COLLECTION_PURCHASE'
+
 export const SET_SELECTED_CATEGORY = 'SAVED/SET_SELECTED_CATEGORY'
 
 export const fetchSaves = (
@@ -68,7 +84,7 @@ export const fetchSavesRequested = () => ({
   type: FETCH_SAVES_REQUESTED
 })
 
-export const fetchSavesSucceeded = (saves) => ({
+export const fetchSavesSucceeded = (saves: Favorite[]) => ({
   type: FETCH_SAVES_SUCCEEDED,
   saves
 })
@@ -77,7 +93,7 @@ export const fetchSavesFailed = () => ({
   type: FETCH_SAVES_FAILED
 })
 
-export const fetchMoreSavesSucceeded = (saves, offset) => ({
+export const fetchMoreSavesSucceeded = (saves: Favorite[], offset: number) => ({
   type: FETCH_MORE_SAVES_SUCCEEDED,
   saves,
   offset
@@ -87,20 +103,80 @@ export const fetchMoreSavesFailed = () => ({
   type: FETCH_MORE_SAVES_FAILED
 })
 
-export const endFetching = (endIndex) => ({
+export const endFetching = (endIndex: number) => ({
   type: END_FETCHING,
   endIndex
 })
 
-export const addLocalSave = (trackId, uid) => ({
-  type: ADD_LOCAL_SAVE,
+export const addLocalTrackSave = (trackId: number, uid: UID) => ({
+  type: ADD_LOCAL_TRACK_FAVORITE,
   trackId,
   uid
 })
 
-export const removeLocalSave = (trackId) => ({
-  type: REMOVE_LOCAL_SAVE,
+export const removeLocalTrackSave = (trackId: number) => ({
+  type: REMOVE_LOCAL_TRACK_FAVORITE,
   trackId
+})
+
+export const addLocalTrackRepost = (trackId: number, uid: UID) => ({
+  type: ADD_LOCAL_TRACK_REPOST,
+  trackId,
+  uid
+})
+
+export const removeLocalTrackRepost = (trackId: number, uid: UID) => ({
+  type: REMOVE_LOCAL_TRACK_REPOST,
+  trackId,
+  uid
+})
+
+export const addLocalCollectionFavorite = ({
+  collectionId,
+  isAlbum
+}: {
+  collectionId: number
+  isAlbum: boolean
+}) => ({
+  type: ADD_LOCAL_COLLECTION_FAVORITE,
+  collectionId,
+  isAlbum
+})
+
+export const removeLocalCollectionFavorite = ({
+  collectionId,
+  isAlbum
+}: {
+  collectionId: number
+  isAlbum: boolean
+}) => ({
+  type: REMOVE_LOCAL_COLLECTION_FAVORITE,
+  collectionId,
+  isAlbum
+})
+
+export const addLocalCollectionRepost = ({
+  collectionId,
+  isAlbum
+}: {
+  collectionId: number
+  isAlbum: boolean
+}) => ({
+  type: ADD_LOCAL_COLLECTION_REPOST,
+  collectionId,
+  isAlbum
+})
+
+export const removeLocalCollectionRepost = ({
+  collectionId,
+  isAlbum
+}: {
+  collectionId: number
+  isAlbum: boolean
+}) => ({
+  type: REMOVE_LOCAL_COLLECTION_REPOST,
+  collectionId,
+  isAlbum
 })
 
 export const setSelectedCategory = (category: LibraryCategoryType) => ({

--- a/packages/common/src/store/pages/saved-page/actions.ts
+++ b/packages/common/src/store/pages/saved-page/actions.ts
@@ -1,4 +1,3 @@
-import { Favorite } from 'models/Favorite'
 import { UID } from 'models/Identifiers'
 
 import { LibraryCategory, LibraryCategoryType } from './types'
@@ -84,7 +83,7 @@ export const fetchSavesRequested = () => ({
   type: FETCH_SAVES_REQUESTED
 })
 
-export const fetchSavesSucceeded = (saves: Favorite[]) => ({
+export const fetchSavesSucceeded = (saves: any[]) => ({
   type: FETCH_SAVES_SUCCEEDED,
   saves
 })
@@ -93,7 +92,7 @@ export const fetchSavesFailed = () => ({
   type: FETCH_SAVES_FAILED
 })
 
-export const fetchMoreSavesSucceeded = (saves: Favorite[], offset: number) => ({
+export const fetchMoreSavesSucceeded = (saves: any[], offset: number) => ({
   type: FETCH_MORE_SAVES_SUCCEEDED,
   saves,
   offset

--- a/packages/common/src/store/pages/saved-page/actions.ts
+++ b/packages/common/src/store/pages/saved-page/actions.ts
@@ -1,6 +1,6 @@
 import { UID } from 'models/Identifiers'
 
-import { LibraryCategory, LibraryCategoryType } from './types'
+import { LibraryCategory, LibraryCategoryType, SavedPageTabs } from './types'
 
 export const FETCH_SAVES = 'SAVED/FETCH_SAVES'
 export const FETCH_SAVES_REQUESTED = 'SAVED/FETCH_SAVES_REQUESTED'
@@ -34,6 +34,10 @@ export const REMOVE_LOCAL_COLLECTION_PURCHASE =
   'SAVED/REMOVE_LOCAL_COLLECTION_PURCHASE'
 
 export const SET_SELECTED_CATEGORY = 'SAVED/SET_SELECTED_CATEGORY'
+export const INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE =
+  'SAVED/INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE'
+export const INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE =
+  'SAVED/INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE'
 
 export const fetchSaves = (
   // the filter query for the "get tracks" query
@@ -178,7 +182,28 @@ export const removeLocalCollectionRepost = ({
   isAlbum
 })
 
-export const setSelectedCategory = (category: LibraryCategoryType) => ({
-  type: SET_SELECTED_CATEGORY,
+export const initializeTracksCategoryFromLocalStorage = (
+  category: LibraryCategoryType
+) => ({
+  type: INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE,
   category
+})
+
+export const initializeCollectionsCategoryFromLocalStorage = (
+  category: LibraryCategoryType
+) => ({
+  type: INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE,
+  category
+})
+
+export const setSelectedCategory = ({
+  category,
+  currentTab
+}: {
+  category: LibraryCategoryType
+  currentTab: SavedPageTabs
+}) => ({
+  type: SET_SELECTED_CATEGORY,
+  category,
+  currentTab
 })

--- a/packages/common/src/store/pages/saved-page/actions.ts
+++ b/packages/common/src/store/pages/saved-page/actions.ts
@@ -1,4 +1,4 @@
-import { UID } from 'models/Identifiers'
+import { Favorite } from 'models/Favorite'
 
 import { LibraryCategory, LibraryCategoryType, SavedPageTabs } from './types'
 
@@ -15,23 +15,10 @@ export const FETCH_MORE_SAVES_FAILED = 'SAVED/FETCH_MORE_SAVES_FAILED'
 // Usually when filtering
 export const END_FETCHING = 'SAVED/END_FETCHING'
 
-export const ADD_LOCAL_TRACK_FAVORITE = 'SAVED/ADD_LOCAL_TRACK_FAVORITE'
-export const REMOVE_LOCAL_TRACK_FAVORITE = 'SAVED/REMOVE_LOCAL_TRACK_FAVORITE'
-export const ADD_LOCAL_TRACK_REPOST = 'SAVED/ADD_LOCAL_TRACK_REPOST'
-export const REMOVE_LOCAL_TRACK_REPOST = 'SAVED/REMOVE_LOCAL_TRACK_REPOST'
-export const ADD_LOCAL_TRACK_PURCHASE = 'SAVED/ADD_LOCAL_TRACK_PURCHASE'
-
-export const ADD_LOCAL_COLLECTION_FAVORITE =
-  'SAVED/ADD_LOCAL_COLLECTION_FAVORITE'
-export const REMOVE_LOCAL_COLLECTION_FAVORITE =
-  'SAVED/REMOVE_LOCAL_COLLECTION_FAVORITE'
-export const ADD_LOCAL_COLLECTION_REPOST = 'SAVED/ADD_LOCAL_COLLECTION_REPOST'
-export const REMOVE_LOCAL_COLLECTION_REPOST =
-  'SAVED/REMOVE_LOCAL_COLLECTION_REPOST'
-export const ADD_LOCAL_COLLECTION_PURCHASE =
-  'SAVED/ADD_LOCAL_COLLECTION_PURCHASE'
-export const REMOVE_LOCAL_COLLECTION_PURCHASE =
-  'SAVED/REMOVE_LOCAL_COLLECTION_PURCHASE'
+export const ADD_LOCAL_TRACK = 'SAVED/ADD_LOCAL_TRACK'
+export const REMOVE_LOCAL_TRACK = 'SAVED/REMOVE_LOCAL_TRACK'
+export const ADD_LOCAL_COLLECTION = 'SAVED/ADD_LOCAL_COLLECTION'
+export const REMOVE_LOCAL_COLLECTION = 'SAVED/REMOVE_LOCAL_COLLECTION'
 
 export const SET_SELECTED_CATEGORY = 'SAVED/SET_SELECTED_CATEGORY'
 export const INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE =
@@ -87,7 +74,7 @@ export const fetchSavesRequested = () => ({
   type: FETCH_SAVES_REQUESTED
 })
 
-export const fetchSavesSucceeded = (saves: any[]) => ({
+export const fetchSavesSucceeded = (saves: Favorite[]) => ({
   type: FETCH_SAVES_SUCCEEDED,
   saves
 })
@@ -96,7 +83,7 @@ export const fetchSavesFailed = () => ({
   type: FETCH_SAVES_FAILED
 })
 
-export const fetchMoreSavesSucceeded = (saves: any[], offset: number) => ({
+export const fetchMoreSavesSucceeded = (saves: Favorite[], offset: number) => ({
   type: FETCH_MORE_SAVES_SUCCEEDED,
   saves,
   offset
@@ -111,75 +98,61 @@ export const endFetching = (endIndex: number) => ({
   endIndex
 })
 
-export const addLocalTrackSave = (trackId: number, uid: UID) => ({
-  type: ADD_LOCAL_TRACK_FAVORITE,
+export const addLocalTrack = ({
   trackId,
-  uid
-})
-
-export const removeLocalTrackSave = (trackId: number) => ({
-  type: REMOVE_LOCAL_TRACK_FAVORITE,
-  trackId
-})
-
-export const addLocalTrackRepost = (trackId: number, uid: UID) => ({
-  type: ADD_LOCAL_TRACK_REPOST,
+  uid,
+  category
+}: {
+  trackId: number
+  uid: number
+  category: LibraryCategoryType
+}) => ({
+  type: ADD_LOCAL_TRACK,
   trackId,
-  uid
+  uid,
+  category
 })
 
-export const removeLocalTrackRepost = (trackId: number, uid: UID) => ({
-  type: REMOVE_LOCAL_TRACK_REPOST,
+export const removeLocalTrack = ({
   trackId,
-  uid
+  category
+}: {
+  trackId: number
+  category: LibraryCategoryType
+}) => ({
+  type: REMOVE_LOCAL_TRACK,
+  trackId,
+  category
 })
 
-export const addLocalCollectionFavorite = ({
+export const addLocalCollection = ({
   collectionId,
-  isAlbum
+  isAlbum,
+  category
 }: {
   collectionId: number
   isAlbum: boolean
+  category: LibraryCategoryType
 }) => ({
-  type: ADD_LOCAL_COLLECTION_FAVORITE,
+  type: ADD_LOCAL_COLLECTION,
   collectionId,
-  isAlbum
+  isAlbum,
+  category
 })
 
-export const removeLocalCollectionFavorite = ({
+export const removeLocalCollection = ({
   collectionId,
-  isAlbum
+  isAlbum,
+  category
 }: {
   collectionId: number
   isAlbum: boolean
+  category: LibraryCategoryType
 }) => ({
-  type: REMOVE_LOCAL_COLLECTION_FAVORITE,
+  type: REMOVE_LOCAL_COLLECTION,
   collectionId,
-  isAlbum
-})
-
-export const addLocalCollectionRepost = ({
-  collectionId,
-  isAlbum
-}: {
-  collectionId: number
-  isAlbum: boolean
-}) => ({
-  type: ADD_LOCAL_COLLECTION_REPOST,
-  collectionId,
-  isAlbum
-})
-
-export const removeLocalCollectionRepost = ({
-  collectionId,
-  isAlbum
-}: {
-  collectionId: number
-  isAlbum: boolean
-}) => ({
-  type: REMOVE_LOCAL_COLLECTION_REPOST,
-  collectionId,
-  isAlbum
+  isAlbum,
+  category
 })
 
 export const initializeTracksCategoryFromLocalStorage = (

--- a/packages/common/src/store/pages/saved-page/reducer.ts
+++ b/packages/common/src/store/pages/saved-page/reducer.ts
@@ -79,8 +79,8 @@ const getLocalCollectionStateKeys = ({
   ) as keyof SavedPageState
   const removalKey = (
     isAlbum
-      ? `localAlbumRemoved${categoryKeySuffix}`
-      : `localPlaylistRemoved${categoryKeySuffix}`
+      ? `localRemovedAlbum${categoryKeySuffix}`
+      : `localRemovedPlaylist${categoryKeySuffix}`
   ) as keyof SavedPageState
   return { additionKey, removalKey }
 }

--- a/packages/common/src/store/pages/saved-page/reducer.ts
+++ b/packages/common/src/store/pages/saved-page/reducer.ts
@@ -20,7 +20,9 @@ import {
   ADD_LOCAL_TRACK_FAVORITE,
   REMOVE_LOCAL_TRACK_FAVORITE,
   END_FETCHING,
-  SET_SELECTED_CATEGORY
+  SET_SELECTED_CATEGORY,
+  INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE,
+  INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE
 } from 'store/pages/saved-page/actions'
 import tracksReducer, {
   initialState as initialLineupState
@@ -30,6 +32,7 @@ import { ActionsMap } from 'utils/reducer'
 
 import { PREFIX as tracksPrefix } from './lineups/tracks/actions'
 import { LibraryCategory, LibraryCategoryType, SavedPageState } from './types'
+import { calculateNewLibraryCategories } from './utils'
 
 const initialState = {
   // id => uid
@@ -51,7 +54,8 @@ const initialState = {
   hasReachedEnd: false,
   fetchingMore: false,
   tracks: initialLineupState,
-  selectedCategory: LibraryCategory.Favorite
+  tracksCategory: LibraryCategory.Favorite,
+  collectionsCategory: LibraryCategory.Favorite
 } as SavedPageState
 
 /** Utility to get the name of key in which locally added or removed collections are stored in SavedPageState.
@@ -241,7 +245,23 @@ const actionsMap: ActionsMap<SavedPageState> = {
   [SET_SELECTED_CATEGORY](state, action) {
     return {
       ...state,
-      selectedCategory: action.category
+      ...calculateNewLibraryCategories({
+        currentTab: action.currentTab,
+        chosenCategory: action.category,
+        prevTracksCategory: state.tracksCategory
+      })
+    }
+  },
+  [INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE](state, action) {
+    return {
+      ...state,
+      tracksCategory: action.category
+    }
+  },
+  [INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE](state, action) {
+    return {
+      ...state,
+      collectionsCategory: action.category
     }
   },
   [signOut.type]() {

--- a/packages/common/src/store/pages/saved-page/selectors.ts
+++ b/packages/common/src/store/pages/saved-page/selectors.ts
@@ -2,13 +2,30 @@ import { CommonState } from 'store/commonStore'
 
 import { ID } from '../../../models/Identifiers'
 
-import { LibraryCategory } from './types'
+import { LibraryCategory, SavedPageTabs } from './types'
 
 export const getSaved = (state: CommonState) => state.pages.savedPage
 export const getTrackSaves = (state: CommonState) =>
   state.pages.savedPage.trackSaves
-export const getSelectedCategory = (state: CommonState) =>
-  state.pages.savedPage.selectedCategory
+
+export const getCollectionsCategory = (state: CommonState) => {
+  return state.pages.savedPage.collectionsCategory
+}
+
+export const getTracksCategory = (state: CommonState) => {
+  return state.pages.savedPage.tracksCategory
+}
+
+export const getCategory = (
+  state: CommonState,
+  props: { currentTab: SavedPageTabs }
+) => {
+  if (props.currentTab === SavedPageTabs.TRACKS) {
+    return getTracksCategory(state)
+  } else {
+    return getCollectionsCategory(state)
+  }
+}
 
 export const getLocalTrackFavorites = (state: CommonState) =>
   state.pages.savedPage.localTrackFavorites
@@ -45,7 +62,9 @@ export const getLocalRemovedPlaylistReposts = (state: CommonState) =>
 
 /** Get the tracks in currently selected category that have been added to the library in current session */
 export const getSelectedCategoryLocalAdds = (state: CommonState) => {
-  const selectedCategory = getSelectedCategory(state)
+  const selectedCategory = getCategory(state, {
+    currentTab: SavedPageTabs.TRACKS
+  })
   const localFavorites = getLocalTrackFavorites(state)
   const localPurchases = getLocalTrackPurchases(state)
   const localReposts = getLocalTrackReposts(state)
@@ -73,7 +92,9 @@ const getSelectedCategoryLocalCollectionUpdates = (
   props: { collectionType: 'album' | 'playlist'; updateType: 'add' | 'remove' }
 ) => {
   const { collectionType, updateType } = props
-  const selectedCategory = getSelectedCategory(state)
+  const currentTab =
+    collectionType === 'album' ? SavedPageTabs.ALBUMS : SavedPageTabs.PLAYLISTS
+  const selectedCategory = getCategory(state, { currentTab })
   let localFavorites: ID[], localPurchases: ID[], localReposts: ID[]
   if (updateType === 'add') {
     localFavorites =

--- a/packages/common/src/store/pages/saved-page/selectors.ts
+++ b/packages/common/src/store/pages/saved-page/selectors.ts
@@ -2,20 +2,149 @@ import { CommonState } from 'store/commonStore'
 
 import { ID } from '../../../models/Identifiers'
 
+import { LibraryCategory } from './types'
+
 export const getSaved = (state: CommonState) => state.pages.savedPage
-export const getSaves = (state: CommonState) => state.pages.savedPage.saves
-export const getLocalSaves = (state: CommonState) =>
-  state.pages.savedPage.localSaves
-export const getLocalSave = (state: CommonState, props: { id: ID }) =>
-  state.pages.savedPage.localSaves[props.id]
+export const getTrackSaves = (state: CommonState) =>
+  state.pages.savedPage.trackSaves
+export const getSelectedCategory = (state: CommonState) =>
+  state.pages.savedPage.selectedCategory
+
+export const getLocalTrackFavorites = (state: CommonState) =>
+  state.pages.savedPage.localTrackFavorites
+export const getLocalTrackFavorite = (state: CommonState, props: { id: ID }) =>
+  state.pages.savedPage.localTrackFavorites[props.id]
+export const getLocalTrackReposts = (state: CommonState) =>
+  state.pages.savedPage.localTrackReposts
+export const getLocalTrackRepost = (state: CommonState, props: { id: ID }) =>
+  state.pages.savedPage.localTrackReposts[props.id]
+export const getLocalTrackPurchases = (state: CommonState) =>
+  state.pages.savedPage.localTrackPurchases
+export const getLocalTrackPurchase = (state: CommonState, props: { id: ID }) =>
+  state.pages.savedPage.localTrackPurchases[props.id]
+
+export const getLocalAlbumFavorites = (state: CommonState) =>
+  state.pages.savedPage.localAlbumFavorites
+export const getLocalAlbumReposts = (state: CommonState) =>
+  state.pages.savedPage.localAlbumReposts
+export const getLocalAlbumPurchases = (state: CommonState) =>
+  state.pages.savedPage.localAlbumPurchases
+export const getLocalRemovedAlbumFavorites = (state: CommonState) =>
+  state.pages.savedPage.localRemovedAlbumFavorites
+export const getLocalRemovedAlbumReposts = (state: CommonState) =>
+  state.pages.savedPage.localRemovedAlbumReposts
+
+export const getLocalPlaylistFavorites = (state: CommonState) =>
+  state.pages.savedPage.localPlaylistFavorites
+export const getLocalPlaylistReposts = (state: CommonState) =>
+  state.pages.savedPage.localPlaylistReposts
+export const getLocalRemovedPlaylistFavorites = (state: CommonState) =>
+  state.pages.savedPage.localRemovedPlaylistFavorites
+export const getLocalRemovedPlaylistReposts = (state: CommonState) =>
+  state.pages.savedPage.localRemovedPlaylistResposts
+
+/** Get the tracks in currently selected category that have been added to the library in current session */
+export const getSelectedCategoryLocalAdds = (state: CommonState) => {
+  const selectedCategory = getSelectedCategory(state)
+  const localFavorites = getLocalTrackFavorites(state)
+  const localPurchases = getLocalTrackPurchases(state)
+  const localReposts = getLocalTrackReposts(state)
+  let localLibraryAdditions
+  if (selectedCategory === LibraryCategory.Favorite) {
+    localLibraryAdditions = localFavorites
+  } else if (selectedCategory === LibraryCategory.Purchase) {
+    localLibraryAdditions = localPurchases
+  } else if (selectedCategory === LibraryCategory.Repost) {
+    localLibraryAdditions = localReposts
+  } else {
+    // Category = ALL
+    localLibraryAdditions = {
+      ...localReposts,
+      ...localFavorites,
+      ...localPurchases
+    }
+  }
+
+  return localLibraryAdditions
+}
+
+const getSelectedCategoryLocalCollectionUpdates = (
+  state: CommonState,
+  props: { collectionType: 'album' | 'playlist'; updateType: 'add' | 'remove' }
+) => {
+  const { collectionType, updateType } = props
+  const selectedCategory = getSelectedCategory(state)
+  let localFavorites: ID[], localPurchases: ID[], localReposts: ID[]
+  if (updateType === 'add') {
+    localFavorites =
+      collectionType === 'album'
+        ? getLocalAlbumFavorites(state)
+        : getLocalPlaylistFavorites(state)
+    localPurchases =
+      collectionType === 'album' ? getLocalAlbumPurchases(state) : [] // Can't buy playlists
+    localReposts =
+      collectionType === 'album'
+        ? getLocalAlbumFavorites(state)
+        : getLocalPlaylistReposts(state)
+  } else {
+    localFavorites =
+      collectionType === 'album'
+        ? getLocalRemovedAlbumFavorites(state)
+        : getLocalRemovedPlaylistFavorites(state)
+    localPurchases = [] // Can't remove purchases
+    localReposts =
+      collectionType === 'album'
+        ? getLocalRemovedAlbumFavorites(state)
+        : getLocalRemovedPlaylistReposts(state)
+  }
+
+  if (selectedCategory === LibraryCategory.Favorite) {
+    return localFavorites
+  } else if (selectedCategory === LibraryCategory.Purchase) {
+    return localPurchases
+  } else if (selectedCategory === LibraryCategory.Repost) {
+    return localReposts
+  } else {
+    // Category = ALL
+    return Array.from(
+      new Set([...localReposts, ...localFavorites, ...localPurchases])
+    )
+  }
+}
+
+export const getSelectedCategoryLocalAlbumAdds = (state: CommonState) => {
+  return getSelectedCategoryLocalCollectionUpdates(state, {
+    collectionType: 'album',
+    updateType: 'add'
+  })
+}
+export const getSelectedCategoryLocalAlbumRemovals = (state: CommonState) => {
+  return getSelectedCategoryLocalCollectionUpdates(state, {
+    collectionType: 'album',
+    updateType: 'remove'
+  })
+}
+export const getSelectedCategoryLocalPlaylistRemovals = (
+  state: CommonState
+) => {
+  return getSelectedCategoryLocalCollectionUpdates(state, {
+    collectionType: 'playlist',
+    updateType: 'remove'
+  })
+}
+export const getSelectedCategoryLocalPlaylistAdds = (state: CommonState) => {
+  return getSelectedCategoryLocalCollectionUpdates(state, {
+    collectionType: 'playlist',
+    updateType: 'add'
+  })
+}
+
 export const getInitialFetchStatus = (state: CommonState) =>
   state.pages.savedPage.initialFetch
 export const getIsFetchingMore = (state: CommonState) =>
   state.pages.savedPage.fetchingMore
 export const hasReachedEnd = (state: CommonState) =>
   state.pages.savedPage.hasReachedEnd
-export const getSelectedCategory = (state: CommonState) =>
-  state.pages.savedPage.selectedCategory
 
 export const getSavedTracksStatus = (state: CommonState) =>
   state.pages.savedPage.tracks.status

--- a/packages/common/src/store/pages/saved-page/selectors.ts
+++ b/packages/common/src/store/pages/saved-page/selectors.ts
@@ -30,40 +30,40 @@ export const getCategory = (
 }
 
 export const getLocalTrackFavorites = (state: CommonState) =>
-  state.pages.savedPage.localTrackFavorites
+  state.pages.savedPage.local.track.favorites.added
 export const getLocalTrackFavorite = (state: CommonState, props: { id: ID }) =>
-  state.pages.savedPage.localTrackFavorites[props.id]
+  state.pages.savedPage.local.track.favorites.added[props.id]
 export const getLocalTrackReposts = (state: CommonState) =>
-  state.pages.savedPage.localTrackReposts
+  state.pages.savedPage.local.track.reposts.added
 export const getLocalTrackRepost = (state: CommonState, props: { id: ID }) =>
-  state.pages.savedPage.localTrackReposts[props.id]
+  state.pages.savedPage.local.track.reposts.added[props.id]
 export const getLocalTrackPurchases = (state: CommonState) =>
-  state.pages.savedPage.localTrackPurchases
+  state.pages.savedPage.local.track.purchased.added
 export const getLocalTrackPurchase = (state: CommonState, props: { id: ID }) =>
-  state.pages.savedPage.localTrackPurchases[props.id]
+  state.pages.savedPage.local.track.purchased.added[props.id]
 
 export const getLocalAlbumFavorites = (state: CommonState) =>
-  state.pages.savedPage.localAlbumFavorites
+  state.pages.savedPage.local.album.favorites.added
 export const getLocalAlbumReposts = (state: CommonState) =>
-  state.pages.savedPage.localAlbumReposts
+  state.pages.savedPage.local.album.reposts.added
 export const getLocalAlbumPurchases = (state: CommonState) =>
-  state.pages.savedPage.localAlbumPurchases
+  state.pages.savedPage.local.album.purchased.added
 export const getLocalRemovedAlbumFavorites = (state: CommonState) =>
-  state.pages.savedPage.localRemovedAlbumFavorites
+  state.pages.savedPage.local.album.favorites.removed
 export const getLocalRemovedAlbumReposts = (state: CommonState) =>
-  state.pages.savedPage.localRemovedAlbumReposts
+  state.pages.savedPage.local.album.reposts.removed
 
 export const getLocalPlaylistFavorites = (state: CommonState) =>
-  state.pages.savedPage.localPlaylistFavorites
+  state.pages.savedPage.local.playlist.favorites.added
 export const getLocalPlaylistReposts = (state: CommonState) =>
-  state.pages.savedPage.localPlaylistReposts
+  state.pages.savedPage.local.playlist.reposts.added
 export const getLocalRemovedPlaylistFavorites = (state: CommonState) =>
-  state.pages.savedPage.localRemovedPlaylistFavorites
+  state.pages.savedPage.local.playlist.favorites.removed
 export const getLocalRemovedPlaylistReposts = (state: CommonState) =>
-  state.pages.savedPage.localRemovedPlaylistResposts
+  state.pages.savedPage.local.playlist.favorites.removed
 
 /** Get the tracks in currently selected category that have been added to the library in current session */
-export const getSelectedCategoryLocalAdds = (state: CommonState) => {
+export const getSelectedCategoryLocalTrackAdds = (state: CommonState) => {
   const selectedCategory = getCategory(state, {
     currentTab: SavedPageTabs.TRACKS
   })
@@ -107,7 +107,7 @@ const getSelectedCategoryLocalCollectionUpdates = (
       collectionType === 'album' ? getLocalAlbumPurchases(state) : [] // Can't buy playlists
     localReposts =
       collectionType === 'album'
-        ? getLocalAlbumFavorites(state)
+        ? getLocalAlbumReposts(state)
         : getLocalPlaylistReposts(state)
   } else {
     localFavorites =
@@ -117,7 +117,7 @@ const getSelectedCategoryLocalCollectionUpdates = (
     localPurchases = [] // Can't remove purchases
     localReposts =
       collectionType === 'album'
-        ? getLocalRemovedAlbumFavorites(state)
+        ? getLocalRemovedAlbumReposts(state)
         : getLocalRemovedPlaylistReposts(state)
   }
 

--- a/packages/common/src/store/pages/saved-page/selectors.ts
+++ b/packages/common/src/store/pages/saved-page/selectors.ts
@@ -1,3 +1,5 @@
+import { uniq } from 'lodash'
+
 import { CommonState } from 'store/commonStore'
 
 import { ID } from '../../../models/Identifiers'
@@ -119,17 +121,16 @@ const getSelectedCategoryLocalCollectionUpdates = (
         : getLocalRemovedPlaylistReposts(state)
   }
 
-  if (selectedCategory === LibraryCategory.Favorite) {
-    return localFavorites
-  } else if (selectedCategory === LibraryCategory.Purchase) {
-    return localPurchases
-  } else if (selectedCategory === LibraryCategory.Repost) {
-    return localReposts
-  } else {
-    // Category = ALL
-    return Array.from(
-      new Set([...localReposts, ...localFavorites, ...localPurchases])
-    )
+  switch (selectedCategory) {
+    case LibraryCategory.Favorite:
+      return localFavorites
+    case LibraryCategory.Purchase:
+      return localPurchases
+    case LibraryCategory.Repost:
+      return localReposts
+    default:
+      // Category = ALL
+      return uniq([...localReposts, ...localFavorites, ...localPurchases])
   }
 }
 

--- a/packages/common/src/store/pages/saved-page/types.ts
+++ b/packages/common/src/store/pages/saved-page/types.ts
@@ -21,9 +21,24 @@ export function isLibraryCategory(value: string): value is LibraryCategoryType {
   return Object.values(LibraryCategory).includes(value as LibraryCategoryType)
 }
 export interface SavedPageState {
-  localSaves: { [id: number]: UID }
+  localTrackFavorites: { [id: number]: UID }
+  localTrackReposts: { [id: number]: UID }
+  localTrackPurchases: { [id: number]: UID }
+
+  localAlbumFavorites: ID[]
+  localAlbumReposts: ID[]
+  localAlbumPurchases: ID[]
+  localRemovedAlbumFavorites: ID[]
+  localRemovedAlbumReposts: ID[]
+
+  localPlaylistFavorites: ID[]
+  localPlaylistReposts: ID[]
+  localPlaylistPurchases: ID[]
+  localRemovedPlaylistFavorites: ID[]
+  localRemovedPlaylistResposts: ID[]
+
   tracks: LineupState<LineupTrack & { id: ID; dateSaved: string }>
-  saves: Favorite[]
+  trackSaves: Favorite[]
   hasReachedEnd: boolean
   initialFetch: boolean
   fetchingMore: boolean

--- a/packages/common/src/store/pages/saved-page/types.ts
+++ b/packages/common/src/store/pages/saved-page/types.ts
@@ -12,7 +12,9 @@ import {
   LineupTrack
 } from '../../../models'
 
-export const LIBRARY_SELECTED_CATEGORY_LS_KEY = 'librarySelectedCategory'
+export const LIBRARY_TRACKS_CATEGORY_LS_KEY = 'libraryTracksCategory'
+
+export const LIBRARY_COLLECTIONS_CATEGORY_LS_KEY = 'libraryCollectionsCategory'
 
 export const LibraryCategory = full.GetUserLibraryTracksTypeEnum
 export type LibraryCategoryType = ValueOf<typeof LibraryCategory>
@@ -42,7 +44,9 @@ export interface SavedPageState {
   hasReachedEnd: boolean
   initialFetch: boolean
   fetchingMore: boolean
-  selectedCategory: LibraryCategoryType
+
+  tracksCategory: LibraryCategoryType
+  collectionsCategory: LibraryCategoryType
 }
 
 export enum SavedPageTabs {

--- a/packages/common/src/store/pages/saved-page/types.ts
+++ b/packages/common/src/store/pages/saved-page/types.ts
@@ -23,22 +23,44 @@ export function isLibraryCategory(value: string): value is LibraryCategoryType {
   return Object.values(LibraryCategory).includes(value as LibraryCategoryType)
 }
 export interface SavedPageState {
-  localTrackFavorites: { [id: number]: UID }
-  localTrackReposts: { [id: number]: UID }
-  localTrackPurchases: { [id: number]: UID }
-
-  localAlbumFavorites: ID[]
-  localAlbumReposts: ID[]
-  localAlbumPurchases: ID[]
-  localRemovedAlbumFavorites: ID[]
-  localRemovedAlbumReposts: ID[]
-
-  localPlaylistFavorites: ID[]
-  localPlaylistReposts: ID[]
-  localPlaylistPurchases: ID[]
-  localRemovedPlaylistFavorites: ID[]
-  localRemovedPlaylistResposts: ID[]
-
+  local: {
+    track: {
+      favorites: {
+        added: { [id: number]: UID }
+        removed: { [id: number]: UID }
+      }
+      reposts: {
+        added: { [id: number]: UID }
+        removed: { [id: number]: UID }
+      }
+      purchased: {
+        added: { [id: number]: UID }
+      }
+    }
+    album: {
+      favorites: {
+        added: ID[]
+        removed: ID[]
+      }
+      reposts: {
+        added: ID[]
+        removed: ID[]
+      }
+      purchased: {
+        added: ID[]
+      }
+    }
+    playlist: {
+      favorites: {
+        added: ID[]
+        removed: ID[]
+      }
+      reposts: {
+        added: ID[]
+        removed: ID[]
+      }
+    }
+  }
   tracks: LineupState<LineupTrack & { id: ID; dateSaved: string }>
   trackSaves: Favorite[]
   hasReachedEnd: boolean

--- a/packages/common/src/store/pages/saved-page/utils.ts
+++ b/packages/common/src/store/pages/saved-page/utils.ts
@@ -1,0 +1,39 @@
+import { LibraryCategory, LibraryCategoryType, SavedPageTabs } from './types'
+
+export const calculateNewLibraryCategories = ({
+  currentTab,
+  chosenCategory,
+  prevTracksCategory
+}: {
+  currentTab: SavedPageTabs
+  chosenCategory: LibraryCategoryType
+  prevTracksCategory: unknown
+}) => {
+  if (
+    currentTab === SavedPageTabs.TRACKS &&
+    chosenCategory === LibraryCategory.Purchase
+  ) {
+    // If the category is changed to "Purchased" on the tracks tab, change the collections tabs category to "All" because collections tabs don't have "Purchased".
+    return {
+      tracksCategory: chosenCategory,
+      collectionsCategory: LibraryCategory.All
+    }
+  }
+  if (
+    (currentTab === SavedPageTabs.ALBUMS ||
+      currentTab === SavedPageTabs.PLAYLISTS) &&
+    prevTracksCategory === LibraryCategory.Purchase
+  ) {
+    // If tracks tab is on "Purchased", we want it to stay on "Purchased" until the user goes back to it.
+    return {
+      tracksCategory: prevTracksCategory,
+      collectionsCategory: chosenCategory
+    }
+  }
+
+  // Default behavior: change category for all tabs.
+  return {
+    collectionsCategory: chosenCategory,
+    tracksCategory: chosenCategory
+  }
+}

--- a/packages/common/src/utils/collectionUtils.ts
+++ b/packages/common/src/utils/collectionUtils.ts
@@ -1,22 +1,26 @@
 import { AccountCollection } from 'store/account'
+import { EnhancedCollection } from 'store/cache/collections/selectors'
 
 type FilterCollectionsOptions = {
   filterText?: string
 }
 
-export function filterCollections(
-  collections: AccountCollection[],
-  { filterText = '' }: FilterCollectionsOptions
-): AccountCollection[] {
-  return collections.filter((item: AccountCollection) => {
-    if (filterText) {
-      const matchesPlaylistName =
-        item.name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
-      const matchesOwnerName =
-        item.user.handle.toLowerCase().indexOf(filterText.toLowerCase()) > -1
+export const isAccountCollection = (
+  collection: AccountCollection | EnhancedCollection
+): collection is AccountCollection => {
+  return (collection as AccountCollection).name !== undefined
+}
 
-      return matchesPlaylistName || matchesOwnerName
-    }
-    return true
+export function filterCollections<
+  T extends AccountCollection | EnhancedCollection
+>(collections: T[], { filterText = '' }: FilterCollectionsOptions): T[] {
+  return collections.filter((item: AccountCollection | EnhancedCollection) => {
+    const name = isAccountCollection(item) ? item.name : item.playlist_name
+    const matchesPlaylistName =
+      name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
+    const matchesOwnerName =
+      item.user.handle.toLowerCase().indexOf(filterText.toLowerCase()) > -1
+
+    return matchesPlaylistName || matchesOwnerName
   })
 }

--- a/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useState } from 'react'
 
-import { reachabilitySelectors, statusIsNotFinalized } from '@audius/common'
+import type { CommonState } from '@audius/common'
+import {
+  reachabilitySelectors,
+  statusIsNotFinalized,
+  savedPageSelectors,
+  LibraryCategory
+} from '@audius/common'
 import { useSelector } from 'react-redux'
 
 import { CollectionList } from 'app/components/collection-list'
@@ -13,10 +19,15 @@ import { NoTracksPlaceholder } from './NoTracksPlaceholder'
 import { OfflineContentBanner } from './OfflineContentBanner'
 import { useCollectionsScreenData } from './useCollectionsScreenData'
 
+const { getSelectedCategory } = savedPageSelectors
 const { getIsReachable } = reachabilitySelectors
 
 const messages = {
-  emptyTabText: "You haven't favorited any albums yet.",
+  emptyAlbumFavoritesText: "You haven't favorited any albums yet.",
+  emptyAlbumRepostsText: "You haven't reposted any albums yet.",
+  emptyAlbumPurchasedText: "You haven't purchased any albums yet.",
+  emptyAlbumAllText:
+    "You haven't favorited, reposted, or purchased any albums yet.",
   inputPlaceholder: 'Filter Albums'
 }
 
@@ -39,6 +50,19 @@ export const AlbumsTab = () => {
     }
   }, [isReachable, hasMore, fetchMore])
 
+  const emptyTabText = useSelector((state: CommonState) => {
+    const selectedCategory = getSelectedCategory(state)
+    if (selectedCategory === LibraryCategory.All) {
+      return messages.emptyAlbumAllText
+    } else if (selectedCategory === LibraryCategory.Favorite) {
+      return messages.emptyAlbumFavoritesText
+    } else if (selectedCategory === LibraryCategory.Purchase) {
+      return messages.emptyAlbumPurchasedText
+    } else {
+      return messages.emptyAlbumRepostsText
+    }
+  })
+
   const loadingSpinner = <LoadingMoreSpinner />
 
   return (
@@ -47,7 +71,7 @@ export const AlbumsTab = () => {
         !isReachable ? (
           <NoTracksPlaceholder />
         ) : (
-          <EmptyTileCTA message={messages.emptyTabText} />
+          <EmptyTileCTA message={emptyTabText} />
         )
       ) : (
         <>

--- a/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import type { CommonState } from '@audius/common'
 import {
+  SavedPageTabs,
   reachabilitySelectors,
   statusIsNotFinalized,
   savedPageSelectors,
@@ -19,7 +20,7 @@ import { NoTracksPlaceholder } from './NoTracksPlaceholder'
 import { OfflineContentBanner } from './OfflineContentBanner'
 import { useCollectionsScreenData } from './useCollectionsScreenData'
 
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 const { getIsReachable } = reachabilitySelectors
 
 const messages = {
@@ -51,7 +52,9 @@ export const AlbumsTab = () => {
   }, [isReachable, hasMore, fetchMore])
 
   const emptyTabText = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.ALBUMS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return messages.emptyAlbumAllText
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/mobile/src/screens/favorites-screen/LibraryCategorySelectionMenu.tsx
+++ b/packages/mobile/src/screens/favorites-screen/LibraryCategorySelectionMenu.tsx
@@ -10,6 +10,7 @@ import { ScrollView, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { HarmonySelectablePill } from 'app/components/core/HarmonySelectablePill'
+import { useIsUSDCEnabled } from 'app/hooks/useIsUSDCEnabled'
 import { makeStyles } from 'app/styles'
 
 const { getCategory } = savedPageSelectors
@@ -26,7 +27,7 @@ const useStyles = makeStyles(({ spacing }) => ({
   }
 }))
 
-const TRACKS_CATEGORIES = [
+const ALL_CATEGORIES = [
   {
     label: 'All',
     value: LibraryCategory.All
@@ -45,7 +46,7 @@ const TRACKS_CATEGORIES = [
   }
 ]
 
-const COLLECTIONS_CATEGORIES = TRACKS_CATEGORIES.slice(0, -1)
+const CATEGORIES_WITHOUT_PURCHASED = ALL_CATEGORIES.slice(0, -1)
 
 type LibraryTabRouteName = 'albums' | 'tracks' | 'playlists'
 const ROUTE_NAME_TO_TAB = {
@@ -92,11 +93,11 @@ export const LibraryCategorySelectionMenu = () => {
     }
   }
 
+  const isUSDCPurchasesEnabled = useIsUSDCEnabled()
   const categories =
-    currentTab === SavedPageTabs.ALBUMS ||
-    currentTab === SavedPageTabs.PLAYLISTS
-      ? COLLECTIONS_CATEGORIES
-      : TRACKS_CATEGORIES
+    currentTab === SavedPageTabs.TRACKS && isUSDCPurchasesEnabled
+      ? ALL_CATEGORIES
+      : CATEGORIES_WITHOUT_PURCHASED
 
   return (
     <View style={styles.container}>

--- a/packages/mobile/src/screens/favorites-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/PlaylistsTab.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useState } from 'react'
 
+import type { CommonState } from '@audius/common'
 import {
   CreatePlaylistSource,
   FeatureFlags,
+  LibraryCategory,
   reachabilitySelectors,
-  statusIsNotFinalized
+  statusIsNotFinalized,
+  savedPageSelectors
 } from '@audius/common'
 import Animated, { FadeIn, FadeOut, Layout } from 'react-native-reanimated'
 import { useSelector } from 'react-redux'
@@ -25,9 +28,13 @@ import { OfflineContentBanner } from './OfflineContentBanner'
 import { useCollectionsScreenData } from './useCollectionsScreenData'
 
 const { getIsReachable } = reachabilitySelectors
+const { getSelectedCategory } = savedPageSelectors
 
 const messages = {
-  emptyTabText: "You haven't favorited any playlists yet.",
+  emptyPlaylistFavoritesText: "You haven't favorited any playlists yet.",
+  emptyPlaylistRepostsText: "You haven't reposted any playlists yet.",
+  emptyPlaylistAllText:
+    "You haven't favorited, reposted, or purchased any playlists yet.",
   inputPlaceholder: 'Filter Playlists'
 }
 
@@ -39,7 +46,6 @@ export const PlaylistsTab = () => {
   const { isEnabled: isPlaylistUpdatesEnabled } = useFeatureFlag(
     FeatureFlags.PLAYLIST_UPDATES_POST_QA
   )
-
   const [filterValue, setFilterValue] = useState('')
   const {
     collectionIds: userPlaylists,
@@ -62,13 +68,24 @@ export const PlaylistsTab = () => {
   const noItemsLoaded =
     !statusIsNotFinalized(status) && !userPlaylists?.length && !filterValue
 
+  const emptyTabText = useSelector((state: CommonState) => {
+    const selectedCategory = getSelectedCategory(state)
+    if (selectedCategory === LibraryCategory.All) {
+      return messages.emptyPlaylistAllText
+    } else if (selectedCategory === LibraryCategory.Favorite) {
+      return messages.emptyPlaylistFavoritesText
+    } else {
+      return messages.emptyPlaylistRepostsText
+    }
+  })
+
   return (
     <VirtualizedScrollView>
       {noItemsLoaded ? (
         !isReachable ? (
           <NoTracksPlaceholder />
         ) : (
-          <EmptyTileCTA message={messages.emptyTabText} />
+          <EmptyTileCTA message={emptyTabText} />
         )
       ) : (
         <>

--- a/packages/mobile/src/screens/favorites-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/PlaylistsTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import type { CommonState } from '@audius/common'
 import {
+  SavedPageTabs,
   CreatePlaylistSource,
   FeatureFlags,
   LibraryCategory,
@@ -28,7 +29,7 @@ import { OfflineContentBanner } from './OfflineContentBanner'
 import { useCollectionsScreenData } from './useCollectionsScreenData'
 
 const { getIsReachable } = reachabilitySelectors
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 
 const messages = {
   emptyPlaylistFavoritesText: "You haven't favorited any playlists yet.",
@@ -69,7 +70,9 @@ export const PlaylistsTab = () => {
     !statusIsNotFinalized(status) && !userPlaylists?.length && !filterValue
 
   const emptyTabText = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.PLAYLISTS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return messages.emptyPlaylistAllText
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import type { ID, Nullable, Track, UID, User } from '@audius/common'
 import {
+  LibraryCategory,
   FavoriteSource,
   PlaybackSource,
   Status,
@@ -45,7 +46,11 @@ const { getTrack } = cacheTracksSelectors
 const { getUserFromTrack } = cacheUsersSelectors
 
 const messages = {
-  emptyTabText: "You haven't favorited any tracks yet.",
+  emptyTracksFavoritesText: "You haven't favorited any tracks yet.",
+  emptyTracksRepostsText: "You haven't reposted any tracks yet.",
+  emptyTracksPurchasedText: "You haven't purchased any tracks yet.",
+  emptyTracksAllText:
+    "You haven't favorited, reposted, or purchased any tracks yet.",
   inputPlaceholder: 'Filter Tracks'
 }
 
@@ -87,6 +92,17 @@ export const TracksTab = () => {
   )
 
   const isLoading = savedTracksStatus !== Status.SUCCESS
+
+  let emptyTabText: string
+  if (selectedCategory === LibraryCategory.All) {
+    emptyTabText = messages.emptyTracksAllText
+  } else if (selectedCategory === LibraryCategory.Favorite) {
+    emptyTabText = messages.emptyTracksFavoritesText
+  } else if (selectedCategory === LibraryCategory.Repost) {
+    emptyTabText = messages.emptyTracksRepostsText
+  } else {
+    emptyTabText = messages.emptyTracksPurchasedText
+  }
 
   const fetchSaves = useCallback(() => {
     dispatch(
@@ -196,7 +212,7 @@ export const TracksTab = () => {
         !isReachable ? (
           <NoTracksPlaceholder />
         ) : (
-          <EmptyTileCTA message={messages.emptyTabText} />
+          <EmptyTileCTA message={emptyTabText} />
         )
       ) : (
         <>

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -33,10 +33,10 @@ import { useFavoritesLineup } from './useFavoritesLineup'
 const { saveTrack, unsaveTrack } = tracksSocialActions
 const { fetchSaves: fetchSavesAction, fetchMoreSaves } = savedPageActions
 const {
-  getSaves,
-  getLocalSaves,
+  getTrackSaves,
   getSavedTracksStatus,
   getInitialFetchStatus,
+  getSelectedCategoryLocalAdds,
   getIsFetchingMore,
   getSelectedCategory
 } = savedPageSelectors
@@ -78,12 +78,12 @@ export const TracksTab = () => {
   const savedTracksStatus = useSelector(getSavedTracksStatus)
   const initialFetch = useSelector(getInitialFetchStatus)
   const isFetchingMore = useSelector(getIsFetchingMore)
-  const saves = useSelector(getSaves)
-  const localSaves = useSelector(getLocalSaves)
+  const saves = useSelector(getTrackSaves)
+  const localAdditions = useSelector(getSelectedCategoryLocalAdds)
 
   const saveCount = useMemo(
-    () => saves.length + Object.keys(localSaves).length,
-    [saves, localSaves]
+    () => saves.length + Object.keys(localAdditions).length,
+    [saves, localAdditions]
   )
 
   const isLoading = savedTracksStatus !== Status.SUCCESS

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ID, Nullable, Track, UID, User } from '@audius/common'
 import {
   LibraryCategory,
+  SavedPageTabs,
   FavoriteSource,
   PlaybackSource,
   Status,
@@ -39,7 +40,7 @@ const {
   getInitialFetchStatus,
   getSelectedCategoryLocalAdds,
   getIsFetchingMore,
-  getSelectedCategory
+  getCategory
 } = savedPageSelectors
 const { getIsReachable } = reachabilitySelectors
 const { getTrack } = cacheTracksSelectors
@@ -79,7 +80,9 @@ export const TracksTab = () => {
 
   const [filterValue, setFilterValue] = useState('')
   const [fetchPage, setFetchPage] = useState(0)
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector((state) =>
+    getCategory(state, { currentTab: SavedPageTabs.TRACKS })
+  )
   const savedTracksStatus = useSelector(getSavedTracksStatus)
   const initialFetch = useSelector(getInitialFetchStatus)
   const isFetchingMore = useSelector(getIsFetchingMore)

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -38,7 +38,7 @@ const {
   getTrackSaves,
   getSavedTracksStatus,
   getInitialFetchStatus,
-  getSelectedCategoryLocalAdds,
+  getSelectedCategoryLocalTrackAdds,
   getIsFetchingMore,
   getCategory
 } = savedPageSelectors
@@ -87,7 +87,7 @@ export const TracksTab = () => {
   const initialFetch = useSelector(getInitialFetchStatus)
   const isFetchingMore = useSelector(getIsFetchingMore)
   const saves = useSelector(getTrackSaves)
-  const localAdditions = useSelector(getSelectedCategoryLocalAdds)
+  const localAdditions = useSelector(getSelectedCategoryLocalTrackAdds)
 
   const saveCount = useMemo(
     () => saves.length + Object.keys(localAdditions).length,

--- a/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
+++ b/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
@@ -1,5 +1,6 @@
 import type { CollectionType, CommonState } from '@audius/common'
 import {
+  removeNullable,
   accountSelectors,
   cacheCollectionsSelectors,
   reachabilitySelectors,
@@ -9,8 +10,10 @@ import {
   useGetLibraryAlbums,
   useGetLibraryPlaylists,
   useProxySelector,
-  savedPageSelectors
+  savedPageSelectors,
+  filterCollections
 } from '@audius/common'
+import uniq from 'lodash/uniq'
 import { useSelector } from 'react-redux'
 
 import { useOfflineTracksStatus } from 'app/hooks/useOfflineTrackStatus'
@@ -23,7 +26,7 @@ import { OfflineDownloadStatus } from 'app/store/offline-downloads/slice'
 
 const { getIsReachable } = reachabilitySelectors
 const { getUserId } = accountSelectors
-const { getCollection } = cacheCollectionsSelectors
+const { getCollection, getCollectionWithUser } = cacheCollectionsSelectors
 const {
   getSelectedCategory,
   getSelectedCategoryLocalAlbumAdds,
@@ -39,7 +42,7 @@ type UseCollectionsScreenDataConfig = {
 
 export const useCollectionsScreenData = ({
   collectionType,
-  filterValue = ''
+  filterValue
 }: UseCollectionsScreenDataConfig) => {
   const isDoneLoadingFromDisk = useSelector(getIsDoneLoadingFromDisk)
   const isReachable = useSelector(getIsReachable)
@@ -73,6 +76,7 @@ export const useCollectionsScreenData = ({
     collectionType === 'albums' ? useGetLibraryAlbums : useGetLibraryPlaylists,
     {
       category: selectedCategory,
+      query: filterValue,
       userId: currentUserId!
     },
     {
@@ -87,8 +91,17 @@ export const useCollectionsScreenData = ({
   const availableCollectionIds = useProxySelector(
     (state: AppState) => {
       if (isReachable) {
-        return [...locallyAddedCollections, ...fetchedCollectionIds].filter(
-          (id) => !locallyRemovedCollections.has(id)
+        const filteredLocallyAddedCollectionIds = filterCollections(
+          locallyAddedCollections
+            .map((c) => getCollectionWithUser(state, { id: c }))
+            .filter(removeNullable),
+          { filterText: filterValue }
+        ).map((p) => p.playlist_id)
+        return uniq(
+          [
+            ...filteredLocallyAddedCollectionIds,
+            ...fetchedCollectionIds
+          ].filter((id) => !locallyRemovedCollections.has(id))
         )
       }
 

--- a/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
+++ b/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
@@ -1,6 +1,7 @@
 import type { CollectionType, CommonState } from '@audius/common'
 import {
   removeNullable,
+  SavedPageTabs,
   accountSelectors,
   cacheCollectionsSelectors,
   reachabilitySelectors,
@@ -28,7 +29,7 @@ const { getIsReachable } = reachabilitySelectors
 const { getUserId } = accountSelectors
 const { getCollection, getCollectionWithUser } = cacheCollectionsSelectors
 const {
-  getSelectedCategory,
+  getCategory,
   getSelectedCategoryLocalAlbumAdds,
   getSelectedCategoryLocalAlbumRemovals,
   getSelectedCategoryLocalPlaylistAdds,
@@ -46,7 +47,14 @@ export const useCollectionsScreenData = ({
 }: UseCollectionsScreenDataConfig) => {
   const isDoneLoadingFromDisk = useSelector(getIsDoneLoadingFromDisk)
   const isReachable = useSelector(getIsReachable)
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector((state) =>
+    getCategory(state, {
+      currentTab:
+        collectionType === 'albums'
+          ? SavedPageTabs.ALBUMS
+          : SavedPageTabs.PLAYLISTS
+    })
+  )
   const currentUserId = useSelector(getUserId)
   const offlineTracksStatus = useOfflineTracksStatus({ skipIfOnline: true })
 

--- a/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/requestDownloadAllFavoritesSaga.ts
@@ -17,7 +17,7 @@ import { addOfflineEntries, requestDownloadAllFavorites } from '../slice'
 
 const { getUserId } = accountSelectors
 
-const { getLocalSaves } = savedPageSelectors
+const { getLocalTrackFavorites } = savedPageSelectors
 
 export function* requestDownloadAllFavoritesSaga() {
   yield* takeEvery(requestDownloadAllFavorites.type, downloadAllFavorites)
@@ -42,7 +42,7 @@ function* downloadAllFavorites() {
 
   // Add local saves
   const favorite_created_at = moment().format('YYYY-MM-DD HH:mm:ss')
-  const localSaves = yield* select(getLocalSaves)
+  const localSaves = yield* select(getLocalTrackFavorites)
   const localSavesToAdd: OfflineEntry[] = Object.keys(localSaves)
     .map((id) => parseInt(id, 10))
     .map((id) => ({

--- a/packages/web/src/common/store/pages/saved/lineups/sagas.js
+++ b/packages/web/src/common/store/pages/saved/lineups/sagas.js
@@ -134,7 +134,7 @@ function* watchAddToLibrary() {
       yield put(saveActions.addLocalTrackSave(trackId, localSaveUid))
     } else {
       // action.type === REPOST_TRACK
-      yield put(saveActions.addLocalRepost(trackId, localSaveUid))
+      yield put(saveActions.addLocalTrackRepost(trackId, localSaveUid))
     }
     yield put(savedTracksActions.add(newEntry, trackId, undefined, true))
 

--- a/packages/web/src/common/store/pages/saved/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/sagas.ts
@@ -115,7 +115,7 @@ function prepareParams({
     userId: account.user_id,
     offset: params.offset ?? 0,
     limit: params.limit ?? account.track_save_count,
-    query: params.query ?? '',
+    query: params.query,
     sortMethod: params.sortMethod || 'added_date',
     sortDirection: params.sortDirection || 'desc',
     category: params.category

--- a/packages/web/src/common/store/pages/saved/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/sagas.ts
@@ -26,7 +26,7 @@ import { waitForRead } from 'utils/sagaHelpers'
 import tracksSagas from './lineups/sagas'
 const { signOut: signOutAction } = signOutActions
 
-const { getSaves } = savedPageSelectors
+const { getTrackSaves } = savedPageSelectors
 const { getAccountUser } = accountSelectors
 
 function* fetchLineupMetadatas(offset: number, limit: number) {
@@ -133,7 +133,7 @@ function* watchFetchSaves() {
     function* (rawParams: ReturnType<typeof actions.fetchSaves>) {
       yield* waitForRead()
       const account: User = yield* call(waitForValue, getAccountUser)
-      const saves = yield* select(getSaves)
+      const saves = yield* select(getTrackSaves)
       const params = prepareParams({ account, params: rawParams })
       const { query, sortDirection, sortMethod, offset, limit, category } =
         params

--- a/packages/web/src/common/store/pages/saved/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/sagas.ts
@@ -18,7 +18,9 @@ import {
   isLibraryCategory,
   LibraryCategoryType,
   Nullable,
-  calculateNewLibraryCategories
+  calculateNewLibraryCategories,
+  Favorite,
+  FavoriteType
 } from '@audius/common'
 import { call, fork, put, select, takeLatest } from 'typed-redux-saga'
 
@@ -96,9 +98,11 @@ function* sendLibraryRequest({
   const saves = savedTracksResponseData
     .filter((save) => Boolean(save.timestamp && save.item))
     .map((save) => ({
-      created_at: save.timestamp,
-      save_item_id: decodeHashId(save.item!.id!)
-    }))
+      created_at: save.timestamp!,
+      save_item_id: decodeHashId(save.item!.id!),
+      save_type: FavoriteType.TRACK,
+      user_id: userId
+    })) as Favorite[]
 
   return {
     saves,
@@ -161,7 +165,7 @@ function* watchFetchSaves() {
 
           const fullSaves = Array(account.track_save_count)
             .fill(0)
-            .map((_) => ({}))
+            .map((_) => ({})) as Favorite[]
 
           fullSaves.splice(offset, saves.length, ...saves)
           yield* put(actions.fetchSavesSucceeded(fullSaves))

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -19,7 +19,8 @@ import {
   playlistLibraryHelpers,
   playlistUpdatesActions,
   confirmerActions,
-  confirmTransaction
+  confirmTransaction,
+  savedPageActions
 } from '@audius/common'
 import { call, select, takeEvery, put } from 'typed-redux-saga'
 
@@ -39,7 +40,12 @@ const { update: updatePlaylistLibrary } = playlistLibraryActions
 const { removeFromPlaylistLibrary } = playlistLibraryHelpers
 const { getUser } = cacheUsersSelectors
 const { getCollections, getCollection } = cacheCollectionsSelectors
-
+const {
+  addLocalCollectionRepost,
+  removeLocalCollectionRepost,
+  addLocalCollectionFavorite,
+  removeLocalCollectionFavorite
+} = savedPageActions
 const { getPlaylistLibrary, getUserId } = accountSelectors
 
 /* REPOST COLLECTION */
@@ -89,7 +95,12 @@ export function* repostCollectionAsync(
       // is_repost_of_repost is true
       { is_repost_of_repost: collection.followee_reposts.length !== 0 }
     : { is_repost_of_repost: false }
-
+  yield* put(
+    addLocalCollectionRepost({
+      collectionId: action.collectionId,
+      isAlbum: collection.is_album
+    })
+  )
   yield* call(
     confirmRepostCollection,
     collection.playlist_owner_id,
@@ -191,6 +202,13 @@ export function* undoRepostCollectionAsync(
     ids: [action.collectionId]
   })
   const collection = collections[action.collectionId]
+
+  yield* put(
+    removeLocalCollectionRepost({
+      collectionId: action.collectionId,
+      isAlbum: collection.is_album
+    })
+  )
 
   const event = make(Name.UNDO_REPOST, {
     kind: collection.is_album ? 'album' : 'playlist',
@@ -386,6 +404,13 @@ export function* saveCollectionAsync(
   yield* call(addPlaylistsNotInLibrary)
 
   yield* put(
+    addLocalCollectionFavorite({
+      collectionId: action.collectionId,
+      isAlbum: collection.is_album
+    })
+  )
+
+  yield* put(
     cacheActions.update(Kind.COLLECTIONS, [
       {
         id: action.collectionId,
@@ -491,6 +516,13 @@ export function* unsaveCollectionAsync(
     ids: [action.collectionId]
   })
   const collection = collections[action.collectionId]
+
+  yield* put(
+    removeLocalCollectionFavorite({
+      collectionId: action.collectionId,
+      isAlbum: collection.is_album
+    })
+  )
 
   const event = make(Name.UNFAVORITE, {
     kind: collection.is_album ? 'album' : 'playlist',

--- a/packages/web/src/common/store/social/collections/sagas.ts
+++ b/packages/web/src/common/store/social/collections/sagas.ts
@@ -20,7 +20,8 @@ import {
   playlistUpdatesActions,
   confirmerActions,
   confirmTransaction,
-  savedPageActions
+  savedPageActions,
+  LibraryCategory
 } from '@audius/common'
 import { call, select, takeEvery, put } from 'typed-redux-saga'
 
@@ -40,12 +41,7 @@ const { update: updatePlaylistLibrary } = playlistLibraryActions
 const { removeFromPlaylistLibrary } = playlistLibraryHelpers
 const { getUser } = cacheUsersSelectors
 const { getCollections, getCollection } = cacheCollectionsSelectors
-const {
-  addLocalCollectionRepost,
-  removeLocalCollectionRepost,
-  addLocalCollectionFavorite,
-  removeLocalCollectionFavorite
-} = savedPageActions
+const { addLocalCollection, removeLocalCollection } = savedPageActions
 const { getPlaylistLibrary, getUserId } = accountSelectors
 
 /* REPOST COLLECTION */
@@ -96,9 +92,10 @@ export function* repostCollectionAsync(
       { is_repost_of_repost: collection.followee_reposts.length !== 0 }
     : { is_repost_of_repost: false }
   yield* put(
-    addLocalCollectionRepost({
+    addLocalCollection({
       collectionId: action.collectionId,
-      isAlbum: collection.is_album
+      isAlbum: collection.is_album,
+      category: LibraryCategory.Repost
     })
   )
   yield* call(
@@ -204,9 +201,10 @@ export function* undoRepostCollectionAsync(
   const collection = collections[action.collectionId]
 
   yield* put(
-    removeLocalCollectionRepost({
+    removeLocalCollection({
       collectionId: action.collectionId,
-      isAlbum: collection.is_album
+      isAlbum: collection.is_album,
+      category: LibraryCategory.Repost
     })
   )
 
@@ -404,9 +402,10 @@ export function* saveCollectionAsync(
   yield* call(addPlaylistsNotInLibrary)
 
   yield* put(
-    addLocalCollectionFavorite({
+    addLocalCollection({
       collectionId: action.collectionId,
-      isAlbum: collection.is_album
+      isAlbum: collection.is_album,
+      category: LibraryCategory.Favorite
     })
   )
 
@@ -518,9 +517,10 @@ export function* unsaveCollectionAsync(
   const collection = collections[action.collectionId]
 
   yield* put(
-    removeLocalCollectionFavorite({
+    removeLocalCollection({
       collectionId: action.collectionId,
-      isAlbum: collection.is_album
+      isAlbum: collection.is_album,
+      category: LibraryCategory.Favorite
     })
   )
 

--- a/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
@@ -4,7 +4,8 @@ import {
   LibraryCategory,
   statusIsNotFinalized,
   savedPageSelectors,
-  CommonState
+  CommonState,
+  SavedPageTabs
 } from '@audius/common'
 import { useSelector } from 'react-redux'
 
@@ -19,7 +20,7 @@ import { emptyStateMessages } from '../emptyStateMessages'
 import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
 
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 
 const messages = {
   emptyAlbumsBody: 'Once you have, this is where you’ll find them!',
@@ -35,7 +36,9 @@ export const AlbumsTabPage = () => {
     collections: albums
   } = useCollectionsData('album')
   const emptyAlbumsHeader = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.ALBUMS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return emptyStateMessages.emptyAlbumAllHeader
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
@@ -1,6 +1,12 @@
 import { useMemo } from 'react'
 
-import { statusIsNotFinalized } from '@audius/common'
+import {
+  LibraryCategory,
+  statusIsNotFinalized,
+  savedPageSelectors,
+  CommonState
+} from '@audius/common'
+import { useSelector } from 'react-redux'
 
 import { InfiniteCardLineup } from 'components/lineup/InfiniteCardLineup'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
@@ -8,11 +14,14 @@ import EmptyTable from 'components/tracks-table/EmptyTable'
 import { useGoToRoute } from 'hooks/useGoToRoute'
 import { useCollectionsData } from 'pages/saved-page/hooks/useCollectionsData'
 
+import { emptyStateMessages } from '../emptyStateMessages'
+
 import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
 
+const { getSelectedCategory } = savedPageSelectors
+
 const messages = {
-  emptyAlbumsHeader: 'You haven’t favorited any albums yet.',
   emptyAlbumsBody: 'Once you have, this is where you’ll find them!',
   goToTrending: 'Go to Trending'
 }
@@ -25,6 +34,18 @@ export const AlbumsTabPage = () => {
     fetchMore,
     collections: albums
   } = useCollectionsData('album')
+  const emptyAlbumsHeader = useSelector((state: CommonState) => {
+    const selectedCategory = getSelectedCategory(state)
+    if (selectedCategory === LibraryCategory.All) {
+      return emptyStateMessages.emptyAlbumAllHeader
+    } else if (selectedCategory === LibraryCategory.Favorite) {
+      return emptyStateMessages.emptyAlbumFavoritesHeader
+    } else if (selectedCategory === LibraryCategory.Purchase) {
+      return emptyStateMessages.emptyAlbumPurchasedHeader
+    } else {
+      return emptyStateMessages.emptyAlbumRepostsHeader
+    }
+  })
 
   const noResults = !statusIsNotFinalized(status) && albums?.length === 0
 
@@ -45,7 +66,7 @@ export const AlbumsTabPage = () => {
   if (noResults || !albums) {
     return (
       <EmptyTable
-        primaryText={messages.emptyAlbumsHeader}
+        primaryText={emptyAlbumsHeader}
         secondaryText={messages.emptyAlbumsBody}
         buttonLabel={messages.goToTrending}
         onClick={() => goToRoute('/trending')}

--- a/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
@@ -1,24 +1,15 @@
 import { useMemo } from 'react'
 
-import {
-  accountSelectors,
-  statusIsNotFinalized,
-  useGetLibraryAlbums,
-  useAllPaginatedQuery,
-  savedPageSelectors
-} from '@audius/common'
-import { useSelector } from 'react-redux'
+import { statusIsNotFinalized } from '@audius/common'
 
 import { InfiniteCardLineup } from 'components/lineup/InfiniteCardLineup'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import EmptyTable from 'components/tracks-table/EmptyTable'
 import { useGoToRoute } from 'hooks/useGoToRoute'
+import { useCollectionsData } from 'pages/saved-page/hooks/useCollectionsData'
 
 import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
-
-const { getUserId } = accountSelectors
-const { getSelectedCategory } = savedPageSelectors
 
 const messages = {
   emptyAlbumsHeader: 'You haven’t favorited any albums yet.',
@@ -28,36 +19,22 @@ const messages = {
 
 export const AlbumsTabPage = () => {
   const goToRoute = useGoToRoute()
-  const currentUserId = useSelector(getUserId)
-  const selectedCategory = useSelector(getSelectedCategory)
-
   const {
-    data: fetchedAlbums,
     status,
     hasMore,
-    loadMore: fetchMore
-  } = useAllPaginatedQuery(
-    useGetLibraryAlbums,
-    {
-      userId: currentUserId!,
-      category: selectedCategory
-    },
-    {
-      pageSize: 20,
-      disabled: currentUserId == null
-    }
-  )
+    fetchMore,
+    collections: albums
+  } = useCollectionsData('album')
 
-  const noFetchedResults =
-    !statusIsNotFinalized(status) && fetchedAlbums?.length === 0
+  const noResults = !statusIsNotFinalized(status) && albums?.length === 0
 
   const cards = useMemo(() => {
-    return fetchedAlbums?.map(({ playlist_id }, i) => {
+    return albums?.map(({ playlist_id }, i) => {
       return (
         <CollectionCard index={i} key={playlist_id} albumId={playlist_id} />
       )
     })
-  }, [fetchedAlbums])
+  }, [albums])
 
   if (statusIsNotFinalized(status)) {
     // TODO(nkang) - Confirm loading state UI
@@ -65,7 +42,7 @@ export const AlbumsTabPage = () => {
   }
 
   // TODO(nkang) - Add separate error state
-  if (noFetchedResults || !fetchedAlbums) {
+  if (noResults || !albums) {
     return (
       <EmptyTable
         primaryText={messages.emptyAlbumsHeader}

--- a/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
@@ -9,12 +9,14 @@ import {
 import { HarmonySelectablePill } from '@audius/stems'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { useIsUSDCEnabled } from 'hooks/useIsUSDCEnabled'
+
 import styles from './LibraryCategorySelectionMenu.module.css'
 
 const { getCategory } = savedPageSelectors
 const { setSelectedCategory } = savedPageActions
 
-const TRACKS_CATEGORIES = [
+const ALL_CATEGORIES = [
   {
     label: 'All',
     value: LibraryCategory.All
@@ -33,7 +35,7 @@ const TRACKS_CATEGORIES = [
   }
 ]
 
-const COLLECTIONS_CATEGORIES = TRACKS_CATEGORIES.slice(0, -1)
+const CATEGORIES_WITHOUT_PURCHASED = ALL_CATEGORIES.slice(0, -1)
 
 type LibraryCategorySelectionMenuProps = { currentTab: SavedPageTabs }
 
@@ -48,10 +50,11 @@ export const LibraryCategorySelectionMenu = ({
     dispatch(setSelectedCategory({ currentTab, category: value }))
   }
 
+  const isUSDCPurchasesEnabled = useIsUSDCEnabled()
   const categories =
-    currentTab === SavedPageTabs.TRACKS
-      ? TRACKS_CATEGORIES
-      : COLLECTIONS_CATEGORIES
+    currentTab === SavedPageTabs.TRACKS && isUSDCPurchasesEnabled
+      ? ALL_CATEGORIES
+      : CATEGORIES_WITHOUT_PURCHASED
 
   return (
     <div role='radiogroup' className={styles.container}>

--- a/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
@@ -1,18 +1,20 @@
 import {
+  CommonState,
+  LibraryCategory,
+  LibraryCategoryType,
   savedPageActions,
   savedPageSelectors,
-  LibraryCategory,
-  LibraryCategoryType
+  SavedPageTabs
 } from '@audius/common'
 import { HarmonySelectablePill } from '@audius/stems'
 import { useDispatch, useSelector } from 'react-redux'
 
 import styles from './LibraryCategorySelectionMenu.module.css'
 
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 const { setSelectedCategory } = savedPageActions
 
-const CATEGORIES = [
+const TRACKS_CATEGORIES = [
   {
     label: 'All',
     value: LibraryCategory.All
@@ -31,16 +33,29 @@ const CATEGORIES = [
   }
 ]
 
-export const LibraryCategorySelectionMenu = () => {
+const COLLECTIONS_CATEGORIES = TRACKS_CATEGORIES.slice(0, -1)
+
+type LibraryCategorySelectionMenuProps = { currentTab: SavedPageTabs }
+
+export const LibraryCategorySelectionMenu = ({
+  currentTab
+}: LibraryCategorySelectionMenuProps) => {
   const dispatch = useDispatch()
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector((state: CommonState) =>
+    getCategory(state, { currentTab })
+  )
   const handleClick = (value: LibraryCategoryType) => {
-    dispatch(setSelectedCategory(value))
+    dispatch(setSelectedCategory({ currentTab, category: value }))
   }
+
+  const categories =
+    currentTab === SavedPageTabs.TRACKS
+      ? TRACKS_CATEGORIES
+      : COLLECTIONS_CATEGORIES
 
   return (
     <div role='radiogroup' className={styles.container}>
-      {CATEGORIES.map((c) => (
+      {categories.map((c) => (
         <HarmonySelectablePill
           role='radio'
           size='large'

--- a/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
@@ -3,23 +3,28 @@ import { useCallback, useMemo } from 'react'
 import {
   cacheCollectionsActions,
   CreatePlaylistSource,
-  statusIsNotFinalized
+  statusIsNotFinalized,
+  savedPageSelectors,
+  LibraryCategory,
+  CommonState
 } from '@audius/common'
 import { IconPlus } from '@audius/stems'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { InfiniteCardLineup } from 'components/lineup/InfiniteCardLineup'
 import LoadingSpinner from 'components/loading-spinner/LoadingSpinner'
 import EmptyTable from 'components/tracks-table/EmptyTable'
 import UploadChip from 'components/upload/UploadChip'
-
 import { useCollectionsData } from 'pages/saved-page/hooks/useCollectionsData'
+
+import { emptyStateMessages } from '../emptyStateMessages'
+
 import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
 const { createPlaylist } = cacheCollectionsActions
+const { getSelectedCategory } = savedPageSelectors
 
 const messages = {
-  emptyPlaylistsHeader: 'You haven’t created or favorited any playlists yet.',
   emptyPlaylistsBody: 'Once you have, this is where you’ll find them!',
   createPlaylist: 'Create Playlist',
   newPlaylist: 'New Playlist'
@@ -29,6 +34,16 @@ export const PlaylistsTabPage = () => {
   const dispatch = useDispatch()
   const { status, hasMore, fetchMore, collections } =
     useCollectionsData('playlist')
+  const emptyPlaylistsHeader = useSelector((state: CommonState) => {
+    const selectedCategory = getSelectedCategory(state)
+    if (selectedCategory === LibraryCategory.All) {
+      return emptyStateMessages.emptyPlaylistAllHeader
+    } else if (selectedCategory === LibraryCategory.Favorite) {
+      return emptyStateMessages.emptyPlaylistFavoritesHeader
+    } else {
+      return emptyStateMessages.emptyPlaylistRepostsHeader
+    }
+  })
 
   const noResults = !statusIsNotFinalized(status) && collections?.length === 0
 
@@ -66,7 +81,7 @@ export const PlaylistsTabPage = () => {
   if (noResults || !collections) {
     return (
       <EmptyTable
-        primaryText={messages.emptyPlaylistsHeader}
+        primaryText={emptyPlaylistsHeader}
         secondaryText={messages.emptyPlaylistsBody}
         buttonLabel={messages.createPlaylist}
         buttonIcon={<IconPlus />}

--- a/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
@@ -2,11 +2,12 @@ import { useCallback, useMemo } from 'react'
 
 import {
   cacheCollectionsActions,
+  CommonState,
   CreatePlaylistSource,
-  statusIsNotFinalized,
-  savedPageSelectors,
   LibraryCategory,
-  CommonState
+  savedPageSelectors,
+  SavedPageTabs,
+  statusIsNotFinalized
 } from '@audius/common'
 import { IconPlus } from '@audius/stems'
 import { useDispatch, useSelector } from 'react-redux'
@@ -21,8 +22,9 @@ import { emptyStateMessages } from '../emptyStateMessages'
 
 import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
+
 const { createPlaylist } = cacheCollectionsActions
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 
 const messages = {
   emptyPlaylistsBody: 'Once you have, this is where you’ll find them!',
@@ -35,7 +37,9 @@ export const PlaylistsTabPage = () => {
   const { status, hasMore, fetchMore, collections } =
     useCollectionsData('playlist')
   const emptyPlaylistsHeader = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.PLAYLISTS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return emptyStateMessages.emptyPlaylistAllHeader
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -8,7 +8,7 @@ import {
   QueueItem,
   SavedPageCollection,
   savedPageSelectors,
-  SavedPageTabs as ProfileTabs,
+  SavedPageTabs,
   SavedPageTrack,
   Status,
   TrackRecord,
@@ -37,7 +37,7 @@ import { LibraryCategorySelectionMenu } from './LibraryCategorySelectionMenu'
 import { PlaylistsTabPage } from './PlaylistsTabPage'
 import styles from './SavedPage.module.css'
 
-const { getInitialFetchStatus, getSelectedCategory } = savedPageSelectors
+const { getInitialFetchStatus, getCategory } = savedPageSelectors
 
 const messages = {
   libraryHeader: 'Library',
@@ -74,11 +74,11 @@ export type SavedPageProps = {
   onClickRepost: (record: TrackRecord) => void
   onPlay: () => void
   onSortTracks: (sorters: any) => void
-  onChangeTab: (tab: ProfileTabs) => void
+  onChangeTab: (tab: SavedPageTabs) => void
   allTracksFetched: boolean
   filterText: string
   initialOrder: UID[] | null
-  currentTab: ProfileTabs
+  currentTab: SavedPageTabs
   account: (User & { albums: SavedPageCollection[] }) | undefined
   tracks: Lineup<SavedPageTrack>
   currentQueueItem: QueueItem
@@ -121,7 +121,9 @@ const SavedPage = ({
   const { mainContentRef } = useContext(MainContentContext)
   const initFetch = useSelector(getInitialFetchStatus)
   const emptyTracksHeader = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.TRACKS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return emptyStateMessages.emptyTrackAllHeader
     } else if (selectedCategory === LibraryCategory.Favorite) {
@@ -146,7 +148,7 @@ const SavedPage = ({
   const queuedAndPlaying = playing && isQueued
 
   // Setup play button
-  const playButtonActive = currentTab === ProfileTabs.TRACKS && !tracksLoading
+  const playButtonActive = currentTab === SavedPageTabs.TRACKS && !tracksLoading
   const playAllButton = (
     <div
       className={styles.playButtonContainer}
@@ -168,7 +170,7 @@ const SavedPage = ({
   )
 
   // Setup filter
-  const filterActive = currentTab === ProfileTabs.TRACKS
+  const filterActive = currentTab === SavedPageTabs.TRACKS
   const filter = (
     <div
       className={styles.filterContainer}
@@ -188,25 +190,25 @@ const SavedPage = ({
   const { tabs, body } = useTabs({
     isMobile: false,
     didChangeTabsFrom: (_, to) => {
-      onChangeTab(to as ProfileTabs)
+      onChangeTab(to as SavedPageTabs)
     },
     bodyClassName: styles.tabBody,
     elementClassName: styles.tabElement,
     tabs: [
       {
         icon: <IconNote />,
-        text: ProfileTabs.TRACKS,
-        label: ProfileTabs.TRACKS
+        text: SavedPageTabs.TRACKS,
+        label: SavedPageTabs.TRACKS
       },
       {
         icon: <IconAlbum />,
-        text: ProfileTabs.ALBUMS,
-        label: ProfileTabs.ALBUMS
+        text: SavedPageTabs.ALBUMS,
+        label: SavedPageTabs.ALBUMS
       },
       {
         icon: <IconPlaylists />,
-        text: ProfileTabs.PLAYLISTS,
-        label: ProfileTabs.PLAYLISTS
+        text: SavedPageTabs.PLAYLISTS,
+        label: SavedPageTabs.PLAYLISTS
       }
     ],
     elements: [
@@ -257,7 +259,7 @@ const SavedPage = ({
     <Header
       primary={messages.libraryHeader}
       secondary={isEmpty ? null : playAllButton}
-      rightDecorator={<LibraryCategorySelectionMenu />}
+      rightDecorator={<LibraryCategorySelectionMenu currentTab={currentTab} />}
       containerStyles={styles.savedPageHeader}
       bottomBar={headerBottomBar}
     />

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -1,7 +1,9 @@
 import { useContext } from 'react'
 
 import {
+  CommonState,
   ID,
+  LibraryCategory,
   Lineup,
   QueueItem,
   SavedPageCollection,
@@ -28,17 +30,18 @@ import EmptyTable from 'components/tracks-table/EmptyTable'
 import useTabs from 'hooks/useTabs/useTabs'
 import { MainContentContext } from 'pages/MainContentContext'
 
+import { emptyStateMessages } from '../emptyStateMessages'
+
 import { AlbumsTabPage } from './AlbumsTabPage'
 import { LibraryCategorySelectionMenu } from './LibraryCategorySelectionMenu'
 import { PlaylistsTabPage } from './PlaylistsTabPage'
 import styles from './SavedPage.module.css'
 
-const { getInitialFetchStatus } = savedPageSelectors
+const { getInitialFetchStatus, getSelectedCategory } = savedPageSelectors
 
 const messages = {
   libraryHeader: 'Library',
   filterPlaceholder: 'Filter Tracks',
-  emptyTracksHeader: 'You haven’t favorited any tracks yet.',
   emptyTracksBody: 'Once you have, this is where you’ll find them!',
   goToTrending: 'Go to Trending'
 }
@@ -117,6 +120,19 @@ const SavedPage = ({
 }: SavedPageProps) => {
   const { mainContentRef } = useContext(MainContentContext)
   const initFetch = useSelector(getInitialFetchStatus)
+  const emptyTracksHeader = useSelector((state: CommonState) => {
+    const selectedCategory = getSelectedCategory(state)
+    if (selectedCategory === LibraryCategory.All) {
+      return emptyStateMessages.emptyTrackAllHeader
+    } else if (selectedCategory === LibraryCategory.Favorite) {
+      return emptyStateMessages.emptyTrackFavoritesHeader
+    } else if (selectedCategory === LibraryCategory.Repost) {
+      return emptyStateMessages.emptyTrackRepostsHeader
+    } else {
+      return emptyStateMessages.emptyTrackPurchasedHeader
+    }
+  })
+
   const [dataSource, playingIndex] =
     status === Status.SUCCESS || entries.length
       ? getFilteredData(entries)
@@ -196,7 +212,7 @@ const SavedPage = ({
     elements: [
       isEmpty && !tracksLoading ? (
         <EmptyTable
-          primaryText={messages.emptyTracksHeader}
+          primaryText={emptyTracksHeader}
           secondaryText={messages.emptyTracksBody}
           buttonLabel={messages.goToTrending}
           onClick={() => goToRoute('/trending')}

--- a/packages/web/src/pages/saved-page/components/emptyStateMessages.ts
+++ b/packages/web/src/pages/saved-page/components/emptyStateMessages.ts
@@ -1,0 +1,18 @@
+export const emptyStateMessages = {
+  emptyTrackFavoritesHeader: 'You haven’t favorited any tracks yet.',
+  emptyTrackRepostsHeader: 'You haven’t reposted any tracks yet.',
+  emptyTrackPurchasedHeader: 'You haven’t purchased any tracks yet.',
+  emptyTrackAllHeader:
+    'You haven’t favorited, reposted, or purchased any tracks yet.',
+
+  emptyAlbumFavoritesHeader: 'You haven’t favorited any albums yet.',
+  emptyAlbumRepostsHeader: 'You haven’t reposted any albums yet.',
+  emptyAlbumPurchasedHeader: 'You haven’t purchased any albums yet.',
+  emptyAlbumAllHeader:
+    'You haven’t favorited, reposted, or purchased any albums yet.',
+
+  emptyPlaylistFavoritesHeader: 'You haven’t favorited any playlists yet.',
+  emptyPlaylistRepostsHeader: 'You haven’t reposted any playlists yet.',
+  emptyPlaylistAllHeader:
+    'You haven’t favorited, reposted, or purchased any playlists yet.'
+}

--- a/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/mobile/SavedPage.tsx
@@ -24,7 +24,8 @@ import {
   cacheUsersSelectors,
   useFetchedSavedCollections,
   usePremiumContentAccessMap,
-  useAccountAlbums
+  useAccountAlbums,
+  LibraryCategory
 } from '@audius/common'
 import { Button, ButtonType } from '@audius/stems'
 import cn from 'classnames'
@@ -49,6 +50,7 @@ import { useGoToRoute } from 'hooks/useGoToRoute'
 import useTabs from 'hooks/useTabs/useTabs'
 import { TRENDING_PAGE, collectionPage } from 'utils/route'
 
+import { emptyStateMessages } from '../emptyStateMessages'
 import { formatCardSecondaryText } from '../utils'
 
 import NewPlaylistButton from './NewPlaylistButton'
@@ -156,6 +158,18 @@ const TracksLineup = ({
       }
     })
   const contentRefCallback = useOffsetScroll()
+
+  const selectedCategory = LibraryCategory.Favorite
+  let emptyTracksHeader: string
+  // @ts-ignore `selectedCategory` will eventually come from store; hardcoded for now until rest of mobile web library is implemented.
+  if (selectedCategory === LibraryCategory.All) {
+    emptyTracksHeader = emptyStateMessages.emptyTrackAllHeader
+  } else if (selectedCategory === LibraryCategory.Favorite) {
+    emptyTracksHeader = emptyStateMessages.emptyTrackFavoritesHeader
+  } else {
+    emptyTracksHeader = emptyStateMessages.emptyTrackRepostsHeader
+  }
+
   return (
     <div className={styles.tracksLineupContainer}>
       {tracks.status !== Status.LOADING ? (
@@ -163,7 +177,7 @@ const TracksLineup = ({
           <EmptyTab
             message={
               <>
-                {messages.emptyTracks}
+                {emptyTracksHeader}
                 <i className={cn('emoji', 'face-with-monocle', styles.emoji)} />
               </>
             }
@@ -252,6 +266,7 @@ const AlbumCardLineup = () => {
 
   const { data: unfilteredAlbums, status: accountAlbumsStatus } =
     useAccountAlbums()
+
   const [filterText, setFilterText] = useState('')
   const filteredAlbumIds = useMemo(
     () => filterCollections(unfilteredAlbums, { filterText }).map((a) => a.id),
@@ -267,6 +282,17 @@ const AlbumCardLineup = () => {
     type: 'albums',
     pageSize: 20
   })
+
+  const selectedCategory = LibraryCategory.Favorite
+  let emptyAlbumsHeader: string
+  // @ts-ignore `selectedCategory` will eventually come from store; hardcoded for now until rest of mobile web library is implemented.
+  if (selectedCategory === LibraryCategory.All) {
+    emptyAlbumsHeader = emptyStateMessages.emptyAlbumAllHeader
+  } else if (selectedCategory === LibraryCategory.Favorite) {
+    emptyAlbumsHeader = emptyStateMessages.emptyAlbumFavoritesHeader
+  } else {
+    emptyAlbumsHeader = emptyStateMessages.emptyAlbumRepostsHeader
+  }
 
   const handleGoToTrending = useCallback(
     () => goToRoute(TRENDING_PAGE),
@@ -291,7 +317,7 @@ const AlbumCardLineup = () => {
         <EmptyTab
           message={
             <>
-              {messages.emptyAlbums}
+              {emptyAlbumsHeader}
               <i className={cn('emoji', 'face-with-monocle', styles.emoji)} />
             </>
           }
@@ -385,6 +411,17 @@ const PlaylistCardLineup = ({
     )
   })
 
+  const selectedCategory = LibraryCategory.Favorite
+  let emptyPlaylistsHeader: string
+  // @ts-ignore `selectedCategory` will eventually come from store; hardcoded for now until rest of mobile web library is implemented.
+  if (selectedCategory === LibraryCategory.All) {
+    emptyPlaylistsHeader = emptyStateMessages.emptyPlaylistAllHeader
+  } else if (selectedCategory === LibraryCategory.Favorite) {
+    emptyPlaylistsHeader = emptyStateMessages.emptyPlaylistFavoritesHeader
+  } else {
+    emptyPlaylistsHeader = emptyStateMessages.emptyPlaylistRepostsHeader
+  }
+
   const contentRefCallback = useOffsetScroll()
 
   return (
@@ -394,7 +431,7 @@ const PlaylistCardLineup = ({
           <EmptyTab
             message={
               <>
-                {messages.emptyPlaylists}
+                {emptyPlaylistsHeader}
                 <i className={cn('emoji', 'face-with-monocle', styles.emoji)} />
               </>
             }
@@ -427,9 +464,6 @@ const PlaylistCardLineup = ({
 }
 
 const messages = {
-  emptyTracks: "You haven't favorited any tracks yet.",
-  emptyAlbums: "You haven't favorited any albums yet.",
-  emptyPlaylists: "You haven't favorited any playlists yet.",
   filterTracks: 'Filter Tracks',
   filterAlbums: 'Filter Albums',
   filterPlaylists: 'Filter Playlists',

--- a/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
+++ b/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react'
+
+import {
+  accountSelectors,
+  cacheCollectionsSelectors,
+  CommonState,
+  savedPageSelectors,
+  useAllPaginatedQuery,
+  useGetLibraryAlbums,
+  useGetLibraryPlaylists
+} from '@audius/common'
+import { uniqBy } from 'lodash'
+import { useSelector } from 'react-redux'
+
+const { getUserId } = accountSelectors
+const {
+  getSelectedCategory,
+  getSelectedCategoryLocalAlbumAdds,
+  getSelectedCategoryLocalAlbumRemovals,
+  getSelectedCategoryLocalPlaylistAdds,
+  getSelectedCategoryLocalPlaylistRemovals
+} = savedPageSelectors
+const { getCollections } = cacheCollectionsSelectors
+
+export const useCollectionsData = (collectionType: 'album' | 'playlist') => {
+  const currentUserId = useSelector(getUserId)
+  const selectedCategory = useSelector(getSelectedCategory)
+
+  const locallyAddedCollections = useSelector((state: CommonState) => {
+    const ids =
+      collectionType === 'album'
+        ? getSelectedCategoryLocalAlbumAdds(state)
+        : getSelectedCategoryLocalPlaylistAdds(state)
+    const collectionsMap = getCollections(state, {
+      ids
+    })
+    return ids.map((id) => collectionsMap[id])
+  })
+
+  const locallyRemovedCollections = useSelector((state: CommonState) => {
+    const ids =
+      collectionType === 'album'
+        ? getSelectedCategoryLocalAlbumRemovals(state)
+        : getSelectedCategoryLocalPlaylistRemovals(state)
+    return new Set(ids)
+  })
+
+  const {
+    data: fetchedCollections,
+    status,
+    hasMore,
+    loadMore: fetchMore
+  } = useAllPaginatedQuery(
+    collectionType === 'album' ? useGetLibraryAlbums : useGetLibraryPlaylists,
+    {
+      userId: currentUserId!,
+      category: selectedCategory
+    },
+    {
+      pageSize: 20,
+      disabled: currentUserId == null
+    }
+  )
+  const collections = useMemo(() => {
+    return uniqBy(
+      [...locallyAddedCollections, ...(fetchedCollections || [])].filter(
+        (a) => !locallyRemovedCollections.has(a.playlist_id)
+      ),
+      'playlist_id'
+    )
+  }, [locallyAddedCollections, fetchedCollections, locallyRemovedCollections])
+
+  return {
+    status,
+    hasMore,
+    fetchMore,
+    collections
+  }
+}

--- a/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
+++ b/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
@@ -14,7 +14,7 @@ import { useSelector } from 'react-redux'
 
 const { getUserId } = accountSelectors
 const {
-  getSelectedCategory,
+  getCollectionsCategory,
   getSelectedCategoryLocalAlbumAdds,
   getSelectedCategoryLocalAlbumRemovals,
   getSelectedCategoryLocalPlaylistAdds,
@@ -24,7 +24,7 @@ const { getCollections } = cacheCollectionsSelectors
 
 export const useCollectionsData = (collectionType: 'album' | 'playlist') => {
   const currentUserId = useSelector(getUserId)
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector(getCollectionsCategory)
 
   const locallyAddedCollections = useSelector((state: CommonState) => {
     const ids =


### PR DESCRIPTION
### Description
- Make sure tracks and collections that are favorited or reposted are added to the library
- Make sure tracks and collections that are un-favorited or un-reposted are removed from the library

For the collections piece of this, I originally tried to use `useUpdateQueryData` from the audius-query library API, but it's not meant/built to be used in a saga. Plus, going that route would get quite tricky and bug prone when/if we add different sorting options to the collections tabs.

So I landed on keeping the locally added/removed collection IDs in the Redux store and using those along with the fetched library collections (from API) to calculate the right collections to show in the library.


### How Has This Been Tested?


### Screenshots

