### PR TITLE
[PAY-1814] Store USDC balances in wallet slice

### DIFF
--- a/packages/common/src/hooks/useUSDCBalance.ts
+++ b/packages/common/src/hooks/useUSDCBalance.ts
@@ -1,19 +1,35 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import BN from 'bn.js'
+import { useDispatch, useSelector } from 'react-redux'
 
 import { Status } from 'models/Status'
-import { BNUSDC } from 'models/Wallet'
+import { BNUSDC, StringUSDC } from 'models/Wallet'
 import { getUserbankAccountInfo } from 'services/index'
 import { useAppContext } from 'src/context/appContext'
+import { getUSDCBalance } from 'store/wallet/selectors'
+import { setUSDCBalance } from 'store/wallet/slice'
 
 /**
- * On mount, fetches the USDC balance for the current user
+ * On mount, fetches the USDC balance for the current user and stores it
+ * in the redux wallet slice.
+ *
+ * Note: a status is returned alongside the balance which may indicate a
+ * stale balance. If absolute latest balance value is needed, defer use until
+ * Status.SUCCESS.
  */
 export const useUSDCBalance = () => {
   const { audiusBackend } = useAppContext()
+  const dispatch = useDispatch()
+
   const [status, setStatus] = useState(Status.IDLE)
-  const [data, setData] = useState<BNUSDC>()
+  const data = useSelector(getUSDCBalance)
+  const setData = useCallback(
+    (balance: BNUSDC) => {
+      dispatch(setUSDCBalance({ amount: balance.toString() as StringUSDC }))
+    },
+    [dispatch]
+  )
 
   useEffect(() => {
     const fetch = async () => {
@@ -30,7 +46,7 @@ export const useUSDCBalance = () => {
       }
     }
     fetch()
-  }, [audiusBackend])
+  }, [audiusBackend, setData])
 
   return { status, data }
 }

--- a/packages/common/src/store/purchase-content/utils.ts
+++ b/packages/common/src/store/purchase-content/utils.ts
@@ -1,6 +1,7 @@
 import BN from 'bn.js'
 
 import { BNUSDC } from 'models/Wallet'
+import { Nullable } from 'utils/typeUtils'
 import { BN_USDC_CENT_WEI, ceilingBNUSDCToNearestCent } from 'utils/wallet'
 
 import { PurchaseContentStage } from './types'
