### PR TITLE
[PAY-1811] Fix default/empty profile picture in now playing bar/dashboard

### DIFF
--- a/packages/web/src/components/dynamic-image/DynamicImage.tsx
+++ b/packages/web/src/components/dynamic-image/DynamicImage.tsx
@@ -55,6 +55,7 @@ const fadeIn = (
 ) => {
   if (ref.current) {
     ref.current.style.zIndex = '2'
+    ref.current.style.removeProperty('background-color')
 
     if (image === placeholder) {
       ref.current.style.backgroundColor = 'unset'
@@ -70,6 +71,7 @@ const fadeIn = (
     } else if (!image.startsWith('data:image/png')) {
       ref.current.style.backgroundColor = 'unset'
     }
+
     // Allow gradient values for 'image' in addition to URIs
     ref.current.style.backgroundImage = image.includes('linear-gradient(')
       ? `${image}`

--- a/packages/web/src/components/play-bar/desktop/components/PlayingTrackInfo.tsx
+++ b/packages/web/src/components/play-bar/desktop/components/PlayingTrackInfo.tsx
@@ -8,7 +8,7 @@ import { animated, useSpring } from 'react-spring'
 import { Draggable } from 'components/dragndrop'
 import DynamicImage from 'components/dynamic-image/DynamicImage'
 import UserBadges from 'components/user-badges/UserBadges'
-import { useUserProfilePicture } from 'hooks/useUserProfilePicture'
+import { useProfilePicture } from 'hooks/useUserProfilePicture'
 import { fullTrackPage } from 'utils/route'
 
 import styles from './PlayingTrackInfo.module.css'
@@ -53,9 +53,8 @@ const PlayingTrackInfo = ({
 }: PlayingTrackInfoProps) => {
   const [artistSpringProps, setArtistSpringProps] = useSpring(() => springProps)
   const [trackSpringProps, setTrackSpringProps] = useSpring(() => springProps)
-  const image = useUserProfilePicture(
-    artistUserId,
-    profilePictureSizes,
+  const profileImage = useProfilePicture(
+    artistUserId ?? null,
     SquareSizes.SIZE_150_BY_150
   )
 
@@ -78,7 +77,7 @@ const PlayingTrackInfo = ({
     <div className={styles.info}>
       <div className={styles.profilePictureWrapper}>
         <DynamicImage
-          image={image}
+          image={profileImage}
           onClick={onClickArtistName}
           className={cn(styles.profilePicture, {
             [styles.isDefault]: !!trackId

--- a/packages/web/src/pages/artist-dashboard-page/components/ArtistCard.module.css
+++ b/packages/web/src/pages/artist-dashboard-page/components/ArtistCard.module.css
@@ -25,6 +25,10 @@
   align-items: center;
 }
 
+.profilePicture {
+  background-color: var(--default-profile-picture-background);
+}
+
 .profilePictureWrapper {
   width: 80px;
   height: 80px;

--- a/packages/web/src/pages/artist-dashboard-page/components/ArtistCard.tsx
+++ b/packages/web/src/pages/artist-dashboard-page/components/ArtistCard.tsx
@@ -30,6 +30,7 @@ export const ArtistCard = ({ userId, handle, name }: ArtistCardProps) => {
       />
       <div className={styles.details}>
         <DynamicImage
+          className={styles.profilePicture}
           wrapperClassName={styles.profilePictureWrapper}
           image={profilePicture}
         />


### PR DESCRIPTION
### Description

* Dashboard didn't have background color set
* Now playing bar setting was removing the background on `moveBehind` in dynamic image. When we switch images in DynamicImage, remove the background color prop first before setting it to what we want.

Probably should refactor this whole beast a bit at some point, but these changes at least are consistent w/ current patterns.

### How Has This Been Tested?

Locally vs. staging -- played a few diff tracks on trending & tested /dashboard

### Screenshots

<img width="697" alt="image" src="https://github.com/AudiusProject/audius-client/assets/2731362/e27e8c93-4a1f-49e0-a942-38327e158a71">

<img width="529" alt="image" src="https://github.com/AudiusProject/audius-client/assets/2731362/ef51b516-0a17-4f66-9611-bb1719e8697f">

