### PR TITLE
[C-3044] Add preview functionality to new upload flow

### DIFF
--- a/packages/web/src/pages/upload-page/UploadPageNew.tsx
+++ b/packages/web/src/pages/upload-page/UploadPageNew.tsx
@@ -16,6 +16,7 @@ import { FinishPageNew } from './components/FinishPageNew'
 import SelectPageNew from './components/SelectPageNew'
 import { EditPage } from './pages/EditPage'
 import { UploadFormState } from './types'
+import { UploadPreviewContextProvider } from './utils/uploadPreviewContext'
 
 const { uploadTracks, undoResetState } = uploadActions
 const { requestOpen: openUploadConfirmationModal } =
@@ -217,9 +218,11 @@ export const UploadPageNew = (props: UploadPageProps) => {
         />
       }
     >
-      <UploadFormScrollContext.Provider value={scrollToTop}>
-        {page}
-      </UploadFormScrollContext.Provider>
+      <UploadPreviewContextProvider>
+        <UploadFormScrollContext.Provider value={scrollToTop}>
+          {page}
+        </UploadFormScrollContext.Provider>
+      </UploadPreviewContextProvider>
     </Page>
   )
 }

--- a/packages/web/src/pages/upload-page/fields/CollectionTrackField.tsx
+++ b/packages/web/src/pages/upload-page/fields/CollectionTrackField.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import {
   HarmonyPlainButton,
   HarmonyPlainButtonType,
   IconDrag,
+  IconPause,
   IconPlay,
   IconTrash
 } from '@audius/stems'
@@ -19,6 +20,7 @@ import { SelectGenreField } from '../fields/SelectGenreField'
 import { SelectMoodField } from '../fields/SelectMoodField'
 import { TrackNameField } from '../fields/TrackNameField'
 import { CollectionTrackForUpload } from '../types'
+import { UploadPreviewContext } from '../utils/uploadPreviewContext'
 
 import styles from './CollectionTrackField.module.css'
 