@@ -24,22 +25,23 @@ type PurchaseSummaryValues = {
 
 export const getPurchaseSummaryValues = (
   price: number,
-  currentBalance: BNUSDC = zeroBalance()
+  currentBalance: Nullable<BNUSDC>
 ): PurchaseSummaryValues => {
   let amountDue = price
   let existingBalance
   const priceBN = new BN(price).mul(BN_USDC_CENT_WEI)
+  const balance = currentBalance ?? zeroBalance()
 
-  if (currentBalance.gte(priceBN)) {
+  if (balance.gte(priceBN)) {
     amountDue = 0
     existingBalance = price
   }
   // Only count the balance if it's greater than 1 cent
-  else if (currentBalance.gt(BN_USDC_CENT_WEI)) {
+  else if (balance.gt(BN_USDC_CENT_WEI)) {
     // Note: Rounding amount due *up* to nearest cent for cases where the balance
     // is between cents so that we aren't advertising *lower* than what the user
     // will have to pay.
-    const diff = priceBN.sub(currentBalance)
+    const diff = priceBN.sub(balance)
     amountDue = ceilingBNUSDCToNearestCent(diff as BNUSDC)
       .div(BN_USDC_CENT_WEI)
       .toNumber()

--- a/packages/common/src/store/wallet/selectors.ts
+++ b/packages/common/src/store/wallet/selectors.ts
@@ -1,5 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit'
+import BN from 'bn.js'
 
+import { BNUSDC } from 'models/Wallet'
 import { CommonState } from 'store/commonStore'
 import { Nullable } from 'utils/typeUtils'
 import { stringWeiToBN, zeroBNWei } from 'utils/wallet'
@@ -35,3 +37,6 @@ export const getLocalBalanceDidChange = (state: CommonState): boolean =>
 
 export const getFreezeUntilTime = (state: CommonState): Nullable<number> =>
   state.wallet.freezeBalanceUntil
+
+export const getUSDCBalance = (state: CommonState): Nullable<BNUSDC> =>
+  state.wallet.usdcBalance ? (new BN(state.wallet.usdcBalance) as BNUSDC) : null

--- a/packages/common/src/store/wallet/slice.ts
+++ b/packages/common/src/store/wallet/slice.ts
@@ -4,7 +4,7 @@ import BN from 'bn.js'
 import { Nullable } from 'utils/typeUtils'
 
 import { Chain } from '../../models/Chain'
-import { StringWei } from '../../models/Wallet'
+import { StringUSDC, StringWei } from '../../models/Wallet'
 
 type WalletState = {
   balance: Nullable<StringWei>
@@ -12,6 +12,7 @@ type WalletState = {
   totalBalance: Nullable<StringWei>
   localBalanceDidChange: boolean
   freezeBalanceUntil: Nullable<number>
+  usdcBalance: Nullable<StringUSDC>
 }
 
 const initialState: WalletState = {
@@ -19,7 +20,8 @@ const initialState: WalletState = {
   balanceLoading: true,
   totalBalance: null,
   localBalanceDidChange: false,
-  freezeBalanceUntil: null
+  freezeBalanceUntil: null,
+  usdcBalance: null
 }
 
 // After optimistically updating the balance, it can be useful
@@ -76,6 +78,12 @@ const slice = createSlice({
       state.localBalanceDidChange = true
       state.freezeBalanceUntil = Date.now() + BALANCE_FREEZE_DURATION_SEC * 1000
     },
+    setUSDCBalance: (
+      state,
+      { payload: { amount } }: PayloadAction<{ amount: StringUSDC }>
+    ) => {
+      state.usdcBalance = amount
+    },
     // Saga Actions
     getBalance: () => {},
     claim: () => {},
@@ -98,6 +106,7 @@ export const {
   setBalance,
   increaseBalance,
   decreaseBalance,
+  setUSDCBalance,
   getBalance,
   claim,
   claimSucceeded,

--- a/packages/common/src/utils/wallet.ts
+++ b/packages/common/src/utils/wallet.ts
@@ -148,6 +148,11 @@ export const ceilingBNUSDCToNearestCent = (value: BNUSDC): BNUSDC => {
     .mul(BN_USDC_CENT_WEI) as BNUSDC
 }
 
+/** Round a USDC value as a BN down to the nearest cent and return as a BN */
+export const floorBNUSDCToNearestCent = (value: BNUSDC): BNUSDC => {
+  return value.div(BN_USDC_CENT_WEI).mul(BN_USDC_CENT_WEI) as BNUSDC
+}
+
 /** Formats a USDC wei string (full precision) to a fixed string suitable for
 display as a dollar amount. Note: will lose precision by rounding _up_ to nearest cent */
 export const formatUSDCWeiToUSDString = (amount: StringUSDC, precision = 2) => {
@@ -157,7 +162,7 @@ export const formatUSDCWeiToUSDString = (amount: StringUSDC, precision = 2) => {
   // with BN, divide by $1 Wei, ceiling up to the nearest cent,
   //  and then convert to JS number and divide back down before formatting to
   // two decimal places.
-  const cents = formatUSDCWeiToNumber(new BN(amountPos) as BNUSDC)
+  const cents = formatUSDCWeiToCeilingDollarNumber(new BN(amountPos) as BNUSDC)
   return formatNumberCommas(cents.toFixed(precision))
 }
 
@@ -165,10 +170,18 @@ export const formatUSDCWeiToUSDString = (amount: StringUSDC, precision = 2) => {
  * Formats a USDC BN (full precision) to a number suitable for display as a dollar amount.
  * Note: will lose precision by rounding _up_ to nearest cent.
  */
-export const formatUSDCWeiToNumber = (amount: BNUSDC) => {
+export const formatUSDCWeiToCeilingDollarNumber = (amount: BNUSDC) => {
   return (
     ceilingBNUSDCToNearestCent(amount).div(BN_USDC_CENT_WEI).toNumber() / 100
   )
+}
+
+/**
+ * Formats a USDC BN (full precision) to a number of cents
+ * Note: will lose precision by rounding _down_ to nearest cent.
+ */
+export const formatUSDCWeiToFloorCentsNumber = (amount: BNUSDC) => {
+  return floorBNUSDCToNearestCent(amount).div(BN_USDC_CENT_WEI).toNumber()
 }
 
 /** General Wallet Utils */

--- a/packages/web/src/components/premium-content-purchase-modal/components/PurchaseDetailsPage.tsx
+++ b/packages/web/src/components/premium-content-purchase-modal/components/PurchaseDetailsPage.tsx
@@ -11,7 +11,8 @@ import {
   PurchaseContentStage,
   Track,
   UserTrackMetadata,
-  Name
+  Name,
+  Nullable
 } from '@audius/common'
 import {
   HarmonyButton,
@@ -75,7 +76,7 @@ const ContentPurchaseError = () => {
 }
 
 export type PurchaseDetailsPageProps = {
-  currentBalance?: BNUSDC
+  currentBalance: Nullable<BNUSDC>
   track: UserTrackMetadata
   onViewTrackClicked: () => void
 }

--- a/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/WithdrawUSDCModal.tsx
@@ -5,9 +5,12 @@ import {
   useUSDCBalance,
   useWithdrawUSDCModal,
   WithdrawUSDCModalPages,
-  withdrawUSDCActions
+  withdrawUSDCActions,
+  BNUSDC,
+  formatUSDCWeiToFloorCentsNumber
 } from '@audius/common'
 import { Modal, ModalContent, ModalHeader } from '@audius/stems'
+import BN from 'bn.js'
 import { Formik } from 'formik'
 import { useDispatch } from 'react-redux'
 import { z } from 'zod'
@@ -59,6 +62,9 @@ export const WithdrawUSDCModal = () => {
   const { isOpen, onClose, onClosed, data, setData } = useWithdrawUSDCModal()
   const { page } = data
   const { data: balance } = useUSDCBalance()
+  const balanceNumberCents = formatUSDCWeiToFloorCentsNumber(
+    (balance ?? new BN(0)) as BNUSDC
+  )
 
   const onSuccess = useCallback(
     (signature: string) => {
@@ -121,7 +127,7 @@ export const WithdrawUSDCModal = () => {
       <ModalContent>
         <Formik
           initialValues={{
-            [AMOUNT]: balance?.toNumber() ?? 0,
+            [AMOUNT]: balanceNumberCents,
             [ADDRESS]: '',
             [CONFIRM]: false
           }}

--- a/packages/web/src/components/withdraw-usdc-modal/components/EnterTransferDetails.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/EnterTransferDetails.tsx
@@ -7,11 +7,11 @@ import {
 
 import {
   useUSDCBalance,
-  formatUSDCWeiToNumber,
   formatCurrencyBalance,
   BNUSDC,
   useWithdrawUSDCModal,
-  WithdrawUSDCModalPages
+  WithdrawUSDCModalPages,
+  formatUSDCWeiToFloorCentsNumber
 } from '@audius/common'
 import {
   HarmonyButton,
@@ -58,7 +58,8 @@ export const EnterTransferDetails = () => {
   const { data: balance } = useUSDCBalance()
   const { setData } = useWithdrawUSDCModal()
 
-  const balanceNumber = formatUSDCWeiToNumber((balance ?? new BN(0)) as BNUSDC)
+  const balanceNumber =
+    formatUSDCWeiToFloorCentsNumber((balance ?? new BN(0)) as BNUSDC) / 100
   const balanceFormatted = formatCurrencyBalance(balanceNumber)
 
   const [

--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferInProgress.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferInProgress.tsx
@@ -1,8 +1,8 @@
 import {
   useUSDCBalance,
-  formatUSDCWeiToNumber,
   formatCurrencyBalance,
-  BNUSDC
+  BNUSDC,
+  formatUSDCWeiToFloorCentsNumber
 } from '@audius/common'
 import BN from 'bn.js'
 import { useField } from 'formik'
@@ -27,7 +27,8 @@ const messages = {
 
 export const TransferInProgress = () => {
   const { data: balance } = useUSDCBalance()
-  const balanceNumber = formatUSDCWeiToNumber((balance ?? new BN(0)) as BNUSDC)
+  const balanceNumber =
+    formatUSDCWeiToFloorCentsNumber((balance ?? new BN(0)) as BNUSDC) / 100
   const balanceFormatted = formatCurrencyBalance(balanceNumber)
 
   const [{ value: amountValue }] = useField(AMOUNT)

--- a/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
+++ b/packages/web/src/components/withdraw-usdc-modal/components/TransferSuccessful.tsx
@@ -1,9 +1,9 @@
 import {
   useUSDCBalance,
-  formatUSDCWeiToNumber,
   formatCurrencyBalance,
   BNUSDC,
-  useWithdrawUSDCModal
+  useWithdrawUSDCModal,
+  formatUSDCWeiToFloorCentsNumber
 } from '@audius/common'
 import {
   HarmonyPlainButton,
@@ -46,7 +46,8 @@ const openExplorer = (signature: string) => {
 export const TransferSuccessful = () => {
   const { data: balance } = useUSDCBalance()
   const { data: modalData } = useWithdrawUSDCModal()
-  const balanceNumber = formatUSDCWeiToNumber((balance ?? new BN(0)) as BNUSDC)
+  const balanceNumber =
+    formatUSDCWeiToFloorCentsNumber((balance ?? new BN(0)) as BNUSDC) / 100
   const balanceFormatted = formatCurrencyBalance(balanceNumber)
 
   const [{ value: amountValue }] = useField(AMOUNT)

--- a/packages/web/src/pages/artist-dashboard-page/components/USDCCard.tsx
+++ b/packages/web/src/pages/artist-dashboard-page/components/USDCCard.tsx
@@ -2,7 +2,7 @@ import {
   BNUSDC,
   WithdrawUSDCModalPages,
   formatCurrencyBalance,
-  formatUSDCWeiToNumber,
+  formatUSDCWeiToCeilingDollarNumber,
   useWithdrawUSDCModal
 } from '@audius/common'
 import {
@@ -39,7 +39,9 @@ export const USDCCard = ({ balance }: { balance: BNUSDC }) => {
   const goToRoute = useGoToRoute()
   const { onOpen: openWithdrawUSDCModal } = useWithdrawUSDCModal()
 
-  const balanceNumber = formatUSDCWeiToNumber((balance ?? new BN(0)) as BNUSDC)
+  const balanceNumber = formatUSDCWeiToCeilingDollarNumber(
+    (balance ?? new BN(0)) as BNUSDC
+  )
   const balanceFormatted = formatCurrencyBalance(balanceNumber)
 
   const menuItems: PopupMenuItem[] = [


### PR DESCRIPTION
### Description

Store USDC balances in common slice so that it stays fresh when updated from misc. usage of `useUSDCBalance`

Issue:
1. User with balance 100 withdraws 5
2. Withdrawal modal UI shows 95, but dashboard page shows 100 still

I think I like this pattern more than polling for balance refresh every 1s.

### How Has This Been Tested?

Locally vs. staging. Tested via withdrawal flow.