### PR TITLE
Add filter functionality back to library PAY-1771

### DIFF
--- a/packages/common/src/api/library.ts
+++ b/packages/common/src/api/library.ts
@@ -37,7 +37,7 @@ const fetchLibraryCollections = async ({
     offset,
     limit,
     category,
-    query = '',
+    query,
     sortMethod = 'added_date',
     sortDirection = 'desc'
   } = args

--- a/packages/common/src/store/cache/collections/selectors.ts
+++ b/packages/common/src/store/cache/collections/selectors.ts
@@ -177,7 +177,7 @@ export const getTracksFromCollection = (
     .filter(Boolean) as EnhancedCollectionTrack[]
 }
 
-type EnhancedCollection = Collection & { user: User }
+export type EnhancedCollection = Collection & { user: User }
 export const getCollectionWithUser = (
   state: CommonState,
   props: { id?: ID }

--- a/packages/common/src/utils/collectionUtils.ts
+++ b/packages/common/src/utils/collectionUtils.ts
@@ -1,22 +1,31 @@
 import { AccountCollection } from 'store/account'
+import { EnhancedCollection } from 'store/cache/collections/selectors'
 
 type FilterCollectionsOptions = {
   filterText?: string
 }
 
-export function filterCollections(
-  collections: AccountCollection[],
-  { filterText = '' }: FilterCollectionsOptions
-): AccountCollection[] {
-  return collections.filter((item: AccountCollection) => {
-    if (filterText) {
-      const matchesPlaylistName =
-        item.name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
-      const matchesOwnerName =
-        item.user.handle.toLowerCase().indexOf(filterText.toLowerCase()) > -1
+export const isAccountCollection = (
+  collection: AccountCollection | EnhancedCollection
+): collection is AccountCollection => {
+  return (collection as AccountCollection).name !== undefined
+}
 
-      return matchesPlaylistName || matchesOwnerName
+export function filterCollections<
+  T extends AccountCollection | EnhancedCollection
+>(collections: T[], { filterText = '' }: FilterCollectionsOptions): T[] {
+  return collections.filter((item: AccountCollection | EnhancedCollection) => {
+    const matchesOwnerName =
+      item.user.handle.toLowerCase().indexOf(filterText.toLowerCase()) > -1
+    let matchesPlaylistName: boolean
+
+    if (isAccountCollection(item)) {
+      matchesPlaylistName =
+        item.name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
+    } else {
+      matchesPlaylistName =
+        item.playlist_name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
     }
-    return true
+    return matchesPlaylistName || matchesOwnerName
   })
 }

--- a/packages/common/src/utils/collectionUtils.ts
+++ b/packages/common/src/utils/collectionUtils.ts
@@ -15,17 +15,12 @@ export function filterCollections<
   T extends AccountCollection | EnhancedCollection
 >(collections: T[], { filterText = '' }: FilterCollectionsOptions): T[] {
   return collections.filter((item: AccountCollection | EnhancedCollection) => {
+    const name = isAccountCollection(item) ? item.name : item.playlist_name
+    const matchesPlaylistName =
+      name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
     const matchesOwnerName =
       item.user.handle.toLowerCase().indexOf(filterText.toLowerCase()) > -1
-    let matchesPlaylistName: boolean
 
-    if (isAccountCollection(item)) {
-      matchesPlaylistName =
-        item.name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
-    } else {
-      matchesPlaylistName =
-        item.playlist_name.toLowerCase().indexOf(filterText.toLowerCase()) > -1
-    }
     return matchesPlaylistName || matchesOwnerName
   })
 }

--- a/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
+++ b/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
@@ -91,16 +91,17 @@ export const useCollectionsScreenData = ({
   const availableCollectionIds = useProxySelector(
     (state: AppState) => {
       if (isReachable) {
-        const filteredLocallyAddedCollections = filterCollections(
+        const filteredLocallyAddedCollectionIds = filterCollections(
           locallyAddedCollections
             .map((c) => getCollectionWithUser(state, { id: c }))
             .filter(removeNullable),
           { filterText: filterValue }
         ).map((p) => p.playlist_id)
         return uniq(
-          [...filteredLocallyAddedCollections, ...fetchedCollectionIds].filter(
-            (id) => !locallyRemovedCollections.has(id)
-          )
+          [
+            ...filteredLocallyAddedCollectionIds,
+            ...fetchedCollectionIds
+          ].filter((id) => !locallyRemovedCollections.has(id))
         )
       }
 

--- a/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
+++ b/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
@@ -1,5 +1,6 @@
 import type { CollectionType, CommonState } from '@audius/common'
 import {
+  removeNullable,
   accountSelectors,
   cacheCollectionsSelectors,
   reachabilitySelectors,
@@ -9,8 +10,10 @@ import {
   useGetLibraryAlbums,
   useGetLibraryPlaylists,
   useProxySelector,
-  savedPageSelectors
+  savedPageSelectors,
+  filterCollections
 } from '@audius/common'
+import uniq from 'lodash/uniq'
 import { useSelector } from 'react-redux'
 
 import { useOfflineTracksStatus } from 'app/hooks/useOfflineTrackStatus'
@@ -23,7 +26,7 @@ import { OfflineDownloadStatus } from 'app/store/offline-downloads/slice'
 
 const { getIsReachable } = reachabilitySelectors
 const { getUserId } = accountSelectors
-const { getCollection } = cacheCollectionsSelectors
+const { getCollection, getCollectionWithUser } = cacheCollectionsSelectors
 const {
   getSelectedCategory,
   getSelectedCategoryLocalAlbumAdds,
@@ -39,7 +42,7 @@ type UseCollectionsScreenDataConfig = {
 
 export const useCollectionsScreenData = ({
   collectionType,
-  filterValue = ''
+  filterValue
 }: UseCollectionsScreenDataConfig) => {
   const isDoneLoadingFromDisk = useSelector(getIsDoneLoadingFromDisk)
   const isReachable = useSelector(getIsReachable)
@@ -73,6 +76,7 @@ export const useCollectionsScreenData = ({
     collectionType === 'albums' ? useGetLibraryAlbums : useGetLibraryPlaylists,
     {
       category: selectedCategory,
+      query: filterValue,
       userId: currentUserId!
     },
     {
@@ -87,8 +91,16 @@ export const useCollectionsScreenData = ({
   const availableCollectionIds = useProxySelector(
     (state: AppState) => {
       if (isReachable) {
-        return [...locallyAddedCollections, ...fetchedCollectionIds].filter(
-          (id) => !locallyRemovedCollections.has(id)
+        const filteredLocallyAddedCollections = filterCollections(
+          locallyAddedCollections
+            .map((c) => getCollectionWithUser(state, { id: c }))
+            .filter(removeNullable),
+          { filterText: filterValue }
+        ).map((p) => p.playlist_id)
+        return uniq(
+          [...filteredLocallyAddedCollections, ...fetchedCollectionIds].filter(
+            (id) => !locallyRemovedCollections.has(id)
+          )
         )
       }
 

--- a/packages/web/src/common/store/pages/saved/sagas.ts
+++ b/packages/web/src/common/store/pages/saved/sagas.ts
@@ -115,7 +115,7 @@ function prepareParams({
     userId: account.user_id,
     offset: params.offset ?? 0,
     limit: params.limit ?? account.track_save_count,
-    query: params.query ?? '',
+    query: params.query,
     sortMethod: params.sortMethod || 'added_date',
     sortDirection: params.sortDirection || 'desc',
     category: params.category


### PR DESCRIPTION
- Make sure tracks/collections filter query works on library tabs
- Note: There is no filter feature on web library collections tabs

<img width="356" alt="Screenshot 2023-09-06 at 5 03 00 PM" src="https://github.com/AudiusProject/audius-client/assets/36916764/e903e98a-6088-4e7b-9f02-3db2e3b779ba">


### Description


### How Has This Been Tested?


### Screenshots