@@ -36,6 +38,8 @@ type CollectionTrackFieldProps = {
 
 export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
   const { disableDelete = false, index, remove } = props
+  const { playingPreviewIndex, togglePreview, stopPreview } =
+    useContext(UploadPreviewContext)
   const [{ value: track }] = useField<CollectionTrackForUpload>(
     `tracks.${index}`
   )
@@ -47,6 +51,7 @@ export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
   const [{ value }] = useField('trackDetails')
 
   const { override } = track
+  const isPreviewPlaying = playingPreviewIndex === index
 
   useEffect(() => {
     if (override) {
@@ -58,8 +63,9 @@ export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
   }, [override])
 
   const handleRemove = useCallback(() => {
+    if (isPreviewPlaying) stopPreview()
     remove(index)
-  }, [remove, index])
+  }, [isPreviewPlaying, stopPreview, remove, index])
 
   return (
     <Tile className={styles.root} key={track.metadata.track_id} elevation='mid'>
@@ -67,9 +73,7 @@ export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
         <span className={styles.iconDrag}>
           <Icon icon={IconDrag} size='large' />
         </span>
-        <Text size='small' className={styles.trackindex}>
-          {index + 1}
-        </Text>
+        <Text size='small'>{index + 1}</Text>
         <TrackNameField name={`tracks.${index}.metadata.title`} />
       </div>
       {override ? (
@@ -90,7 +94,10 @@ export const CollectionTrackField = (props: CollectionTrackFieldProps) => {
           <HarmonyPlainButton
             variant={HarmonyPlainButtonType.SUBDUED}
             text={messages.preview}
-            iconLeft={IconPlay}
+            iconLeft={isPreviewPlaying ? IconPause : IconPlay}
+            onClick={() => {
+              togglePreview(track.preview, index)
+            }}
           />
           <HarmonyPlainButton
             variant={HarmonyPlainButtonType.SUBDUED}

--- a/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
+++ b/packages/web/src/pages/upload-page/fields/MultiTrackSidebar.tsx
@@ -20,6 +20,7 @@ import { Text } from 'components/typography'
 import { UploadFormScrollContext } from '../UploadPageNew'
 import { useIndexedField } from '../hooks'
 import { SingleTrackEditValues, TrackEditFormValues } from '../types'
+import { UploadPreviewContext } from '../utils/uploadPreviewContext'
 
 import styles from './MultiTrackSidebar.module.css'
 
@@ -89,6 +90,7 @@ const TrackRow = (props: TrackRowProps) => {
   const scrollToTop = useContext(UploadFormScrollContext)
   const { values, setValues, errors, submitCount } =
     useFormikContext<TrackEditFormValues>()
+  const { playingPreviewIndex, stopPreview } = useContext(UploadPreviewContext)
   const [{ value: title }] = useIndexedField<SingleTrackEditValues['title']>(
     'trackMetadatas',
     index,
@@ -114,6 +116,8 @@ const TrackRow = (props: TrackRowProps) => {
 
   const handleRemoveTrack = useCallback(
     (e: MouseEvent<HTMLDivElement>, index: number) => {
+      if (index === playingPreviewIndex) stopPreview()
+
       e.stopPropagation()
       const newTrackMetadatas = [...values.trackMetadatas]
       const newTracks = [...values.tracks]
@@ -129,7 +133,14 @@ const TrackRow = (props: TrackRowProps) => {
       })
       scrollToTop()
     },
-    [scrollToTop, selectedIndex, setValues, values]
+    [
+      playingPreviewIndex,
+      scrollToTop,
+      selectedIndex,
+      setValues,
+      stopPreview,
+      values
+    ]
   )
 
   const isTitleMissing = isEmpty(title)

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -29,6 +29,7 @@ import { SourceFilesField } from '../fields/SourceFilesField'
 import { TrackMetadataFields } from '../fields/TrackMetadataFields'
 import { defaultHiddenFields } from '../fields/availability/HiddenAvailabilityFields'
 import { TrackEditFormValues, TrackFormState } from '../types'
+import { UploadPreviewContext } from '../utils/uploadPreviewContext'
 import { TrackMetadataFormSchema } from '../validation'
 
 import styles from './EditTrackForm.module.css'
@@ -114,6 +115,10 @@ export const EditTrackForm = (props: EditTrackFormProps) => {
 const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
   const { values, dirty } = props
   const isMultiTrack = values.trackMetadatas.length > 1
+  const trackIdx = values.trackMetadatasIndex
+  const { playingPreviewIndex, togglePreview } =
+    useContext(UploadPreviewContext)
+  const isPreviewPlaying = playingPreviewIndex === trackIdx
 
   return (
     <Form>
@@ -136,7 +141,12 @@ const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
               <AccessAndSaleField isUpload />
               <AttributionField />
             </div>
-            <PreviewButton playing={false} onClick={() => {}} />
+            <PreviewButton
+              playing={isPreviewPlaying}
+              onClick={() => {
+                togglePreview(values.tracks[trackIdx].preview, trackIdx)
+              }}
+            />
           </div>
           {isMultiTrack ? <MultiTrackFooter /> : null}
         </div>

--- a/packages/web/src/pages/upload-page/pages/EditPage.tsx
+++ b/packages/web/src/pages/upload-page/pages/EditPage.tsx
@@ -1,8 +1,12 @@
+import { useContext } from 'react'
+
 import { UploadType } from '@audius/common'
+import { useUnmount } from 'react-use'
 
 import { EditCollectionForm } from '../forms/EditCollectionForm'
 import { EditTrackForm } from '../forms/EditTrackForm'
 import { CollectionFormState, TrackFormState, UploadFormState } from '../types'
+import { UploadPreviewContext } from '../utils/uploadPreviewContext'
 
 type EditPageProps = {
   formState: TrackFormState | CollectionFormState
@@ -11,6 +15,9 @@ type EditPageProps = {
 
 export const EditPage = (props: EditPageProps) => {
   const { formState, onContinue } = props
+  const { stopPreview } = useContext(UploadPreviewContext)
+  useUnmount(stopPreview)
+
   switch (formState.uploadType) {
     case UploadType.INDIVIDUAL_TRACK:
     case UploadType.INDIVIDUAL_TRACKS:

--- a/packages/web/src/pages/upload-page/utils/uploadPreviewContext.tsx
+++ b/packages/web/src/pages/upload-page/utils/uploadPreviewContext.tsx
@@ -1,0 +1,76 @@
+import { createContext, useCallback, useState } from 'react'
+
+import { Nullable, playerSelectors, queueActions } from '@audius/common'
+import { useSelector, useDispatch } from 'react-redux'
+
+const { getPlaying } = playerSelectors
+const { pause: pauseQueue } = queueActions
+
+type PreviewContextProps = {
+  playPreview: (preview: HTMLAudioElement, idx: number) => void
+  stopPreview: () => void
+  togglePreview: (preview: HTMLAudioElement, idx: number) => void
+  playingPreviewIndex: number
+}
+
+export const UploadPreviewContext = createContext<PreviewContextProps>({
+  playPreview: () => {},
+  stopPreview: () => {},
+  togglePreview: () => {},
+  playingPreviewIndex: -1
+})
+
+export const UploadPreviewContextProvider = (props: {
+  children: JSX.Element
+}) => {
+  const dispatch = useDispatch()
+  const isPlaying = useSelector(getPlaying)
+  const [preview, setPreview] = useState<Nullable<HTMLAudioElement>>(null)
+  const [previewIndex, setPreviewIndex] = useState<number>(-1)
+
+  const stopPreview = useCallback(() => {
+    if (preview !== null) {
+      preview.pause()
+      preview.currentTime = 0
+      setPreview(null)
+      setPreviewIndex(-1)
+    }
+  }, [preview])
+
+  const playPreview = useCallback(
+    (trackPreview: HTMLAudioElement, trackIdx: number) => {
+      if (isPlaying) dispatch(pauseQueue)
+      if (preview !== null) {
+        preview.pause()
+        preview.currentTime = 0
+      }
+
+      trackPreview.play()
+      setPreview(trackPreview)
+      setPreviewIndex(trackIdx)
+    },
+    [dispatch, isPlaying, preview]
+  )
+
+  const togglePreview = useCallback(
+    (trackPreview: HTMLAudioElement, trackIdx: number) => {
+      trackIdx === previewIndex
+        ? stopPreview()
+        : playPreview(trackPreview, trackIdx)
+    },
+    [playPreview, previewIndex, stopPreview]
+  )
+
+  return (
+    <UploadPreviewContext.Provider
+      value={{
+        playPreview,
+        stopPreview,
+        togglePreview,
+        playingPreviewIndex: previewIndex
+      }}
+    >
+      {props.children}
+    </UploadPreviewContext.Provider>
+  )
+}


### PR DESCRIPTION
### Description
Add a new context for previews in the upload page and hook up the buttons in the edit track and collection forms

### How Has This Been Tested?
Manually tested

### Screenshots
[image of the sound waves being produced in my headphones now]
