### PR TITLE
[C-3035] Stale stats for offline tracks

### DIFF
--- a/packages/common/src/models/Collection.ts
+++ b/packages/common/src/models/Collection.ts
@@ -57,6 +57,7 @@ export type CollectionMetadata = {
   playlist_image_multihash?: string
   playlist_image_sizes_multihash?: string
   offline?: OfflineCollectionMetadata
+  local?: boolean
 }
 
 export type CollectionDownloadReason = { is_from_favorites: boolean }

--- a/packages/common/src/models/Track.ts
+++ b/packages/common/src/models/Track.ts
@@ -208,6 +208,7 @@ export type TrackMetadata = {
   duration: number
 
   offline?: OfflineTrackMetadata
+  local?: boolean
 } & Timestamped
 
 export type DownloadReason = {

--- a/packages/common/src/store/cache/reducer.ts
+++ b/packages/common/src/store/cache/reducer.ts
@@ -207,6 +207,7 @@ const addEntries = (state: CacheState, entries: any[], replace?: boolean) => {
     ) {
       // do nothing
     } else if (existing) {
+      delete existing.local
       let newMetadata = mergeWith(
         {},
         existing,

--- a/packages/mobile/src/store/offline-downloads/sagas/rehydrateOfflineDataSaga.ts
+++ b/packages/mobile/src/store/offline-downloads/sagas/rehydrateOfflineDataSaga.ts
@@ -69,7 +69,7 @@ export function* rehydrateOfflineDataSaga() {
     collectionsToCache.push({
       id,
       uid: makeUid(Kind.COLLECTIONS, id),
-      metadata: collection
+      metadata: { ...collection, local: true }
     })
 
     if (user) {
@@ -77,7 +77,7 @@ export function* rehydrateOfflineDataSaga() {
       usersToCache.push({
         id: user_id,
         uid: makeUid(Kind.USERS, user_id),
-        metadata: user
+        metadata: { ...user, local: true }
       })
     }
   }
@@ -103,7 +103,7 @@ export function* rehydrateOfflineDataSaga() {
     tracksToCache.push({
       id: track_id,
       uid: makeUid(Kind.TRACKS, track_id),
-      metadata: track
+      metadata: { ...track, local: true }
     })
 
     if (user) {
@@ -111,7 +111,7 @@ export function* rehydrateOfflineDataSaga() {
       usersToCache.push({
         id: user_id,
         uid: makeUid(Kind.USERS, user_id),
-        metadata: user
+        metadata: { ...user, local: true }
       })
     }
   }


### PR DESCRIPTION
### Description

Fixes issue where downloaded tracks have stale stats when user is online. This is because the downloaded track is populated in the cache, and then doesn't update until cache TTL. Added update where any track, collection, or user that enters the cache from offline data has a `local` flag on it so the cache knows to flush it next time it's requested. We do the same thing for local account user.
