### PR TITLE
[PAY-1793] Use existing SOL to fund dest ATA

### DIFF
--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -21,8 +21,9 @@ import {
 // Allowable slippage amount for USDC jupiter swaps in %.
 const USDC_SLIPPAGE = 3
 
-const getWithdrawUSDCFees = async (account: PublicKey) => {
-  // TODO: factor in existing sol balance
+export const getFundDestinationTokenAccountFees = async (
+  account: PublicKey
+) => {
   // TODO: might have to pay rent for root sol account, see BuyAudio.ts
   const rent = await getAssociatedTokenAccountRent()
   const fee = await getTransferTransactionFee(account)
@@ -35,15 +36,15 @@ const getWithdrawUSDCFees = async (account: PublicKey) => {
  */
 export const getSwapUSDCUserBankInstructions = async ({
   destinationAddress,
+  amount,
   feePayer
 }: {
   destinationAddress: string
+  amount: number
   feePayer: PublicKey
 }): Promise<TransactionInstruction[]> => {
   const libs = await getLibs()
 
-  // Destination associated token account does not exist - create and fund it
-  const feeAmount = await getWithdrawUSDCFees(new PublicKey(destinationAddress))
   const solanaRootAccount = await getRootSolanaAccount()
   const usdcUserBank = await libs.solanaWeb3Manager!.deriveUserBank({
     mint: 'usdc'
@@ -54,7 +55,7 @@ export const getSwapUSDCUserBankInstructions = async ({
   const quoteRoute = await JupiterSingleton.getQuote({
     inputTokenSymbol: 'USDC',
     outputTokenSymbol: 'SOL',
-    inputAmount: feeAmount,
+    inputAmount: amount,
     slippage: USDC_SLIPPAGE,
     swapMode: 'ExactOut' as SwapMode,
     onlyDirectRoutes: true

--- a/packages/web/src/services/solana/solana.ts
+++ b/packages/web/src/services/solana/solana.ts
@@ -14,7 +14,7 @@ import {
 
 import { getLibs } from 'services/audius-libs'
 
-const ROOT_ACCOUNT_SIZE = 0 // Root account takes 0 bytes, but still pays rent!
+export const ROOT_ACCOUNT_SIZE = 0 // Root account takes 0 bytes, but still pays rent!
 
 /**
  * Gets the solana connection from libs.

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -14,6 +14,7 @@ import {
   Token
 } from '@solana/spl-token'
 import {
+  LAMPORTS_PER_SOL,
   PublicKey,
   Transaction,
   sendAndConfirmTransaction
@@ -23,7 +24,10 @@ import { takeLatest } from 'redux-saga/effects'
 import { call, put, select } from 'typed-redux-saga'
 
 import { getLibs } from 'services/audius-libs'
-import { getSwapUSDCUserBankInstructions } from 'services/solana/WithdrawUSDC'
+import {
+  getSwapUSDCUserBankInstructions,
+  getFundDestinationTokenAccountFees
+} from 'services/solana/WithdrawUSDC'
 import {
   isSolWallet,
   getTokenAccountInfo,
@@ -156,41 +160,59 @@ function* doWithdrawUSDC({ payload }: ReturnType<typeof beginWithdrawUSDC>) {
         console.debug(
           'Withdraw USDC - destination associated token account does not exist'
         )
-        // First swap some USDC for SOL to fund the destination associated token account
-        const swapInstructions = yield* call(getSwapUSDCUserBankInstructions, {
-          destinationAddress,
-          feePayer: feePayerPubkey
-        })
-        const swapRecentBlockhash = yield* call(getRecentBlockhash)
-        const signatureWithPubkey = yield* call(getSignatureForTransaction, {
-          instructions: swapInstructions,
-          signer: rootSolanaAccount,
-          feePayer: feePayerPubkey,
-          recentBlockhash: swapRecentBlockhash
-        })
-        // Send swap instructions to relay
-        const { res: swapRes, error: swapError } = yield* call(
-          [transactionHandler, transactionHandler.handleTransaction],
-          {
-            instructions: swapInstructions,
-            feePayerOverride: feePayerPubkey,
-            skipPreflight: false,
-            signatures: signatureWithPubkey.map((s) => ({
-              signature: s.signature!,
-              publicKey: s.publicKey.toString()
-            })),
-            recentBlockhash: swapRecentBlockhash
-          }
+        // Check if there is enough SOL to fund the destination associated token account
+        const feeAmount = yield* call(
+          getFundDestinationTokenAccountFees,
+          new PublicKey(destinationAddress)
         )
-        if (swapError) {
-          throw new Error(`Swap transaction failed: ${swapError}`)
+        console.debug('REED feeAmount: ', feeAmount)
+        const existingBalance =
+          (yield* call(
+            [connection, connection.getBalance],
+            rootSolanaAccount.publicKey
+          )) / LAMPORTS_PER_SOL
+        console.debug('REED existingBalance: ', existingBalance)
+        if (feeAmount > existingBalance) {
+          // Swap USDC for SOL to fund the destination associated token account
+          console.debug(
+            'Withdraw USDC - not enough SOL to fund destination account, attempting to swap USDC for SOL'
+          )
+          const swapInstructions = yield* call(
+            getSwapUSDCUserBankInstructions,
+            {
+              destinationAddress,
+              amount: feeAmount - existingBalance,
+              feePayer: feePayerPubkey
+            }
+          )
+          const swapRecentBlockhash = yield* call(getRecentBlockhash)
+          const signatureWithPubkey = yield* call(getSignatureForTransaction, {
+            instructions: swapInstructions,
+            signer: rootSolanaAccount,
+            feePayer: feePayerPubkey,
+            recentBlockhash: swapRecentBlockhash
+          })
+          // Send swap instructions to relay
+          const { res: swapRes, error: swapError } = yield* call(
+            [transactionHandler, transactionHandler.handleTransaction],
+            {
+              instructions: swapInstructions,
+              feePayerOverride: feePayerPubkey,
+              skipPreflight: false,
+              signatures: signatureWithPubkey.map((s) => ({
+                signature: s.signature!,
+                publicKey: s.publicKey.toString()
+              })),
+              recentBlockhash: swapRecentBlockhash
+            }
+          )
+          if (swapError) {
+            throw new Error(`Swap transaction failed: ${swapError}`)
+          }
+          console.debug(`Withdraw USDC - swap successful: ${swapRes}`)
         }
-        console.debug(`Withdraw USDC - swap successful: ${swapRes}`)
 
         // Then create and fund the destination associated token account
-        // using funds from the root solana account that we just swapped for.
-        // TODO: use existing funds if possible
-        // https://linear.app/audius/issue/PAY-1793/use-existing-sol-funds-for-withdraw-usdc-fees
         const createRecentBlockhash = yield* call(getRecentBlockhash)
         const tx = new Transaction({ recentBlockhash: createRecentBlockhash })
         const createTokenAccountInstruction = yield* call(
@@ -228,7 +250,7 @@ function* doWithdrawUSDC({ payload }: ReturnType<typeof beginWithdrawUSDC>) {
       destinationTokenAccount = destinationTokenAccountPubkey.toString()
     }
     const amountWei = new BN(amount).mul(
-      new BN(TOKEN_LISTING_MAP.usdc.decimals)
+      new BN(TOKEN_LISTING_MAP.USDC.decimals)
     )
     const usdcUserBank = yield* call(getUSDCUserBank)
     const transferInstructions = yield* call(

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -181,7 +181,7 @@ function* doWithdrawUSDC({ payload }: ReturnType<typeof beginWithdrawUSDC>) {
         if (feeAmount > existingBalance - rootSolanaAccountRent) {
           // Swap USDC for SOL to fund the destination associated token account
           console.debug(
-            'Withdraw USDC - not enough SOL to fund destination account, attempting to swap USDC for SOL'
+            `Withdraw USDC - not enough SOL to fund destination account, attempting to swap USDC for SOL. Fee amount: ${feeAmount}, existing balance: ${existingBalance}, rent for root solana account: ${rootSolanaAccountRent}`
           )
           const swapInstructions = yield* call(
             getSwapUSDCUserBankInstructions,


### PR DESCRIPTION
### Description
Check for existing SOL in root solana account that can be used to fund destination token account.
Also maintains minimum balance in root solana account for rent.
Bonus - fix a small bug: was using `TOKEN_LISTING_MAP.usdc` instead of `TOKEN_LISTING_MAP.USDC`.

### How Has This Been Tested?
Local web stage
Successfully created this token account without any swaps: https://solscan.io/account/3UV5mKKCDt6sPKi7RburgDfvrHtRKgrGmmdfbjggxNzL

### Screenshots

