### PR TITLE
Fix Jupiter caching bad route info

### DIFF
--- a/packages/web/src/services/solana/WithdrawUSDC.ts
+++ b/packages/web/src/services/solana/WithdrawUSDC.ts
@@ -35,11 +35,9 @@ export const getFundDestinationTokenAccountFees = async (
  * SOL, which is deposited into the user's root solana account.
  */
 export const getSwapUSDCUserBankInstructions = async ({
-  destinationAddress,
   amount,
   feePayer
 }: {
-  destinationAddress: string
   amount: number
   feePayer: PublicKey
 }): Promise<TransactionInstruction[]> => {
@@ -66,6 +64,8 @@ export const getSwapUSDCUserBankInstructions = async ({
     outputTokenSymbol: 'SOL',
     inputAmount: usdcNeededAmount.uiAmount,
     slippage: USDC_SLIPPAGE,
+    swapMode: 'ExactIn' as SwapMode,
+    forceFetch: true,
     onlyDirectRoutes: true
   })
   const exchangeInfo = await JupiterSingleton.exchange({

--- a/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
+++ b/packages/web/src/store/application/ui/withdraw-usdc/sagas.ts
@@ -181,12 +181,13 @@ function* doWithdrawUSDC({ payload }: ReturnType<typeof beginWithdrawUSDC>) {
         if (feeAmount > existingBalance - rootSolanaAccountRent) {
           // Swap USDC for SOL to fund the destination associated token account
           console.debug(
-            `Withdraw USDC - not enough SOL to fund destination account, attempting to swap USDC for SOL. Fee amount: ${feeAmount}, existing balance: ${existingBalance}, rent for root solana account: ${rootSolanaAccountRent}`
+            `Withdraw USDC - not enough SOL to fund destination account, attempting to swap USDC for SOL. Fee amount: ${feeAmount}, existing balance: ${existingBalance}, rent for root solana account: ${rootSolanaAccountRent}, amount needed: ${
+              feeAmount - (existingBalance - rootSolanaAccountRent)
+            }`
           )
           const swapInstructions = yield* call(
             getSwapUSDCUserBankInstructions,
             {
-              destinationAddress,
               amount: feeAmount - existingBalance,
               feePayer: feePayerPubkey
             }


### PR DESCRIPTION
### Description
The two calls to `computeRoutes` were happening close enough together that Jupiter was caching the response, but for some reason the routes were empty in the cached response. Force-fetching fixes the bug.

Also includes some small cleanup.

### How Has This Been Tested?
Local web stage


### Screenshots

