### PR TITLE
Add guard to prevent attempted read of undefined queue items

### DIFF
--- a/packages/web/src/common/store/lineup/sagas.js
+++ b/packages/web/src/common/store/lineup/sagas.js
@@ -373,7 +373,7 @@ function* play(lineupActions, lineupSelector, prefix, action) {
           const queueable = yield call(getToQueue, lineup.prefix, e)
           // If the entry is the one we're playing, set isPreview to incoming
           // value
-          if (queueable.uid === action.uid) {
+          if (queueable?.uid === action.uid) {
             queueable.isPreview = isPreview
           }
           return queueable


### PR DESCRIPTION
### Description
`getToQueue` has code paths that can return `undefined`, so we need to guard the check against `uid` for the new preview functionality

### How Has This Been Tested?
I am unable to reproduce the original crash, but will do coordinated testing with somebody who can.

