### PR TITLE
PAY-1798 Don't show purchased filter for Library collections tabs

### DIFF
--- a/packages/common/src/store/pages/index.ts
+++ b/packages/common/src/store/pages/index.ts
@@ -61,6 +61,7 @@ export { tracksActions as savedPageTracksLineupActions } from './saved-page/line
 export * as savedPageActions from './saved-page/actions'
 export * as savedPageSelectors from './saved-page/selectors'
 export * from './saved-page/types'
+export * from './saved-page/utils'
 export { default as savedPageReducer } from './saved-page/reducer'
 
 export {

--- a/packages/common/src/store/pages/saved-page/actions.ts
+++ b/packages/common/src/store/pages/saved-page/actions.ts
@@ -1,6 +1,6 @@
 import { UID } from 'models/Identifiers'
 
-import { LibraryCategory, LibraryCategoryType } from './types'
+import { LibraryCategory, LibraryCategoryType, SavedPageTabs } from './types'
 
 export const FETCH_SAVES = 'SAVED/FETCH_SAVES'
 export const FETCH_SAVES_REQUESTED = 'SAVED/FETCH_SAVES_REQUESTED'
@@ -34,6 +34,10 @@ export const REMOVE_LOCAL_COLLECTION_PURCHASE =
   'SAVED/REMOVE_LOCAL_COLLECTION_PURCHASE'
 
 export const SET_SELECTED_CATEGORY = 'SAVED/SET_SELECTED_CATEGORY'
+export const INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE =
+  'SAVED/INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE'
+export const INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE =
+  'SAVED/INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE'
 
 export const fetchSaves = (
   // the filter query for the "get tracks" query
@@ -178,7 +182,28 @@ export const removeLocalCollectionRepost = ({
   isAlbum
 })
 
-export const setSelectedCategory = (category: LibraryCategoryType) => ({
-  type: SET_SELECTED_CATEGORY,
+export const initializeTracksCategoryFromLocalStorage = (
+  category: LibraryCategoryType
+) => ({
+  type: INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE,
   category
+})
+
+export const initializeCollectionsCategoryFromLocalStorage = (
+  category: LibraryCategoryType
+) => ({
+  type: INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE,
+  category
+})
+
+export const setSelectedCategory = ({
+  category,
+  currentTab
+}: {
+  category: LibraryCategoryType
+  currentTab: SavedPageTabs
+}) => ({
+  type: SET_SELECTED_CATEGORY,
+  category,
+  currentTab
 })

--- a/packages/common/src/store/pages/saved-page/reducer.ts
+++ b/packages/common/src/store/pages/saved-page/reducer.ts
@@ -20,7 +20,9 @@ import {
   ADD_LOCAL_TRACK_FAVORITE,
   REMOVE_LOCAL_TRACK_FAVORITE,
   END_FETCHING,
-  SET_SELECTED_CATEGORY
+  SET_SELECTED_CATEGORY,
+  INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE,
+  INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE
 } from 'store/pages/saved-page/actions'
 import tracksReducer, {
   initialState as initialLineupState
@@ -30,6 +32,7 @@ import { ActionsMap } from 'utils/reducer'
 
 import { PREFIX as tracksPrefix } from './lineups/tracks/actions'
 import { LibraryCategory, LibraryCategoryType, SavedPageState } from './types'
+import { calculateNewLibraryCategories } from './utils'
 
 const initialState = {
   // id => uid
@@ -51,7 +54,8 @@ const initialState = {
   hasReachedEnd: false,
   fetchingMore: false,
   tracks: initialLineupState,
-  selectedCategory: LibraryCategory.Favorite
+  tracksCategory: LibraryCategory.Favorite,
+  collectionsCategory: LibraryCategory.Favorite
 } as SavedPageState
 
 /** Utility to get the name of key in which locally added or removed collections are stored in SavedPageState.
@@ -241,7 +245,23 @@ const actionsMap: ActionsMap<SavedPageState> = {
   [SET_SELECTED_CATEGORY](state, action) {
     return {
       ...state,
-      selectedCategory: action.category
+      ...calculateNewLibraryCategories({
+        currentTab: action.currentTab,
+        chosenCategory: action.category,
+        prevTracksCategory: state.tracksCategory
+      })
+    }
+  },
+  [INIT_TRACKS_CATEGORY_FROM_LOCAL_STORAGE](state, action) {
+    return {
+      ...state,
+      tracksCategory: action.category
+    }
+  },
+  [INIT_COLLECTIONS_CATEGORY_FROM_LOCAL_STORAGE](state, action) {
+    return {
+      ...state,
+      collectionsCategory: action.category
     }
   },
   [signOut.type]() {

--- a/packages/common/src/store/pages/saved-page/selectors.ts
+++ b/packages/common/src/store/pages/saved-page/selectors.ts
@@ -2,13 +2,30 @@ import { CommonState } from 'store/commonStore'
 
 import { ID } from '../../../models/Identifiers'
 
-import { LibraryCategory } from './types'
+import { LibraryCategory, SavedPageTabs } from './types'
 
 export const getSaved = (state: CommonState) => state.pages.savedPage
 export const getTrackSaves = (state: CommonState) =>
   state.pages.savedPage.trackSaves
-export const getSelectedCategory = (state: CommonState) =>
-  state.pages.savedPage.selectedCategory
+
+export const getCollectionsCategory = (state: CommonState) => {
+  return state.pages.savedPage.collectionsCategory
+}
+
+export const getTracksCategory = (state: CommonState) => {
+  return state.pages.savedPage.tracksCategory
+}
+
+export const getCategory = (
+  state: CommonState,
+  props: { currentTab: SavedPageTabs }
+) => {
+  if (props.currentTab === SavedPageTabs.TRACKS) {
+    return getTracksCategory(state)
+  } else {
+    return getCollectionsCategory(state)
+  }
+}
 
 export const getLocalTrackFavorites = (state: CommonState) =>
   state.pages.savedPage.localTrackFavorites
@@ -45,7 +62,9 @@ export const getLocalRemovedPlaylistReposts = (state: CommonState) =>
 
 /** Get the tracks in currently selected category that have been added to the library in current session */
 export const getSelectedCategoryLocalAdds = (state: CommonState) => {
-  const selectedCategory = getSelectedCategory(state)
+  const selectedCategory = getCategory(state, {
+    currentTab: SavedPageTabs.TRACKS
+  })
   const localFavorites = getLocalTrackFavorites(state)
   const localPurchases = getLocalTrackPurchases(state)
   const localReposts = getLocalTrackReposts(state)
@@ -73,7 +92,9 @@ const getSelectedCategoryLocalCollectionUpdates = (
   props: { collectionType: 'album' | 'playlist'; updateType: 'add' | 'remove' }
 ) => {
   const { collectionType, updateType } = props
-  const selectedCategory = getSelectedCategory(state)
+  const currentTab =
+    collectionType === 'album' ? SavedPageTabs.ALBUMS : SavedPageTabs.PLAYLISTS
+  const selectedCategory = getCategory(state, { currentTab })
   let localFavorites: ID[], localPurchases: ID[], localReposts: ID[]
   if (updateType === 'add') {
     localFavorites =

--- a/packages/common/src/store/pages/saved-page/types.ts
+++ b/packages/common/src/store/pages/saved-page/types.ts
@@ -12,7 +12,9 @@ import {
   LineupTrack
 } from '../../../models'
 
-export const LIBRARY_SELECTED_CATEGORY_LS_KEY = 'librarySelectedCategory'
+export const LIBRARY_TRACKS_CATEGORY_LS_KEY = 'libraryTracksCategory'
+
+export const LIBRARY_COLLECTIONS_CATEGORY_LS_KEY = 'libraryCollectionsCategory'
 
 export const LibraryCategory = full.GetUserLibraryTracksTypeEnum
 export type LibraryCategoryType = ValueOf<typeof LibraryCategory>
@@ -42,7 +44,9 @@ export interface SavedPageState {
   hasReachedEnd: boolean
   initialFetch: boolean
   fetchingMore: boolean
-  selectedCategory: LibraryCategoryType
+
+  tracksCategory: LibraryCategoryType
+  collectionsCategory: LibraryCategoryType
 }
 
 export enum SavedPageTabs {

--- a/packages/common/src/store/pages/saved-page/utils.ts
+++ b/packages/common/src/store/pages/saved-page/utils.ts
@@ -1,0 +1,39 @@
+import { LibraryCategory, LibraryCategoryType, SavedPageTabs } from './types'
+
+export const calculateNewLibraryCategories = ({
+  currentTab,
+  chosenCategory,
+  prevTracksCategory
+}: {
+  currentTab: SavedPageTabs
+  chosenCategory: LibraryCategoryType
+  prevTracksCategory: unknown
+}) => {
+  if (
+    currentTab === SavedPageTabs.TRACKS &&
+    chosenCategory === LibraryCategory.Purchase
+  ) {
+    // If the category is changed to "Purchased" on the tracks tab, change the collections tabs category to "All" because collections tabs don't have "Purchased".
+    return {
+      tracksCategory: chosenCategory,
+      collectionsCategory: LibraryCategory.All
+    }
+  }
+  if (
+    (currentTab === SavedPageTabs.ALBUMS ||
+      currentTab === SavedPageTabs.PLAYLISTS) &&
+    prevTracksCategory === LibraryCategory.Purchase
+  ) {
+    // If tracks tab is on "Purchased", we want it to stay on "Purchased" until the user goes back to it.
+    return {
+      tracksCategory: prevTracksCategory,
+      collectionsCategory: chosenCategory
+    }
+  }
+
+  // Default behavior: change category for all tabs.
+  return {
+    collectionsCategory: chosenCategory,
+    tracksCategory: chosenCategory
+  }
+}

--- a/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/AlbumsTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import type { CommonState } from '@audius/common'
 import {
+  SavedPageTabs,
   reachabilitySelectors,
   statusIsNotFinalized,
   savedPageSelectors,
@@ -19,7 +20,7 @@ import { NoTracksPlaceholder } from './NoTracksPlaceholder'
 import { OfflineContentBanner } from './OfflineContentBanner'
 import { useCollectionsScreenData } from './useCollectionsScreenData'
 
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 const { getIsReachable } = reachabilitySelectors
 
 const messages = {
@@ -51,7 +52,9 @@ export const AlbumsTab = () => {
   }, [isReachable, hasMore, fetchMore])
 
   const emptyTabText = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.ALBUMS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return messages.emptyAlbumAllText
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/mobile/src/screens/favorites-screen/PlaylistsTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/PlaylistsTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import type { CommonState } from '@audius/common'
 import {
+  SavedPageTabs,
   CreatePlaylistSource,
   FeatureFlags,
   LibraryCategory,
@@ -28,7 +29,7 @@ import { OfflineContentBanner } from './OfflineContentBanner'
 import { useCollectionsScreenData } from './useCollectionsScreenData'
 
 const { getIsReachable } = reachabilitySelectors
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 
 const messages = {
   emptyPlaylistFavoritesText: "You haven't favorited any playlists yet.",
@@ -69,7 +70,9 @@ export const PlaylistsTab = () => {
     !statusIsNotFinalized(status) && !userPlaylists?.length && !filterValue
 
   const emptyTabText = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.PLAYLISTS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return messages.emptyPlaylistAllText
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
+++ b/packages/mobile/src/screens/favorites-screen/TracksTab.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ID, Nullable, Track, UID, User } from '@audius/common'
 import {
   LibraryCategory,
+  SavedPageTabs,
   FavoriteSource,
   PlaybackSource,
   Status,
@@ -39,7 +40,7 @@ const {
   getInitialFetchStatus,
   getSelectedCategoryLocalAdds,
   getIsFetchingMore,
-  getSelectedCategory
+  getCategory
 } = savedPageSelectors
 const { getIsReachable } = reachabilitySelectors
 const { getTrack } = cacheTracksSelectors
@@ -79,7 +80,9 @@ export const TracksTab = () => {
 
   const [filterValue, setFilterValue] = useState('')
   const [fetchPage, setFetchPage] = useState(0)
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector((state) =>
+    getCategory(state, { currentTab: SavedPageTabs.TRACKS })
+  )
   const savedTracksStatus = useSelector(getSavedTracksStatus)
   const initialFetch = useSelector(getInitialFetchStatus)
   const isFetchingMore = useSelector(getIsFetchingMore)

--- a/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
+++ b/packages/mobile/src/screens/favorites-screen/useCollectionsScreenData.ts
@@ -1,6 +1,7 @@
 import type { CollectionType, CommonState } from '@audius/common'
 import {
   removeNullable,
+  SavedPageTabs,
   accountSelectors,
   cacheCollectionsSelectors,
   reachabilitySelectors,
@@ -28,7 +29,7 @@ const { getIsReachable } = reachabilitySelectors
 const { getUserId } = accountSelectors
 const { getCollection, getCollectionWithUser } = cacheCollectionsSelectors
 const {
-  getSelectedCategory,
+  getCategory,
   getSelectedCategoryLocalAlbumAdds,
   getSelectedCategoryLocalAlbumRemovals,
   getSelectedCategoryLocalPlaylistAdds,
@@ -46,7 +47,14 @@ export const useCollectionsScreenData = ({
 }: UseCollectionsScreenDataConfig) => {
   const isDoneLoadingFromDisk = useSelector(getIsDoneLoadingFromDisk)
   const isReachable = useSelector(getIsReachable)
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector((state) =>
+    getCategory(state, {
+      currentTab:
+        collectionType === 'albums'
+          ? SavedPageTabs.ALBUMS
+          : SavedPageTabs.PLAYLISTS
+    })
+  )
   const currentUserId = useSelector(getUserId)
   const offlineTracksStatus = useOfflineTracksStatus({ skipIfOnline: true })
 

--- a/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/AlbumsTabPage.tsx
@@ -4,7 +4,8 @@ import {
   LibraryCategory,
   statusIsNotFinalized,
   savedPageSelectors,
-  CommonState
+  CommonState,
+  SavedPageTabs
 } from '@audius/common'
 import { useSelector } from 'react-redux'
 
@@ -19,7 +20,7 @@ import { emptyStateMessages } from '../emptyStateMessages'
 import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
 
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 
 const messages = {
   emptyAlbumsBody: 'Once you have, this is where you’ll find them!',
@@ -35,7 +36,9 @@ export const AlbumsTabPage = () => {
     collections: albums
   } = useCollectionsData('album')
   const emptyAlbumsHeader = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.ALBUMS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return emptyStateMessages.emptyAlbumAllHeader
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/LibraryCategorySelectionMenu.tsx
@@ -1,18 +1,20 @@
 import {
+  CommonState,
+  LibraryCategory,
+  LibraryCategoryType,
   savedPageActions,
   savedPageSelectors,
-  LibraryCategory,
-  LibraryCategoryType
+  SavedPageTabs
 } from '@audius/common'
 import { HarmonySelectablePill } from '@audius/stems'
 import { useDispatch, useSelector } from 'react-redux'
 
 import styles from './LibraryCategorySelectionMenu.module.css'
 
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 const { setSelectedCategory } = savedPageActions
 
-const CATEGORIES = [
+const TRACKS_CATEGORIES = [
   {
     label: 'All',
     value: LibraryCategory.All
@@ -31,16 +33,29 @@ const CATEGORIES = [
   }
 ]
 
-export const LibraryCategorySelectionMenu = () => {
+const COLLECTIONS_CATEGORIES = TRACKS_CATEGORIES.slice(0, -1)
+
+type LibraryCategorySelectionMenuProps = { currentTab: SavedPageTabs }
+
+export const LibraryCategorySelectionMenu = ({
+  currentTab
+}: LibraryCategorySelectionMenuProps) => {
   const dispatch = useDispatch()
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector((state: CommonState) =>
+    getCategory(state, { currentTab })
+  )
   const handleClick = (value: LibraryCategoryType) => {
-    dispatch(setSelectedCategory(value))
+    dispatch(setSelectedCategory({ currentTab, category: value }))
   }
+
+  const categories =
+    currentTab === SavedPageTabs.TRACKS
+      ? TRACKS_CATEGORIES
+      : COLLECTIONS_CATEGORIES
 
   return (
     <div role='radiogroup' className={styles.container}>
-      {CATEGORIES.map((c) => (
+      {categories.map((c) => (
         <HarmonySelectablePill
           role='radio'
           size='large'

--- a/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
@@ -6,6 +6,7 @@ import {
   CreatePlaylistSource,
   LibraryCategory,
   savedPageSelectors,
+  SavedPageTabs,
   statusIsNotFinalized
 } from '@audius/common'
 import { IconPlus } from '@audius/stems'
@@ -23,7 +24,7 @@ import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
 
 const { createPlaylist } = cacheCollectionsActions
-const { getSelectedCategory } = savedPageSelectors
+const { getCategory } = savedPageSelectors
 
 const messages = {
   emptyPlaylistsBody: 'Once you have, this is where you’ll find them!',
@@ -36,7 +37,9 @@ export const PlaylistsTabPage = () => {
   const { status, hasMore, fetchMore, collections } =
     useCollectionsData('playlist')
   const emptyPlaylistsHeader = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.PLAYLISTS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return emptyStateMessages.emptyPlaylistAllHeader
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/PlaylistsTabPage.tsx
@@ -2,11 +2,11 @@ import { useCallback, useMemo } from 'react'
 
 import {
   cacheCollectionsActions,
+  CommonState,
   CreatePlaylistSource,
-  statusIsNotFinalized,
-  savedPageSelectors,
   LibraryCategory,
-  CommonState
+  savedPageSelectors,
+  statusIsNotFinalized
 } from '@audius/common'
 import { IconPlus } from '@audius/stems'
 import { useDispatch, useSelector } from 'react-redux'
@@ -21,6 +21,7 @@ import { emptyStateMessages } from '../emptyStateMessages'
 
 import { CollectionCard } from './CollectionCard'
 import styles from './SavedPage.module.css'
+
 const { createPlaylist } = cacheCollectionsActions
 const { getSelectedCategory } = savedPageSelectors
 

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -8,7 +8,7 @@ import {
   QueueItem,
   SavedPageCollection,
   savedPageSelectors,
-  SavedPageTabs as ProfileTabs,
+  SavedPageTabs,
   SavedPageTrack,
   Status,
   TrackRecord,
@@ -74,11 +74,11 @@ export type SavedPageProps = {
   onClickRepost: (record: TrackRecord) => void
   onPlay: () => void
   onSortTracks: (sorters: any) => void
-  onChangeTab: (tab: ProfileTabs) => void
+  onChangeTab: (tab: SavedPageTabs) => void
   allTracksFetched: boolean
   filterText: string
   initialOrder: UID[] | null
-  currentTab: ProfileTabs
+  currentTab: SavedPageTabs
   account: (User & { albums: SavedPageCollection[] }) | undefined
   tracks: Lineup<SavedPageTrack>
   currentQueueItem: QueueItem
@@ -146,7 +146,7 @@ const SavedPage = ({
   const queuedAndPlaying = playing && isQueued
 
   // Setup play button
-  const playButtonActive = currentTab === ProfileTabs.TRACKS && !tracksLoading
+  const playButtonActive = currentTab === SavedPageTabs.TRACKS && !tracksLoading
   const playAllButton = (
     <div
       className={styles.playButtonContainer}
@@ -168,7 +168,7 @@ const SavedPage = ({
   )
 
   // Setup filter
-  const filterActive = currentTab === ProfileTabs.TRACKS
+  const filterActive = currentTab === SavedPageTabs.TRACKS
   const filter = (
     <div
       className={styles.filterContainer}
@@ -188,25 +188,25 @@ const SavedPage = ({
   const { tabs, body } = useTabs({
     isMobile: false,
     didChangeTabsFrom: (_, to) => {
-      onChangeTab(to as ProfileTabs)
+      onChangeTab(to as SavedPageTabs)
     },
     bodyClassName: styles.tabBody,
     elementClassName: styles.tabElement,
     tabs: [
       {
         icon: <IconNote />,
-        text: ProfileTabs.TRACKS,
-        label: ProfileTabs.TRACKS
+        text: SavedPageTabs.TRACKS,
+        label: SavedPageTabs.TRACKS
       },
       {
         icon: <IconAlbum />,
-        text: ProfileTabs.ALBUMS,
-        label: ProfileTabs.ALBUMS
+        text: SavedPageTabs.ALBUMS,
+        label: SavedPageTabs.ALBUMS
       },
       {
         icon: <IconPlaylists />,
-        text: ProfileTabs.PLAYLISTS,
-        label: ProfileTabs.PLAYLISTS
+        text: SavedPageTabs.PLAYLISTS,
+        label: SavedPageTabs.PLAYLISTS
       }
     ],
     elements: [
@@ -257,7 +257,7 @@ const SavedPage = ({
     <Header
       primary={messages.libraryHeader}
       secondary={isEmpty ? null : playAllButton}
-      rightDecorator={<LibraryCategorySelectionMenu />}
+      rightDecorator={<LibraryCategorySelectionMenu currentTab={currentTab} />}
       containerStyles={styles.savedPageHeader}
       bottomBar={headerBottomBar}
     />

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -121,7 +121,9 @@ const SavedPage = ({
   const { mainContentRef } = useContext(MainContentContext)
   const initFetch = useSelector(getInitialFetchStatus)
   const emptyTracksHeader = useSelector((state: CommonState) => {
-    const selectedCategory = getCategory(state, SavedPageTabs.TRACKS)
+    const selectedCategory = getCategory(state, {
+      currentTab: SavedPageTabs.TRACKS
+    })
     if (selectedCategory === LibraryCategory.All) {
       return emptyStateMessages.emptyTrackAllHeader
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
+++ b/packages/web/src/pages/saved-page/components/desktop/SavedPage.tsx
@@ -37,7 +37,7 @@ import { LibraryCategorySelectionMenu } from './LibraryCategorySelectionMenu'
 import { PlaylistsTabPage } from './PlaylistsTabPage'
 import styles from './SavedPage.module.css'
 
-const { getInitialFetchStatus, getSelectedCategory } = savedPageSelectors
+const { getInitialFetchStatus, getCategory } = savedPageSelectors
 
 const messages = {
   libraryHeader: 'Library',
@@ -121,7 +121,7 @@ const SavedPage = ({
   const { mainContentRef } = useContext(MainContentContext)
   const initFetch = useSelector(getInitialFetchStatus)
   const emptyTracksHeader = useSelector((state: CommonState) => {
-    const selectedCategory = getSelectedCategory(state)
+    const selectedCategory = getCategory(state, SavedPageTabs.TRACKS)
     if (selectedCategory === LibraryCategory.All) {
       return emptyStateMessages.emptyTrackAllHeader
     } else if (selectedCategory === LibraryCategory.Favorite) {

--- a/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
+++ b/packages/web/src/pages/saved-page/hooks/useCollectionsData.tsx
@@ -14,7 +14,7 @@ import { useSelector } from 'react-redux'
 
 const { getUserId } = accountSelectors
 const {
-  getSelectedCategory,
+  getCollectionsCategory,
   getSelectedCategoryLocalAlbumAdds,
   getSelectedCategoryLocalAlbumRemovals,
   getSelectedCategoryLocalPlaylistAdds,
@@ -24,7 +24,7 @@ const { getCollections } = cacheCollectionsSelectors
 
 export const useCollectionsData = (collectionType: 'album' | 'playlist') => {
   const currentUserId = useSelector(getUserId)
-  const selectedCategory = useSelector(getSelectedCategory)
+  const selectedCategory = useSelector(getCollectionsCategory)
 
   const locallyAddedCollections = useSelector((state: CommonState) => {
     const ids =


### PR DESCRIPTION
### Description
- Don't show purchased filter on Library collections tabs
- From Figma: 
Since users can not purchase playlists or albums, if a user selects 'purchased' pill on the tracks tab and then attempt to click on playlists/albums tab, just take users to the ALL filter (without “Purchased”). If they return to the tracks (or album) page, the purchased filter should remain.
- ^Make sure this behavior persists from session to session

### How Has This Been Tested?
Local web + mobile

### Screenshots
![filters](https://github.com/AudiusProject/audius-client/assets/36916764/2df0d2e0-b84c-4a6a-bcea-6f7203227493)

