### PR TITLE
[C-2950 C-3033] Fix and simplify issues resulting from collection fetching

### DIFF
--- a/packages/common/src/store/pages/collection/actions.ts
+++ b/packages/common/src/store/pages/collection/actions.ts
@@ -5,8 +5,6 @@ export const FETCH_COLLECTION = 'FETCH_COLLECTION'
 export const FETCH_COLLECTION_SUCCEEDED = 'FETCH_COLLECTION_SUCCEEDED'
 export const FETCH_COLLECTION_FAILED = 'FETCH_COLLECTION_FAILED'
 export const RESET_COLLECTION = 'RESET_COLLECTION'
-export const RESET_AND_FETCH_COLLECTION_TRACKS =
-  'RESET_AND_FETCH_COLLECTION_TRACKS'
 export const SET_SMART_COLLECTION = 'SET_SMART_COLLECTION'
 
 export const fetchCollection = (
@@ -39,19 +37,12 @@ export const fetchCollectionFailed = (userUid: UID) => ({
 })
 
 export const resetCollection = (
-  collectionUid: Nullable<UID>,
-  userUid: Nullable<UID>
+  collectionUid?: Nullable<UID>,
+  userUid?: Nullable<UID>
 ) => ({
   type: RESET_COLLECTION,
   collectionUid,
   userUid
-})
-
-export const resetAndFetchCollectionTracks = (
-  collectionId: Nullable<ID | SmartCollectionVariant>
-) => ({
-  type: RESET_AND_FETCH_COLLECTION_TRACKS,
-  collectionId
 })
 
 export const setSmartCollection = (

--- a/packages/common/src/store/pages/collection/selectors.ts
+++ b/packages/common/src/store/pages/collection/selectors.ts
@@ -4,6 +4,7 @@ import { getCollection as getCachedCollection } from 'store/cache/collections/se
 import { getUser as getCachedUser } from 'store/cache/users/selectors'
 import { CommonState } from 'store/commonStore'
 import { getCollection as getSmartCollection } from 'store/pages/smart-collection/selectors'
+import { Nullable } from 'utils/typeUtils'
 
 import { ID, UID, Status } from '../../../models'
 
@@ -18,7 +19,10 @@ export const getSmartCollectionVariant = (state: CommonState) =>
   state.pages.collection.smartCollectionVariant
 export const getCollectionPermalink = (state: CommonState) =>
   state.pages.collection.collectionPermalink
-export const getCollection = (state: CommonState, params?: { id: ID }) => {
+export const getCollection = (
+  state: CommonState,
+  params?: { id?: Nullable<ID> }
+) => {
   const smartCollectionVariant = getSmartCollectionVariant(state)
   if (smartCollectionVariant) {
     return getSmartCollection(state, { variant: smartCollectionVariant })

--- a/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
+++ b/packages/mobile/src/components/navigation-container/NavigationContainer.tsx
@@ -104,7 +104,7 @@ const NavigationContainer = (props: NavigationContainerProps) => {
                       initialRouteName: 'Feed',
                       screens: {
                         Feed: 'feed',
-                        Collection: ':handle/collection/:collectionName',
+                        Collection: ':handle/collection/:slug',
                         TrackRemixes: ':handle/:slug/remixes',
                         Track: 'track/:handle/:slug',
                         Profile: {

--- a/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
+++ b/packages/mobile/src/screens/app-screen/AppTabScreen.tsx
@@ -71,9 +71,10 @@ export type AppTabScreenParamList = {
   Profile: { handle: string; id?: ID } | { handle?: string; id: ID }
   Collection: {
     id?: ID
-    collectionName?: string
+    slug?: string
     searchCollection?: SearchPlaylist
     collectionType?: 'playlist' | 'album'
+    handle?: string
   }
   EditPlaylist: { id: ID }
   Favorited: { id: ID; favoriteType: FavoriteType }

--- a/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreen.tsx
@@ -31,7 +31,6 @@ import type {
   SearchPlaylist,
   SearchUser
 } from '@audius/common'
-import { useFocusEffect } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
 
 import {
@@ -54,6 +53,7 @@ import { useThemePalette } from 'app/utils/theme'
 
 import { CollectionScreenDetailsTile } from './CollectionScreenDetailsTile'
 import { CollectionScreenSkeleton } from './CollectionScreenSkeleton'
+import { useFetchCollectionLineup } from './useFetchCollectionLineup'
 
 const { open: openEditPlaylist } = createPlaylistModalUIActions
 const { setFavorite } = favoritesUserListActions
@@ -66,7 +66,7 @@ const {
   undoRepostCollection,
   unsaveCollection
 } = collectionsSocialActions
-const { fetchCollection } = collectionPageActions
+const { resetCollection, fetchCollection } = collectionPageActions
 const { getCollection, getUser } = collectionPageSelectors
 const getUserId = accountSelectors.getUserId
 const { requestOpen: openPublishConfirmation } =
@@ -91,30 +91,21 @@ export const CollectionScreen = () => {
 
   // params is incorrectly typed and can sometimes be undefined
   const {
-    id: idParam,
+    id = null,
     searchCollection,
-    collectionName,
-    collectionType
+    slug,
+    collectionType,
+    handle
   } = params ?? {}
 
-  const id = useMemo(() => {
-    if (collectionName) {
-      // Use collectionName from params if provided
-      // This is to support deep linking
-      // TODO: update this when collections are updated to use slug url format
-      // https://linear.app/audius/issue/C-1198/update-mobile-deep-linking-to-support-collection-slug-url-format
-      const nameParts = collectionName.split('-')
-      const collectionId = parseInt(nameParts[nameParts.length - 1], 10)
-      return collectionId as number
-    }
-    return idParam as number
-  }, [collectionName, idParam])
+  const permalink = slug ? `/${handle}/${collectionType}/${slug}` : undefined
 
   const handleFetchCollection = useCallback(() => {
-    dispatch(fetchCollection(id, undefined, true))
-  }, [dispatch, id])
+    dispatch(resetCollection())
+    dispatch(fetchCollection(id, permalink, true))
+  }, [dispatch, id, permalink])
 
-  useFocusEffect(handleFetchCollection)
+  useFetchCollectionLineup(id, handleFetchCollection)
 
   const cachedCollection = useSelector((state) =>
     getCollection(state, { id })

--- a/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
+++ b/packages/mobile/src/screens/collection-screen/CollectionScreenDetailsTile.tsx
@@ -4,7 +4,6 @@ import type { ID, Maybe, SmartCollectionVariant, UID } from '@audius/common'
 import {
   removeNullable,
   collectionPageSelectors,
-  collectionPageActions,
   playerSelectors,
   Status,
   Name,
@@ -31,8 +30,6 @@ import { makeStyles } from 'app/styles'
 import { formatCount } from 'app/utils/format'
 
 import { CollectionHeader } from './CollectionHeader'
-import { useFetchCollectionLineup } from './useFetchCollectionLineup'
-const { resetAndFetchCollectionTracks } = collectionPageActions
 const { getPlaying, getUid, getCurrentTrack } = playerSelectors
 const { getIsReachable } = reachabilitySelectors
 const { getCollectionTracksLineup } = collectionPageSelectors
@@ -158,12 +155,6 @@ export const CollectionScreenDetailsTile = ({
   const dispatch = useDispatch()
 
   const isReachable = useSelector(getIsReachable)
-
-  const fetchLineup = useCallback(() => {
-    dispatch(resetAndFetchCollectionTracks(collectionId))
-  }, [dispatch, collectionId])
-
-  useFetchCollectionLineup(collectionId, fetchLineup)
 
   const trackUids = useSelector(selectTrackUids)
   const collectionTrackCount = useSelector(selectTrackCount)

--- a/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
+++ b/packages/mobile/src/screens/smart-collection-screen/SmartCollectionScreen.tsx
@@ -6,7 +6,8 @@ import {
   smartCollectionPageSelectors,
   collectionsSocialActions,
   smartCollectionPageActions,
-  playlistLibraryHelpers
+  playlistLibraryHelpers,
+  collectionPageActions
 } from '@audius/common'
 import { useFocusEffect } from '@react-navigation/native'
 import { View } from 'react-native'
@@ -24,6 +25,7 @@ const { saveSmartCollection, unsaveSmartCollection } = collectionsSocialActions
 const { getCollection } = smartCollectionPageSelectors
 const getPlaylistLibrary = accountSelectors.getPlaylistLibrary
 const { fetchSmartCollection } = smartCollectionPageActions
+const { resetCollection } = collectionPageActions
 
 const useStyles = makeStyles(({ spacing }) => ({
   root: {
@@ -60,6 +62,7 @@ export const SmartCollectionScreen = (props: SmartCollectionScreenProps) => {
   const dispatch = useDispatch()
 
   const handleFetchSmartCollection = useCallback(() => {
+    dispatch(resetCollection())
     dispatch(fetchSmartCollection({ variant }))
   }, [dispatch, variant])
 

--- a/packages/web/src/common/store/smart-collection/sagas.ts
+++ b/packages/web/src/common/store/smart-collection/sagas.ts
@@ -7,7 +7,8 @@ import {
   smartCollectionPageActions,
   collectionPageActions,
   getContext,
-  removeNullable
+  removeNullable,
+  collectionPageLineupActions
 } from '@audius/common'
 import { takeEvery, put, call, select } from 'typed-redux-saga'
 
@@ -148,7 +149,7 @@ function* fetchMostLoved() {
       track: track.track_id
     }))
 
-  yield call(processAndCacheTracks, tracks)
+  yield* call(processAndCacheTracks, tracks)
 
   return {
     ...MOST_LOVED,
@@ -249,7 +250,7 @@ const fetchMap = {
 }
 
 function* watchFetch() {
-  yield takeEvery(
+  yield* takeEvery(
     fetchSmartCollection.type,
     function* (action: ReturnType<typeof fetchSmartCollection>) {
       yield* waitForRead()
@@ -259,14 +260,22 @@ function* watchFetch() {
       const collection: any = yield* call(fetchMap[variant])
 
       if (collection) {
-        yield put(
+        yield* put(
           fetchSmartCollectionSucceeded({
             variant,
             collection
           })
         )
       }
-      yield put(setSmartCollection(variant))
+      yield* put(setSmartCollection(variant))
+      yield put(
+        collectionPageLineupActions.fetchLineupMetadatas(
+          0,
+          200,
+          false,
+          undefined
+        )
+      )
     }
   )
 }

--- a/packages/web/src/pages/collection-page/CollectionPage.tsx
+++ b/packages/web/src/pages/collection-page/CollectionPage.tsx
@@ -22,7 +22,6 @@ const CollectionPage = (props: CollectionPageProps) => {
       isMobile={isMobileClient}
       smartCollection={smartCollection}
       type={type}
-      playlistByPermalinkEnabled={true}
     >
       {content}
     </CollectionPageProvider>

--- a/packages/web/src/utils/route/collectionRouteParser.ts
+++ b/packages/web/src/utils/route/collectionRouteParser.ts
@@ -38,48 +38,43 @@ type CollectionRouteParams =
  * If the route is a hash id route, title, handle, and type are not returned
  * @param route
  */
-export const parseCollectionRoute = (
-  route: string,
-  playlistByPermalinkEnabled?: boolean
-): CollectionRouteParams => {
-  if (playlistByPermalinkEnabled) {
-    const playlistByPermalinkMatch = matchPath<{
-      handle: string
-      slug: string
-    }>(route, {
-      path: PLAYLIST_BY_PERMALINK_PAGE,
-      exact: true
-    })
+export const parseCollectionRoute = (route: string): CollectionRouteParams => {
+  const playlistByPermalinkMatch = matchPath<{
+    handle: string
+    slug: string
+  }>(route, {
+    path: PLAYLIST_BY_PERMALINK_PAGE,
+    exact: true
+  })
 
-    if (playlistByPermalinkMatch) {
-      const { handle, slug } = playlistByPermalinkMatch.params
-      const permalink = `/${handle}/playlist/${slug}`
-      return {
-        title: null,
-        collectionId: null,
-        permalink,
-        handle: null,
-        collectionType: 'playlist'
-      }
+  if (playlistByPermalinkMatch) {
+    const { handle, slug } = playlistByPermalinkMatch.params
+    const permalink = `/${handle}/playlist/${slug}`
+    return {
+      title: null,
+      collectionId: null,
+      permalink,
+      handle: null,
+      collectionType: 'playlist'
     }
-    const albumByPermalinkMatch = matchPath<{
-      handle: string
-      slug: string
-    }>(route, {
-      path: ALBUM_BY_PERMALINK_PAGE,
-      exact: true
-    })
+  }
+  const albumByPermalinkMatch = matchPath<{
+    handle: string
+    slug: string
+  }>(route, {
+    path: ALBUM_BY_PERMALINK_PAGE,
+    exact: true
+  })
 
-    if (albumByPermalinkMatch) {
-      const { handle, slug } = albumByPermalinkMatch.params
-      const permalink = `/${handle}/album/${slug}`
-      return {
-        title: null,
-        collectionId: null,
-        permalink,
-        handle: null,
-        collectionType: 'album'
-      }
+  if (albumByPermalinkMatch) {
+    const { handle, slug } = albumByPermalinkMatch.params
+    const permalink = `/${handle}/album/${slug}`
+    return {
+      title: null,
+      collectionId: null,
+      permalink,
+      handle: null,
+      collectionType: 'album'
     }
   }
 


### PR DESCRIPTION
### Description

Fixes issues with collection fetching where mobile/web smart/not-smart collection pages all implement their own behavior for fetching collection metadata and fetching collection tracks. This PR merges all those paths, which in turn fix multiple issues:
1. Fixes mobile collection deep links
2. Fixes offline-mode collection loading
3. Fixes cases where smart collections sometimes would not fetch their tracks on mobile and web
4. Fixes duplicate fetch on mobile


### How Has This Been Tested?

Tested deep links for mobile and web, and tested navigating to and between collections on mobile and web. Tested that offline mode works
