### PR TITLE
[C-3049] Fix upload type error where upload type is undefined

### DIFF
--- a/packages/web/src/pages/upload-page/UploadPageNew.tsx
+++ b/packages/web/src/pages/upload-page/UploadPageNew.tsx
@@ -120,7 +120,7 @@ export const UploadPageNew = (props: UploadPageProps) => {
       )
       break
     case Phase.EDIT:
-      if (formState.uploadType) {
+      if (formState.uploadType !== undefined) {
         page = (
           <EditPage
             formState={formState}
@@ -137,7 +137,7 @@ export const UploadPageNew = (props: UploadPageProps) => {
       }
       break
     case Phase.FINISH:
-      if (formState.uploadType) {
+      if (formState.uploadType !== undefined) {
         page = (
           <FinishPageNew
             formState={formState}

--- a/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
+++ b/packages/web/src/pages/upload-page/forms/EditTrackForm.tsx
@@ -10,6 +10,7 @@ import {
 import cn from 'classnames'
 import { Form, Formik, FormikProps, useField } from 'formik'
 import moment from 'moment'
+import { useUnmount } from 'react-use'
 import { z } from 'zod'
 import { toFormikValidationSchema } from 'zod-formik-adapter'
 
@@ -119,6 +120,10 @@ const TrackEditForm = (props: FormikProps<TrackEditFormValues>) => {
   const { playingPreviewIndex, togglePreview } =
     useContext(UploadPreviewContext)
   const isPreviewPlaying = playingPreviewIndex === trackIdx
+  const [, , { setValue: setIndex }] = useField('trackMetadatasIndex')
+  useUnmount(() => {
+    setIndex(0)
+  })
 
   return (
     <Form>


### PR DESCRIPTION
### Description
* Added a useUnmount hook to the edit page to reset the track metadata index
* updated some check for upload type to handle 0 bc its an enum

### How Has This Been Tested?
Manually tested

### Screenshots
[image of the page not being empty]
